### PR TITLE
HIVE-28140: Remove unnecessary shading of test jars in Kafka module to speedup build

### DIFF
--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -176,7 +176,6 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <shadeTestJar>true</shadeTestJar>
                   <createDependencyReducedPom>false</createDependencyReducedPom>
                   <artifactSet>
                     <includes>


### PR DESCRIPTION
### Why are the changes needed?
When the shadeTestJar option is enabled it tries to fetch the test jars from all dependencies and include them in the shaded artifact. For every dependency, and every available repository, there is a download attempt that fails most of the time (since most dependencies do not publish the test artifacts).

```
Downloading from confluent: https://packages.confluent.io/maven/com/sun/jersey/contribs/jersey-guice/1.19.4/jersey-guice-1.19.4-tests.jar
Downloading from central: https://repo.maven.apache.org/maven2/com/sun/jersey/contribs/jersey-guice/1.19.4/jersey-guice-1.19.4-tests.jar
Downloading from repository-release: https://repository.apache.org/content/repositories/releases/com/sun/jersey/contribs/jersey-guice/1.19.4/jersey-guice-1.19.4-tests.jar
Downloading from shibboleth: https://build.shibboleth.net/nexus/content/groups/public/com/sun/jersey/contribs/jersey-guice/1.19.4/jersey-guice-1.19.4-tests.jar
[WARNING] Could not get tests for com.sun.jersey.contribs:jersey-guice:jar:1.19.4:compile
```
All these download attempts increase build time noticeably, especially on slow internet connections.

Shading the test jars in Kafka module is not necessary since we are not using the resulting jars (kafka-handler-4.1.0-SNAPSHOT-tests.jar) anywhere inside the project (no occurrence of <artifactId>kafka-handler</artifactId> along with <classifier>tests</classifier>).

### Does this PR introduce _any_ user-facing change?
No. 

It may have an impact on projects/developers that use the tests artifacts of kafka-handler from Maven central but this highly unlikely. At the given moment, nobody seems to use the kafka-handler module [1] outside Hive so shading the tests just adds build overhead.

[1] https://central.sonatype.com/artifact/org.apache.hive/kafka-handler/dependents

### Is the change a dependency upgrade?
No

### How was this patch tested?
Existing tests