### PR TITLE
HIVE-12930: Support SSL Shuffle for LLAP

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/configuration/LlapDaemonConfiguration.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/configuration/LlapDaemonConfiguration.java
@@ -32,7 +32,7 @@ public class LlapDaemonConfiguration extends Configuration {
       "hdfs-site.xml", "yarn-site.xml", "tez-site.xml", "hive-site.xml" };
 
   @InterfaceAudience.Private
-  public static final String[] SSL_DAEMON_CONFIGS = { "ssl-client.xml" };
+  public static final String[] SSL_DAEMON_CONFIGS = { "ssl-server.xml", "ssl-client.xml"};
 
   public LlapDaemonConfiguration() {
     super(true); // Load the defaults.

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
@@ -204,6 +204,9 @@ public class ShuffleHandler implements AttemptRegistrationListener {
 
   public static final String CONNECTION_CLOSE = "close";
 
+  public static final String SHUFFLE_SSL_ENABLED_KEY = "hive.llap.shuffle.ssl.enabled";
+  public static final boolean SHUFFLE_SSL_ENABLED_DEFAULT = false;
+
   public static final String SUFFLE_SSL_FILE_BUFFER_SIZE_KEY =
     "llap.shuffle.ssl.file.buffer.size";
 
@@ -376,13 +379,12 @@ public class ShuffleHandler implements AttemptRegistrationListener {
 
   private void initPipeline(ServerBootstrap bootstrap, Configuration conf) throws Exception {
     SHUFFLE = getShuffle(conf);
-    // TODO Setup SSL Shuffle
-    //  if (conf.getBoolean(MRConfig.SHUFFLE_SSL_ENABLED_KEY,
-    //                      MRConfig.SHUFFLE_SSL_ENABLED_DEFAULT)) {
-    //    LOG.info("Encrypted shuffle is enabled.");
-    //    sslFactory = new SSLFactory(SSLFactory.Mode.SERVER, conf);
-    //    sslFactory.init();
-    //  }
+     // Setup SSL Shuffle
+      if (conf.getBoolean(SHUFFLE_SSL_ENABLED_KEY, SHUFFLE_SSL_ENABLED_DEFAULT)) {
+        LOG.info("Encrypted shuffle is enabled.");
+        sslFactory = new SSLFactory(SSLFactory.Mode.SERVER, conf);
+        sslFactory.init();
+      }
 
     ChannelInitializer<NioSocketChannel> channelInitializer =
         new ChannelInitializer<NioSocketChannel>() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Added support for enabling SSL for LLAP shuffle. Made changes in LLAP Shuffle handler similar to Tez shuffle handler. Added ssl-server.xml configuration file to LLAP daemon configs since LLAP daemon acts as both server and client for shuffle.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are needed to enable SSL for LLAP shuffle. 


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this change introduces _hive.llap.shuffle.ssl.enabled_ configuration property for enabling SSL for LLAP shuffle. Both _tez.runtime.shuffle.ssl.enable_ and _hive.llap.shuffle.ssl.enabled_ have to be enabled for enabling SSL for LLAP shuffle. This is because the shuffle fetcher implementation in Tez is dependent on _tez.runtime.shuffle.ssl.enable_  for enabling SSL while communicating with shuffle handler for fetching shuffle data. 

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manually verified that SSL is enabled for the LLAP shuffle. 
