### PR TITLE
HIVE-28188:Upgrade Postgres to 42.7.3 to target CVE-2024-1597

### DIFF
--- a/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -113,9 +113,9 @@ public class TestBeelineArgParsing {
         + File.separator + "org"
         + File.separator + "postgresql"
         + File.separator + "postgresql"
-        + File.separator + "42.5.1"
+        + File.separator + "42.5.6"
         + File.separator
-        + "postgresql-42.5.1.jar";
+        + "postgresql-42.5.6.jar";
     return Arrays.asList(new Object[][] {
         { "jdbc:postgresql://host:5432/testdb", "org.postgresql.Driver", pathToPostgresJar, true },
         { "jdbc:dummy://host:5432/testdb", dummyDriverClazzName, pathToDummyDriver, false } });

--- a/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -113,9 +113,9 @@ public class TestBeelineArgParsing {
         + File.separator + "org"
         + File.separator + "postgresql"
         + File.separator + "postgresql"
-        + File.separator + "42.5.6"
+        + File.separator + "42.7.3"
         + File.separator
-        + "postgresql-42.5.6.jar";
+        + "postgresql-42.7.3.jar";
     return Arrays.asList(new Object[][] {
         { "jdbc:postgresql://host:5432/testdb", "org.postgresql.Driver", pathToPostgresJar, true },
         { "jdbc:dummy://host:5432/testdb", dummyDriverClazzName, pathToDummyDriver, false } });

--- a/packaging/src/docker/README.md
+++ b/packaging/src/docker/README.md
@@ -60,7 +60,7 @@ For a quick start, launch the Metastore with Derby,
   docker run -d -p 9083:9083 --env SERVICE_NAME=metastore --env DB_DRIVER=postgres \
        --env SERVICE_OPTS="-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver -Djavax.jdo.option.ConnectionURL=jdbc:postgresql://postgres:5432/metastore_db -Djavax.jdo.option.ConnectionUserName=hive -Djavax.jdo.option.ConnectionPassword=password" \
        --mount source=warehouse,target=/opt/hive/data/warehouse \
-       --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar,target=/opt/hive/lib/postgres.jar \
+       --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar,target=/opt/hive/lib/postgres.jar \
        --name metastore-standalone apache/hive:${HIVE_VERSION}
   ```
 
@@ -69,7 +69,7 @@ For a quick start, launch the Metastore with Derby,
   ```shell
    docker run -d -p 9083:9083 --env SERVICE_NAME=metastore --env DB_DRIVER=postgres \
         -v /opt/hive/conf:/hive_custom_conf --env HIVE_CUSTOM_CONF_DIR=/hive_custom_conf \
-        --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar,target=/opt/hive/lib/postgres.jar \
+        --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar,target=/opt/hive/lib/postgres.jar \
         --name metastore apache/hive:${HIVE_VERSION}
   ```
 
@@ -118,7 +118,7 @@ export POSTGRES_LOCAL_PATH=your_local_path_to_postgres_driver
 Example:
 ```shell
 mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.7.3" && \
-export POSTGRES_LOCAL_PATH=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar 
+export POSTGRES_LOCAL_PATH=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar 
 ```
 If you don't install maven or have problem in resolving the postgres driver, you can always download this jar yourself,
 change the `POSTGRES_LOCAL_PATH` to the path of the downloaded jar.

--- a/packaging/src/docker/README.md
+++ b/packaging/src/docker/README.md
@@ -117,7 +117,7 @@ export POSTGRES_LOCAL_PATH=your_local_path_to_postgres_driver
 ```
 Example:
 ```shell
-mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.5.1" && \
+mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.5.6" && \
 export POSTGRES_LOCAL_PATH=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar 
 ```
 If you don't install maven or have problem in resolving the postgres driver, you can always download this jar yourself,

--- a/packaging/src/docker/README.md
+++ b/packaging/src/docker/README.md
@@ -117,7 +117,7 @@ export POSTGRES_LOCAL_PATH=your_local_path_to_postgres_driver
 ```
 Example:
 ```shell
-mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.5.6" && \
+mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.7.3" && \
 export POSTGRES_LOCAL_PATH=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar 
 ```
 If you don't install maven or have problem in resolving the postgres driver, you can always download this jar yourself,

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.31</mysql.version>
-    <postgres.version>42.5.6</postgres.version>
+    <postgres.version>42.7.3</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.8.5</orc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.31</mysql.version>
-    <postgres.version>42.5.1</postgres.version>
+    <postgres.version>42.5.6</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.8.5</orc.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -71,7 +71,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.31</mysql.version>
-    <postgres.version>42.5.6</postgres.version>
+    <postgres.version>42.7.3</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -71,7 +71,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.31</mysql.version>
-    <postgres.version>42.5.1</postgres.version>
+    <postgres.version>42.5.6</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrade Postgres to 42.5.6


### Why are the changes needed?
Target Critical CVE-2024-1597

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes
https://issues.apache.org/jira/secure/attachment/13068348/mvn_dependency_tree.txt

### How was this patch tested?
Locally Built relying on precommit tests
