### PR TITLE
HIVE-28164: Remove log4j:log4j transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <maven.cyclonedx.plugin.version>2.7.10</maven.cyclonedx.plugin.version>
     <maven.license.plugin.version>2.3.0</maven.license.plugin.version>
     <!-- Library Dependency Versions -->
-    <accumulo.version>1.10.1</accumulo.version>
+    <accumulo.version>1.10.4</accumulo.version>
     <ant.version>1.10.13</ant.version>
     <antlr.version>3.5.2</antlr.version>
     <!-- Make sure to sync it with standalone-metastore/pom.xml -->
@@ -1607,11 +1607,17 @@
                   <excludes>
                     <!-- Move to SLF4J -->
                     <exclude>commons-logging:commons-logging</exclude>
-                    <exclude>log4j:log4j</exclude>
                     <exclude>ch.qos.reload4j:reload4j</exclude>
                   </excludes>
                   <searchTransitive>false</searchTransitive>
                   <message>A banned logging dependency was found!</message>
+                </bannedDependencies>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>log4j:log4j</exclude>
+                  </excludes>
+                  <searchTransitive>true</searchTransitive>
+                  <message>Banned log4j:log4j dependency/transitive dependency was found!</message>
                 </bannedDependencies>
               </rules>
               <fail>true</fail>

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/pom.xml
@@ -84,11 +84,6 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${jmh.version}</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12 -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are dependency like accumulo and slf4j bringing log4j vulnerable jars in dependency tree. There are few dependencies also which don't appear in dependecy tree but are bringing old and vulnerable log4j. This can be observed in local m2 repo cache.


### Why are the changes needed?
For CVE's and security reasons.


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
Yes, here is new dependency tree on 771b0038d84758897c80d6931f21ff7073f4da31 (master): 
[dependency_tree.txt](https://github.com/user-attachments/files/17363530/dependency_tree.txt)



### How was this patch tested?
Will see the UT from CI
