### PR TITLE
HIVE-28210: Print Tez summary by default in tests

### DIFF
--- a/data/conf/hive-site.xml
+++ b/data/conf/hive-site.xml
@@ -369,4 +369,9 @@
     <name>hive.async.cleanup.service.thread.count</name>
     <value>4</value>
   </property>
+
+  <property>
+    <name>hive.tez.exec.print.summary</name>
+    <value>true</value>
+  </property>
 </configuration>

--- a/data/conf/iceberg/llap/hive-site.xml
+++ b/data/conf/iceberg/llap/hive-site.xml
@@ -279,6 +279,11 @@
     </property>
 
     <property>
+        <name>hive.tez.exec.print.summary</name>
+        <value>true</value>
+    </property>
+
+    <property>
         <name>hive.llap.cache.allow.synthetic.fileid</name>
         <value>true</value>
     </property>

--- a/data/conf/iceberg/tez/hive-site.xml
+++ b/data/conf/iceberg/tez/hive-site.xml
@@ -265,6 +265,11 @@
 </property>
 
 <property>
+  <name>hive.tez.exec.print.summary</name>
+  <value>true</value>
+</property>
+
+<property>
   <name>hive.orc.splits.ms.footer.cache.enabled</name>
   <value>true</value>
 </property>

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -276,6 +276,11 @@
 </property>
 
 <property>
+  <name>hive.tez.exec.print.summary</name>
+  <value>true</value>
+</property>
+
+<property>
   <name>hive.llap.cache.allow.synthetic.fileid</name>
   <value>true</value>
 </property>

--- a/data/conf/perf/tpcds30tb/tez/hive-site.xml
+++ b/data/conf/perf/tpcds30tb/tez/hive-site.xml
@@ -182,6 +182,10 @@
         <name>hive.tez.auto.reducer.parallelism</name>
         <value>true</value>
     </property>
+    <property>
+        <name>hive.tez.exec.print.summary</name>
+        <value>true</value>
+    </property>
     <!-- Metastore properties -->
     <property>
         <name>hive.metastore.db.type</name>

--- a/data/conf/tez/hive-site.xml
+++ b/data/conf/tez/hive-site.xml
@@ -266,6 +266,11 @@
 </property>
 
 <property>
+  <name>hive.tez.exec.print.summary</name>
+  <value>true</value>
+</property>
+
+<property>
   <name>hive.orc.splits.ms.footer.cache.enabled</name>
   <value>true</value>
 </property>

--- a/packaging/src/docker/conf/hive-site.xml
+++ b/packaging/src/docker/conf/hive-site.xml
@@ -25,6 +25,10 @@
         <value>false</value>
     </property>
     <property>
+        <name>hive.tez.exec.print.summary</name>
+        <value>true</value>
+    </property>
+    <property>
         <name>hive.exec.scratchdir</name>
         <value>/opt/hive/scratch_dir</value>
     </property>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the value of hive.tez.exec.print.summary to true in some hive-site.xml files in the repo to have the tez summary printed for devs where it's applicable.

### Why are the changes needed?
Because the output of that is quite useful.

### Does this PR introduce _any_ user-facing change?
No, because it is getting upgraded in hive-site.xml files that are used in case of tests.
Users in production have their config.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Locally:
1. start StartMiniHS2Cluster
2. run queries on tez with beeline
```
CREATE EXTERNAL TABLE test_part(id int) PARTITIONED BY(dt string) STORED AS ORC;
INSERT INTO test_part values (1, '1');
```
3. A summary was printed
```
INFO  : Status: DAG finished successfully in 0.96 seconds
INFO  : DAG ID: dag_1713942599258_0001_4
INFO  :
INFO  : Query Execution Summary
INFO  : ----------------------------------------------------------------------------------------------
INFO  : OPERATION                            DURATION
INFO  : ----------------------------------------------------------------------------------------------
INFO  : Compile Query                           0.12s
INFO  : Prepare Plan                            0.04s
INFO  : Get Query Coordinator (AM)              0.00s
INFO  : Submit Plan                             0.03s
INFO  : Start DAG                               0.02s
INFO  : Run DAG                                 0.96s
INFO  : ----------------------------------------------------------------------------------------------
INFO  :
...
```