### PR TITLE
HIVE-28093: Re-execute DAG in case of NoCurrentDAGException

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezRuntimeException.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezRuntimeException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.tez;
+
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+
+/**
+ * An exception class to be thrown by TezTask to provide further details for certain parts of Hive.
+ */
+public class TezRuntimeException extends HiveException {
+  private static final long serialVersionUID = 1L;
+
+  private String dagId = null;
+
+  public TezRuntimeException(String dagId, String diagnostics) {
+    super(diagnostics);
+    this.dagId = dagId;
+  }
+
+  public String getDagId() {
+    return dagId;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -262,7 +262,7 @@ public class TezTask extends Task<TezWork> {
         rc = monitor.monitorExecution();
 
         if (rc != 0) {
-          this.setException(new HiveException(monitor.getDiagnostics()));
+          this.setException(new TezRuntimeException(dagId, monitor.getDiagnostics()));
         }
 
         try {

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecDriver.java
@@ -194,6 +194,8 @@ public class ReExecDriver implements IDriver {
       boolean shouldReExecute = explainReOptimization && executionIndex==1;
       shouldReExecute |= cpr == null && plugins.stream().anyMatch(p -> p.shouldReExecute(executionIndex));
 
+      LOG.info("Deciding re-execution is made according to: executionIndex: {}, maxExecutions: {}, shouldReExecute: {}",
+          executionIndex, maxExecutions, shouldReExecute);
       if (executionIndex >= maxExecutions || !shouldReExecute) {
         if (cpr != null) {
           return cpr;

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecDriver.java
@@ -194,7 +194,7 @@ public class ReExecDriver implements IDriver {
       boolean shouldReExecute = explainReOptimization && executionIndex==1;
       shouldReExecute |= cpr == null && plugins.stream().anyMatch(p -> p.shouldReExecute(executionIndex));
 
-      LOG.info("Deciding re-execution is made according to: executionIndex: {}, maxExecutions: {}, shouldReExecute: {}",
+      LOG.info("Re-execution decision is made according to: executionIndex: {}, maxExecutions: {}, shouldReExecute: {}",
           executionIndex, maxExecutions, shouldReExecute);
       if (executionIndex >= maxExecutions || !shouldReExecute) {
         if (cpr != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.hive.ql.plan.mapper.PlanMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -35,14 +35,21 @@ import java.util.regex.Pattern;
  */
 public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
   private static final Logger LOG = LoggerFactory.getLogger(ReExecuteLostAMQueryPlugin.class);
+
+  // Lost am container have exit code -100, due to node failures. This pattern of exception is thrown when
+  // AM is managed by HS2.
+  private static final Pattern LOST_AM_CONTAINER_ERROR_PATTERN =
+      Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*");
+  // When HS2 does not manage the AMs, tez AMs are registered with zookeeper and HS2 discovers it,
+  // failure of unmanaged AMs will throw AM record not being found in zookeeper.
+  private static final String UNMANAGED_AM_FAILURE = "AM record not found (likely died)";
+  // DAG lost in the scenario described at TEZ-4543
+  private static final String DAG_LOST_FAILURE = "No running DAG at present";
+
   private boolean retryPossible;
   // a list to track DAG ids seen by this re-execution plugin during the same query
   // it can help a lot with identifying the previous DAGs in case of retries
-  private List<String> dagIds = new ArrayList<>();
-
-  // Lost am container have exit code -100, due to node failures. This pattern of exception is thrown when AM is managed
-  // by HS2.
-  private final Pattern lostAMContainerErrorPattern = Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*");
+  private Set<String> dagIds = new HashSet<>();
 
   class LocalHook implements ExecuteWithHookContext {
     @Override
@@ -56,21 +63,16 @@ public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
         }
 
         TezRuntimeException tre = (TezRuntimeException)exception;
-
-        if (tre != null && tre.getMessage() != null) {
+        String message = tre.getMessage();
+        if (message != null) {
           dagIds.add(tre.getDagId());
-          // When HS2 does not manage the AMs, tez AMs are registered with zookeeper and HS2 discovers it,
-          // failure of unmanaged AMs will throw AM record not being found in zookeeper.
-          String unmanagedAMFailure = "AM record not found (likely died)";
-          // DAG lost in the scenario described at TEZ-4543
-          String dagLostFailure = "No running DAG at present";
 
-          if (lostAMContainerErrorPattern.matcher(tre.getMessage()).matches()
-              || tre.getMessage().contains(unmanagedAMFailure)
-              || tre.getMessage().contains(dagLostFailure)) {
+          if (LOST_AM_CONTAINER_ERROR_PATTERN.matcher(message).matches()
+              || message.contains(UNMANAGED_AM_FAILURE)
+              || message.contains(DAG_LOST_FAILURE)) {
             retryPossible = true;
           }
-          LOG.info("Got exception message: {} retryPossible: {}, dags seen so far: {}", tre.getMessage(), retryPossible,
+          LOG.info("Got exception message: {} retryPossible: {}, dags seen so far: {}", message, retryPossible,
               dagIds);
         }
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/reexec/TestReExecuteLostAMQueryPlugin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/reexec/TestReExecuteLostAMQueryPlugin.java
@@ -28,31 +28,25 @@ public class TestReExecuteLostAMQueryPlugin {
 
   @Test
   public void testRetryOnUnmanagedAmFailure() throws Exception {
-    ReExecuteLostAMQueryPlugin plugin = new ReExecuteLostAMQueryPlugin();
-    ReExecuteLostAMQueryPlugin.LocalHook hook = plugin.new LocalHook();
-
-    HookContext context = new HookContext(null, QueryState.getNewQueryState(new HiveConf(), null), null, null, null,
-        null, null, null, null, false, null, null);
-    context.setHookType(HookContext.HookType.ON_FAILURE_HOOK);
-    context.setException(new TezRuntimeException("dag_0_0", "AM record not found (likely died)"));
-
-    hook.run(context);
-
-    Assert.assertEquals(true, plugin.shouldReExecute(1));
+    testReExecuteWithExceptionMessage("AM record not found (likely died)");
   }
 
   @Test
   public void testRetryOnNoCurrentDAGException() throws Exception {
+    testReExecuteWithExceptionMessage("No running DAG at present");
+  }
+
+  private void testReExecuteWithExceptionMessage(String message) throws Exception {
     ReExecuteLostAMQueryPlugin plugin = new ReExecuteLostAMQueryPlugin();
     ReExecuteLostAMQueryPlugin.LocalHook hook = plugin.new LocalHook();
 
     HookContext context = new HookContext(null, QueryState.getNewQueryState(new HiveConf(), null), null, null, null,
         null, null, null, null, false, null, null);
     context.setHookType(HookContext.HookType.ON_FAILURE_HOOK);
-    context.setException(new TezRuntimeException("dag_0_0", "No running DAG at present"));
+    context.setException(new TezRuntimeException("dag_0_0", message));
 
     hook.run(context);
 
-    Assert.assertEquals(true, plugin.shouldReExecute(1));
+    Assert.assertTrue(plugin.shouldReExecute(1));
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/reexec/TestReExecuteLostAMQueryPlugin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/reexec/TestReExecuteLostAMQueryPlugin.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.reexec;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.exec.tez.TezRuntimeException;
+import org.apache.hadoop.hive.ql.hooks.HookContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestReExecuteLostAMQueryPlugin {
+
+  @Test
+  public void testRetryOnUnmanagedAmFailure() throws Exception {
+    ReExecuteLostAMQueryPlugin plugin = new ReExecuteLostAMQueryPlugin();
+    ReExecuteLostAMQueryPlugin.LocalHook hook = plugin.new LocalHook();
+
+    HookContext context = new HookContext(null, QueryState.getNewQueryState(new HiveConf(), null), null, null, null,
+        null, null, null, null, false, null, null);
+    context.setHookType(HookContext.HookType.ON_FAILURE_HOOK);
+    context.setException(new TezRuntimeException("dag_0_0", "AM record not found (likely died)"));
+
+    hook.run(context);
+
+    Assert.assertEquals(true, plugin.shouldReExecute(1));
+  }
+
+  @Test
+  public void testRetryOnNoCurrentDAGException() throws Exception {
+    ReExecuteLostAMQueryPlugin plugin = new ReExecuteLostAMQueryPlugin();
+    ReExecuteLostAMQueryPlugin.LocalHook hook = plugin.new LocalHook();
+
+    HookContext context = new HookContext(null, QueryState.getNewQueryState(new HiveConf(), null), null, null, null,
+        null, null, null, null, false, null, null);
+    context.setHookType(HookContext.HookType.ON_FAILURE_HOOK);
+    context.setException(new TezRuntimeException("dag_0_0", "No running DAG at present"));
+
+    hook.run(context);
+
+    Assert.assertEquals(true, plugin.shouldReExecute(1));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Related to [TEZ-4543](https://issues.apache.org/jira/browse/TEZ-4543), this is to rerun DAG if the client faces a DAG_FAILED due to NoCurrentDAGException in the AM.


### Why are the changes needed?
TEZ-4543 takes care of returning quite fast if a restarted AM doesn't run the queried DAG.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Tested on cluster, and unit tests for AM + Hive already added.

This is logged when dag_1708961199044_0002_1 failed earlier, and as I kept injected OOM into an AM (making it crash in a k8s environment), dag_1708961199044_0003_1 is failed again.
```
hiveserver2 <14>1 2024-02-26T16:00:37.730Z hiveserver2-0 hiveserver2 1 dedef3f4-339f-4ba3-a6ae-300751d3561d [mdc@18060 class="reexec.ReExecuteLostAMQueryPlugin" dagId="dag_1708961199044_0003_1" level="INFO" operationLogLevel="EXECUTION" queryId="hive_20240226155836_6b1e9eb9-efd7-42fd-8872-f4189c5dda3a" sessionId="9e4cb344-ad7f-4344-9b24-aedaf0e73bf4" thread="HiveServer2-Background-Pool: Thread-129"] Got exception message: No running DAG at present retryPossible: true, dags seen so far: [dag_1708961199044_0002_1, dag_1708961199044_0003_1]
```
