### PR TITLE
HIVE-28115: Sync mockito-core version in standalone-metastore with parent pom.xml

### DIFF
--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -88,7 +88,7 @@
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
     <log4j2.version>2.18.0</log4j2.version>
-    <mockito-core.version>3.3.3</mockito-core.version>
+    <mockito-core.version>3.4.4</mockito-core.version>
     <orc.version>1.8.5</orc.version>
     <protobuf.version>3.24.4</protobuf.version>
     <io.grpc.version>1.51.0</io.grpc.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HIVE-28115](https://issues.apache.org/jira/browse/HIVE-28115)


### Why are the changes needed?
There is a difference between pom.xml and stanalone-metastore/pom.xml.

### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
Yes


### How was this patch tested?
Will see result of the UT
