### PR TITLE
HIVE-27968: Fix & enable testFetchResultsOfLogWithOrientation

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingAPIWithMr.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingAPIWithMr.java
@@ -141,6 +141,12 @@ public class TestOperationLoggingAPIWithMr extends OperationLoggingAPITestBase {
             null);
     int logLength = fetchAndVerifyLog(operationHandleWithOrientation, expectedLogLength);
     Assert.assertEquals(expectedLogLength, logLength);
+
+
+    // (FETCH_FIRST) fetch again from the same operation handle with FETCH_FIRST orientation
+    RowSet rowSetLogWithOrientation = client.fetchResults(operationHandleWithOrientation,
+            FetchOrientation.FETCH_FIRST, 1000, FetchType.LOG);
+    verifyFetchedLog(rowSetLogWithOrientation,  expectedLogsVerbose);
   }
 
   private int fetchAndVerifyLog(OperationHandle operationHandle, int expectedLogLength) throws Exception {
@@ -152,9 +158,6 @@ public class TestOperationLoggingAPIWithMr extends OperationLoggingAPITestBase {
               FetchOrientation.FETCH_NEXT, maxRows, FetchType.LOG);
       logLength += rowSetLogWithOrientation.numRows();
     } while (rowSetLogWithOrientation.numRows() == maxRows);
-
-    // Close the operation handle after fetching all results
-    client.closeOperation(operationHandle);
 
     return logLength;
   }


### PR DESCRIPTION
What changes were proposed in this pull request?
Fix of flaky test -- testFetchResultsOfLogWithOrientation. 
Root cause identified -- The fetching of logs was not properly synchronized earlier, causing the computation length of fetched logs to be different than actual.

Why are the changes needed?
In order to fix the flakiness of the test that was earlier disabled. 

Does this PR introduce any user-facing change?
No

Is the change a dependency upgrade?
No

How was this patch tested?
[http://ci.hive.apache.org/job/hive-flaky-check/829/](url)