### PR TITLE
[HIVE-28162] Fix incorrect argument replacement of Hive JDBC

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HivePreparedStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HivePreparedStatement.java
@@ -142,7 +142,6 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
   private List<String> splitSqlStatement(String sql) {
     List<String> parts = new ArrayList<>();
     boolean inSingleQuote = false;
-    boolean inDoubleQuote = false;
     boolean inComment = false;
     int off = 0;
     boolean skip = false;
@@ -159,29 +158,22 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
       }
       switch (c) {
         case '\'':
-          if (!inDoubleQuote) {
-            inSingleQuote = !inSingleQuote;
-          }
-          break;
-        case '\"':
-          if (!inSingleQuote) {
-            inDoubleQuote = !inDoubleQuote;
-          }
+          inSingleQuote = !inSingleQuote;
           break;
         case '-':
-          if (!inSingleQuote && !inDoubleQuote) {
+          if (!inSingleQuote) {
             if (i < sql.length() - 1 && sql.charAt(i + 1) == '-') {
               inComment = true;
             }
           }
           break;
         case '\\':
-          if (!inSingleQuote && !inDoubleQuote) {
+          if (!inSingleQuote) {
             skip = true;
           }
           break;
         case '?':
-          if (!inSingleQuote && !inDoubleQuote) {
+          if (!inSingleQuote) {
             parts.add(sql.substring(off, i));
             off = i + 1;
           }

--- a/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
@@ -223,22 +223,13 @@ public class TestHivePreparedStatement {
     String executedSql = captureExecutedSql(inSingleQuote, times++, null);
     assertEquals("select '?' from table_a", executedSql);
 
-    String inDoubleQuote = "select \"?\" from table_a";
-    executedSql = captureExecutedSql(inDoubleQuote, times++, null);
-    assertEquals("select \"?\" from table_a", executedSql);
-
-    String inDoubleQuoteLikeRegex =
-        "select field_a from table_a where field_b rlike \"[a-zA-Z]+?\"";
-    executedSql = captureExecutedSql(inDoubleQuoteLikeRegex, times++, null);
-    assertEquals("select field_a from table_a where field_b rlike \"[a-zA-Z]+?\"", executedSql);
-
     String inComment = "select\n" + "-- ? in the comments\n" + "field_a\n" + "from table_a";
     executedSql = captureExecutedSql(inComment, times++, null);
     assertEquals("select\n" + "-- ? in the comments\n" + "field_a\n" + "from table_a", executedSql);
 
     // Mix non-effective and effective
     String lastOneIsEffective =
-        "select\n" + "-- ? in the comments\n" + "'?',\n" + "\"?\",\n" + "field_a\n" + "from ?";
+        "select\n" + "-- ? in the comments\n" + "'?',\n" + "field_a\n" + "from ?";
     executedSql =
         captureExecutedSql(
             lastOneIsEffective,
@@ -255,7 +246,6 @@ public class TestHivePreparedStatement {
         "select\n"
             + "-- ? in the comments\n"
             + "'?',\n"
-            + "\"?\",\n"
             + "field_a\n"
             + "from 'value_of_second_placeholder'",
         executedSql);

--- a/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
@@ -44,6 +44,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
 
 public class TestHivePreparedStatement {
 
@@ -208,5 +211,67 @@ public class TestHivePreparedStatement {
     verify(client, times(2)).ExecuteStatement(argument.capture());
     assertEquals("select * from table where value='\\'anyValue\\' or 1=1'",
         argument.getValue().getStatement());
+  }
+
+  @Test
+  public void testNonEffectiveArgumentPlaceholder() throws Exception {
+
+    int times = 1;
+
+    // Non-effective
+    String inSingleQuote = "select '?' from table_a";
+    String executedSql = captureExecutedSql(inSingleQuote, times++, null);
+    assertEquals("select '?' from table_a", executedSql);
+
+    String inDoubleQuote = "select \"?\" from table_a";
+    executedSql = captureExecutedSql(inDoubleQuote, times++, null);
+    assertEquals("select \"?\" from table_a", executedSql);
+
+    String inDoubleQuoteLikeRegex =
+        "select field_a from table_a where field_b rlike \"[a-zA-Z]+?\"";
+    executedSql = captureExecutedSql(inDoubleQuoteLikeRegex, times++, null);
+    assertEquals("select field_a from table_a where field_b rlike \"[a-zA-Z]+?\"", executedSql);
+
+    String inComment = "select\n" + "-- ? in the comments\n" + "field_a\n" + "from table_a";
+    executedSql = captureExecutedSql(inComment, times++, null);
+    assertEquals("select\n" + "-- ? in the comments\n" + "field_a\n" + "from table_a", executedSql);
+
+    // Mix non-effective and effective
+    String lastOneIsEffective =
+        "select\n" + "-- ? in the comments\n" + "'?',\n" + "\"?\",\n" + "field_a\n" + "from ?";
+    executedSql =
+        captureExecutedSql(
+            lastOneIsEffective,
+            times++,
+            Arrays.asList(
+                ps -> {
+                  try {
+                    ps.setString(1, "value_of_second_placeholder");
+                  } catch (SQLException e) {
+                    e.printStackTrace();
+                  }
+                }));
+    assertEquals(
+        "select\n"
+            + "-- ? in the comments\n"
+            + "'?',\n"
+            + "\"?\",\n"
+            + "field_a\n"
+            + "from 'value_of_second_placeholder'",
+        executedSql);
+  }
+
+  private String captureExecutedSql(
+      String sql, int times, List<Consumer<HivePreparedStatement>> statementArguments)
+      throws Exception {
+    ArgumentCaptor<TExecuteStatementReq> argument =
+        ArgumentCaptor.forClass(TExecuteStatementReq.class);
+    HivePreparedStatement ps = new HivePreparedStatement(connection, client, sessHandle, sql);
+    if (statementArguments != null) {
+      statementArguments.forEach(statementArgument -> statementArgument.accept(ps));
+    }
+    ps.execute();
+    verify(client, times(times)).ExecuteStatement(argument.capture());
+    return argument.getValue().getStatement();
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The argument place holder inside comment will be ignore just like inside the single quote

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Meet issue when the comment contains  argument placeholder '?'
```
java.sql.SQLException: Parameter #1 is unset

    at org.apache.hive.jdbc.HivePreparedStatement.updateSql(HivePreparedStatement.java:122)
    at org.apache.hive.jdbc.HivePreparedStatement.execute(HivePreparedStatement.java:89)
```
Example sql to reproduce:
The sql might contain comments and the ? should be an invalid placeholder if it's within the comment block
```
select 
-- ? some comment
field_a,
field_b
from table_any
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
After this change the '?' in the comment will be treated as non-effective one just align with current behavior under single quote

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested by the UT: TestHivePreparedStatement.testNonEffectiveArgumentPlaceholder