### PR TITLE
HIVE-28099: Fix logging in HMS benchmarks

### DIFF
--- a/standalone-metastore/metastore-tools/metastore-benchmarks/README.md
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/README.md
@@ -2,16 +2,20 @@
 
 ## Installation
 
-    mvn clean install
+    mvn clean install -Pperf
 
 You can run tests as well. Just set `HMS_HOST` environment variable to some HMS instance which is
 capable of running your requests (non-kerberised one) and run
 
-    mvn install
+    mvn install -Pperf
 
 target directory has two mega-jars which have all the dependencies.
 
-Alternatively you can use [bin/hbench](../bin/hbench) script which use Maven to run the code.
+## Use local build
+
+    mvn clean package -Pperf
+
+**Note:** It does benchmarks on HMS. So do not forget to start a standalone metastore service to be able to run. 
 
 ## HmsBench usage
 
@@ -53,25 +57,30 @@ Alternatively you can use [bin/hbench](../bin/hbench) script which use Maven to 
 
 ### Using single jar
 
-    java -jar hbench-jar-with-dependencies.jar <optins> [test]...
+    java -jar hmsbench.jar <optins> [test]...
 
 ### Using hbench on kerberized cluster
 
-    java -jar hbench-jar-with-dependencies.jar -H `hostname` <optins> [test]...
+    java -jar hmsbench.jar -H `hostname` <optins> [test]...
 
 ### Examples
 1. Run all tests with default settings
-    java -jar hmsbench-jar-with-dependencies.jar -d `metastore_db_name` -H `hostname`
 
-2. Run tests with 500 objects created, 10 times warm-up and exclude concurrent operations and drop operations
+   ```java -jar hmsbench.jar -d `metastore_db_name` -H `hostname` ```
 
-    java -jar hmsbench-jar-with-dependencies.jar -d `metastore_db_name` -H `hostname` -N 500 -W 10 -E 'drop.*' -E 'concurrent.*'
+2. Run a single test
+   
+    ```java -jar hmsbench.jar -d `metastore_db_name` -H `hostname` -M "TestGetValidWriteIds"```
 
-3. Run tests, produce output in tab-separated format and write individual data points in 'data' directory
+3. Run tests with 500 objects created, 10 times warm-up and exclude concurrent operations and drop operations
 
-    java -jar hmsbench-jar-with-dependencies.jar -d `metastore_db_name` -H `hostname` -o result.csv --csv --savedata data
+    ```java -jar hmsbench.jar -d `metastore_db_name` -H `hostname` -N 500 -W 10 -E 'drop.*' -E 'concurrent.*'```
 
-4. Run tests on localhost
+4. Run tests, produce output in tab-separated format and write individual data points in 'data' directory
+
+    ```java -jar hmsbench.jar -d `metastore_db_name` -H `hostname` -o result.csv --csv --savedata data```
+
+5. Run tests on localhost
  * save raw data in directory /tmp/benchdata
  * sanitize results (remove outliers)
  * produce tab-separated file
@@ -80,7 +89,7 @@ Alternatively you can use [bin/hbench](../bin/hbench) script which use Maven to 
  * run with 100 and thousand partitions
 
 
-       java -jar hmsbench-jar-with-dependencies.jar -H `hostname` \
+       java -jar hmsbench.jar -H `hostname` \
             --savedata /tmp/benchdata \
             --sanitize \
             -N 100 -N 1000 \

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
@@ -68,10 +68,10 @@
           <groupId>io.netty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jcl</artifactId>
-          </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
@@ -145,6 +145,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <version>3.4.0</version>
             <executions>
               <execution>
                 <phase>package</phase>
@@ -154,7 +155,7 @@
                 <configuration>
                   <finalName>hmsbench</finalName>
                   <transformers>
-                    <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer"/>
+                    <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.apache.hadoop.hive.metastore.tools.BenchmarkTool</mainClass>
                     </transformer>
@@ -162,8 +163,7 @@
                   <filters>
                     <filter>
                       <!--
-                      Shading signed JARs will fail without this.
-                      http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                      https://logging.apache.org/log4j/transform/latest/#log4j-plugin-cache-transformer
                       -->
                       <artifact>*:*</artifact>
                       <excludes>
@@ -178,9 +178,9 @@
             </executions>
             <dependencies>
               <dependency>
-                <groupId>com.github.edwgiz</groupId>
-                <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                <version>2.1</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+                <version>0.1.0</version>
               </dependency>
             </dependencies>
           </plugin>

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
@@ -72,7 +72,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-jcl</artifactId>
           </exclusion>
-
       </exclusions>
     </dependency>
     <dependency>

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
@@ -68,6 +68,11 @@
           <groupId>io.netty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jcl</artifactId>
+          </exclusion>
+
       </exclusions>
     </dependency>
     <dependency>
@@ -139,30 +144,46 @@
       <build>
         <plugins>
           <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>
-                <configuration>
-                  <archive>
-                    <manifest>
-                      <mainClass>org.apache.hadoop.hive.metastore.tools.BenchmarkTool</mainClass>
-                      <addClasspath>true</addClasspath>
-                    </manifest>
-                  </archive>
-                  <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                  </descriptorRefs>
-                  <finalName>hmsbench</finalName>
-                </configuration>
-                <id>make-assembly-hclient</id>
-                <!-- this is used for inheritance merges -->
                 <phase>package</phase>
-                <!-- bind to the packaging phase -->
                 <goals>
-                  <goal>single</goal>
+                  <goal>shade</goal>
                 </goals>
+                <configuration>
+                  <finalName>hmsbench</finalName>
+                  <transformers>
+                    <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer"/>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <mainClass>org.apache.hadoop.hive.metastore.tools.BenchmarkTool</mainClass>
+                    </transformer>
+                  </transformers>
+                  <filters>
+                    <filter>
+                      <!--
+                      Shading signed JARs will fail without this.
+                      http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                      -->
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
               </execution>
             </executions>
+            <dependencies>
+              <dependency>
+                <groupId>com.github.edwgiz</groupId>
+                <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+                <version>2.1</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
The logging is completely broken in HMS benchmarks. When we create a Log entry, it only outputs a format pattern string instead of the log message. 

Example output:

`%d [%thread] %-5level %logger - %msg`

### What changes were proposed in this pull request?
TxnHandler refactor introduced Spring and it seems spring logging causes the issue. There are two changes in the PR: 
- exclude spring-jcl (https://stackoverflow.com/questions/50176843/log42-xml-is-not-picked-up-when-running-jmh-benchmark-from-test-directory)
- move from assembly to shading plugin to be able to run log4j2CacheTransformer (https://stackoverflow.com/questions/25065580/log4j2-custom-plugins-annotation-processing-with-maven-assembly-plugin)

### Why are the changes needed?
I want to do some metastore performance benchmarks. It is pretty hard to do that without logging.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Manually test: `java    -jar ./target/hmsbench.jar -H localhost --savedata /tmp/benchdata --sanitize -N 100 -N 1000 -o bench_results_direct.csv -C -d testbench_http --params=100 -M "TestGetValidWriteIds" --runMode ACID`
