### PR TITLE
HIVE-28037: Run multiple Qtest with Postgres

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
@@ -92,6 +92,7 @@ public class CoreCliDriver extends CliAdapter {
   @AfterClass
   public void shutdown() throws Exception {
     qt.shutdown();
+    metaStoreHandler.getRule().after();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestMetaStoreHandler.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestMetaStoreHandler.java
@@ -98,14 +98,12 @@ public class QTestMetaStoreHandler {
   }
 
   public void beforeTest() throws Exception {
-    getRule().before();
-    if (!isDerby()) {// derby is handled with old QTestUtil logic (TxnDbUtil stuff)
-      getRule().install();
+    if (isDerby()) {
+      getRule().before();
     }
   }
 
   public void afterTest(QTestUtil qt) throws Exception {
-    getRule().after();
 
     // special qtest logic, which doesn't fit quite well into Derby.after()
     if (isDerby()) {


### PR DESCRIPTION
Running multiple qtests with Postgre will not fail with "Database does not exist: default". It keeps docker up and running between tests. 

### What changes were proposed in this pull request?
Changes to be able to run multiple Qtests with Postgre.


### Why are the changes needed?
Without this change only one Qtest can be run with Postgre.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Locally.
