### PR TITLE
HIVE-28118: Hive Insert Into S3 with Viewfs overload scheme fails wit…

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestInsertIntoViewFsOverload.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestInsertIntoViewFsOverload.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.ViewDistributedFileSystem;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.*;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+
+public class TestInsertIntoViewFsOverload {
+  private static final Logger LOG = LoggerFactory.getLogger(TestInsertIntoViewFsOverload.class);
+  private static MiniDFSCluster cluster;
+  private static WarehouseInstance hiveWarehouse;
+  @Rule
+  public final TestName testName = new TestName();
+  private static String dbName;
+  private static String jksFile = System.getProperty("java.io.tmpdir") + "/test.jks";
+
+  @BeforeClass
+  public static void beforeClassSetup() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set("hadoop.security.key.provider.path", "jceks://file" + jksFile);
+    conf.set("fs.hdfs.impl", ViewDistributedFileSystem.class.getName());
+    String FS_DEFAULT_NAME = "hdfs://localhost:55149/";
+    URI defaultURI = URI.create(FS_DEFAULT_NAME);
+    conf.set("fs.viewfs.mounttable." + defaultURI.getHost() + ".linkFallback", defaultURI.toString());
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).nameNodePort(55149).format(true).build();
+    hiveWarehouse = new WarehouseInstance(LOG, cluster, new HashMap<String, String>() {{
+      put(HiveConf.ConfVars.HIVE_IN_TEST.varname, "false");
+    }});
+  }
+
+  @AfterClass
+  public static void classLevelTearDown() throws IOException {
+    if (cluster != null) {
+      FileSystem.closeAll();
+      cluster.shutdown();
+    }
+    hiveWarehouse.close();
+  }
+
+  @Before
+  public void setUpDB() throws Throwable {
+    dbName = testName.getMethodName() + "_" + +System.currentTimeMillis();
+    hiveWarehouse.run("create database " + dbName);
+  }
+
+  // Tests the functionality of hive insert into HDFS with ViewFs Overload scheme enabled
+  @Test
+  public void testInsertIntoHDFSViewFsOverload() throws Throwable {
+    hiveWarehouse.run("use " + dbName)
+        .run("create table t1 (a int)")
+        .run("insert into table t1 values (1),(2)")
+        .run("select * from t1")
+        .verifyResults(new String[] { "1", "2" });
+  }
+}
+

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -5290,7 +5290,8 @@ private void constructOneLBLocationMap(FileStatus fSta,
     try {
       return srcHdfsEncryptionShim != null
           && destHdfsEncryptionShim != null
-          && (srcHdfsEncryptionShim.isPathEncrypted(srcf) || destHdfsEncryptionShim.isPathEncrypted(destf))
+          && (srcFs.exists(srcf) && srcHdfsEncryptionShim.isPathEncrypted(srcf)
+          || destFs.exists(destf) && destHdfsEncryptionShim.isPathEncrypted(destf))
           && !srcHdfsEncryptionShim.arePathsOnSameEncryptionZone(srcf, destf, destHdfsEncryptionShim);
     } catch (IOException e) {
       throw new HiveException(e);


### PR DESCRIPTION
…h MoveTask Error

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
During hive staging, isPathEncrypted of the source tmp path returns false, check for isPathEncrypted of destination tmp path leads to resolvePath which throws a FileNotFoundException leading to MoveTask error. We add a check for file existence before call to isPathEncrypted.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When ViewFs Overload scheme is enabled and HDFS encryption is enabled (hadoop.security.key.provider.path is not null), hive insert into fails in below cases without the fix: 
1. Encryption zone is not enabled for hive warehouse directory.
2. Insert Into is done for the partition present in S3 (mount link created using Viewfs overload).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tests to verify the behaviour are added.
