### PR TITLE
HIVE-26926: SHOW PARTITIONS for a non partitioned table should just throw execution error instead of full stack trace.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLTask.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableDesc;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
@@ -87,20 +86,16 @@ public final class DDLTask extends Task<DDLWork> implements Serializable {
         throw new IllegalArgumentException("Unknown DDL request: " + ddlDesc.getClass());
       }
     } catch (Throwable e) {
-      if (work.isReplication() && ReplUtils.shouldIgnoreOnError(ddlOperation, e)) {
+      if(work.isReplication() && ReplUtils.shouldIgnoreOnError(ddlOperation, e)) {
         LOG.warn("Error while table creation: ", e);
         return 0;
       }
-      int errorCode = ReplUtils.handleException(work.isReplication(), e, work.getDumpDirectory(),
-              work.getMetricCollector(), getName(), conf);
-      if (errorCode == ErrorMsg.TABLE_NOT_PARTITIONED.getErrorCode()) {
-        return errorCode;
-      }
       failed(e);
-      if (ddlOperation != null) {
+      if(ddlOperation != null) {
         LOG.error("DDLTask failed, DDL Operation: " + ddlOperation.getClass().toString(), e);
       }
-      return errorCode;
+      return ReplUtils.handleException(work.isReplication(), e, work.getDumpDirectory(),
+              work.getMetricCollector(), getName(), conf);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLTask.java
@@ -88,14 +88,14 @@ public final class DDLTask extends Task<DDLWork> implements Serializable {
         throw new IllegalArgumentException("Unknown DDL request: " + ddlDesc.getClass());
       }
     } catch (Throwable e) {
+      if(work.isReplication() && ReplUtils.shouldIgnoreOnError(ddlOperation, e)) {
+        LOG.warn("Error while table creation: ", e);
+        return 0;
+      }
       int excpErrorCode = ReplUtils.handleException(work.isReplication(), e, work.getDumpDirectory(),
               work.getMetricCollector(), getName(), conf);
       if(excpErrorCode == ErrorMsg.TABLE_NOT_PARTITIONED.getErrorCode()){
         return excpErrorCode;
-      }
-      if(work.isReplication() && ReplUtils.shouldIgnoreOnError(ddlOperation, e)) {
-        LOG.warn("Error while table creation: ", e);
-        return 0;
       }
       failed(e);
       if(ddlOperation != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLTask.java
@@ -95,7 +95,7 @@ public final class DDLTask extends Task<DDLWork> implements Serializable {
         LOG.error("DDLTask failed, DDL Operation: " + ddlOperation.getClass().toString(), e);
       }
       return ReplUtils.handleException(work.isReplication(), e, work.getDumpDirectory(),
-              work.getMetricCollector(), getName(), conf);
+                                       work.getMetricCollector(), getName(), conf);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLTask.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableDesc;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.parse.ExplainConfiguration.AnalyzeState;
 import org.apache.hadoop.hive.ql.plan.api.StageType;
 import org.reflections.Reflections;
@@ -88,20 +87,20 @@ public final class DDLTask extends Task<DDLWork> implements Serializable {
         throw new IllegalArgumentException("Unknown DDL request: " + ddlDesc.getClass());
       }
     } catch (Throwable e) {
-      if(work.isReplication() && ReplUtils.shouldIgnoreOnError(ddlOperation, e)) {
+      if (work.isReplication() && ReplUtils.shouldIgnoreOnError(ddlOperation, e)) {
         LOG.warn("Error while table creation: ", e);
         return 0;
       }
-      int excpErrorCode = ReplUtils.handleException(work.isReplication(), e, work.getDumpDirectory(),
+      int errorCode = ReplUtils.handleException(work.isReplication(), e, work.getDumpDirectory(),
               work.getMetricCollector(), getName(), conf);
-      if(excpErrorCode == ErrorMsg.TABLE_NOT_PARTITIONED.getErrorCode()){
-        return excpErrorCode;
+      if (errorCode == ErrorMsg.TABLE_NOT_PARTITIONED.getErrorCode()) {
+        return errorCode;
       }
       failed(e);
-      if(ddlOperation != null) {
+      if (ddlOperation != null) {
         LOG.error("DDLTask failed, DDL Operation: " + ddlOperation.getClass().toString(), e);
       }
-      return excpErrorCode;
+      return errorCode;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/show/ShowPartitionsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/show/ShowPartitionsOperation.java
@@ -58,7 +58,8 @@ public class ShowPartitionsOperation extends DDLOperation<ShowPartitionsDesc> {
     if (tbl.isNonNative() && tbl.getStorageHandler().supportsPartitionTransform()) {
       parts = tbl.getStorageHandler().showPartitions(context, tbl);
     } else if (!tbl.isPartitioned()) {
-      throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, desc.getTabName());
+      context.getTask().setException(new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, desc.getTabName()));
+      return ErrorMsg.TABLE_NOT_PARTITIONED.getErrorCode();
     } else if (desc.getCond() != null || desc.getOrder() != null) {
       parts = getPartitionNames(tbl);
     } else if (desc.getPartSpec() != null) {


### PR DESCRIPTION
What changes were proposed in this pull request?
SHOW PARTITIONS command implemented on a  non partitioned table should just throw execution error instead of full stack trace.

Why are the changes needed?
It is an improvement to already existing flow where a huge stack trace is shown to user wherein only a small prompt is useful.

Does this PR introduce any user-facing change?
Yes,
Earlier: 
<img width="989" alt="Screenshot 2024-03-26 at 5 05 02 PM" src="https://github.com/apache/hive/assets/157357971/8049a1d9-d7a8-4381-afc6-6142e9bc41f9">

<img width="988" alt="Screenshot 2024-03-26 at 5 05 22 PM" src="https://github.com/apache/hive/assets/157357971/ae96c5f4-5988-4877-af3d-accabbff15e1">

This PR proposes the following change:
<img width="1388" alt="Screenshot 2024-03-26 at 5 05 58 PM" src="https://github.com/apache/hive/assets/157357971/dd858ed4-be95-4b6d-81e7-6b0abaf97abb">


Is the change a dependency upgrade?
No

How was this patch tested?
Manual tests.
After making the necessary changes, we build hive again, and then ran some manual commands to make sure hive is working as expected as well as the required change is working fine.