### PR TITLE
HIVE-28173: Fixed staging dir issues on materialized views on HDFS en…

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestParseUtilsStagingDir.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestParseUtilsStagingDir.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.session.SessionState;
+
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test ParseUtils to see if a staging dir is created.
+ */
+public class TestParseUtilsStagingDir {
+  protected static final Logger LOG = LoggerFactory.getLogger(TestParseUtilsStagingDir.class.getName());
+
+  private static String jksFile = System.getProperty("java.io.tmpdir") + "/test.jks";
+
+  private static WarehouseInstance primary;
+  private static HiveConf conf;
+  private static MiniDFSCluster miniDFSCluster;
+
+  private static final String TABLE = "tbl";
+
+  @BeforeClass
+  public static void beforeClassSetup() throws Exception {
+    System.setProperty("jceks.key.serialFilter", "java.lang.Enum;java.security.KeyRep;" +
+        "java.security.KeyRep$Type;javax.crypto.spec.SecretKeySpec;" +
+        "org.apache.hadoop.crypto.key.JavaKeyStoreProvider$KeyMetadata;!*");
+    conf = new HiveConf();
+    conf.set("hadoop.security.key.provider.path", "jceks://file" + jksFile);
+
+    miniDFSCluster =
+        new MiniDFSCluster.Builder(conf).numDataNodes(1).format(true).build();
+
+    DFSTestUtil.createKey("test_key", miniDFSCluster, conf);
+    primary = new WarehouseInstance(LOG, miniDFSCluster, new HashMap<String, String>(),
+        "test_key");
+    SessionState.start((HiveConf) conf);
+  }
+
+  @AfterClass
+  public static void classLevelTearDown() throws IOException {
+    SessionState.get().close();
+    primary.close();
+    FileUtils.deleteQuietly(new File(jksFile));
+  }
+
+  /**
+   * Test to make sure staging directory is not created when the
+   * isLoadingMaterializedView flag is true and the file system
+   * is encrypted.
+   */
+  @Test
+  public void testGetStagingDirEncryptedWithMV() throws Exception {
+    Table table = createTable(TABLE, primary.warehouseRoot);
+    QB qb = createQB(table);
+    Context ctx = new Context(conf);
+    ctx.setIsLoadingMaterializedView(true);
+    Path path = SemanticAnalyzer.getStagingDirectoryPathname(qb, conf, ctx);
+    Assert.assertFalse(miniDFSCluster.getFileSystem().exists(path.getParent()));
+  }
+
+  /**
+   * Test to make sure staging directory is created when with no flags set when
+   * the file system is encrypted.
+   *
+   * Note: This might not be the correct behavior, but this was the behavior
+   * HIVE-28173 was fixed. It is too risky to change behavior for
+   * the default path.
+   */
+  @Test
+  public void testGetStagingDirEncrypted() throws Exception {
+    Table table = createTable(TABLE, primary.warehouseRoot);
+    QB qb = createQB(table);
+    Context ctx = new Context(conf);
+    Path path = SemanticAnalyzer.getStagingDirectoryPathname(qb, conf, ctx);
+    Assert.assertTrue(miniDFSCluster.getFileSystem().exists(path.getParent()));
+  }
+
+  /**
+   * Test that no staging directory is created for default behavior where the
+   * directory location is on the local file system.
+   */
+  @Test
+  public void testGetStagingDir() throws Exception {
+    Context ctx = new Context(conf);
+    QB qb = new QB("", "", false);
+    Path path = SemanticAnalyzer.getStagingDirectoryPathname(qb, conf, ctx);
+    FileSystem fs = FileSystem.getLocal(conf);
+    Assert.assertFalse(fs.exists(path.getParent()));
+  }
+
+  private static QB createQB(Table table) {
+    String tableName = table.getTTable().getTableName();
+    QB qb = new QB("", "", false);
+    qb.setTabAlias(tableName, tableName);
+    qb.getMetaData().setSrcForAlias(tableName, table);
+    return qb;
+  }
+
+  private static Table createTable(String tableName, Path location) {
+    Table table = new Table();
+    table.setTTable(createTTableObject(tableName));
+    table.setDataLocation(location);
+    return table;
+  }
+
+  private static org.apache.hadoop.hive.metastore.api.Table createTTableObject(String tableName) {
+    org.apache.hadoop.hive.metastore.api.Table tTable =
+        new org.apache.hadoop.hive.metastore.api.Table();
+    tTable.setSd(new StorageDescriptor());
+    tTable.setTableName(tableName);
+    return tTable;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -674,7 +674,7 @@ public class Context {
    *
    */
   public Path getMRScratchDir() {
-    return getMRScratchDir(!isExplainSkipExecution());
+    return getMRScratchDir(!isExplainSkipExecution() && !isLoadingMaterializedView());
   }
 
   /**
@@ -850,7 +850,9 @@ public class Context {
   }
 
   public Path getMRTmpPath(URI uri) {
-    return new Path(getStagingDir(new Path(uri), !isExplainSkipExecution()), MR_PREFIX + nextPathId());
+    return new Path(getStagingDir(new Path(uri),
+        !isExplainSkipExecution() && !isLoadingMaterializedView()),
+        MR_PREFIX + nextPathId());
   }
 
   public Path getMRTmpPath(boolean mkDir) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -364,7 +364,7 @@ public final class HiveMaterializedViewsRegistry {
     return materializedViewsCache.get(ast);
   }
 
-  private Context createContext(HiveConf conf) throws IOException {
+  private Context createContext(HiveConf conf) {
     Context ctx = new Context(conf);
     ctx.setIsLoadingMaterializedView(true);
     ctx.setHDFSCleanup(true);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.metadata;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.metadata;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -53,6 +54,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.DefaultMetaStoreFilterHookImpl;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.optimizer.calcite.CalciteSemanticException;
@@ -227,7 +229,7 @@ public final class HiveMaterializedViewsRegistry {
     }
     final CBOPlan plan;
     try {
-      plan = ParseUtils.parseQuery(conf, viewQuery);
+      plan = ParseUtils.parseQuery(createContext(conf), viewQuery);
     } catch (Exception e) {
       LOG.warn("Materialized view " + materializedViewTable.getCompleteName() +
           " ignored; error parsing original query; " + e);
@@ -360,6 +362,13 @@ public final class HiveMaterializedViewsRegistry {
 
   public List<HiveRelOptMaterialization> getRewritingMaterializedViews(ASTNode ast) {
     return materializedViewsCache.get(ast);
+  }
+
+  private Context createContext(HiveConf conf) throws IOException {
+    Context ctx = new Context(conf);
+    ctx.setIsLoadingMaterializedView(true);
+    ctx.setHDFSCleanup(true);
+    return ctx;
   }
 
   public boolean isEmpty() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
@@ -534,12 +534,10 @@ public final class ParseUtils {
     return sb.toString();
   }
 
-  public static CBOPlan parseQuery(HiveConf conf, String viewQuery)
+  public static CBOPlan parseQuery(Context ctx, String viewQuery)
       throws SemanticException, ParseException {
-    final Context ctx = new Context(conf);
-    ctx.setIsLoadingMaterializedView(true);
     final ASTNode ast = parse(viewQuery, ctx);
-    final CalcitePlanner analyzer = getAnalyzer(conf, ctx);
+    final CalcitePlanner analyzer = getAnalyzer((HiveConf) ctx.getConf(), ctx);
     RelNode logicalPlan = analyzer.genLogicalPlan(ast);
     return new CBOPlan(
         ast, logicalPlan, analyzer.getMaterializationValidationResult().getSupportedRewriteAlgorithms());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -2647,7 +2647,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           } else {
             // This is the only place where isQuery is set to true; it defaults to false.
             qb.setIsQuery(true);
-            Path stagingPath = getStagingDirectoryPathname(qb);
+            Path stagingPath = getStagingDirectoryPathname(qb, conf, ctx);
             fname = stagingPath.toString();
             ctx.setResDir(stagingPath);
           }
@@ -2715,7 +2715,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @return True if the path is encrypted; False if it is not encrypted
    * @throws HiveException If an error occurs while checking for encryption
    */
-  private boolean isPathEncrypted(Path path) throws HiveException {
+  private static boolean isPathEncrypted(Path path, HiveConf conf) throws HiveException {
 
     try {
       HadoopShims.HdfsEncryptionShim hdfsEncryptionShim =
@@ -2740,7 +2740,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @return -1 if strength is weak; 0 if is equals; 1 if it is stronger
    * @throws HiveException If an error occurs while comparing key strengths.
    */
-  private int comparePathKeyStrength(Path p1, Path p2) throws HiveException {
+  private static int comparePathKeyStrength(Path p1, Path p2, HiveConf conf) throws HiveException {
     try {
       HadoopShims.HdfsEncryptionShim hdfsEncryptionShim1 = SessionState.get().getHdfsEncryptionShim(p1.getFileSystem(conf), conf);
       HadoopShims.HdfsEncryptionShim hdfsEncryptionShim2 = SessionState.get().getHdfsEncryptionShim(p2.getFileSystem(conf), conf);
@@ -2762,7 +2762,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @return True if the path is read-only; False otherwise.
    * @throws HiveException If an error occurs while checking file permissions.
    */
-  private boolean isPathReadOnly(Path path) throws HiveException {
+  private static boolean isPathReadOnly(Path path) throws HiveException {
     HiveConf conf = SessionState.get().getConf();
     try {
       FileSystem fs = path.getFileSystem(conf);
@@ -2791,7 +2791,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @return The strongest encrypted path. It may return NULL if there are not tables encrypted, or are not HDFS tables.
    * @throws HiveException if an error occurred attempting to compare the encryption strength
    */
-  private Path getStrongestEncryptedTablePath(QB qb) throws HiveException {
+  private static Path getStrongestEncryptedTablePath(QB qb, HiveConf conf) throws HiveException {
     List<String> tabAliases = new ArrayList<String>(qb.getTabAliases());
     Path strongestPath = null;
 
@@ -2802,10 +2802,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         Path tablePath = tab.getDataLocation();
         if (tablePath != null) {
           if ("hdfs".equalsIgnoreCase(tablePath.toUri().getScheme())) {
-            if (isPathEncrypted(tablePath)) {
+            if (isPathEncrypted(tablePath, conf)) {
               if (strongestPath == null) {
                 strongestPath = tablePath;
-              } else if (comparePathKeyStrength(tablePath, strongestPath) > 0) {
+              } else if (comparePathKeyStrength(tablePath, strongestPath, conf) > 0) {
                 strongestPath = tablePath;
               }
             }
@@ -2829,19 +2829,19 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @return The path to the staging directory.
    * @throws HiveException If an error occurs while identifying the correct staging location.
    */
-  private Path getStagingDirectoryPathname(QB qb) throws HiveException {
+  static Path getStagingDirectoryPathname(QB qb, HiveConf conf, Context ctx) throws HiveException {
     Path stagingPath = null, tablePath = null;
 
     if (DFSUtilClient.isHDFSEncryptionEnabled(conf)) {
       // Looks for the most encrypted table location
       // It may return null if there are not tables encrypted, or are not part of HDFS
-      tablePath = getStrongestEncryptedTablePath(qb);
+      tablePath = getStrongestEncryptedTablePath(qb, conf);
     }
     if (tablePath != null) {
       // At this point, tablePath is part of HDFS and it is encrypted
       if (isPathReadOnly(tablePath)) {
         Path tmpPath = ctx.getMRTmpPath();
-        if (comparePathKeyStrength(tablePath, tmpPath) < 0) {
+        if (comparePathKeyStrength(tablePath, tmpPath, conf) < 0) {
           throw new HiveException("Read-only encrypted tables cannot be read " +
               "if the scratch directory is not encrypted (or encryption is weak)");
         } else {


### PR DESCRIPTION
…crypted tables

There are 2 issues involving staging directories on hdfs encrypted tables

1) The staging directory is created at compile time.  For non hdfs encrypted tables, the "mkdir" flag is set to false.
There is no such flag for hdfs encrypted tables.

2) The "FileSystem.deleteOnFileExit()" method is not called from the HiveMaterializedViewRegistry thread.

For the first issue, the fix has only been implemented for the materialized view registry thread. It is a bit more risky to implement this for all compiled queries in the SemanticAnalyzer, but perhaps it is correct. However, the implemented fix in this commit is similar to previous implemented logic and a customer has this specific problem on their production machines so this fix is important.

The second issue is also specifically fixed for the materialized view registry thread. A small refactoring was done since the "isLoadingMaterializedView" flag should not be set within ParseUtils

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Mentioned above

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixes an issue in a production environment.  Staging directories are being left behind after a materialized view update on an hdfs encrypted table

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Patch was tested in my local environment. Existing materialized view tests should test some of the changes. However, a huge framework change would have to be created to test things are working properly for the materialized view registry test. Given that this is a small change and given that this is a problem on a production environment, I think it's a bit hard to implement this kind of testing in a customer expected amount of time.
