### PR TITLE
HIVE-28110: MetastoreConf - String casting of default values breaks Hive

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -2242,9 +2242,8 @@ public class MetastoreConf {
    * @return value, or default value if value not in config file
    */
   public static String getVar(Configuration conf, ConfVars var) {
-    assert var.defaultVal.getClass() == String.class;
     String val = conf.get(var.varname);
-    return val == null ? conf.get(var.hiveName, (String)var.defaultVal) : val;
+    return val == null ? conf.get(var.hiveName, var.defaultVal.toString()) : val;
   }
 
   /**
@@ -2267,10 +2266,9 @@ public class MetastoreConf {
    * @return collection of strings.  If the value is unset it will return an empty collection.
    */
   public static Collection<String> getStringCollection(Configuration conf, ConfVars var) {
-    assert var.defaultVal.getClass() == String.class;
     String val = conf.get(var.varname);
     if (val == null) {
-      val = conf.get(var.hiveName, (String)var.defaultVal);
+      val = conf.get(var.hiveName, var.defaultVal.toString());
     }
     if (val == null) {
       return Collections.emptySet();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
@@ -510,4 +510,29 @@ public class TestMetastoreConf {
     Assert.assertEquals(MetastoreConf.ACID_OPEN_TXNS_COUNTER_SERVICE_CLASS,
         AcidOpenTxnsCounterService.class.getName());
   }
+
+  /**
+   * Verify that getVar(Configuration conf, ConfVars var) method of MetaStoreConf.java runs as expected in case of unset environment variables
+   * or any other variables that don't have default Value type of String
+   */
+  @Test
+  public void testGetVarForUnsetSystemProperties(){
+    conf = MetastoreConf.newMetastoreConf();
+    System.clearProperty(ConfVars.USE_SSL.getVarname());
+    Assert.assertEquals("false", MetastoreConf.getVar(conf, ConfVars.USE_SSL));
+  }
+
+  /**
+   * Verify that getStringCollection(Configuration conf, ConfVars var) method of MetaStoreConf.java runs as expected in case of unset environment variables
+   * or any other properties that don't have default Value type of String
+   */
+  @Test
+  public void testGetStringCollectionForUnsetSystemProperties(){
+    conf = MetastoreConf.newMetastoreConf();
+    System.clearProperty(ConfVars.USE_SSL.getVarname());
+    Collection<String> list = MetastoreConf.getStringCollection(conf, ConfVars.USE_SSL);
+    Assert.assertEquals(1, list.size());
+    Assert.assertTrue(list.contains("false"));
+  }
+
 }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
@@ -518,7 +518,7 @@ public class TestMetastoreConf {
   @Test
   public void testGetVarForUnsetSystemProperties(){
     conf = MetastoreConf.newMetastoreConf();
-    System.clearProperty(ConfVars.USE_SSL.getVarname());
+    conf.unset(ConfVars.USE_SSL.getVarname());
     Assert.assertEquals("false", MetastoreConf.getVar(conf, ConfVars.USE_SSL));
   }
 
@@ -529,7 +529,7 @@ public class TestMetastoreConf {
   @Test
   public void testGetStringCollectionForUnsetSystemProperties(){
     conf = MetastoreConf.newMetastoreConf();
-    System.clearProperty(ConfVars.USE_SSL.getVarname());
+    conf.unset(ConfVars.USE_SSL.getVarname());
     Collection<String> list = MetastoreConf.getStringCollection(conf, ConfVars.USE_SSL);
     Assert.assertEquals(1, list.size());
     Assert.assertTrue(list.contains("false"));


### PR DESCRIPTION
What changes were proposed in this pull request?
Modify the getVar(Configuration conf, ConfVars var) & getStringCollection(Configuration conf, ConfVars var) methods of the MetastoreConf class to use toString() method instead of type-casting.

Why are the changes needed?
When using the getVar(Configuration conf, ConfVars var) method of the MetastoreConf class, Apache breaks when e.g. trying to retrieve the environment variable "USE_SSL" and it isn't set in the system. The method then tries to cast the default value, which is the boolean false for USE_SSL, to a String which can't work. Also in the getStringCollection(Configuration conf, ConfVars var) method it tries to cast any default values to a String.

Does this PR introduce any user-facing change?
No

Is the change a dependency upgrade?
No

How was this patch tested?
Manual tests.
After making the necessary changes, we build the hive project again.
After manually testing some DDL and SQL commands, hive is working as expected.