### PR TITLE
HIVE-28161: Incorrect Copyright years in META-INF/NOTICE files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
   <packaging>pom</packaging>
   <name>Hive</name>
   <url>https://hive.apache.org</url>
+  <inceptionYear>2008</inceptionYear>
   <modules>
     <module>storage-api</module>
     <module>accumulo-handler</module>
@@ -225,6 +226,7 @@
     <jansi.version>2.4.0</jansi.version>
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
     <spring.version>5.3.21</spring.version>
+    <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
   <repositories>
     <!-- This needs to be removed before checking in-->

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -24,6 +24,7 @@
   <version>4.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Hive Standalone Metastore</name>
+  <inceptionYear>2008</inceptionYear>
   <modules>
     <module>metastore-common</module>
     <module>metastore-server</module>
@@ -117,6 +118,7 @@
     <thrift.gen.dir>${basedir}/src/gen/thrift</thrift.gen.dir>
     <thrift.args>-I ${thrift.home} -strict --gen java:beans,generated_annotations=undated --gen cpp --gen php --gen py --gen rb
     </thrift.args>
+    <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -24,6 +24,7 @@
   <version>4.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Hive Storage API</name>
+  <inceptionYear>2008</inceptionYear>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -38,6 +39,7 @@
     <checkstyle.conf.dir>${basedir}/checkstyle/</checkstyle.conf.dir>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
   <dependencies>
     <!-- compile inter-project -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set the necessary properties in the pom file to generate an appropriate Copyright timespan (used by maven-remote-resources-plugin).

### Why are the changes needed?
The generated META-INF/NOTICE file which resides inside each jar produced by Hive has incorrect copyright years.

Inside all jars the NOTICE file has the following incorrect content:

```
Copyright 2020 The Apache Software Foundation
```
The Copyright statement should include the timespan from the inception of the project to now.
```
Copyright 2008-2024 The Apache Software Foundation
```
The problem can be easily seen by inspecting the jar content after building any module or checking the previously published jars in Maven central.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Inspecting various jars before/after the changes
```
mvn clean install -DskipTests -pl common/
jar xf common/target/hive-common-4.1.0-SNAPSHOT.jar META-INF
cat META-INF/NOTICE 
```