### PR TITLE
HIVE-28228: Remove redundant/unused sources maven profile

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -197,27 +197,6 @@
       <optional>true</optional>
     </dependency>
   </dependencies>
-  <profiles>
-    <profile>
-      <id>sources</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <build>
     <sourceDirectory>${basedir}/src/java</sourceDirectory>
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>

--- a/classification/pom.xml
+++ b/classification/pom.xml
@@ -26,27 +26,6 @@
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
   </properties>
-  <profiles>
-    <profile>
-      <id>sources</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <build>
     <sourceDirectory>${basedir}/src/java</sourceDirectory>
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -317,25 +317,6 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>sources</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>dist</id>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1937,25 +1937,6 @@
       </build>
     </profile>
     <profile>
-      <id>sources</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>javadoc</id>
       <build>
         <plugins>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -873,25 +873,6 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>sources</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>protobuf</id>
       <build>
         <plugins>

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -250,27 +250,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <profiles>
-    <profile>
-      <id>sources</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <build>
     <sourceDirectory>${basedir}/src/java</sourceDirectory>
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>


### PR DESCRIPTION
### Why are the changes needed?
Simplify build and reduce maintenance overhead

The sources maven profile was introduced in HIVE-5717 among others to package source code into a .jar and publish it to maven. However, after adding Apache pom as parent in HIVE-6608 the sources profile is now redundant; it is subsumed by the apache-release profile.

In some cases, the sources profile allows to package the test sources in a jar file (HIVE-13206) but this profile is not used during the release so the generated test-sources.jars are not consumed by anyone. This seems like an unused dev only feature thus it can be removed.

### Does this PR introduce _any_ user-facing change?
Devs will no longer have the option to generate test-sources.jar using the `sources` profile.

### Is the change a dependency upgrade?
No

### How was this patch tested?
N/A