### PR TITLE
HIVE-28237: Add a default tez-site.xml to data/conf

### DIFF
--- a/data/conf/tez-site.xml
+++ b/data/conf/tez-site.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+  <property>
+    <name>tez.am.resource.memory.mb</name>
+    <value>512</value>
+  </property>
+  <property>
+    <name>tez.runtime.io.sort.mb</name>
+    <value>24</value>
+  </property>
+  <property>
+    <name>tez.runtime.unordered.output.buffer.size-mb</name>
+    <value>10</value>
+  </property>
+  <property>
+    <name>tez.runtime.shuffle.fetch.buffer.percent</name>
+    <value>0.4</value>
+  </property>
+  <property>
+    <name>tez.am.dag.scheduler.class</name>
+    <value>org.apache.tez.dag.app.dag.impl.DAGSchedulerNaturalOrderControlled</value>
+  </property>
+  <property>
+    <name>tez.local.mode</name>
+    <value>true</value>
+  </property>
+</configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added a tez-site.xml file to data/conf: copied from data/conf/tez and added a typical test scenario setting as below:
```
  <property>
    <name>tez.local.mode</name>
    <value>true</value>
  </property>
```


### Why are the changes needed?
As described on jira, users of StartMiniHS2Cluster might find it confusing where to set tez configs, not even defined without this patch.


### Does this PR introduce _any_ user-facing change?
No.


### Is the change a dependency upgrade?
No.



### How was this patch tested?
With StartMiniHS2Cluster, tez.local.mode=true was kicking in with the patch, this log line below was found in the log file of StartMiniHS2Cluster, so it created a LocalClient as expected
```
2024-04-30T02:55:14,168  INFO [DAGAppMaster Thread] client.LocalClient: Using working directory: /tmp/hive/scratch/laszlobodor/_tez_session_dir/7c9b847c-9d48-469a-a1e7-fa4d29b3148f/.tez/application_1714470913855_0001_wd
```