### PR TITLE
HIVE-28225: Iceberg: Delete on entire table fails on COW mode.

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/delete_iceberg_copy_on_write_unpartitioned.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/delete_iceberg_copy_on_write_unpartitioned.q
@@ -48,3 +48,8 @@ insert into tbl_ice_with_nulls values
 
 delete from tbl_ice_with_nulls where id in (select id from tbl_ice_with_nulls where id > 9) or name in (select name from tbl_ice_with_nulls where name = 'sdf');
 select * from tbl_ice_with_nulls order by id;
+
+-- delete without where clause and disabled conversion to truncate
+set hive.optimize.delete.all=false;
+delete from tbl_ice_with_nulls;
+select * from tbl_ice_with_nulls;

--- a/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_copy_on_write_unpartitioned.q.out
@@ -1890,3 +1890,19 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 7	SDF
 8	POIKL
 9	NULL
+PREHOOK: query: delete from tbl_ice_with_nulls
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice_with_nulls
+PREHOOK: Output: default@tbl_ice_with_nulls
+POSTHOOK: query: delete from tbl_ice_with_nulls
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice_with_nulls
+POSTHOOK: Output: default@tbl_ice_with_nulls
+PREHOOK: query: select * from tbl_ice_with_nulls
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice_with_nulls
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from tbl_ice_with_nulls
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice_with_nulls
+POSTHOOK: Output: hdfs://### HDFS PATH ###

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteDeleteRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteDeleteRewriter.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.ParseUtils;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.rewrite.sql.COWWithClauseBuilder;
@@ -44,9 +45,13 @@ public class CopyOnWriteDeleteRewriter implements Rewriter<DeleteStatement> {
   public ParseUtils.ReparseResult rewrite(Context context, DeleteStatement deleteBlock)
       throws SemanticException {
 
-    Tree wherePredicateNode = deleteBlock.getWhereTree().getChild(0);
-    String whereClause = context.getTokenRewriteStream().toString(
-        wherePredicateNode.getTokenStartIndex(), wherePredicateNode.getTokenStopIndex());
+    ASTNode whereTree = deleteBlock.getWhereTree();
+    String whereClause = "true";
+    if (whereTree != null) {
+      Tree wherePredicateNode = whereTree.getChild(0);
+      whereClause = context.getTokenRewriteStream()
+          .toString(wherePredicateNode.getTokenStartIndex(), wherePredicateNode.getTokenStopIndex());
+    }
     String filePathCol = HiveUtils.unparseIdentifier(VirtualColumn.FILE_PATH.getName(), conf);
 
     MultiInsertSqlGenerator sqlGenerator = sqlGeneratorFactory.createSqlGenerator();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix delete on entire iceberg table with COW mode, with truncate disabled

### Why are the changes needed?

To avoid NPE & make the command work


### Does this PR introduce _any_ user-facing change?

Yes, instead of NPE, the query succeeds

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT