### PR TITLE
HIVE-28199: Fix docker issues with Hive 3.1.3 on Mac.

### DIFF
--- a/packaging/src/docker/Dockerfile
+++ b/packaging/src/docker/Dockerfile
@@ -84,6 +84,7 @@ COPY entrypoint.sh /
 COPY conf $HIVE_HOME/conf
 RUN chmod +x /entrypoint.sh
 
+
 ARG UID=1000
 RUN adduser --no-create-home --disabled-login --gecos "" --uid $UID hive && \
     chown hive /opt/tez && \
@@ -91,7 +92,9 @@ RUN adduser --no-create-home --disabled-login --gecos "" --uid $UID hive && \
     chown hive /opt/hadoop && \
     chown hive /opt/hive/conf && \
     mkdir -p /opt/hive/data/warehouse && \
-    chown hive /opt/hive/data/warehouse
+    chown hive /opt/hive/data/warehouse && \
+    mkdir -p /home/hive/.beeline && \
+    chown hive /home/hive/.beeline
 
 USER hive
 WORKDIR /opt/hive

--- a/packaging/src/docker/docker-compose.yml
+++ b/packaging/src/docker/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - '5432:5432'
     volumes:
       - hive-db:/var/lib/postgresql
+    networks:
+      - hive
 
   metastore:
     image: apache/hive:${HIVE_VERSION}
@@ -35,6 +37,8 @@ services:
         - type: bind
           source: ${POSTGRES_LOCAL_PATH}
           target: /opt/hive/lib/postgres.jar
+    networks:
+      - hive
 
   hiveserver2:
     image: apache/hive:${HIVE_VERSION}
@@ -52,7 +56,13 @@ services:
       - '10002:10002'
     volumes:
       - warehouse:/opt/hive/data/warehouse
+    networks:
+      - hive
 
 volumes:
   hive-db:
   warehouse:
+
+networks:
+  hive:
+    name: hive


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Fix docker quickstart issues when running Hive 3.1.3 on Mac M2

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[HIVE-28199](https://issues.apache.org/jira/browse/HIVE-28199)

On Mac M2, `docker-compose up` for `HIVE_VERSION=3.1.3` gives the following errors

* `/home/hive/.beeline` directory issue
```
metastore    | *** schemaTool failed ***
metastore    | [
metastore    | WARN] Failed to create directory:
metastore    | /home/hive/.beeline
metastore    | No such file or directory
```

* Underscore in network name, from `/tmp/hive/hive.log` on `hiveserver2`:
```
2024-04-02T16:26:24,867 ERROR [main] utils.MetaStoreUtils: Got exception: java.net.URISyntaxException Illegal character in hostname at index 25: thrift://metastore.docker_default:9083
java.net.URISyntaxException: Illegal character in hostname at index 25: thrift://metastore.docker_default:9083
...
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

`docker-compose up` works after the changes and building the Docker image with `./build.sh -hive 3.1.3`
