### PR TITLE
HIVE-28200: Improve get_partitions_by_filter/expr when partition limit enabled

### DIFF
--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
@@ -472,7 +472,7 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   @Override
   public List<String> listPartitionNames(String catName, String dbName, String tblName,
       String defaultPartName, byte[] exprBytes, String order,
-      short maxParts) throws MetaException, NoSuchObjectException {
+      int maxParts) throws MetaException, NoSuchObjectException {
 
     return objectStore.listPartitionNames(catName, dbName, tblName,
         defaultPartName, exprBytes, order, maxParts);
@@ -532,6 +532,12 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   public int getNumPartitionsByFilter(String catName, String dbName, String tblName,
                                       String filter) throws MetaException, NoSuchObjectException {
     return objectStore.getNumPartitionsByFilter(catName, dbName, tblName, filter);
+  }
+
+  @Override
+  public int getNumPartitionsByExpr(String catName, String dbName, String tblName,
+                                    byte[] expr) throws MetaException, NoSuchObjectException {
+    return objectStore.getNumPartitionsByExpr(catName, dbName, tblName, expr);
   }
 
   @Override
@@ -1632,12 +1638,6 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   public boolean getPartitionsByExpr(String catName, String dbName, String tblName,
                                      List<Partition> result, GetPartitionsArgs args) throws TException {
     return objectStore.getPartitionsByExpr(catName, dbName, tblName, result, args);
-  }
-
-  @Override
-  public boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
-                                           List<String> result, GetPartitionsArgs args) throws MetaException {
-    return objectStore.prunePartitionNamesByExpr(catName, dbName, tblName, result, args);
   }
 
   @Override

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
@@ -479,6 +479,12 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   }
 
   @Override
+  public List<String> listPartitionNamesByFilter(String catName, String dbName, String tblName,
+      GetPartitionsArgs args) throws MetaException, NoSuchObjectException {
+    return objectStore.listPartitionNamesByFilter(catName, dbName, tblName, args);
+  }
+
+  @Override
   public PartitionValuesResponse listPartitionValues(String catName, String db_name,
                                                      String tbl_name, List<FieldSchema> cols,
                                                      boolean applyDistinct, String filter,
@@ -526,12 +532,6 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   public int getNumPartitionsByFilter(String catName, String dbName, String tblName,
                                       String filter) throws MetaException, NoSuchObjectException {
     return objectStore.getNumPartitionsByFilter(catName, dbName, tblName, filter);
-  }
-
-  @Override
-  public int getNumPartitionsByExpr(String catName, String dbName, String tblName,
-                                    byte[] expr) throws MetaException, NoSuchObjectException {
-    return objectStore.getNumPartitionsByExpr(catName, dbName, tblName, expr);
   }
 
   @Override
@@ -1632,6 +1632,12 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   public boolean getPartitionsByExpr(String catName, String dbName, String tblName,
                                      List<Partition> result, GetPartitionsArgs args) throws TException {
     return objectStore.getPartitionsByExpr(catName, dbName, tblName, result, args);
+  }
+
+  @Override
+  public boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
+                                           List<String> result, GetPartitionsArgs args) throws MetaException {
+    return objectStore.prunePartitionNamesByExpr(catName, dbName, tblName, result, args);
   }
 
   @Override

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestMetaStoreLimitPartitionRequest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestMetaStoreLimitPartitionRequest.java
@@ -160,7 +160,7 @@ public class TestMetaStoreLimitPartitionRequest {
   @Test
   public void testSimpleQueryWithDirectSqlTooManyPartitions() throws Exception {
     String queryString = "select value from %s where ds>'2008-04-20'";
-    executeQueryExceedPartitionLimit(queryString, 8);
+    executeQueryExceedPartitionLimit(queryString, 5);
   }
 
   @Test
@@ -244,20 +244,20 @@ public class TestMetaStoreLimitPartitionRequest {
   public void testQueryWithInWithFallbackToORMTooManyPartitions() throws Exception {
     setupNumTmpTable();
     String queryString = "select value from %s a where a.num in (select value from " + TABLE_NAME + "_num_tmp)";
-    executeQueryExceedPartitionLimit(queryString, 12);
+    executeQueryExceedPartitionLimit(queryString, 5);
   }
 
   @Test
   public void testQueryWithInWithFallbackToORMTooManyPartitions2() throws Exception {
     setupNumTmpTable();
     String queryString = "select value from %s a where a.num in (select value from " + TABLE_NAME + "_num_tmp where value='25')";
-    executeQueryExceedPartitionLimit(queryString, 12);
+    executeQueryExceedPartitionLimit(queryString, 5);
   }
 
   @Test
   public void testQueryWithLikeWithFallbackToORMTooManyPartitions() throws Exception {
     String queryString = "select value from %s where num like '3%%'";
-    executeQueryExceedPartitionLimit(queryString, 6);
+    executeQueryExceedPartitionLimit(queryString, 5);
   }
 
   private void setupNumTmpTable() throws SQLException {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1052,7 +1052,7 @@ public class MetastoreConf {
                 "get_partitions_by_names, \n" +
                 "get_partitions_with_auth, \n" +
                 "get_partitions_by_filter, \n" +
-                "get_partitions_spec_by_filter, \n" +
+                "get_partitions_spec_by_expr, \n" +
                 "get_partitions_by_expr,\n" +
                 "get_partitions_ps,\n" +
                 "get_partitions_ps_with_auth.\n" +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -7227,10 +7227,11 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       authorizeTableForPartitionMetadata(catName, dbName, tblName);
       if (needCheckPartitionLimit(args.getMax())) {
         // Since partition limit is configured, we need fetch at most (limit + 1) partition names
+        int requestMax = args.getMax();
         int max = MetastoreConf.getIntVar(conf, ConfVars.LIMIT_PARTITION_REQUEST) + 1;
         args = new GetPartitionsArgs.GetPartitionsArgsBuilder(args).max(max).build();
         List<String> partNames = rs.listPartitionNamesByFilter(catName, dbName, tblName, args);
-        checkLimitNumberOfPartitions(tblName, partNames.size(), args.getMax());
+        checkLimitNumberOfPartitions(tblName, partNames.size(), requestMax);
         ret = rs.getPartitionsByNames(catName, dbName, tblName,
             new GetPartitionsArgs.GetPartitionsArgsBuilder(args).partNames(partNames).build());
       } else {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -5569,15 +5569,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     }
   }
 
-  private void checkLimitNumberOfPartitionsByExpr(String catName, String dbName, String tblName,
-                                                  byte[] filterExpr, int maxParts)
-      throws TException {
-    if (isPartitionLimitEnabled()) {
-      checkLimitNumberOfPartitions(tblName, get_num_partitions_by_expr(catName, dbName, tblName,
-          filterExpr), maxParts);
-    }
-  }
-
   private void checkLimitNumberOfPartitionsByPs(String catName, String dbName, String tblName,
                                                 List<String> partVals, int maxParts)
           throws TException {
@@ -7223,13 +7214,21 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     fireReadTablePreEvent(catName, dbName, tblName);
     List<Partition> ret = null;
     Exception ex = null;
+    RawStore rs = getMS();
     try {
-      checkLimitNumberOfPartitionsByFilter(catName, dbName,
-          tblName, args.getFilter(), args.getMax());
-
       authorizeTableForPartitionMetadata(catName, dbName, tblName);
+      if (isPartitionLimitEnabled()) {
+        // Since partition limit is configured, we need fetch at most (limit + 1) partition names
+        int partitionLimit = MetastoreConf.getIntVar(conf, ConfVars.LIMIT_PARTITION_REQUEST);
+        int max = args.getMax() < 0 ? partitionLimit + 1 : Math.min(args.getMax(), partitionLimit + 1);
+        args = new GetPartitionsArgs.GetPartitionsArgsBuilder(args).max(max).build();
+        List<String> partNames = rs.listPartitionNamesByFilter(catName, dbName, tblName, args);
+        checkLimitNumberOfPartitions(TableName.getQualified(catName, dbName, tblName), partNames.size(), -1);
+        ret = rs.getPartitionsByNames(catName, dbName, tblName, partNames);
+      } else {
+        ret = rs.getPartitionsByFilter(catName, dbName, tblName, args);
+      }
 
-      ret = getMS().getPartitionsByFilter(catName, dbName, tblName, args);
       ret = FilterUtils.filterPartitionsIfEnabled(isServerFilterEnabled, filterHook, ret);
     } catch (Exception e) {
       ex = e;
@@ -7296,9 +7295,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     PartitionsSpecByExprResult ret = null;
     Exception ex = null;
     try {
-      checkLimitNumberOfPartitionsByExpr(catName, dbName, tblName, req.getExpr(), UNLIMITED_MAX_PARTITIONS);
-      List<Partition> partitions = new LinkedList<>();
-      boolean hasUnknownPartitions = getMS().getPartitionsByExpr(catName, dbName, tblName, partitions,
+      PartitionsByExprResult result = get_partitions_by_expr_internal(catName, dbName, tblName,
           new GetPartitionsArgs.GetPartitionsArgsBuilder()
               .expr(req.getExpr()).max(req.getMaxParts()).defaultPartName(req.getDefaultPartitionName())
               .skipColumnSchemaForPartition(req.isSkipColumnSchemaForPartition())
@@ -7307,8 +7304,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
               .build());
       Table table = get_table_core(catName, dbName, tblName);
       List<PartitionSpec> partitionSpecs =
-          MetaStoreServerUtils.getPartitionspecsGroupedByStorageDescriptor(table, partitions);
-      ret = new PartitionsSpecByExprResult(partitionSpecs, hasUnknownPartitions);
+          MetaStoreServerUtils.getPartitionspecsGroupedByStorageDescriptor(table, result.getPartitions());
+      ret = new PartitionsSpecByExprResult(partitionSpecs, result.isHasUnknownPartitions());
     } catch (Exception e) {
       ex = e;
       rethrowException(e);
@@ -7331,16 +7328,13 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     PartitionsByExprResult ret = null;
     Exception ex = null;
     try {
-      checkLimitNumberOfPartitionsByExpr(catName, dbName, tblName, req.getExpr(), UNLIMITED_MAX_PARTITIONS);
-      List<Partition> partitions = new LinkedList<>();
-      boolean hasUnknownPartitions = getMS().getPartitionsByExpr(catName, dbName, tblName, partitions,
+      ret = get_partitions_by_expr_internal(catName, dbName, tblName,
           new GetPartitionsArgs.GetPartitionsArgsBuilder()
               .expr(req.getExpr()).defaultPartName(req.getDefaultPartitionName()).max(req.getMaxParts())
               .skipColumnSchemaForPartition(req.isSkipColumnSchemaForPartition())
               .excludeParamKeyPattern(req.getExcludeParamKeyPattern())
               .includeParamKeyPattern(req.getIncludeParamKeyPattern())
               .build());
-      ret = new PartitionsByExprResult(partitions, hasUnknownPartitions);
     } catch (Exception e) {
       ex = e;
       rethrowException(e);
@@ -7348,6 +7342,24 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       endFunction("get_partitions_by_expr", ret != null, ex, tblName);
     }
     return ret;
+  }
+
+  private PartitionsByExprResult get_partitions_by_expr_internal(
+      String catName, String dbName, String tblName, GetPartitionsArgs args) throws TException {
+    List<Partition> partitions = new LinkedList<>();
+    boolean hasUnknownPartitions = false;
+    RawStore rs = getMS();
+    if (isPartitionLimitEnabled()) {
+      // Since partition limit is configured, we need fetch at most (limit + 1) partition names
+      int partitionLimit = MetastoreConf.getIntVar(conf, ConfVars.LIMIT_PARTITION_REQUEST);
+      int max = args.getMax() < 0 ? partitionLimit + 1 : Math.min(args.getMax(), partitionLimit + 1);
+      List<String> partNames = rs.listPartitionNames(catName, dbName, tblName, args.getDefaultPartName(), args.getExpr(), null, (short) max);
+      checkLimitNumberOfPartitions(TableName.getQualified(catName, dbName, tblName), partNames.size(), -1);
+      partitions = rs.getPartitionsByNames(catName, dbName, tblName, partNames);
+    } else {
+      hasUnknownPartitions = rs.getPartitionsByExpr(catName, dbName, tblName, partitions, args);
+    }
+    return new PartitionsByExprResult(partitions, hasUnknownPartitions);
   }
 
   @Override
@@ -7373,22 +7385,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       rethrowException(e);
     } finally {
       endFunction("get_num_partitions_by_filter", ret != -1, ex, tblName);
-    }
-    return ret;
-  }
-
-  private int get_num_partitions_by_expr(final String catName, final String dbName,
-                                         final String tblName, final byte[] expr)
-      throws TException {
-    int ret = -1;
-    Exception ex = null;
-    try {
-      ret = getMS().getNumPartitionsByExpr(catName, dbName, tblName, expr);
-    } catch (Exception e) {
-      ex = e;
-      rethrowException(e);
-    } finally {
-      endFunction("get_num_partitions_by_expr", ret != -1, ex, tblName);
     }
     return ret;
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -1030,7 +1030,7 @@ class MetaStoreDirectSql {
     return getPartitionsByQuery(catName, dbName, tblName, queryText, params, isAcidTable, args);
   }
 
-  public List<Partition> getPartitionsByPartitionIdsInBatch(String catName, String dbName,
+  private List<Partition> getPartitionsByPartitionIdsInBatch(String catName, String dbName,
       String tblName, List<Long> partIdList, boolean isAcidTable, GetPartitionsArgs args)
       throws MetaException {
     if (partIdList.isEmpty()) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -757,15 +757,8 @@ class MetaStoreDirectSql {
     List<Long> partitionIds = getPartitionIdsViaSqlFilter(catName,
         dbName, tableName, filter.filter, filter.params,
         filter.joins, args.getMax());
-    if (partitionIds.isEmpty()) {
-      return Collections.emptyList(); // no partitions, bail early.
-    }
-    return Batchable.runBatched(batchSize, partitionIds, new Batchable<Long, Partition>() {
-      @Override
-      public List<Partition> run(List<Long> input) throws MetaException {
-        return getPartitionsByPartitionIds(catName, dbName, tableName, input, isAcidTable, args);
-      }
-    });
+
+    return getPartitionsByPartitionIdsInBatch(catName, dbName, tableName, partitionIds, isAcidTable, args);
   }
 
   /**
@@ -909,18 +902,9 @@ class MetaStoreDirectSql {
       String dbName, String tblName, GetPartitionsArgs args) throws MetaException {
     List<Long> partitionIds = getPartitionIdsViaSqlFilter(catName, dbName,
         tblName, null, Collections.<String>emptyList(), Collections.<String>emptyList(), args.getMax());
-    if (partitionIds.isEmpty()) {
-      return Collections.emptyList(); // no partitions, bail early.
-    }
 
     // Get full objects. For Oracle/etc. do it in batches.
-    List<Partition> result = Batchable.runBatched(batchSize, partitionIds, new Batchable<Long, Partition>() {
-      @Override
-      public List<Partition> run(List<Long> input) throws MetaException {
-        return getPartitionsByPartitionIds(catName, dbName, tblName, input, false, args);
-      }
-    });
-    return result;
+    return getPartitionsByPartitionIdsInBatch(catName, dbName, tblName, partitionIds, false, args);
   }
 
   private static Boolean isViewTable(Table t) {
@@ -1044,6 +1028,20 @@ class MetaStoreDirectSql {
 
     Object[] params = new Object[]{tblName, dbName, catName};
     return getPartitionsByQuery(catName, dbName, tblName, queryText, params, isAcidTable, args);
+  }
+
+  public List<Partition> getPartitionsByPartitionIdsInBatch(String catName, String dbName,
+      String tblName, List<Long> partIdList, boolean isAcidTable, GetPartitionsArgs args)
+      throws MetaException {
+    if (partIdList.isEmpty()) {
+      return Collections.emptyList(); // no partitions, bail early.
+    }
+    return Batchable.runBatched(batchSize, partIdList, new Batchable<Long, Partition>() {
+      @Override
+      public List<Partition> run(List<Long> input) throws MetaException {
+        return getPartitionsByPartitionIds(catName, dbName, tblName, input, isAcidTable, args);
+      }
+    });
   }
 
   /** Should be called with the list short enough to not trip up Oracle/etc. */

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
@@ -697,7 +697,7 @@ public interface RawStore extends Configurable {
    */
   List<String> listPartitionNames(String catName, String dbName, String tblName,
       String defaultPartName, byte[] exprBytes, String order,
-      short maxParts) throws MetaException, NoSuchObjectException;
+      int maxParts) throws MetaException, NoSuchObjectException;
 
   /**
    * Get partition names with a filter. This is a portion of the SQL where clause.
@@ -869,20 +869,6 @@ public interface RawStore extends Configurable {
       throws TException;
 
   /**
-   * Prune the input partition names that match the expressions.
-   * @param catName catalog name
-   * @param dbName database name
-   * @param tblName table name
-   * @param result input list of partition names
-   * @param args additional arguments for pruning
-   * @return true if the result contains unknown partition names.
-   * @throws MetaException error executing the expression
-   */
-  boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
-      List<String> result, GetPartitionsArgs args)
-      throws MetaException;
-
-  /**
    * Get the number of partitions that match a provided SQL filter.
    * @param catName catalog name.
    * @param dbName database name.
@@ -894,6 +880,20 @@ public interface RawStore extends Configurable {
    */
   int getNumPartitionsByFilter(String catName, String dbName, String tblName, String filter)
     throws MetaException, NoSuchObjectException;
+
+  /**
+   * Get the number of partitions that match an already parsed expression.
+   * @param catName catalog name.
+   * @param dbName database name.
+   * @param tblName table name.
+   * @param expr an already parsed Hive expression
+   * @return number of matching partitions.
+   * @throws MetaException error accessing the RDBMS or working with the expression.
+   * @throws NoSuchObjectException no such table.
+   */
+  @Deprecated
+  int getNumPartitionsByExpr(String catName, String dbName, String tblName, byte[] expr)
+      throws MetaException, NoSuchObjectException;
 
   /**
    * Get the number of partitions that match a given partial specification.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
@@ -700,6 +700,19 @@ public interface RawStore extends Configurable {
       short maxParts) throws MetaException, NoSuchObjectException;
 
   /**
+   * Get partition names with a filter. This is a portion of the SQL where clause.
+   * @param catName catalog name
+   * @param dbName database name
+   * @param tblName table name
+   * @param args additional arguments for getting partition names
+   * @return list of partition names matching the criteria
+   * @throws MetaException Error accessing the RDBMS or processing the filter.
+   * @throws NoSuchObjectException no such table.
+   */
+  List<String> listPartitionNamesByFilter(String catName, String dbName, String tblName,
+      GetPartitionsArgs args) throws MetaException, NoSuchObjectException;
+
+  /**
    * Get a list of partition values as one big struct.
    * @param catName catalog name.
    * @param db_name database name.
@@ -856,6 +869,20 @@ public interface RawStore extends Configurable {
       throws TException;
 
   /**
+   * Prune the input partition names that match the expressions.
+   * @param catName catalog name
+   * @param dbName database name
+   * @param tblName table name
+   * @param result input list of partition names
+   * @param args additional arguments for pruning
+   * @return true if the result contains unknown partition names.
+   * @throws MetaException error executing the expression
+   */
+  boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
+      List<String> result, GetPartitionsArgs args)
+      throws MetaException;
+
+  /**
    * Get the number of partitions that match a provided SQL filter.
    * @param catName catalog name.
    * @param dbName database name.
@@ -867,19 +894,6 @@ public interface RawStore extends Configurable {
    */
   int getNumPartitionsByFilter(String catName, String dbName, String tblName, String filter)
     throws MetaException, NoSuchObjectException;
-
-  /**
-   * Get the number of partitions that match an already parsed expression.
-   * @param catName catalog name.
-   * @param dbName database name.
-   * @param tblName table name.
-   * @param expr an already parsed Hive expression
-   * @return number of matching partitions.
-   * @throws MetaException error accessing the RDBMS or working with the expression.
-   * @throws NoSuchObjectException no such table.
-   */
-  int getNumPartitionsByExpr(String catName, String dbName, String tblName, byte[] expr)
-      throws MetaException, NoSuchObjectException;
 
   /**
    * Get the number of partitions that match a given partial specification.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
@@ -1643,7 +1643,7 @@ public class CachedStore implements RawStore, Configurable {
 
   @Override
   public List<String> listPartitionNames(String catName, String dbName, String tblName, String defaultPartName,
-      byte[] exprBytes, String order, short maxParts) throws MetaException, NoSuchObjectException {
+      byte[] exprBytes, String order, int maxParts) throws MetaException, NoSuchObjectException {
     throw new UnsupportedOperationException();
   }
 
@@ -1749,14 +1749,28 @@ public class CachedStore implements RawStore, Configurable {
     return hasUnknownPartitions;
   }
 
-  @Override public boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
-      List<String> result, GetPartitionsArgs args) throws MetaException {
-    return rawStore.prunePartitionNamesByExpr(catName, dbName, tblName, result, args);
-  }
-
   @Override public int getNumPartitionsByFilter(String catName, String dbName, String tblName, String filter)
       throws MetaException, NoSuchObjectException {
     return rawStore.getNumPartitionsByFilter(catName, dbName, tblName, filter);
+  }
+
+  @Override public int getNumPartitionsByExpr(String catName, String dbName, String tblName, byte[] expr)
+      throws MetaException, NoSuchObjectException {
+    catName = normalizeIdentifier(catName);
+    dbName = StringUtils.normalizeIdentifier(dbName);
+    tblName = StringUtils.normalizeIdentifier(tblName);
+    if (!shouldCacheTable(catName, dbName, tblName) || (canUseEvents && rawStore.isActiveTransaction())) {
+      return rawStore.getNumPartitionsByExpr(catName, dbName, tblName, expr);
+    }
+    String defaultPartName = MetastoreConf.getVar(getConf(), ConfVars.DEFAULTPARTITIONNAME);
+    List<String> partNames = new LinkedList<>();
+    Table table = sharedCache.getTableFromCache(catName, dbName, tblName);
+    if (table == null) {
+      // The table is not yet loaded in cache
+      return rawStore.getNumPartitionsByExpr(catName, dbName, tblName, expr);
+    }
+    getPartitionNamesPrunedByExprNoTxn(table, expr, defaultPartName, Short.MAX_VALUE, partNames, sharedCache);
+    return partNames.size();
   }
 
   @VisibleForTesting public static List<String> partNameToVals(String name) {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
@@ -444,6 +444,12 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
   }
 
   @Override
+  public List<String> listPartitionNamesByFilter(String catName, String dbName, String tblName,
+      GetPartitionsArgs args) throws MetaException, NoSuchObjectException {
+    return objectStore.listPartitionNamesByFilter(catName, dbName, tblName, args);
+  }
+
+  @Override
   public PartitionValuesResponse listPartitionValues(String catName, String db_name,
       String tbl_name, List<FieldSchema> cols, boolean applyDistinct, String filter,
       boolean ascending, List<FieldSchema> order, long maxParts) throws MetaException {
@@ -490,12 +496,6 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
   }
 
   @Override
-  public int getNumPartitionsByExpr(String catName, String dbName, String tblName,
-                                      byte[] expr) throws MetaException, NoSuchObjectException {
-    return objectStore.getNumPartitionsByExpr(catName, dbName, tblName, expr);
-  }
-
-  @Override
   public int getNumPartitionsByPs(String catName, String dbName, String tblName, List<String> partVals)
       throws MetaException, NoSuchObjectException {
     return objectStore.getNumPartitionsByPs(catName, dbName, tblName, partVals);
@@ -525,6 +525,12 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
                                        List<Partition> result, GetPartitionsArgs args) throws TException {
         return objectStore.getPartitionsByExpr(catName, dbName, tblName, result, args);
     }
+
+  @Override
+  public boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
+                                           List<String> result, GetPartitionsArgs args) throws MetaException {
+    return objectStore.prunePartitionNamesByExpr(catName, dbName, tblName, result, args);
+  }
 
   @Override
   public Table markPartitionForEvent(String catName, String dbName, String tblName,

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
@@ -438,7 +438,7 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
 
   @Override
   public List<String> listPartitionNames(String catName, String dbName, String tblName, String defaultPartName,
-      byte[] exprBytes, String order, short maxParts) throws MetaException, NoSuchObjectException {
+      byte[] exprBytes, String order, int maxParts) throws MetaException, NoSuchObjectException {
     return objectStore.listPartitionNames(catName, dbName, tblName,
         defaultPartName, exprBytes, order, maxParts);
   }
@@ -496,6 +496,12 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
   }
 
   @Override
+  public int getNumPartitionsByExpr(String catName, String dbName, String tblName,
+                                      byte[] expr) throws MetaException, NoSuchObjectException {
+    return objectStore.getNumPartitionsByExpr(catName, dbName, tblName, expr);
+  }
+
+  @Override
   public int getNumPartitionsByPs(String catName, String dbName, String tblName, List<String> partVals)
       throws MetaException, NoSuchObjectException {
     return objectStore.getNumPartitionsByPs(catName, dbName, tblName, partVals);
@@ -525,12 +531,6 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
                                        List<Partition> result, GetPartitionsArgs args) throws TException {
         return objectStore.getPartitionsByExpr(catName, dbName, tblName, result, args);
     }
-
-  @Override
-  public boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
-                                           List<String> result, GetPartitionsArgs args) throws MetaException {
-    return objectStore.prunePartitionNamesByExpr(catName, dbName, tblName, result, args);
-  }
 
   @Override
   public Table markPartitionForEvent(String catName, String dbName, String tblName,

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
@@ -453,7 +453,7 @@ public class DummyRawStoreForJdoConnection implements RawStore {
 
   @Override
   public List<String> listPartitionNames(String catName, String dbName, String tblName, String defaultPartName,
-      byte[] exprBytes, String order, short maxParts) throws MetaException, NoSuchObjectException {
+      byte[] exprBytes, String order, int maxParts) throws MetaException, NoSuchObjectException {
 
     return Collections.emptyList();
   }
@@ -534,14 +534,14 @@ public class DummyRawStoreForJdoConnection implements RawStore {
   }
 
   @Override
-  public boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
-      List<String> result, GetPartitionsArgs args) throws MetaException {
-    return false;
+  public int getNumPartitionsByFilter(String catName, String dbName, String tblName, String filter)
+    throws MetaException, NoSuchObjectException {
+    return -1;
   }
 
   @Override
-  public int getNumPartitionsByFilter(String catName, String dbName, String tblName, String filter)
-    throws MetaException, NoSuchObjectException {
+  public int getNumPartitionsByExpr(String catName, String dbName, String tblName, byte[] expr)
+      throws MetaException, NoSuchObjectException {
     return -1;
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
@@ -459,6 +459,12 @@ public class DummyRawStoreForJdoConnection implements RawStore {
   }
 
   @Override
+  public List<String> listPartitionNamesByFilter(String catName, String dbName, String tblName,
+      GetPartitionsArgs args) throws MetaException, NoSuchObjectException {
+    return Collections.emptyList();
+  }
+
+  @Override
   public PartitionValuesResponse listPartitionValues(String catName, String db_name,
                                                      String tbl_name, List<FieldSchema> cols,
                                                      boolean applyDistinct, String filter,
@@ -528,14 +534,14 @@ public class DummyRawStoreForJdoConnection implements RawStore {
   }
 
   @Override
-  public int getNumPartitionsByFilter(String catName, String dbName, String tblName, String filter)
-    throws MetaException, NoSuchObjectException {
-    return -1;
+  public boolean prunePartitionNamesByExpr(String catName, String dbName, String tblName,
+      List<String> result, GetPartitionsArgs args) throws MetaException {
+    return false;
   }
 
   @Override
-  public int getNumPartitionsByExpr(String catName, String dbName, String tblName, byte[] expr)
-      throws MetaException, NoSuchObjectException {
+  public int getNumPartitionsByFilter(String catName, String dbName, String tblName, String filter)
+    throws MetaException, NoSuchObjectException {
     return -1;
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -509,6 +509,66 @@ public class TestObjectStore {
   }
 
   @Test
+  public void testListPartitionNamesByFilter() throws Exception {
+    Database db1 = new DatabaseBuilder()
+        .setName(DB1)
+        .setDescription("description")
+        .setLocation("locationurl")
+        .build(conf);
+    try (AutoCloseable c = deadline()) {
+      objectStore.createDatabase(db1);
+    }
+    StorageDescriptor sd = createFakeSd("location");
+    HashMap<String, String> tableParams = new HashMap<>();
+    tableParams.put("EXTERNAL", "false");
+    FieldSchema partitionKey1 = new FieldSchema("Country", ColumnType.STRING_TYPE_NAME, "");
+    FieldSchema partitionKey2 = new FieldSchema("State", ColumnType.STRING_TYPE_NAME, "");
+    Table tbl1 =
+        new Table(TABLE1, DB1, "owner", 1, 2, 3, sd, Arrays.asList(partitionKey1, partitionKey2),
+            tableParams, null, null, "MANAGED_TABLE");
+    try (AutoCloseable c = deadline()) {
+      objectStore.createTable(tbl1);
+    }
+    HashMap<String, String> partitionParams = new HashMap<>();
+    partitionParams.put("PARTITION_LEVEL_PRIVILEGE", "true");
+    List<String> value1 = Arrays.asList("US", "CA");
+    Partition part1 = new Partition(value1, DB1, TABLE1, 111, 111, sd, partitionParams);
+    part1.setCatName(DEFAULT_CATALOG_NAME);
+    try (AutoCloseable c = deadline()) {
+      objectStore.addPartition(part1);
+    }
+    List<String> value2 = Arrays.asList("US", "MA");
+    Partition part2 = new Partition(value2, DB1, TABLE1, 222, 222, sd, partitionParams);
+    part2.setCatName(DEFAULT_CATALOG_NAME);
+    try (AutoCloseable c = deadline()) {
+      objectStore.addPartition(part2);
+    }
+
+    List<String> partNames;
+    try (AutoCloseable c = deadline()) {
+      partNames = objectStore.listPartitionNamesByFilter(DEFAULT_CATALOG_NAME, DB1, TABLE1,
+          new GetPartitionsArgs.GetPartitionsArgsBuilder().filter("Country = 'US'").build());
+    }
+    Assert.assertEquals(2, partNames.size());
+    Assert.assertEquals("country=US/state=CA", partNames.get(0));
+    Assert.assertEquals("country=US/state=MA", partNames.get(1));
+
+    try (AutoCloseable c = deadline()) {
+      partNames = objectStore.listPartitionNamesByFilter(DEFAULT_CATALOG_NAME, DB1, TABLE1,
+          new GetPartitionsArgs.GetPartitionsArgsBuilder().filter("State = 'MA'").build());
+    }
+    Assert.assertEquals(1, partNames.size());
+    Assert.assertEquals("country=US/state=MA", partNames.get(0));
+
+    try (AutoCloseable c = deadline()) {
+      partNames = objectStore.listPartitionNamesByFilter(DEFAULT_CATALOG_NAME, DB1, TABLE1,
+          new GetPartitionsArgs.GetPartitionsArgsBuilder().filter("Country = 'US' and State = 'MA'").build());
+    }
+    Assert.assertEquals(1, partNames.size());
+    Assert.assertEquals("country=US/state=MA", partNames.get(0));
+  }
+
+  @Test
   public void testDropPartitionByName() throws Exception {
     Database db1 = new DatabaseBuilder()
         .setName(DB1)

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/BenchmarkUtils.java
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/BenchmarkUtils.java
@@ -58,11 +58,15 @@ public class BenchmarkUtils {
 
   // Create a simple table with a single column and single partition
   static void createPartitionedTable(HMSClient client, String dbName, String tableName) {
+    createPartitionedTable(client, dbName, tableName, createSchema(Collections.singletonList("date")));
+  }
+
+  static void createPartitionedTable(HMSClient client, String dbName, String tableName, List<FieldSchema> partitionKeys) {
     throwingSupplierWrapper(() -> client.createTable(
         new Util.TableBuilder(dbName, tableName)
             .withType(TableType.MANAGED_TABLE)
             .withColumns(createSchema(Collections.singletonList("name:string")))
-            .withPartitionKeys(createSchema(Collections.singletonList("date")))
+            .withPartitionKeys(partitionKeys)
             .build()));
   }
 

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/HMSBenchmarks.java
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/HMSBenchmarks.java
@@ -419,14 +419,19 @@ final class HMSBenchmarks {
     String dbName = data.dbName;
     String tableName = data.tableName;
 
-    BenchmarkUtils.createPartitionedTable(client, dbName, tableName);
+    BenchmarkUtils.createPartitionedTable(client, dbName, tableName, createSchema(Arrays.asList("p_a", "p_b", "p_c")));
     try {
       addManyPartitionsNoException(client, dbName, tableName, null,
-              Collections.singletonList("d"), count);
+              Arrays.asList("a", "b", "c"), count);
       return bench.measure(
           () ->
-              throwingSupplierWrapper(() ->
-                  client.getPartitionsByFilter(dbName, tableName, "`date`='d0'"))
+              throwingSupplierWrapper(() -> {
+                  // test multiple cases for get_partitions_by_filter
+                  client.getPartitionsByFilter(dbName, tableName, "`p_a`='a0'");
+                  client.getPartitionsByFilter(dbName, tableName,
+                      "`p_a`='a0' or `p_b`='b0' or `p_c`='c0' or `p_a`='a1' or `p_b`='b1' or `p_c`='c1'");
+              return null;
+              })
       );
     } finally {
       throwingSupplierWrapper(() -> client.dropTable(dbName, tableName));


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `hive.metastore.limit.partition.request` is configured, HMS would get the matched partition counts before getting the real partition objects. The count operation could be a slow query if the input filter or expr is too complex, and such slow filter will be executed twice.
We can make an improvement by the new steps:
1. get matched partition names firstly, 
2. then check limit through the size of partition names,
3.  finally get the partitions by the partition names.

### Why are the changes needed?
To reduce the slow filter execute times.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Add unit test and benchmark test.

```bash
java -jar hmsbench.jar -H localhost --savedata /tmp/benchdata --sanitize -N 100 -N 10000 -o bench_results.csv -C -d testbench_http --params=100 -M 'getPartitionsByFilter.*'
```
- Before this patch
```bash
Operation       Mean    Med     Min     Max     Err%
getPartitionsByFilter   15.5682 15.1223 14.1135 20.1627 8.36433
getPartitionsByFilter.100       15.0892 14.9975 14.4175 17.5468 3.42779
getPartitionsByFilter.10000     36.3477 36.1636 35.1360 40.1805 2.22496
```
- After this patch
```bash
Operation       Mean    Med     Min     Max     Err%
getPartitionsByFilter   10.5924 10.4109 9.78332 21.0283 12.3698
getPartitionsByFilter.100       10.5717 10.4636 9.89701 18.8140 8.36692
getPartitionsByFilter.10000     22.5289 21.8280 20.8911 30.0108 7.28651
```