### PR TITLE
HIVE-28105:Beeline: Show current database in prompt

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -431,6 +431,13 @@ public class BeeLine implements Closeable {
         .withLongOpt("property-file")
         .withDescription("The file to read configuration properties from")
         .create());
+
+    // -hideDbNameInPrompt
+    options.addOption(OptionBuilder
+            .withLongOpt("hideDbNameInPrompt")
+            .withDescription("The flag to hide DB name in prompt")
+            .create());
+
   }
 
 
@@ -729,7 +736,7 @@ public class BeeLine implements Closeable {
 
     private boolean isBeeLineOpt(String arg) {
       return arg.startsWith("--") && !(HIVE_VAR_PREFIX.equals(arg) || (HIVE_CONF_PREFIX.equals(arg))
-          || "--help".equals(arg) || PROP_FILE_PREFIX.equals(arg) || "--getUrlsFromBeelineSite".equals(arg));
+          || "--help".equals(arg) || PROP_FILE_PREFIX.equals(arg) || "--getUrlsFromBeelineSite".equals(arg) || "--hideDbNameInPrompt".equals(arg));
     }
   }
 
@@ -857,6 +864,9 @@ public class BeeLine implements Closeable {
     String driver = null, user = null, pass = "", url = null;
     String auth = null;
 
+    if(cl.hasOption("hideDbNameInPrompt")){
+      opts.setShowDbInPrompt(false);
+    }
 
     if (cl.hasOption("help")) {
       usage();

--- a/beeline/src/java/org/apache/hive/beeline/BeeLineOpts.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLineOpts.java
@@ -72,7 +72,7 @@ public class BeeLineOpts implements Completer {
   private boolean color = false;
   private boolean showHeader = true;
   private boolean escapeCRLF = false;
-  private boolean showDbInPrompt = false;
+  private boolean showDbInPrompt = true;
   private int headerInterval = 100;
   private boolean fastConnect = true;
   private boolean autoCommit = true;

--- a/beeline/src/main/resources/BeeLine.properties
+++ b/beeline/src/main/resources/BeeLine.properties
@@ -185,7 +185,6 @@ cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine \n \
 \  --autoCommit=[true/false]       enable/disable automatic transaction commit\n \
 \  --verbose=[true/false]          show verbose error messages and debug info\n \
 \  --showWarnings=[true/false]     display connection warnings\n \
-\  --showDbInPrompt=[true/false]   display the current database name in the prompt\n \
 \  --showNestedErrs=[true/false]   display nested errors\n \
 \  --numberFormat=[pattern]        format numbers using DecimalFormat pattern\n \
 \  --force=[true/false]            continue running script even after errors\n \
@@ -217,6 +216,7 @@ cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine \n \
 \  --convertBinaryArrayToString=[true/false]    display binary column data as string or as byte array \n \
 \  --getUrlsFromBeelineSite        Print all urls from beeline-site.xml, if it is present in the classpath\n \
 \  --help                          display this message\n \
+\  --hideDbNameInPrompt            Database Name should not appear in beeline prompt\n \
 \n \
 \  Example:\n \
 \   1. Connect using simple authentication to HiveServer2 on localhost:10000\n \

--- a/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -254,17 +254,17 @@ public class TestBeelineArgParsing {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] { "-u", "url" };
     Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertFalse(bl.getOpts().getShowDbInPrompt());
-    Assert.assertEquals("", bl.getFormattedDb());
+    Assert.assertTrue(bl.getOpts().getShowDbInPrompt());
+    Assert.assertEquals(" (default)", bl.getFormattedDb());
   }
 
   @Test
-  public void testBeelineShowDbInPromptOptsTrue() throws Exception {
+  public void testBeelineShowDbInPromptOptsFalse() throws Exception {
     TestBeeline bl = new TestBeeline();
-    String args[] = new String[] { "-u", "url", "--showDbInPrompt=true" };
+    String args[] = new String[] { "-u", "url", "--hideDbNameInPrompt" };
     Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.getOpts().getShowDbInPrompt());
-    Assert.assertEquals(" (default)", bl.getFormattedDb());
+    Assert.assertFalse(bl.getOpts().getShowDbInPrompt());
+    Assert.assertEquals("", bl.getFormattedDb());
   }
 
 

--- a/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestBeeLineWithArgs.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestBeeLineWithArgs.java
@@ -1033,10 +1033,9 @@ import org.junit.Test;
    * Print PASSED or FAILED
    */
   @Test
-  public void testShowDbInPrompt() throws Throwable {
+  public void testShowDbNameInPrompt() throws Throwable {
     final String EXPECTED_PATTERN = " \\(default\\)>";
     List<String> argList = new ArrayList<>();
-    argList.add("--showDbInPrompt");
     argList.add("-u");
     argList.add(miniHS2.getBaseJdbcURL() + ";user=hivetest;password=hive");
     String SCRIPT_TEXT = "select current_user();";


### PR DESCRIPTION
What changes were proposed in this pull request?
In order to make the beeline better, this change suggests to show the current operating database name in the beeline prompt. It also provides the functionality to disable the same by using an argument ( --hideDbNameInPrompt ) while initialising beeline.

Why are the changes needed?
The changes are needed in order to make beeline better & more user-friendly.

Does this PR introduce any user-facing change?
Yes
Currently, Beeline prompt is as follows: 
            0: jdbc:hive2://link> use dbs;
            0: jdbc:hive2://link>

This change suggests prompt to be as follows:
            0: jdbc:hive2://link> use dbs;
            0: jdbc:hive2://link (dbs)> 

Is the change a dependency upgrade?
No

How was this patch tested?
Manual tests.
After making the necessary changes, we build the hive project again.
After manually testing some DDL and SQL commands, hive is working as expected.