### PR TITLE
HIVE-28219: Support drop partitions by names in IMetaStoreClient

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -54,7 +54,7 @@ import org.apache.hadoop.hive.metastore.api.SQLPrimaryKey;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
-import org.apache.hadoop.hive.metastore.client.BaseMetaStoreClient;
+import org.apache.hadoop.hive.metastore.client.ThriftHiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.QueryState;
@@ -1242,7 +1242,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     } else if (partsSpec.isSetNames()) {
       preTruncateTable(hmsTable, context, partsSpec.getNames());
     }
-    context.putToProperties(BaseMetaStoreClient.SKIP_DROP_PARTITION, "true");
+    context.putToProperties(ThriftHiveMetaStoreClient.SKIP_DROP_PARTITION, "true");
   }
 
   private static void validatePartitionSpec(SearchArgument sarg, PartitionSpec partitionSpec) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -1225,7 +1225,6 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     } catch (IOException e) {
       throw new MetaException(String.format("Error while fetching the partitions due to: %s", e));
     }
-    context.putToProperties(BaseMetaStoreClient.SKIP_DROP_PARTITION, "true");
   }
 
   @Override
@@ -1242,8 +1241,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       preDropPartitions(hmsTable, context, partExprs);
     } else if (partsSpec.isSetNames()) {
       preTruncateTable(hmsTable, context, partsSpec.getNames());
-      context.putToProperties(BaseMetaStoreClient.SKIP_DROP_PARTITION, "true");
     }
+    context.putToProperties(BaseMetaStoreClient.SKIP_DROP_PARTITION, "true");
   }
 
   private static void validatePartitionSpec(SearchArgument sarg, PartitionSpec partitionSpec) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4081,13 +4081,13 @@ private void constructOneLBLocationMap(FileStatus fSta,
       exprs.add(dpe);
     }
     rps.setExprs(exprs);
-    return dropPartitions(getDefaultCatalog(conf), dbName, tableName, rps, dropOptions);
+    return dropPartitions(new TableName(getDefaultCatalog(conf), dbName, tableName), rps, dropOptions);
   }
 
-  public List<Partition> dropPartitions(String catName, String dbName, String tableName,
+  public List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions dropOptions) throws HiveException {
     try {
-      Table table = getTable(dbName, tableName);
+      Table table = getTable(tableName.getDb(), tableName.getTable());
       if (!dropOptions.deleteData) {
         AcidUtils.TableSnapshot snapshot = AcidUtils.getTableSnapshot(conf, table, true);
         if (snapshot != null) {
@@ -4098,7 +4098,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
         dropOptions.setTxnId(txnId);
       }
       List<org.apache.hadoop.hive.metastore.api.Partition> partitions = getMSC().dropPartitions(
-          catName, dbName, tableName, partsSpec, dropOptions, null);
+          tableName, partsSpec, dropOptions, null);
       return convertFromMetastore(table, partitions);
     } catch (NoSuchObjectException e) {
       throw new HiveException("Partition or table doesn't exist.", e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
@@ -1562,11 +1562,11 @@ public class SessionHiveMetaStoreClient extends MetaStoreClientWrapper {
   }
 
   @Override
-  public List<Partition> dropPartitions(String catName, String dbName, String tblName,
+  public List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
       throws TException {
-    if (isDefaultCatalog(catName)) {
-      Table table = getTempTable(dbName, tblName);
+    if (isDefaultCatalog(tableName.getCat())) {
+      Table table = getTempTable(tableName.getDb(), tableName.getTable());
       if (table != null) {
         TempTable tt = getPartitionedTempTable(table);
             List<List<String>> partValues = new ArrayList<>();
@@ -1602,7 +1602,7 @@ public class SessionHiveMetaStoreClient extends MetaStoreClientWrapper {
       }
     }
 
-    return delegate.dropPartitions(catName, dbName, tblName, partsSpec, options, context);
+    return delegate.dropPartitions(tableName, partsSpec, options, context);
   }
 
   @Override

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
@@ -747,9 +748,10 @@ public class TestHive {
   public void testDropPartitionsByNames() throws Throwable {
     String catName = Warehouse.DEFAULT_CATALOG_NAME;
     String dbName = Warehouse.DEFAULT_DATABASE_NAME;
-    String tableName = "table_for_testDropPartitionsByNames";
+    String tblName = "table_for_testDropPartitionsByNames";
+    TableName tableName = new TableName(catName, dbName, tblName);
 
-    Table table = createPartitionedTable(dbName, tableName);
+    Table table = createPartitionedTable(dbName, tblName);
     for (int i = 10; i <= 12; i++) {
       Map<String, String> partitionSpec = new ImmutableMap.Builder<String, String>()
           .put("ds", "20231129")
@@ -763,13 +765,13 @@ public class TestHive {
 
     RequestPartsSpec partsSpec = new RequestPartsSpec();
     partsSpec.setNames(Arrays.asList("ds=20231129/hr=10"));
-    hm.dropPartitions(catName, dbName, tableName, partsSpec, PartitionDropOptions.instance());
+    hm.dropPartitions(tableName, partsSpec, PartitionDropOptions.instance());
     assertEquals(2, hm.getPartitions(table).size());
 
     try {
       // drop missing partition name
       partsSpec.setNames(Arrays.asList("ds=20231129/hr=10", "ds=20231129/hr=11"));
-      hm.dropPartitions(catName, dbName, tableName, partsSpec, PartitionDropOptions.instance());
+      hm.dropPartitions(tableName, partsSpec, PartitionDropOptions.instance());
       fail("Expected exception");
     } catch (HiveException e) {
       // expected
@@ -778,7 +780,7 @@ public class TestHive {
     }
 
     partsSpec.setNames(Arrays.asList("ds=20231129/hr=12", "ds=20231129/hr=11"));
-    hm.dropPartitions(catName, dbName, tableName, partsSpec, PartitionDropOptions.instance());
+    hm.dropPartitions(tableName, partsSpec, PartitionDropOptions.instance());
     assertEquals(0, hm.getPartitions(table).size());
   }
 

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -2092,6 +2092,10 @@ public interface IMetaStoreClient extends AutoCloseable {
       List<Pair<Integer, byte[]>> partExprs, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException;
 
+  List<Partition> dropPartitions(String catName, String dbName, String tblName,
+      RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
+      throws NoSuchObjectException, MetaException, TException;
+
   /**
    * Drop a partition.
    * @param db_name database name.

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -1980,6 +1980,7 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Drop partitions based on an expression.
+   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
    * @param dbName database name.
    * @param tblName table name.
    * @param partExprs I don't understand this fully, so can't completely explain it.  The second
@@ -1994,12 +1995,14 @@ public interface IMetaStoreClient extends AutoCloseable {
    * @throws MetaException error access the RDBMS or storage.
    * @throws TException Thrift transport error.
    */
+  @Deprecated
   List<Partition> dropPartitions(String dbName, String tblName,
                                  List<Pair<Integer, byte[]>> partExprs, boolean deleteData,
                                  boolean ifExists) throws NoSuchObjectException, MetaException, TException;
 
   /**
    * Drop partitions based on an expression.
+   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
    * @param catName catalog name.
    * @param dbName database name.
    * @param tblName table name.
@@ -2015,6 +2018,7 @@ public interface IMetaStoreClient extends AutoCloseable {
    * @throws MetaException error access the RDBMS or storage.
    * @throws TException Thrift transport error.
    */
+  @Deprecated
   default List<Partition> dropPartitions(String catName, String dbName, String tblName,
                                          List<Pair<Integer, byte[]>> partExprs,
                                          boolean deleteData, boolean ifExists)
@@ -2027,6 +2031,7 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Drop partitions based on an expression.
+   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
    * @param catName catalog name.
    * @param dbName database name.
    * @param tblName table name.
@@ -2044,6 +2049,7 @@ public interface IMetaStoreClient extends AutoCloseable {
    * @throws MetaException error access the RDBMS or storage.
    * @throws TException Thrift transport error.
    */
+  @Deprecated
   default List<Partition> dropPartitions(String catName, String dbName, String tblName,
                                          List<Pair<Integer, byte[]>> partExprs, boolean deleteData,
                                          boolean ifExists, boolean needResults)
@@ -2057,6 +2063,7 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Generalization of dropPartitions(),
+   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
    * @param dbName Name of the database
    * @param tblName Name of the table
    * @param partExprs Partition-specification
@@ -2066,6 +2073,7 @@ public interface IMetaStoreClient extends AutoCloseable {
    * @throws MetaException error access the RDBMS or storage.
    * @throws TException On failure
    */
+  @Deprecated
   List<Partition> dropPartitions(String dbName, String tblName,
                                  List<Pair<Integer, byte[]>> partExprs,
                                  PartitionDropOptions options)
@@ -2073,6 +2081,7 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Generalization of dropPartitions(),
+   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
    * @param catName catalog name
    * @param dbName Name of the database
    * @param tblName Name of the table
@@ -2083,18 +2092,23 @@ public interface IMetaStoreClient extends AutoCloseable {
    * @throws MetaException error access the RDBMS or storage.
    * @throws TException On failure
    */
+  @Deprecated
   List<Partition> dropPartitions(String catName, String dbName, String tblName,
                                  List<Pair<Integer, byte[]>> partExprs,
                                  PartitionDropOptions options)
       throws NoSuchObjectException, MetaException, TException;
 
+  /**
+   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
+   */
+  @Deprecated
   List<Partition> dropPartitions(String catName, String dbName, String tblName,
       List<Pair<Integer, byte[]>> partExprs, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException;
 
   List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
-      throws NoSuchObjectException, MetaException, TException;
+      throws TException;
 
   /**
    * Drop a partition.

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -1980,7 +1980,8 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Drop partitions based on an expression.
-   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
+   * @deprecated since 4.1.0, will be removed in 5.0.0
+   * use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead.
    * @param dbName database name.
    * @param tblName table name.
    * @param partExprs I don't understand this fully, so can't completely explain it.  The second
@@ -2002,7 +2003,8 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Drop partitions based on an expression.
-   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
+   * @deprecated since 4.1.0, will be removed in 5.0.0
+   * use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead.
    * @param catName catalog name.
    * @param dbName database name.
    * @param tblName table name.
@@ -2031,7 +2033,8 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Drop partitions based on an expression.
-   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
+   * @deprecated since 4.1.0, will be removed in 5.0.0
+   * use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead.
    * @param catName catalog name.
    * @param dbName database name.
    * @param tblName table name.
@@ -2063,7 +2066,8 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Generalization of dropPartitions(),
-   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
+   * @deprecated since 4.1.0, will be removed in 5.0.0
+   * use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead.
    * @param dbName Name of the database
    * @param tblName Name of the table
    * @param partExprs Partition-specification
@@ -2081,7 +2085,8 @@ public interface IMetaStoreClient extends AutoCloseable {
 
   /**
    * Generalization of dropPartitions(),
-   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
+   * @deprecated since 4.1.0, will be removed in 5.0.0
+   * use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead.
    * @param catName catalog name
    * @param dbName Name of the database
    * @param tblName Name of the table
@@ -2099,13 +2104,23 @@ public interface IMetaStoreClient extends AutoCloseable {
       throws NoSuchObjectException, MetaException, TException;
 
   /**
-   * @deprecated Use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead
+   * @deprecated since 4.1.0, will be removed in 5.0.0
+   * use {@link #dropPartitions(TableName, RequestPartsSpec, PartitionDropOptions, EnvironmentContext)} instead.
    */
   @Deprecated
   List<Partition> dropPartitions(String catName, String dbName, String tblName,
       List<Pair<Integer, byte[]>> partExprs, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException;
 
+  /**
+   * Drop partitions based on the request partitions specification.
+   * @param tableName Name of the table.
+   * @param partsSpec Specification of the partitions to drop.
+   * @param options Options for dropping partitions.
+   * @param context Environment context for the operation.
+   * @return List of Partitions dropped.
+   * @throws TException thrift transport error.
+   */
   List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
       throws TException;

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -2092,7 +2092,7 @@ public interface IMetaStoreClient extends AutoCloseable {
       List<Pair<Integer, byte[]>> partExprs, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException;
 
-  List<Partition> dropPartitions(String catName, String dbName, String tblName,
+  List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException;
 

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/BaseMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/BaseMetaStoreClient.java
@@ -584,7 +584,7 @@ public abstract class BaseMetaStoreClient implements IMetaStoreClient {
       exprs.add(dpe);
     }
     rps.setExprs(exprs);
-    return dropPartitions(catName, dbName, tblName, rps, options, context);
+    return dropPartitions(new TableName(catName, dbName, tblName), rps, options, context);
   }
 
   @Override

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/BaseMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/BaseMetaStoreClient.java
@@ -45,7 +45,6 @@ import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.convertToGet
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
 
 public abstract class BaseMetaStoreClient implements IMetaStoreClient {
-  public static final String SKIP_DROP_PARTITION = "dropPartitionSkip";
 
   // Keep a copy of HiveConf so if Session conf changes, we may need to get a new HMS client.
   protected final Configuration conf;
@@ -565,15 +564,6 @@ public abstract class BaseMetaStoreClient implements IMetaStoreClient {
   public List<Partition> dropPartitions(String catName, String dbName, String tblName,
       List<Pair<Integer, byte[]>> partExprs, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException {
-    if (context == null) {
-      context = new EnvironmentContext();
-    }
-
-    if (context.getProperties() != null &&
-        Boolean.parseBoolean(context.getProperties().get(SKIP_DROP_PARTITION))) {
-      return Lists.newArrayList();
-    }
-
     RequestPartsSpec rps = new RequestPartsSpec();
     List<DropPartitionsExpr> exprs = new ArrayList<>(partExprs.size());
 

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/HookEnabledMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/HookEnabledMetaStoreClient.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore.client;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.metastore.DefaultHiveMetaHook;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
@@ -327,10 +328,10 @@ public class HookEnabledMetaStoreClient extends MetaStoreClientWrapper {
   }
 
   @Override
-  public List<Partition> dropPartitions(String catName, String dbName, String tblName,
+  public List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
       throws TException {
-    Table table = delegate.getTable(catName, dbName, tblName);
+    Table table = delegate.getTable(tableName.getCat(), tableName.getDb(), tableName.getTable());
     HiveMetaHook hook = getHook(table);
     if (hook != null) {
       if (context == null) {
@@ -338,7 +339,7 @@ public class HookEnabledMetaStoreClient extends MetaStoreClientWrapper {
       }
       hook.preDropPartitions(table, context, partsSpec);
     }
-    return delegate.dropPartitions(catName, dbName, tblName, partsSpec, options, context);
+    return delegate.dropPartitions(tableName, partsSpec, options, context);
   }
 
   @Override

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/HookEnabledMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/HookEnabledMetaStoreClient.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.RequestPartsSpec;
 import org.apache.hadoop.hive.metastore.api.SQLCheckConstraint;
 import org.apache.hadoop.hive.metastore.api.SQLDefaultConstraint;
 import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
@@ -323,6 +324,21 @@ public class HookEnabledMetaStoreClient extends MetaStoreClientWrapper {
       hook.preDropPartitions(table, context, partExprs);
     }
     return delegate.dropPartitions(catName, dbName, tblName, partExprs, options, context);
+  }
+
+  @Override
+  public List<Partition> dropPartitions(String catName, String dbName, String tblName,
+      RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
+      throws TException {
+    Table table = delegate.getTable(catName, dbName, tblName);
+    HiveMetaHook hook = getHook(table);
+    if (hook != null) {
+      if (context == null) {
+        context = new EnvironmentContext();
+      }
+      hook.preDropPartitions(table, context, partsSpec);
+    }
+    return delegate.dropPartitions(catName, dbName, tblName, partsSpec, options, context);
   }
 
   @Override

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/HookEnabledMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/HookEnabledMetaStoreClient.java
@@ -313,21 +313,6 @@ public class HookEnabledMetaStoreClient extends MetaStoreClientWrapper {
   }
 
   @Override
-  public List<Partition> dropPartitions(String catName, String dbName, String tblName,
-      List<Pair<Integer, byte[]>> partExprs, PartitionDropOptions options, EnvironmentContext context)
-      throws TException {
-    Table table = delegate.getTable(catName, dbName, tblName);
-    HiveMetaHook hook = getHook(table);
-    if (hook != null) {
-      if (context == null) {
-        context = new EnvironmentContext();
-      }
-      hook.preDropPartitions(table, context, partExprs);
-    }
-    return delegate.dropPartitions(catName, dbName, tblName, partExprs, options, context);
-  }
-
-  @Override
   public List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
       throws TException {

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/MetaStoreClientWrapper.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/MetaStoreClientWrapper.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hive.metastore.client;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -504,10 +504,10 @@ public abstract class MetaStoreClientWrapper extends BaseMetaStoreClient {
   }
 
   @Override
-  public List<Partition> dropPartitions(String catName, String dbName, String tblName,
+  public List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException {
-    return delegate.dropPartitions(catName, dbName, tblName, partsSpec, options, context);
+    return delegate.dropPartitions(tableName, partsSpec, options, context);
   }
 
   @Override

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/MetaStoreClientWrapper.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/MetaStoreClientWrapper.java
@@ -505,9 +505,9 @@ public abstract class MetaStoreClientWrapper extends BaseMetaStoreClient {
 
   @Override
   public List<Partition> dropPartitions(String catName, String dbName, String tblName,
-      List<Pair<Integer, byte[]>> partExprs, PartitionDropOptions options, EnvironmentContext context)
+      RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException {
-    return delegate.dropPartitions(catName, dbName, tblName, partExprs, options, context);
+    return delegate.dropPartitions(catName, dbName, tblName, partsSpec, options, context);
   }
 
   @Override

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.metastore.DefaultMetaStoreFilterHookImpl;
@@ -1587,15 +1588,18 @@ public class ThriftHiveMetaStoreClient extends BaseMetaStoreClient {
   }
 
   @Override
-  public List<Partition> dropPartitions(String catName, String dbName, String tblName,
+  public List<Partition> dropPartitions(TableName tableName,
       RequestPartsSpec partsSpec, PartitionDropOptions options, EnvironmentContext context)
       throws NoSuchObjectException, MetaException, TException {
-    DropPartitionsRequest req = new DropPartitionsRequest(dbName, tblName, partsSpec);
-    req.setCatName(catName);
+    DropPartitionsRequest req = new DropPartitionsRequest(tableName.getDb(), tableName.getTable(), partsSpec);
+    req.setCatName(tableName.getCat());
     req.setDeleteData(options.deleteData);
     req.setNeedResult(options.returnResults);
     req.setIfExists(options.ifExists);
 
+    if (context == null) {
+      context = new EnvironmentContext();
+    }
     if (options.purgeData) {
       LOG.info("Dropped partitions will be purged!");
       context.putToProperties("ifPurge", "true");

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
@@ -1600,16 +1600,18 @@ public class ThriftHiveMetaStoreClient extends BaseMetaStoreClient {
     if (context == null) {
       context = new EnvironmentContext();
     }
+    if (context.getProperties() != null &&
+        Boolean.parseBoolean(context.getProperties().get(SKIP_DROP_PARTITION))) {
+      return Lists.newArrayList();
+    }
     if (options.purgeData) {
       LOG.info("Dropped partitions will be purged!");
       context.putToProperties("ifPurge", "true");
     }
     if (options.writeId != null) {
-      context = Optional.ofNullable(context).orElse(new EnvironmentContext());
       context.putToProperties(hive_metastoreConstants.WRITE_ID, options.writeId.toString());
     }
     if (options.txnId != null) {
-      context = Optional.ofNullable(context).orElse(new EnvironmentContext());
       context.putToProperties(hive_metastoreConstants.TXN_ID, options.txnId.toString());
     }
     req.setEnvironmentContext(context);

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
@@ -112,6 +112,7 @@ public class ThriftHiveMetaStoreClient extends BaseMetaStoreClient {
   public final static ClientCapabilities TEST_VERSION = new ClientCapabilities(
       Lists.newArrayList(ClientCapability.INSERT_ONLY_TABLES, ClientCapability.TEST_CAPABILITY));
   public static final String TRUNCATE_SKIP_DATA_DELETION = "truncateSkipDataDeletion";
+  public static final String SKIP_DROP_PARTITION = "dropPartitionSkip";
   public static final String SNAPSHOT_REF = "snapshot_ref";
 
   // Name of the HiveMetaStore class. It is used to initialize embedded metastore

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
@@ -218,7 +218,8 @@ public interface HiveMetaHook {
 
   /**
    * Called before dropping the partitions from the table in the metastore during ALTER TABLE DROP PARTITION.
-   * @deprecated Use {@link #preDropPartitions(Table, EnvironmentContext, RequestPartsSpec)} instead.
+   * @deprecated since 4.1.0, will be removed in 5.0.0
+   * use {@link #preDropPartitions(Table, EnvironmentContext, RequestPartsSpec)} instead.
    * @param table table whose partition needs to be dropped
    * @param context context of the  operation
    * @param partExprs List of partition expressions

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
@@ -218,11 +218,13 @@ public interface HiveMetaHook {
 
   /**
    * Called before dropping the partitions from the table in the metastore during ALTER TABLE DROP PARTITION.
+   * @deprecated Use {@link #preDropPartitions(Table, EnvironmentContext, RequestPartsSpec)} instead.
    * @param table table whose partition needs to be dropped
    * @param context context of the  operation
    * @param partExprs List of partition expressions
    * @throws MetaException
    */
+  @Deprecated
   default void preDropPartitions(Table table,
       EnvironmentContext context, List<Pair<Integer, byte[]>> partExprs) throws MetaException {
     // Do nothing

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.hive.metastore.api.CreateTableRequest;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.RequestPartsSpec;
 import org.apache.hadoop.hive.metastore.api.Table;
 import com.google.common.collect.ImmutableList;
 
@@ -224,6 +225,18 @@ public interface HiveMetaHook {
    */
   default void preDropPartitions(Table table,
       EnvironmentContext context, List<Pair<Integer, byte[]>> partExprs) throws MetaException {
+    // Do nothing
+  }
+
+ /**
+   * Called before dropping the partitions from the table in the metastore during ALTER TABLE DROP PARTITION.
+   * @param table table whose partition needs to be dropped
+   * @param context context of the  operation
+   * @param partsSpec request partition specification
+   * @throws MetaException
+   */
+  default void preDropPartitions(Table table,
+      EnvironmentContext context, RequestPartsSpec partsSpec) throws MetaException {
     // Do nothing
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In thrift api definition, HMS support to drop partitions by both partition names and expressions. But current api in `IMetaStoreClient` only support drop partitions by expressions, we should add new api to support drop partitions by names.
```java
  // IMetaStoreClient.java
  List<Partition> dropPartitions(String catName, String dbName, String tblName,
                                 RequestPartsSpec partsSpec, PartitionDropOptions options)
      throws NoSuchObjectException, MetaException, TException;
```

### Why are the changes needed?
To improve the `dropPartitions` function.


### Does this PR introduce _any_ user-facing change?
Yes, user can use the new api to drop partitions by names.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Add unit test:
```bash
mvn test -Dtest=org.apache.hadoop.hive.ql.metadata.TestHive -pl :hive-exec
```
