### PR TITLE
HIVE-28080: Propagate statistics from a source table to the materialized CTE

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.cleanup.CleanupService;
 import org.apache.hadoop.hive.ql.cleanup.SyncCleanupService;
-import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.TaskRunner;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
@@ -65,6 +64,7 @@ import org.apache.hadoop.hive.ql.parse.ExplainConfiguration.AnalyzeState;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.QB;
 import org.apache.hadoop.hive.ql.plan.LoadTableDesc;
+import org.apache.hadoop.hive.ql.plan.Statistics;
 import org.apache.hadoop.hive.ql.plan.mapper.EmptyStatsSource;
 import org.apache.hadoop.hive.ql.plan.mapper.PlanMapper;
 import org.apache.hadoop.hive.ql.plan.mapper.StatsSource;
@@ -142,7 +142,7 @@ public class Context {
   private AtomicInteger sequencer = new AtomicInteger();
 
   private final Map<String, Table> cteTables = new HashMap<String, Table>();
-  private final Map<TableName, FileSinkOperator> cteSources = new HashMap<>();
+  private final Map<TableName, Statistics> cteTableStats = new HashMap<>();
 
   // Keep track of the mapping from load table desc to the output and the lock
   private final Map<LoadTableDesc, WriteEntity> loadTableOutputMap =
@@ -1228,16 +1228,14 @@ public class Context {
     return cteTables.get(cteName);
   }
 
-  public void addMaterializedTable(String cteName, Table table) {
+  public void addMaterializedTable(String cteName, Table table, Statistics statistics) {
     cteTables.put(cteName, table);
+    cteTables.put(table.getFullyQualifiedName(), table);
+    cteTableStats.put(table.getFullTableName(), statistics);
   }
 
-  public FileSinkOperator getMaterializedTableSource(TableName tableName) {
-    return cteSources.get(tableName);
-  }
-
-  public void addMaterializedTableSource(TableName tableName, FileSinkOperator operator) {
-    cteSources.put(tableName, operator);
+  public Statistics getMaterializedTableStats(TableName tableName) {
+    return cteTableStats.get(tableName);
   }
 
   public AtomicInteger getSequencer() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -45,9 +45,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hive.common.BlobStorageUtils;
 import org.apache.hadoop.hive.common.FileUtils;
+import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.cleanup.CleanupService;
 import org.apache.hadoop.hive.ql.cleanup.SyncCleanupService;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.TaskRunner;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
@@ -140,6 +142,7 @@ public class Context {
   private AtomicInteger sequencer = new AtomicInteger();
 
   private final Map<String, Table> cteTables = new HashMap<String, Table>();
+  private final Map<TableName, FileSinkOperator> cteSources = new HashMap<>();
 
   // Keep track of the mapping from load table desc to the output and the lock
   private final Map<LoadTableDesc, WriteEntity> loadTableOutputMap =
@@ -1227,6 +1230,14 @@ public class Context {
 
   public void addMaterializedTable(String cteName, Table table) {
     cteTables.put(cteName, table);
+  }
+
+  public FileSinkOperator getMaterializedTableSource(TableName tableName) {
+    return cteSources.get(tableName);
+  }
+
+  public void addMaterializedTableSource(TableName tableName, FileSinkOperator operator) {
+    cteSources.put(tableName, operator);
   }
 
   public AtomicInteger getSequencer() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -169,8 +169,13 @@ public class StatsRulesProcFactory {
       Table table = tsop.getConf().getTableMetadata();
 
       try {
-        // gather statistics for the first time and the attach it to table scan operator
-        Statistics stats = StatsUtils.collectStatistics(aspCtx.getConf(), partList, colStatsCached, table, tsop);
+        Statistics stats;
+        if (table.isMaterializedTable()) {
+          stats = tsop.getStatistics();
+        } else {
+          // gather statistics for the first time and attach it to table scan operator
+          stats = StatsUtils.collectStatistics(aspCtx.getConf(), partList, colStatsCached, table, tsop);
+        }
 
         stats = applyRuntimeStats(aspCtx.getParseContext().getContext(), stats, tsop);
         tsop.setStatistics(stats);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1071,9 +1071,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
     LOG.info(cteName + " will be materialized into " + location);
     cte.source = analyzer;
 
-    ctx.addMaterializedTable(cteName, table);
-    // For CalcitePlanner, store qualified name too
-    ctx.addMaterializedTable(table.getFullyQualifiedName(), table);
+    ctx.addMaterializedTable(cteName, table, getMaterializedTableStats(analyzer.getSinkOp(), table));
 
     return table;
   }

--- a/ql/src/test/queries/clientpositive/cte_mat_11.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_11.q
@@ -1,0 +1,15 @@
+--! qt:dataset:src
+set hive.optimize.cte.materialize.threshold=2;
+set hive.optimize.cte.materialize.full.aggregate.only=false;
+
+EXPLAIN WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT *
+  FROM materialized_cte1 a
+  JOIN materialized_cte1 b ON (a.key = b.key)
+)
+SELECT *
+FROM materialized_cte2 a
+JOIN materialized_cte2 b ON (a.key = b.key);

--- a/ql/src/test/queries/clientpositive/cte_mat_11.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_11.q
@@ -6,10 +6,46 @@ EXPLAIN WITH materialized_cte1 AS (
   SELECT * FROM src
 ),
 materialized_cte2 AS (
-  SELECT *
+  SELECT a.key
   FROM materialized_cte1 a
   JOIN materialized_cte1 b ON (a.key = b.key)
 )
-SELECT *
+SELECT a.key
 FROM materialized_cte2 a
 JOIN materialized_cte2 b ON (a.key = b.key);
+
+EXPLAIN CBO WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT a.key
+  FROM materialized_cte1 a
+  JOIN materialized_cte1 b ON (a.key = b.key)
+)
+SELECT a.key
+FROM materialized_cte2 a
+JOIN materialized_cte2 b ON (a.key = b.key);
+
+EXPLAIN WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT * FROM materialized_cte1
+  UNION ALL
+  SELECT * FROM materialized_cte1
+)
+SELECT * FROM materialized_cte2
+UNION ALL
+SELECT * FROM materialized_cte2;
+
+EXPLAIN CBO WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT * FROM materialized_cte1
+  UNION ALL
+  SELECT * FROM materialized_cte1
+)
+SELECT * FROM materialized_cte2
+UNION ALL
+SELECT * FROM materialized_cte2;

--- a/ql/src/test/results/clientpositive/llap/cte_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_3.q.out
@@ -34,8 +34,8 @@ Stage-3
     limit:-1
     Select Operator [SEL_9]
       Output:["_col0"]
-      TableScan [TS_8]
-        Output:["key"]
+      TableScan [TS_8] (rows=2 width=85)
+        default@q1,q1,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
 
 PREHOOK: query: with q1 as ( select key from src where key = '5')
 select *
@@ -92,8 +92,8 @@ Stage-3
     limit:-1
     Select Operator [SEL_9]
       Output:["_col0"]
-      TableScan [TS_8]
-        Output:["key"]
+      TableScan [TS_8] (rows=2 width=85)
+        default@q1,q1,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
 
 PREHOOK: query: with q1 as ( select key from src where key = '5')
 select * from (select key from q1) a
@@ -136,12 +136,12 @@ Stage-5
       Map 2 vectorized, llap
       File Output Operator [FS_15]
         table:{"name:":"default.q1"}
-        Select Operator [SEL_14] (rows=1 width=184)
+        Select Operator [SEL_14] (rows=2 width=85)
           Output:["_col0"]
-          Filter Operator [FIL_13] (rows=1 width=184)
+          Filter Operator [FIL_13] (rows=2 width=85)
             predicate:(key = '5')
-            TableScan [TS_8] (rows=1 width=184)
-              default@q2,q2,Tbl:COMPLETE,Col:NONE,Output:["key"]
+            TableScan [TS_8] (rows=2 width=85)
+              default@q2,q2,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
         Stage-2
           Dependency Collection{}
             Stage-1
@@ -165,8 +165,8 @@ Stage-6
     limit:-1
     Select Operator [SEL_17]
       Output:["_col0"]
-      TableScan [TS_16]
-        Output:["key"]
+      TableScan [TS_16] (rows=2 width=85)
+        default@q1,q1,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
 
 PREHOOK: query: with q1 as ( select key from q2 where key = '5'),
 q2 as ( select key from src where key = '5')

--- a/ql/src/test/results/clientpositive/llap/cte_mat_10.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_10.q.out
@@ -98,14 +98,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a2
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: concat('a3 <- ', id) (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -133,14 +133,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: b1
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 86 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: concat('b2 <- ', id) (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 6 Data size: 1005 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 6 Data size: 913 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -151,14 +151,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a2
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 6 Data size: 1005 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 6 Data size: 913 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -177,7 +177,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 85 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 6 Data size: 1005 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 6 Data size: 913 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -188,14 +188,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a3
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 6 Data size: 1005 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 6 Data size: 913 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -206,14 +206,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a3
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 6 Data size: 1005 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 6 Data size: 913 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -224,14 +224,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: b1
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 86 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: concat('b2 <- ', id) (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 6 Data size: 1005 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 6 Data size: 913 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/cte_mat_11.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_11.q.out
@@ -2,11 +2,11 @@ PREHOOK: query: EXPLAIN WITH materialized_cte1 AS (
   SELECT * FROM src
 ),
 materialized_cte2 AS (
-  SELECT *
+  SELECT a.key
   FROM materialized_cte1 a
   JOIN materialized_cte1 b ON (a.key = b.key)
 )
-SELECT *
+SELECT a.key
 FROM materialized_cte2 a
 JOIN materialized_cte2 b ON (a.key = b.key)
 PREHOOK: type: QUERY
@@ -16,11 +16,11 @@ POSTHOOK: query: EXPLAIN WITH materialized_cte1 AS (
   SELECT * FROM src
 ),
 materialized_cte2 AS (
-  SELECT *
+  SELECT a.key
   FROM materialized_cte1 a
   JOIN materialized_cte1 b ON (a.key = b.key)
 )
-SELECT *
+SELECT a.key
 FROM materialized_cte2 a
 JOIN materialized_cte2 b ON (a.key = b.key)
 POSTHOOK: type: QUERY
@@ -80,13 +80,16 @@ STAGE PLANS:
                   Filter Operator
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: key (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: key (type: string)
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: value (type: string)
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 4 
@@ -98,13 +101,16 @@ STAGE PLANS:
                   Filter Operator
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: key (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: key (type: string)
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: value (type: string)
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 3 
@@ -114,22 +120,18 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 key (type: string)
-                  1 key (type: string)
-                outputColumnNames: _col0, _col1, _col6, _col7
-                Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: string), _col1 (type: string), _col6 (type: string), _col7 (type: string)
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.hadoop.mapred.TextInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                        name: default.materialized_cte2
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.TextInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                      name: default.materialized_cte2
 
   Stage: Stage-5
     Dependency Collection
@@ -146,36 +148,42 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 791 Data size: 143962 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: key (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: key (type: string)
-                      Statistics: Num rows: 791 Data size: 143962 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: value (type: string)
-            Execution mode: llap
+                    Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 7 
             Map Operator Tree:
                 TableScan
                   alias: b
                   filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 791 Data size: 143962 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: key (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: key (type: string)
-                      Statistics: Num rows: 791 Data size: 143962 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: value (type: string)
-            Execution mode: llap
+                    Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 6 
             Execution mode: llap
@@ -184,21 +192,17 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 key (type: string)
-                  1 key (type: string)
-                outputColumnNames: _col0, _col1, _col6, _col7
-                Statistics: Num rows: 1980 Data size: 720720 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: string), _col1 (type: string), _col6 (type: string), _col7 (type: string)
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 1980 Data size: 720720 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 1980 Data size: 720720 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1980 Data size: 172260 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1980 Data size: 172260 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-3
     Move Operator
@@ -217,4 +221,260 @@ STAGE PLANS:
       limit: -1
       Processor Tree:
         ListSink
+
+PREHOOK: query: EXPLAIN CBO WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT a.key
+  FROM materialized_cte1 a
+  JOIN materialized_cte1 b ON (a.key = b.key)
+)
+SELECT a.key
+FROM materialized_cte2 a
+JOIN materialized_cte2 b ON (a.key = b.key)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@materialized_cte2
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT a.key
+  FROM materialized_cte1 a
+  JOIN materialized_cte1 b ON (a.key = b.key)
+)
+SELECT a.key
+FROM materialized_cte2 a
+JOIN materialized_cte2 b ON (a.key = b.key)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@materialized_cte2
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(key=[$0])
+  HiveJoin(condition=[=($0, $1)], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(key=[$0])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveTableScan(table=[[default, materialized_cte2]], table:alias=[a])
+    HiveProject(key=[$0])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveTableScan(table=[[default, materialized_cte2]], table:alias=[b])
+
+PREHOOK: query: EXPLAIN WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT * FROM materialized_cte1
+  UNION ALL
+  SELECT * FROM materialized_cte1
+)
+SELECT * FROM materialized_cte2
+UNION ALL
+SELECT * FROM materialized_cte2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@materialized_cte2
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT * FROM materialized_cte1
+  UNION ALL
+  SELECT * FROM materialized_cte1
+)
+SELECT * FROM materialized_cte2
+UNION ALL
+SELECT * FROM materialized_cte2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@materialized_cte2
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-4 depends on stages: Stage-2, Stage-0
+  Stage-5 depends on stages: Stage-4
+  Stage-7 depends on stages: Stage-5, Stage-3
+  Stage-3 depends on stages: Stage-4
+  Stage-0 depends on stages: Stage-1
+  Stage-6 depends on stages: Stage-7
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.TextInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          name: default.materialized_cte1
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-4
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 2 <- Union 3 (CONTAINS)
+        Map 4 <- Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: materialized_cte1
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.TextInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          name: default.materialized_cte2
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: materialized_cte1
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.TextInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          name: default.materialized_cte2
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-5
+    Dependency Collection
+
+  Stage: Stage-7
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 5 <- Union 6 (CONTAINS)
+        Map 7 <- Union 6 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: materialized_cte2
+                  Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 7 
+            Map Operator Tree:
+                TableScan
+                  alias: materialized_cte2
+                  Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Union 6 
+            Vertex: Union 6
+
+  Stage: Stage-3
+    Move Operator
+      files:
+          hdfs directory: true
+#### A masked pattern was here ####
+
+  Stage: Stage-0
+    Move Operator
+      files:
+          hdfs directory: true
+#### A masked pattern was here ####
+
+  Stage: Stage-6
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: EXPLAIN CBO WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT * FROM materialized_cte1
+  UNION ALL
+  SELECT * FROM materialized_cte1
+)
+SELECT * FROM materialized_cte2
+UNION ALL
+SELECT * FROM materialized_cte2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@materialized_cte2
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT * FROM materialized_cte1
+  UNION ALL
+  SELECT * FROM materialized_cte1
+)
+SELECT * FROM materialized_cte2
+UNION ALL
+SELECT * FROM materialized_cte2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@materialized_cte2
+#### A masked pattern was here ####
+CBO PLAN:
+HiveUnion(all=[true])
+  HiveProject(key=[$0], value=[$1])
+    HiveTableScan(table=[[default, materialized_cte2]], table:alias=[materialized_cte2])
+  HiveProject(key=[$0], value=[$1])
+    HiveTableScan(table=[[default, materialized_cte2]], table:alias=[materialized_cte2])
 

--- a/ql/src/test/results/clientpositive/llap/cte_mat_11.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_11.q.out
@@ -1,0 +1,220 @@
+PREHOOK: query: EXPLAIN WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT *
+  FROM materialized_cte1 a
+  JOIN materialized_cte1 b ON (a.key = b.key)
+)
+SELECT *
+FROM materialized_cte2 a
+JOIN materialized_cte2 b ON (a.key = b.key)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@materialized_cte2
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN WITH materialized_cte1 AS (
+  SELECT * FROM src
+),
+materialized_cte2 AS (
+  SELECT *
+  FROM materialized_cte1 a
+  JOIN materialized_cte1 b ON (a.key = b.key)
+)
+SELECT *
+FROM materialized_cte2 a
+JOIN materialized_cte2 b ON (a.key = b.key)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@materialized_cte2
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-4 depends on stages: Stage-2, Stage-0
+  Stage-5 depends on stages: Stage-4
+  Stage-7 depends on stages: Stage-5, Stage-3
+  Stage-3 depends on stages: Stage-4
+  Stage-0 depends on stages: Stage-1
+  Stage-6 depends on stages: Stage-7
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.TextInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          name: default.materialized_cte1
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-4
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 3 <- Map 2 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: value (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: value (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 key (type: string)
+                  1 key (type: string)
+                outputColumnNames: _col0, _col1, _col6, _col7
+                Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  expressions: _col0 (type: string), _col1 (type: string), _col6 (type: string), _col7 (type: string)
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                    table:
+                        input format: org.apache.hadoop.mapred.TextInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                        name: default.materialized_cte2
+
+  Stage: Stage-5
+    Dependency Collection
+
+  Stage: Stage-7
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: value (type: string)
+            Execution mode: llap
+            LLAP IO: all inputs
+        Map 7 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: value (type: string)
+            Execution mode: llap
+            LLAP IO: all inputs
+        Reducer 6 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 key (type: string)
+                  1 key (type: string)
+                outputColumnNames: _col0, _col1, _col6, _col7
+                Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  expressions: _col0 (type: string), _col1 (type: string), _col6 (type: string), _col7 (type: string)
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-3
+    Move Operator
+      files:
+          hdfs directory: true
+#### A masked pattern was here ####
+
+  Stage: Stage-0
+    Move Operator
+      files:
+          hdfs directory: true
+#### A masked pattern was here ####
+
+  Stage: Stage-6
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+

--- a/ql/src/test/results/clientpositive/llap/cte_mat_11.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_11.q.out
@@ -76,16 +76,16 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
-                      Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: value (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -94,16 +94,16 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
-                      Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: value (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -117,14 +117,14 @@ STAGE PLANS:
                   0 key (type: string)
                   1 key (type: string)
                 outputColumnNames: _col0, _col1, _col6, _col7
-                Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), _col1 (type: string), _col6 (type: string), _col7 (type: string)
                   outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.TextInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -146,16 +146,16 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 791 Data size: 143962 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
-                      Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 791 Data size: 143962 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: value (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -164,16 +164,16 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 791 Data size: 281596 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 791 Data size: 143962 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
-                      Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 791 Data size: 143962 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: value (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -187,14 +187,14 @@ STAGE PLANS:
                   0 key (type: string)
                   1 key (type: string)
                 outputColumnNames: _col0, _col1, _col6, _col7
-                Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1980 Data size: 720720 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), _col1 (type: string), _col6 (type: string), _col7 (type: string)
                   outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1980 Data size: 720720 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1980 Data size: 720720 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/cte_mat_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_3.q.out
@@ -25,26 +25,26 @@ Stage-3
     Stage-4
       Reducer 3 llap
       File Output Operator [FS_18]
-        Merge Join Operator [MERGEJOIN_33] (rows=1 width=202)
+        Merge Join Operator [MERGEJOIN_33] (rows=4 width=85)
           Conds:RS_36._col0=RS_39._col0(Inner),Output:["_col0"]
         <-Map 2 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_36]
             PartitionCols:_col0
-            Select Operator [SEL_35] (rows=1 width=184)
+            Select Operator [SEL_35] (rows=2 width=85)
               Output:["_col0"]
-              Filter Operator [FIL_34] (rows=1 width=184)
+              Filter Operator [FIL_34] (rows=2 width=176)
                 predicate:key is not null
-                TableScan [TS_8] (rows=1 width=184)
-                  default@q1,a,Tbl:COMPLETE,Col:NONE,Output:["key"]
+                TableScan [TS_8] (rows=2 width=176)
+                  default@q1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
         <-Map 4 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_39]
             PartitionCols:_col0
-            Select Operator [SEL_38] (rows=1 width=184)
+            Select Operator [SEL_38] (rows=2 width=85)
               Output:["_col0"]
-              Filter Operator [FIL_37] (rows=1 width=184)
+              Filter Operator [FIL_37] (rows=2 width=176)
                 predicate:key is not null
-                TableScan [TS_11] (rows=1 width=184)
-                  default@q1,b,Tbl:COMPLETE,Col:NONE,Output:["key"]
+                TableScan [TS_11] (rows=2 width=176)
+                  default@q1,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
         Stage-2
           Dependency Collection{}
             Stage-1

--- a/ql/src/test/results/clientpositive/llap/cte_mat_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_4.q.out
@@ -50,26 +50,26 @@ Stage-3
     Stage-4
       Reducer 3 llap
       File Output Operator [FS_18]
-        Merge Join Operator [MERGEJOIN_33] (rows=1 width=202)
+        Merge Join Operator [MERGEJOIN_33] (rows=4 width=85)
           Conds:RS_36._col0=RS_39._col0(Inner),Output:["_col0"]
         <-Map 2 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_36]
             PartitionCols:_col0
-            Select Operator [SEL_35] (rows=1 width=184)
+            Select Operator [SEL_35] (rows=2 width=85)
               Output:["_col0"]
-              Filter Operator [FIL_34] (rows=1 width=184)
+              Filter Operator [FIL_34] (rows=2 width=176)
                 predicate:key is not null
-                TableScan [TS_8] (rows=1 width=184)
-                  default@q1,a,Tbl:COMPLETE,Col:NONE,Output:["key"]
+                TableScan [TS_8] (rows=2 width=176)
+                  default@q1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
         <-Map 4 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_39]
             PartitionCols:_col0
-            Select Operator [SEL_38] (rows=1 width=184)
+            Select Operator [SEL_38] (rows=2 width=85)
               Output:["_col0"]
-              Filter Operator [FIL_37] (rows=1 width=184)
+              Filter Operator [FIL_37] (rows=2 width=176)
                 predicate:key is not null
-                TableScan [TS_11] (rows=1 width=184)
-                  default@q1,b,Tbl:COMPLETE,Col:NONE,Output:["key"]
+                TableScan [TS_11] (rows=2 width=176)
+                  default@q1,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
         Stage-2
           Dependency Collection{}
             Stage-1
@@ -174,26 +174,26 @@ Stage-3
     Stage-4
       Reducer 3 llap
       File Output Operator [FS_18]
-        Merge Join Operator [MERGEJOIN_33] (rows=1 width=202)
+        Merge Join Operator [MERGEJOIN_33] (rows=4 width=85)
           Conds:RS_36._col0=RS_39._col0(Inner),Output:["_col0"]
         <-Map 2 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_36]
             PartitionCols:_col0
-            Select Operator [SEL_35] (rows=1 width=184)
+            Select Operator [SEL_35] (rows=2 width=85)
               Output:["_col0"]
-              Filter Operator [FIL_34] (rows=1 width=184)
+              Filter Operator [FIL_34] (rows=2 width=176)
                 predicate:key is not null
-                TableScan [TS_8] (rows=1 width=184)
-                  default@q1,a,Tbl:COMPLETE,Col:NONE,Output:["key"]
+                TableScan [TS_8] (rows=2 width=176)
+                  default@q1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
         <-Map 4 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_39]
             PartitionCols:_col0
-            Select Operator [SEL_38] (rows=1 width=184)
+            Select Operator [SEL_38] (rows=2 width=85)
               Output:["_col0"]
-              Filter Operator [FIL_37] (rows=1 width=184)
+              Filter Operator [FIL_37] (rows=2 width=176)
                 predicate:key is not null
-                TableScan [TS_11] (rows=1 width=184)
-                  default@q1,b,Tbl:COMPLETE,Col:NONE,Output:["key"]
+                TableScan [TS_11] (rows=2 width=176)
+                  default@q1,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
         Stage-2
           Dependency Collection{}
             Stage-1

--- a/ql/src/test/results/clientpositive/llap/cte_mat_5.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_5.q.out
@@ -70,7 +70,7 @@ Stage-3
     Stage-4
       Reducer 3 llap
       File Output Operator [FS_18]
-        Merge Join Operator [MERGEJOIN_33] (rows=1 width=13)
+        Merge Join Operator [MERGEJOIN_33] (rows=2 width=4)
           Conds:RS_36._col1=RS_39._col0(Inner),Output:["_col0"]
         <-Map 2 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_36]
@@ -84,12 +84,12 @@ Stage-3
         <-Map 4 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_39]
             PartitionCols:_col0
-            Select Operator [SEL_38] (rows=1 width=184)
+            Select Operator [SEL_38] (rows=2 width=8)
               Output:["_col0"]
-              Filter Operator [FIL_37] (rows=1 width=184)
+              Filter Operator [FIL_37] (rows=2 width=176)
                 predicate:UDFToDouble(key) is not null
-                TableScan [TS_11] (rows=1 width=184)
-                  default@q1,b,Tbl:COMPLETE,Col:NONE,Output:["key"]
+                TableScan [TS_11] (rows=2 width=176)
+                  default@q1,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
         Stage-2
           Dependency Collection{}
             Stage-1

--- a/ql/src/test/results/clientpositive/llap/cte_mat_6.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_6.q.out
@@ -21,8 +21,8 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@t0
 POSTHOOK: Lineage: t0.col0 SCRIPT []
-Warning: Shuffle Join MERGEJOIN[37][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
-Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_1, $hdt$_2, $hdt$_0]] in Stage 'Reducer 6' is a cross product
+Warning: Shuffle Join MERGEJOIN[37][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_1, $hdt$_2, $hdt$_0]] in Stage 'Reducer 5' is a cross product
 PREHOOK: query: explain
 with cte as (select count(*) as small_count from t0 where col0 < 10)
 select t0.col0, (select small_count from cte)
@@ -104,39 +104,39 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 3 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 8 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 8 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 3 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 3 
             Map Operator Tree:
                 TableScan
                   alias: cte
-                  Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
-                        value expressions: _col0 (type: bigint)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: small_count (type: bigint)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       null sort order: 
                       sort order: 
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint)
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 8 
@@ -156,23 +156,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 4 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
-                Filter Operator
-                  predicate: sq_count_check(_col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
-        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -182,13 +165,13 @@ STAGE PLANS:
                   0 
                   1 
                 outputColumnNames: _col1
-                Statistics: Num rows: 1 Data size: 17 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   null sort order: 
                   sort order: 
-                  Statistics: Num rows: 1 Data size: 17 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -198,31 +181,48 @@ STAGE PLANS:
                   0 
                   1 
                 outputColumnNames: _col1, _col2
-                Statistics: Num rows: 7 Data size: 154 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 7 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col2 (type: int), _col1 (type: bigint)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 7 Data size: 154 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 7 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
                     null sort order: z
                     sort order: +
-                    Statistics: Num rows: 7 Data size: 154 Basic stats: PARTIAL Column stats: NONE
+                    Statistics: Num rows: 7 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: bigint)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 7 Data size: 154 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 7 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 7 Data size: 154 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 7 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: sq_count_check(_col0) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Move Operator
@@ -236,8 +236,8 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[37][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
-Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_1, $hdt$_2, $hdt$_0]] in Stage 'Reducer 6' is a cross product
+Warning: Shuffle Join MERGEJOIN[37][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_1, $hdt$_2, $hdt$_0]] in Stage 'Reducer 5' is a cross product
 PREHOOK: query: with cte as (select count(*) as small_count from t0 where col0 < 10)
 select t0.col0, (select small_count from cte)
 from t0
@@ -496,31 +496,31 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: cte
-                  Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
-                      minReductionHashAggr: 0.99
+                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: small_count is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: small_count (type: bigint)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -551,16 +551,16 @@ STAGE PLANS:
                 aggregations: count(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: sq_count_check(_col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       null sort order: 
                       sort order: 
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
@@ -571,11 +571,11 @@ STAGE PLANS:
                   0 
                   1 
                 outputColumnNames: _col1
-                Statistics: Num rows: 1 Data size: 17 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   null sort order: 
                   sort order: 
-                  Statistics: Num rows: 1 Data size: 17 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
         Reducer 6 
             Execution mode: llap
@@ -588,26 +588,26 @@ STAGE PLANS:
                   1 
                 outputColumnNames: _col1, _col2, _col3
                 residual filter predicates: {(_col3 > _col1)}
-                Statistics: Num rows: 2 Data size: 60 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 2 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col2 (type: int)
                   outputColumnNames: _col0
-                  Statistics: Num rows: 2 Data size: 60 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
                     null sort order: z
                     sort order: +
-                    Statistics: Num rows: 2 Data size: 60 Basic stats: PARTIAL Column stats: NONE
+                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int)
                 outputColumnNames: _col0
-                Statistics: Num rows: 2 Data size: 60 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 60 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -752,31 +752,31 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: cte
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: small_count is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: small_count (type: bigint)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
                   Select Operator
-                    Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
-                      minReductionHashAggr: 0.99
+                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -815,11 +815,11 @@ STAGE PLANS:
                   0 
                   1 
                 outputColumnNames: _col1
-                Statistics: Num rows: 1 Data size: 17 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   null sort order: 
                   sort order: 
-                  Statistics: Num rows: 1 Data size: 17 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
         Reducer 5 
             Execution mode: llap
@@ -832,16 +832,16 @@ STAGE PLANS:
                   1 
                 outputColumnNames: _col1, _col2, _col3
                 residual filter predicates: {(_col3 > _col1)}
-                Statistics: Num rows: 1 Data size: 30 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col2 (type: int), _col3 (type: bigint)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 30 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
                     null sort order: z
                     sort order: +
-                    Statistics: Num rows: 1 Data size: 30 Basic stats: PARTIAL Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
@@ -849,10 +849,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: bigint)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 30 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 30 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -864,16 +864,16 @@ STAGE PLANS:
                 aggregations: count(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: sq_count_check(_col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       null sort order: 
                       sort order: 
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1035,31 +1035,31 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: cte2
-                  Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
-                      minReductionHashAggr: 0.99
+                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: all_count is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: all_count (type: bigint)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -1152,16 +1152,16 @@ STAGE PLANS:
                 aggregations: count(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: sq_count_check(_col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       null sort order: 
                       sort order: 
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
@@ -1172,11 +1172,11 @@ STAGE PLANS:
                   0 
                   1 
                 outputColumnNames: _col1
-                Statistics: Num rows: 1 Data size: 17 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   null sort order: 
                   sort order: 
-                  Statistics: Num rows: 1 Data size: 17 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
         Reducer 6 
             Execution mode: llap
@@ -1189,14 +1189,14 @@ STAGE PLANS:
                   1 
                 outputColumnNames: _col1, _col2
                 residual filter predicates: {(_col2 > _col1)}
-                Statistics: Num rows: 1 Data size: 26 Basic stats: PARTIAL Column stats: NONE
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: 5 (type: int), _col2 (type: bigint)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 26 Basic stats: PARTIAL Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 26 Basic stats: PARTIAL Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/cte_mat_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_8.q.out
@@ -75,14 +75,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a1
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 86 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: concat('a2 <- ', id) (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -108,14 +108,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a1
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 86 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 86 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 4 Data size: 637 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 4 Data size: 539 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -134,7 +134,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 85 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 4 Data size: 637 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 4 Data size: 539 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -145,14 +145,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a2
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 4 Data size: 637 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 4 Data size: 539 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -163,14 +163,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a2
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: string)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 4 Data size: 637 Basic stats: COMPLETE Column stats: PARTIAL
+                      Statistics: Num rows: 4 Data size: 539 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/cte_mat_9.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_9.q.out
@@ -155,14 +155,14 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: b1
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: int), concat('b2 <- ', tag) (type: string)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -187,17 +187,17 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: b1
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: int), tag (type: string)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -223,17 +223,17 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: b2
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: int), tag (type: string)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -241,17 +241,17 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: b2
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: id (type: int), concat('b3 <- ', tag) (type: string)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -265,11 +265,11 @@ STAGE PLANS:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col3
-                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   null sort order: 
                   sort order: 
-                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col1 (type: string), _col3 (type: string)
         Reducer 5 
             Execution mode: llap
@@ -284,14 +284,14 @@ STAGE PLANS:
                   0 
                   1 
                 outputColumnNames: _col0, _col1, _col3, _col5
-                Statistics: Num rows: 1 Data size: 413 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 4 Data size: 1488 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: int), _col1 (type: string), _col3 (type: string), _col5 (type: string)
                   outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 1 Data size: 413 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 4 Data size: 1488 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 413 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 4 Data size: 1488 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -306,15 +306,15 @@ STAGE PLANS:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col3
-                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 2 Data size: 744 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: int), concat(concat(concat(concat('c <- (', _col1), ' & '), _col3), ')') (type: string)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     null sort order: 
                     sort order: 
-                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: int), _col1 (type: string)
 
   Stage: Stage-3


### PR DESCRIPTION
### What changes were proposed in this pull request?

Copy statistics of the source FileSinkOperator into the TableScanOperator, which scans a materialized CTE written by the FileSinkOperator.

### Why are the changes needed?

Currently, Hive estimates the statistics of materialized CTEs are always empty. It causes OOM or significant slowdown.

### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

I added a new test case. [The first commit explains the result with the current master branch](https://github.com/apache/hive/pull/5089/commits/ca6cae1ee2ecacd5fdf4291225edf1c79130a2b2).