### PR TITLE
HIVE-28154: Throw friendly exception if the table does not support partition transform

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
@@ -486,6 +486,7 @@ public enum ErrorMsg {
   NON_NATIVE_ACID_UPDATE(10435, "Update and Merge to a non-native ACID table in \"merge-on-read\" mode is only supported when \"" +
           HiveConf.ConfVars.SPLIT_UPDATE.varname + "\"=\"true\""),
   READ_ONLY_DATABASE(10436, "Database {0} is read-only", true),
+  UNEXPECTED_PARTITION_TRANSFORM_SPEC(10437, "Partition transforms are only supported by Iceberg storage handler", true),
 
   //========================== 20000 range starts here ========================//
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -435,7 +435,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
                     "STRING) PARTITIONED BY spec(TRUNCATE(2, last_name)) STORED AS ORC");
     Assertions.assertThatThrownBy(() -> shell.executeStatement(query))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Partition transform is only supported for specific storage handler");
+            .hasMessageContaining("Partition transforms are only supported by Iceberg storage handler");
   }
 
   @Test

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -429,6 +429,16 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
+  public void testInvalidCreateWithPartitionTransform() {
+    Assume.assumeTrue("Test on hive catalog is enough", testTableType == TestTables.TestTableType.HIVE_CATALOG);
+    String query = String.format("CREATE EXTERNAL TABLE customers (customer_id BIGINT, first_name STRING, last_name " +
+                    "STRING) PARTITIONED BY spec(TRUNCATE(2, last_name)) STORED AS ORC");
+    Assertions.assertThatThrownBy(() -> shell.executeStatement(query))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Partition transform is only supported for specific storage handler");
+  }
+
+  @Test
   public void testCreateDropTable() throws TException, IOException, InterruptedException {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -14496,8 +14496,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         }
       }
     } else if (partitionTransformSpecExists) {
-      throw new SemanticException("Partition transform is only supported for specific storage handler tables. e.g. " +
-              "Iceberg tables");
+      throw new SemanticException("Partition transforms are only supported by Iceberg storage handler");
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -14495,6 +14495,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
                           + "'='" + fileFormat + "')");
         }
       }
+    } else if (partitionTransformSpecExists) {
+      throw new SemanticException("Partition transform is only supported for specific storage handler tables. e.g. " +
+              "Iceberg tables");
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -14496,7 +14496,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         }
       }
     } else if (partitionTransformSpecExists) {
-      throw new SemanticException("Partition transforms are only supported by Iceberg storage handler");
+      throw new SemanticException(ErrorMsg.UNEXPECTED_PARTITION_TRANSFORM_SPEC.getMsg());
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
At present, create basic tables such as orc/parquet with partition transform will succeed. However, we only support iceberg tables for partition transform now, so i think we need to throw a friendly exception if the table does not support partition transform, to avoid user misunderstanding that the basic tables have such ability.

We can throw friendly exception to client if the table does not support partition transform, such as the following exception:
```
0: jdbc:hive2://127.0.0.1:10000/default> create table customer(customer_id int,first_name string,last_name string) partitioned by spec(TRUNCATE(2, last_name)) stored as orc;
Error: Error while compiling statement: FAILED: SemanticException Partition transforms are only supported by Iceberg storage handler (state=42000,code=40000)
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Throw friendly exception if the table does not support partition transform to avoid user misunderstanding.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added UT.