### PR TITLE
HIVE-28138: Hive metastore benchmarks jar should use log4j2CacheTransformer

### DIFF
--- a/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
@@ -150,7 +150,7 @@
                 <configuration>
                   <finalName>hmsbench-jar-with-dependencies</finalName>
                   <transformers>
-                    <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
+                    <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer"/>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.apache.hadoop.hive.metastore.tools.BenchmarkTool</mainClass>
                     </transformer>
@@ -170,9 +170,9 @@
             </executions>
             <dependencies>
               <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
-                <version>0.1.0</version>
+                <groupId>com.github.edwgiz</groupId>
+                <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+                <version>2.1</version>
               </dependency>
             </dependencies>
           </plugin>

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
@@ -139,30 +139,42 @@
       <build>
         <plugins>
           <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>
-                <configuration>
-                  <archive>
-                    <manifest>
-                      <mainClass>org.apache.hadoop.hive.metastore.tools.BenchmarkTool</mainClass>
-                      <addClasspath>true</addClasspath>
-                    </manifest>
-                  </archive>
-                  <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                  </descriptorRefs>
-                  <finalName>hmsbench</finalName>
-                </configuration>
-                <id>make-assembly-hclient</id>
-                <!-- this is used for inheritance merges -->
                 <phase>package</phase>
-                <!-- bind to the packaging phase -->
                 <goals>
-                  <goal>single</goal>
+                  <goal>shade</goal>
                 </goals>
+                <configuration>
+                  <finalName>hmsbench-jar-with-dependencies</finalName>
+                  <transformers>
+                    <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <mainClass>org.apache.hadoop.hive.metastore.tools.BenchmarkTool</mainClass>
+                    </transformer>
+                  </transformers>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
               </execution>
             </executions>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+                <version>0.1.0</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?
```bash
java -jar hmsbench-jar-with-dependencies.jar
```

```
ERROR StatusLogger Unrecognized format specifier [d]
ERROR StatusLogger Unrecognized conversion specifier [d] starting at position 16 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [thread]
ERROR StatusLogger Unrecognized conversion specifier [thread] starting at position 25 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [level]
```

https://logging.apache.org/log4j/transform/latest/

https://stackoverflow.com/questions/48033792/log4j2-error-statuslogger-unrecognized-conversion-specifier

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
local test