### PR TITLE
HIVE-28102: Iceberg: Invoke validateDataFilesExist for RowDelta operations.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/FilesForCommit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/FilesForCommit.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.util.CharSequenceSet;
 
 public class FilesForCommit implements Serializable {
 
@@ -35,19 +36,29 @@ public class FilesForCommit implements Serializable {
   private final Collection<DeleteFile> deleteFiles;
   private Collection<DataFile> referencedDataFiles;
 
+  private final CharSequenceSet referencedDataFilesInDeleteFiles;
+
   public FilesForCommit(Collection<DataFile> dataFiles, Collection<DeleteFile> deleteFiles) {
     this(dataFiles, deleteFiles, Collections.emptyList());
   }
 
   public FilesForCommit(Collection<DataFile> dataFiles, Collection<DeleteFile> deleteFiles,
-                        Collection<DataFile> referencedDataFiles) {
+      Collection<DataFile> referencedDataFiles, CharSequenceSet referencedDataFilesInDeleteFiles) {
     this.dataFiles = dataFiles;
     this.deleteFiles = deleteFiles;
     this.referencedDataFiles = referencedDataFiles;
+    this.referencedDataFilesInDeleteFiles = referencedDataFilesInDeleteFiles;
   }
 
-  public static FilesForCommit onlyDelete(Collection<DeleteFile> deleteFiles) {
-    return new FilesForCommit(Collections.emptyList(), deleteFiles);
+  public FilesForCommit(Collection<DataFile> dataFiles, Collection<DeleteFile> deleteFiles,
+      Collection<DataFile> referencedDataFiles) {
+    this(dataFiles, deleteFiles, referencedDataFiles, CharSequenceSet.empty());
+  }
+
+  public static FilesForCommit onlyDelete(Collection<DeleteFile> deleteFiles,
+      CharSequenceSet referencedDataFilesInDeleteFiles) {
+    return new FilesForCommit(Collections.emptyList(), deleteFiles, Collections.emptyList(),
+        referencedDataFilesInDeleteFiles);
   }
 
   public static FilesForCommit onlyData(Collection<DataFile> dataFiles) {
@@ -74,6 +85,10 @@ public class FilesForCommit implements Serializable {
     return referencedDataFiles;
   }
 
+  public CharSequenceSet getReferencedDataFilesInDeleteFiles() {
+    return referencedDataFilesInDeleteFiles;
+  }
+
   public Collection<? extends ContentFile> allFiles() {
     return Stream.concat(dataFiles.stream(), deleteFiles.stream()).collect(Collectors.toList());
   }
@@ -88,6 +103,7 @@ public class FilesForCommit implements Serializable {
         .add("dataFiles", dataFiles.toString())
         .add("deleteFiles", deleteFiles.toString())
         .add("referencedDataFiles", referencedDataFiles.toString())
+        .add("referencedDataFilesInDeleteFiles", referencedDataFilesInDeleteFiles)
         .toString();
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/FilesForCommit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/FilesForCommit.java
@@ -28,45 +28,42 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.util.CharSequenceSet;
 
 public class FilesForCommit implements Serializable {
 
   private final Collection<DataFile> dataFiles;
   private final Collection<DeleteFile> deleteFiles;
-  private Collection<DataFile> referencedDataFiles;
-
-  private final CharSequenceSet referencedDataFilesInDeleteFiles;
+  private final Collection<DataFile> replacedDataFiles;
+  private final Collection<CharSequence> referencedDataFiles;
 
   public FilesForCommit(Collection<DataFile> dataFiles, Collection<DeleteFile> deleteFiles) {
     this(dataFiles, deleteFiles, Collections.emptyList());
   }
 
   public FilesForCommit(Collection<DataFile> dataFiles, Collection<DeleteFile> deleteFiles,
-      Collection<DataFile> referencedDataFiles, CharSequenceSet referencedDataFilesInDeleteFiles) {
+      Collection<DataFile> replacedDataFiles, Collection<CharSequence> referencedDataFiles) {
     this.dataFiles = dataFiles;
     this.deleteFiles = deleteFiles;
+    this.replacedDataFiles = replacedDataFiles;
     this.referencedDataFiles = referencedDataFiles;
-    this.referencedDataFilesInDeleteFiles = referencedDataFilesInDeleteFiles;
   }
 
   public FilesForCommit(Collection<DataFile> dataFiles, Collection<DeleteFile> deleteFiles,
-      Collection<DataFile> referencedDataFiles) {
-    this(dataFiles, deleteFiles, referencedDataFiles, CharSequenceSet.empty());
+      Collection<DataFile> replacedDataFiles) {
+    this(dataFiles, deleteFiles, replacedDataFiles, Collections.emptySet());
   }
 
   public static FilesForCommit onlyDelete(Collection<DeleteFile> deleteFiles,
-      CharSequenceSet referencedDataFilesInDeleteFiles) {
-    return new FilesForCommit(Collections.emptyList(), deleteFiles, Collections.emptyList(),
-        referencedDataFilesInDeleteFiles);
+      Collection<CharSequence> referencedDataFiles) {
+    return new FilesForCommit(Collections.emptyList(), deleteFiles, Collections.emptyList(), referencedDataFiles);
   }
 
   public static FilesForCommit onlyData(Collection<DataFile> dataFiles) {
     return new FilesForCommit(dataFiles, Collections.emptyList());
   }
 
-  public static FilesForCommit onlyData(Collection<DataFile> dataFiles, Collection<DataFile> referencedDataFiles) {
-    return new FilesForCommit(dataFiles, Collections.emptyList(), referencedDataFiles);
+  public static FilesForCommit onlyData(Collection<DataFile> dataFiles, Collection<DataFile> replacedDataFiles) {
+    return new FilesForCommit(dataFiles, Collections.emptyList(), replacedDataFiles);
   }
 
   public static FilesForCommit empty() {
@@ -81,12 +78,12 @@ public class FilesForCommit implements Serializable {
     return deleteFiles;
   }
 
-  public Collection<DataFile> referencedDataFiles() {
-    return referencedDataFiles;
+  public Collection<DataFile> replacedDataFiles() {
+    return replacedDataFiles;
   }
 
-  public CharSequenceSet getReferencedDataFilesInDeleteFiles() {
-    return referencedDataFilesInDeleteFiles;
+  public Collection<CharSequence> referencedDataFiles() {
+    return referencedDataFiles;
   }
 
   public Collection<? extends ContentFile> allFiles() {
@@ -94,7 +91,7 @@ public class FilesForCommit implements Serializable {
   }
 
   public boolean isEmpty() {
-    return dataFiles.isEmpty() && deleteFiles.isEmpty() && referencedDataFiles.isEmpty();
+    return dataFiles.isEmpty() && deleteFiles.isEmpty() && replacedDataFiles.isEmpty();
   }
 
   @Override
@@ -102,8 +99,8 @@ public class FilesForCommit implements Serializable {
     return MoreObjects.toStringHelper(this)
         .add("dataFiles", dataFiles.toString())
         .add("deleteFiles", deleteFiles.toString())
+        .add("replacedDataFiles", replacedDataFiles.toString())
         .add("referencedDataFiles", referencedDataFiles.toString())
-        .add("referencedDataFilesInDeleteFiles", referencedDataFilesInDeleteFiles)
         .toString();
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/HiveIcebergCopyOnWriteRecordWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/HiveIcebergCopyOnWriteRecordWriter.java
@@ -45,7 +45,7 @@ class HiveIcebergCopyOnWriteRecordWriter extends HiveIcebergWriterBase {
   private final int currentSpecId;
 
   private final GenericRecord rowDataTemplate;
-  private final List<DataFile> referencedDataFiles;
+  private final List<DataFile> replacedDataFiles;
 
   HiveIcebergCopyOnWriteRecordWriter(Schema schema, Map<Integer, PartitionSpec> specs, int currentSpecId,
       FileWriterFactory<Record> fileWriterFactory, OutputFileFactory fileFactory, FileIO io,
@@ -54,7 +54,7 @@ class HiveIcebergCopyOnWriteRecordWriter extends HiveIcebergWriterBase {
         new ClusteredDataWriter<>(fileWriterFactory, fileFactory, io, targetFileSize));
     this.currentSpecId = currentSpecId;
     this.rowDataTemplate = GenericRecord.create(schema);
-    this.referencedDataFiles = Lists.newArrayList();
+    this.replacedDataFiles = Lists.newArrayList();
   }
 
   @Override
@@ -72,7 +72,7 @@ class HiveIcebergCopyOnWriteRecordWriter extends HiveIcebergWriterBase {
             .withFileSizeInBytes(0)
             .withRecordCount(0)
             .build();
-      referencedDataFiles.add(dataFile);
+      replacedDataFiles.add(dataFile);
     } else {
       writer.write(rowData, specs.get(currentSpecId), partition(rowData, currentSpecId));
     }
@@ -81,6 +81,6 @@ class HiveIcebergCopyOnWriteRecordWriter extends HiveIcebergWriterBase {
   @Override
   public FilesForCommit files() {
     List<DataFile> dataFiles = ((DataWriteResult) writer.result()).dataFiles();
-    return FilesForCommit.onlyData(dataFiles, referencedDataFiles);
+    return FilesForCommit.onlyData(dataFiles, replacedDataFiles);
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/HiveIcebergDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/HiveIcebergDeleteWriter.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.mr.hive.writer;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.hadoop.io.Writable;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.PartitionSpec;
@@ -37,7 +38,6 @@ import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.mr.hive.FilesForCommit;
 import org.apache.iceberg.mr.hive.IcebergAcidUtil;
 import org.apache.iceberg.mr.mapred.Container;
-import org.apache.iceberg.util.CharSequenceSet;
 
 class HiveIcebergDeleteWriter extends HiveIcebergWriterBase {
 
@@ -69,7 +69,7 @@ class HiveIcebergDeleteWriter extends HiveIcebergWriterBase {
   @Override
   public FilesForCommit files() {
     List<DeleteFile> deleteFiles = ((DeleteWriteResult) writer.result()).deleteFiles();
-    CharSequenceSet referencedDataFilesInDeleteFiles = ((DeleteWriteResult) writer.result()).referencedDataFiles();
-    return FilesForCommit.onlyDelete(deleteFiles, referencedDataFilesInDeleteFiles);
+    Set<CharSequence> referencedDataFiles = ((DeleteWriteResult) writer.result()).referencedDataFiles();
+    return FilesForCommit.onlyDelete(deleteFiles, referencedDataFiles);
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/HiveIcebergDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/HiveIcebergDeleteWriter.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.mr.hive.FilesForCommit;
 import org.apache.iceberg.mr.hive.IcebergAcidUtil;
 import org.apache.iceberg.mr.mapred.Container;
+import org.apache.iceberg.util.CharSequenceSet;
 
 class HiveIcebergDeleteWriter extends HiveIcebergWriterBase {
 
@@ -68,6 +69,7 @@ class HiveIcebergDeleteWriter extends HiveIcebergWriterBase {
   @Override
   public FilesForCommit files() {
     List<DeleteFile> deleteFiles = ((DeleteWriteResult) writer.result()).deleteFiles();
-    return FilesForCommit.onlyDelete(deleteFiles);
+    CharSequenceSet referencedDataFilesInDeleteFiles = ((DeleteWriteResult) writer.result()).referencedDataFiles();
+    return FilesForCommit.onlyDelete(deleteFiles, referencedDataFilesInDeleteFiles);
   }
 }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/writer/TestHiveIcebergDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/writer/TestHiveIcebergDeleteWriter.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.mr.hive.writer;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -67,7 +68,7 @@ public class TestHiveIcebergDeleteWriter extends HiveIcebergWriterTestBase {
 
     RowDelta rowDelta = table.newRowDelta();
     testWriter.files().deleteFiles().forEach(rowDelta::addDeletes);
-    CharSequenceSet actualDataFiles = testWriter.files().getReferencedDataFilesInDeleteFiles();
+    Collection<CharSequence> actualDataFiles = testWriter.files().referencedDataFiles();
     rowDelta.commit();
 
     Assert.assertTrue("Actual :" + actualDataFiles + " Expected: " + expectedDataFiles,

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/writer/TestHiveIcebergDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/writer/TestHiveIcebergDeleteWriter.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.mr.hive.IcebergAcidUtil;
 import org.apache.iceberg.mr.mapred.Container;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.Assert;
 import org.junit.Test;
@@ -54,17 +55,23 @@ public class TestHiveIcebergDeleteWriter extends HiveIcebergWriterTestBase {
     Collections.sort(deleteRecords,
         Comparator.comparing(a -> a.getField(MetadataColumns.PARTITION_COLUMN_NAME).toString()));
 
+    CharSequenceSet expectedDataFiles = CharSequenceSet.empty();
     Container<Record> container = new Container<>();
     for (Record deleteRecord : deleteRecords) {
       container.set(deleteRecord);
       testWriter.write(container);
+      expectedDataFiles.add((String) deleteRecord.getField(MetadataColumns.FILE_PATH.name()));
     }
 
     testWriter.close(false);
 
     RowDelta rowDelta = table.newRowDelta();
     testWriter.files().deleteFiles().forEach(rowDelta::addDeletes);
+    CharSequenceSet actualDataFiles = testWriter.files().getReferencedDataFilesInDeleteFiles();
     rowDelta.commit();
+
+    Assert.assertTrue("Actual :" + actualDataFiles + " Expected: " + expectedDataFiles,
+        actualDataFiles.containsAll(expectedDataFiles));
 
     StructLikeSet expected = rowSetWithoutIds(RECORDS, DELETED_IDS);
     StructLikeSet actual = actualRowSet(table);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Validate Data Files Exist for RowDelta Operations

### Why are the changes needed?

RewriteFiles Operations called by compaction jobs(Spark), leads to data corruption when running concurrently with MERGE?UPDATE/DELETE Queries

### Does this PR introduce _any_ user-facing change?

Prevents Data corruption

### Is the change a dependency upgrade?

No

### How was this patch tested?

CI
