### PR TITLE
HIVE-28099: Fix logging in HMS benchmarks

### DIFF
--- a/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
@@ -68,6 +68,11 @@
           <groupId>io.netty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jcl</artifactId>
+          </exclusion>
+
       </exclusions>
     </dependency>
     <dependency>
@@ -139,30 +144,46 @@
       <build>
         <plugins>
           <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>
-                <configuration>
-                  <archive>
-                    <manifest>
-                      <mainClass>org.apache.hadoop.hive.metastore.tools.BenchmarkTool</mainClass>
-                      <addClasspath>true</addClasspath>
-                    </manifest>
-                  </archive>
-                  <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                  </descriptorRefs>
-                  <finalName>hmsbench</finalName>
-                </configuration>
-                <id>make-assembly-hclient</id>
-                <!-- this is used for inheritance merges -->
                 <phase>package</phase>
-                <!-- bind to the packaging phase -->
                 <goals>
-                  <goal>single</goal>
+                  <goal>shade</goal>
                 </goals>
+                <configuration>
+                  <finalName>hmsbench</finalName>
+                  <transformers>
+                    <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer"/>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <mainClass>org.apache.hadoop.hive.metastore.tools.BenchmarkTool</mainClass>
+                    </transformer>
+                  </transformers>
+                  <filters>
+                    <filter>
+                      <!--
+                      Shading signed JARs will fail without this.
+                      http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                      -->
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
               </execution>
             </executions>
+            <dependencies>
+              <dependency>
+                <groupId>com.github.edwgiz</groupId>
+                <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+                <version>2.1</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
The logging is completely broken in HMS benchmarks. When we create a Log entry, it only outputs a format pattern string instead of the log message. 

Example output:

`%d [%thread] %-5level %logger - %msg`

### What changes were proposed in this pull request?
TxnHandler refactor introduced Spring and it seems spring logging causes the issue. There are two changes in the PR: 
- exclude spring-jcl (https://stackoverflow.com/questions/50176843/log42-xml-is-not-picked-up-when-running-jmh-benchmark-from-test-directory)
- move from assembly to shading plugin to be able to run log4j2CacheTransformer (https://stackoverflow.com/questions/25065580/log4j2-custom-plugins-annotation-processing-with-maven-assembly-plugin)

### Why are the changes needed?
I want to do some metastore performance benchmarks. It is pretty hard to do that without logging.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Manually test: `java    -jar ./target/hmsbench.jar -H localhost --savedata /tmp/benchdata --sanitize -N 100 -N 1000 -o bench_results_direct.csv -C -d testbench_http --params=100 -M "TestGetValidWriteIds" --runMode ACID`
