### PR TITLE
HIVE-28142: Fix flakyness in acid_bloom_filter_orc_file_dump

### DIFF
--- a/ql/src/test/queries/clientpositive/acid_bloom_filter_orc_file_dump.q
+++ b/ql/src/test/queries/clientpositive/acid_bloom_filter_orc_file_dump.q
@@ -1,4 +1,5 @@
 --! qt:replace:/(File Version:)(.+)/$1#Masked#/
+-- SORT_QUERY_RESULTS
 SET hive.vectorized.execution.enabled=FALSE;
 SET hive.mapred.mode=nonstrict;
 


### PR DESCRIPTION
The test uses the PostExecOrcFileDump post exec hook on a limit 1 query. 
It has no order by and the test table contains two rows. Sometimes it picks up the other row than it is in the q.out file. 


### What changes were proposed in this pull request?
Define explicit order

### Why are the changes needed?
Test stability


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
`mvn test -Pitests -pl itests/qtest -Dtest=TestMiniLlapLocalCliDriver -Dqfile=acid_bloom_filter_orc_file_dump.q`
