### PR TITLE
HIVE-28192 Iceberg: Fix thread safety issue with PositionDeleteInfo i…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/IOContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/IOContext.java
@@ -51,7 +51,7 @@ public class IOContext {
    */
   private  RecordIdentifier ri;
   private boolean isDeletedRecord;
-  private PositionDeleteInfo pdi;
+  private ThreadLocal<PositionDeleteInfo> pdi = new ThreadLocal<>();
 
   public static enum Comparison {
     GREATER,
@@ -189,11 +189,11 @@ public class IOContext {
   }
 
   public void parsePositionDeleteInfo(Configuration configuration) {
-    this.pdi = PositionDeleteInfo.parseFromConf(configuration);
+    pdi.set(PositionDeleteInfo.parseFromConf(configuration));
   }
 
   public PositionDeleteInfo getPositionDeleteInfo() {
-    return pdi;
+    return pdi.get();
   }
 
   public boolean isDeletedRecord() {


### PR DESCRIPTION
…n IOContext

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Make PositionDeleteInfo in IOContext Thread Safe

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Assume:
Query in thread 1:  UPDATE customers SET first_name='Changed' WHERE  last_name='Henderson' OR last_name='Johnson'

Query in thread 2:  UPDATE customers SET first_name='Changed' WHERE  last_name='Taylor' AND customer_id=1

When there are concurrent update queries, PositionDeleteInfo is not thread safe, as a result the delete file of thread 1 end up with pointing to the delete record of query in thread 2  leading to a corrupted delete file. 

In this example, The delete file for "henderson" in thread 1 is pointing to the record "taylor"   in thread 2. As a result we are ending up with 2 entries for henderson
```
   ~  $HIVE_HOME/bin/hive --orcfiledump -d -p  /Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive3325124320669640146/external/customers/data/last_name=Henderson/customer_id_bucket=3/00000-0-delete-simhadri.govindappa_20240328120113_3f3c2165-9f33-4238-bc22-9095399c3b9e-job_17116524743461_0001-4-00002.orc

Processing data file /Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive3325124320669640146/external/customers/data/last_name=Henderson/customer_id_bucket=3/00000-0-delete-simhadri.govindappa_20240328120113_3f3c2165-9f33-4238-bc22-9095399c3b9e-job_17116524743461_0001-4-00002.orc [length: 1300]
{"file_path":"file:/Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive3325124320669640146/external/customers/data/last_name=Taylor/customer_id_bucket=4/00000-0-data-simhadri.govindappa_20240328120056_632c8bb7-b3af-42af-a931-2c1bd9094414-job_17116524611241_0001-1-00008.orc","pos":0}
```

writer.HiveIcebergDeleteWriter PositionDeleteInfo
```
2024-04-09T16:30:33,668  INFO [TezChild] writer.HiveIcebergDeleteWriter: Position Delete path : file:/Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive1709770127492899330/external/customers/data/last_name=Taylor/customer_id_bucket=4/00000-0-data-simhadri.govindappa_20240409163016_ef491269-f8b6-4626-b8fa-29a2b79f8fb5-job_17127054207561_0001-1-00008.orc, position delete: 0 position record : Record(1, Sharon, Taylor), this: org.apache.iceberg.mr.hive.writer.HiveIcebergDeleteWriter@48baf9bb

2024-04-09T16:30:33,669  INFO [TezChild] writer.HiveIcebergDeleteWriter: Position Delete path : file:/Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive1709770127492899330/external/customers/data/last_name=Johnson/customer_id_bucket=3/00000-0-data-simhadri.govindappa_20240409163016_ef491269-f8b6-4626-b8fa-29a2b79f8fb5-job_17127054207561_0001-1-00004.orc, position delete: 0 position record : Record(3, Trudy, Johnson), this: org.apache.iceberg.mr.hive.writer.HiveIcebergDeleteWriter@6f5d5991

2024-04-09T16:30:33,777  INFO [TezChild] writer.HiveIcebergDeleteWriter: Position Delete path : file:/Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive1709770127492899330/external/customers/data/last_name=Taylor/customer_id_bucket=4/00000-0-data-simhadri.govindappa_20240409163016_ef491269-f8b6-4626-b8fa-29a2b79f8fb5-job_17127054207561_0001-1-00008.orc, position delete: 0 position record : Record(3, Trudy, Henderson), this: org.apache.iceberg.mr.hive.writer.HiveIcebergDeleteWriter@6f5d5991
```

ORC Filedump of duplicate/old record.
```
$HIVE_HOME/bin/hive --orcfiledump -d -p  /Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive3325124320669640146/external/customers/data/last_name=Henderson/customer_id_bucket=3/00000-0-data-simhadri.govindappa_20240328120056_632c8bb7-b3af-42af-a931-2c1bd9094414-job_17116524611241_0001-1-00003.orc

Processing data file /Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive3325124320669640146/external/customers/data/last_name=Henderson/customer_id_bucket=3/00000-0-data-simhadri.govindappa_20240328120056_632c8bb7-b3af-42af-a931-2c1bd9094414-job_17116524611241_0001-1-00003.orc [length: 517]
{"customer_id":3,"first_name":"Trudy","last_name":"Henderson"}
________________________________________________________________________________________________________________________


$HIVE_HOME/bin/hive --orcfiledump -d -p  /Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive3325124320669640146/external/customers/data/last_name=Henderson/customer_id_bucket=3/00000-0-data-simhadri.govindappa_20240328120113_3f3c2165-9f33-4238-bc22-9095399c3b9e-job_17116524743462_0001-6-00001.orc

Processing data file /Users/simhadri.govindappa/Documents/apache/hive/iceberg/iceberg-handler/target/tmp/hive3325124320669640146/external/customers/data/last_name=Henderson/customer_id_bucket=3/00000-0-data-simhadri.govindappa_20240328120113_3f3c2165-9f33-4238-bc22-9095399c3b9e-job_17116524743462_0001-6-00001.orc [length: 523]
{"customer_id":3,"first_name":"Changed","last_name":"Henderson"}
________________________________________________________________________________________________________________________
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test: 
TestConflictingDataFiles