### PR TITLE
HIVE-28163: Upgrade apache directory server to 2.0.0-M24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <antlr.version>3.5.2</antlr.version>
     <!-- Make sure to sync it with standalone-metastore/pom.xml -->
     <antlr4.version>4.9.3</antlr4.version>
-    <apache-directory-server.version>1.5.7</apache-directory-server.version>
+    <apache-directory-server.version>2.0.0-M24</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
     <arrow.version>12.0.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -329,6 +329,10 @@
           <groupId>dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -58,7 +58,7 @@
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
     <!-- Dependency versions -->
     <antlr.version>4.9.3</antlr.version>
-    <apache-directory-server.version>1.5.7</apache-directory-server.version>
+    <apache-directory-server.version>2.0.0-M24</apache-directory-server.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
@@ -447,6 +447,10 @@
           <exclusion>
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Please refer to [HIVE-28163](https://issues.apache.org/jira/browse/HIVE-28163) for stacktrace


### Why are the changes needed?
When running Hive3 + (patches from master branch), with jdk17, there were failure in service module regarding apache directory server. Here is the test which failed.
`mvn test -Dtest='org.apache.hive.service.auth.TestLdapAtnProviderWithMiniDS#testGroupFilterPositive' -pl service`

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes. Attaching updated dependency tree: 
[new-dependency-tree.txt](https://github.com/apache/hive/files/14801810/new-dependency-tree.txt)

### How was this patch tested?
In my org we have hive3 + master branch patches, with jdk17. There we are running it. Will see the UT once by running it here.
