### PR TITLE
HIVE-28235 : Hive should honour heapsize set in hive-env

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -380,6 +380,26 @@ if [[ "$SERVICE" =~ ^(hiveserver2|beeline|cli)$ ]] ; then
   fi
 fi
 
+# set heap size of hive processes based on HADOOP_HEAPSIZE
+if [[ -n "${HADOOP_HEAPSIZE_MAX}" ]]; then
+  if [[ "${HADOOP_HEAPSIZE_MAX}" =~ ^[0-9]+$ ]]; then
+    HADOOP_HEAPSIZE_MAX="${HADOOP_HEAPSIZE_MAX}m"
+  fi
+  export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx${HADOOP_HEAPSIZE_MAX}m "
+elif [[ -n "${HADOOP_HEAPSIZE}" ]]; then
+  if [[ "${HADOOP_HEAPSIZE}" =~ ^[0-9]+$ ]]; then
+    HADOOP_HEAPSIZE="${HADOOP_HEAPSIZE}m"
+  fi
+  export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx${HADOOP_HEAPSIZE}m "
+fi
+
+if [[ -n "${HADOOP_HEAPSIZE_MIN}" ]]; then
+  if [[ "${HADOOP_HEAPSIZE_MIN}" =~ ^[0-9]+$ ]]; then
+    HADOOP_HEAPSIZE_MIN="${HADOOP_HEAPSIZE_MIN}m"
+  fi
+  export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xms${HADOOP_HEAPSIZE_MIN}m "
+fi
+
 export JVM_PID="$$"
 
 if [ "$TORUN" = "" ] ; then

--- a/bin/hive
+++ b/bin/hive
@@ -383,21 +383,18 @@ fi
 # set heap size of hive processes based on HADOOP_HEAPSIZE
 if [[ -n "${HADOOP_HEAPSIZE_MAX}" ]]; then
   if [[ "${HADOOP_HEAPSIZE_MAX}" =~ ^[0-9]+$ ]]; then
-    HADOOP_HEAPSIZE_MAX="${HADOOP_HEAPSIZE_MAX}m"
+    export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx${HADOOP_HEAPSIZE_MAX}m "
   fi
-  export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx${HADOOP_HEAPSIZE_MAX}m "
 elif [[ -n "${HADOOP_HEAPSIZE}" ]]; then
   if [[ "${HADOOP_HEAPSIZE}" =~ ^[0-9]+$ ]]; then
-    HADOOP_HEAPSIZE="${HADOOP_HEAPSIZE}m"
+    export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx${HADOOP_HEAPSIZE}m "
   fi
-  export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx${HADOOP_HEAPSIZE}m "
 fi
 
 if [[ -n "${HADOOP_HEAPSIZE_MIN}" ]]; then
   if [[ "${HADOOP_HEAPSIZE_MIN}" =~ ^[0-9]+$ ]]; then
-    HADOOP_HEAPSIZE_MIN="${HADOOP_HEAPSIZE_MIN}m"
+    export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xms${HADOOP_HEAPSIZE_MIN}m "
   fi
-  export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xms${HADOOP_HEAPSIZE_MIN}m "
 fi
 
 export JVM_PID="$$"

--- a/bin/hive
+++ b/bin/hive
@@ -380,7 +380,7 @@ if [[ "$SERVICE" =~ ^(hiveserver2|beeline|cli)$ ]] ; then
   fi
 fi
 
-# set heap size of hive processes based on HADOOP_HEAPSIZE
+# set heap size of hive processes based on HADOOP_HEAPSIZE env variables
 if [[ -n "${HADOOP_HEAPSIZE_MAX}" ]]; then
   if [[ "${HADOOP_HEAPSIZE_MAX}" =~ ^[0-9]+$ ]]; then
     export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx${HADOOP_HEAPSIZE_MAX}m "


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Hive processes do not honour the heap size set in hive-env. Right now, they only consider the value set in hadoop-env and ignore those set in hive-env.  


### Why are the changes needed?
Bug - because values related to Heap set in hive-env is ignored. 



### Does this PR introduce _any_ user-facing change?
No


### Is the change a dependency upgrade?
No


### How was this patch tested?
With the updated script, heap values set in hive-env is honoured over hadoop-env. 
