### PR TITLE
HIVE-28208: WITH column list doesn't work with CTE materialization

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
@@ -103,6 +103,7 @@ public class CreateTableDesc extends DDLDescWithTableProperties implements Seria
   List<String> skewedColNames;
   List<List<String>> skewedColValues;
   boolean isStoredAsSubDirectories = false;
+  private List<String> withColList;
   private boolean replaceMode = false;
   private ReplicationSpec replicationSpec = null;
   private boolean isCTAS = false;
@@ -650,6 +651,20 @@ public class CreateTableDesc extends DDLDescWithTableProperties implements Seria
    */
   public void setMaterialization(boolean isMaterialization) {
     this.isMaterialization = isMaterialization;
+  }
+
+  /**
+   * @return the with-column-list of this CTE
+   */
+  public List<String> getWithColList() {
+    return withColList;
+  }
+
+  /**
+   * @param withColList the column list
+   */
+  public void setWithColList(List<String> withColList) {
+    this.withColList = withColList;
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1048,6 +1048,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
     createTable.addChild(tableName);
     createTable.addChild(temporary);
+    if (cte.withColList != null) {
+      createTable.addChild(cte.withColList);
+    }
     createTable.addChild(cte.cteNode);
 
     CalcitePlanner analyzer = new CalcitePlanner(queryState);

--- a/ql/src/test/queries/clientnegative/cte_mat_col_alias.q
+++ b/ql/src/test/queries/clientnegative/cte_mat_col_alias.q
@@ -1,0 +1,8 @@
+create table t1(int_col int, bigint_col bigint);
+
+set hive.optimize.cte.materialize.threshold=1;
+set hive.optimize.cte.materialize.full.aggregate.only=false;
+
+explain cbo
+with cte1(a, b, c) as (select int_col x, bigint_col y from t1)
+select a, b from cte1;

--- a/ql/src/test/queries/clientpositive/cte_mat_1.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_1.q
@@ -1,10 +1,37 @@
 --! qt:dataset:src
 set hive.mapred.mode=nonstrict;
 set hive.optimize.cte.materialize.threshold=-1;
-set hive.explain.user=true;
 
 explain
 with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey, b.srcValue
+from q1 a join q1 b
+on a.srcKey=b.srcKey;
+
+set hive.optimize.cte.materialize.threshold=2;
+set hive.optimize.cte.materialize.full.aggregate.only=false;
+-- Use a format that retains column names
+set hive.default.fileformat=parquet;
+
+explain
+with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey, b.srcValue
+from q1 a join q1 b
+on a.srcKey=b.srcKey;
+
+with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey, b.srcValue
+from q1 a join q1 b
+on a.srcKey=b.srcKey;
+
+-- Hive allows <with column list> to have a smaller number of columns than the query expression
+explain
+with q1(`srcKey`) as (select * from src where key= '5')
+select a.srcKey
+from q1 a join q1 b
+on a.srcKey=b.srcKey;
+
+with q1(`srcKey`) as (select * from src where key= '5')
 select a.srcKey
 from q1 a join q1 b
 on a.srcKey=b.srcKey;

--- a/ql/src/test/results/clientnegative/cte_mat_col_alias.q.out
+++ b/ql/src/test/results/clientnegative/cte_mat_col_alias.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table t1(int_col int, bigint_col bigint)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(int_col int, bigint_col bigint)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+FAILED: SemanticException [Error 10425]: WITH-clause query cte1 returns 2 columns, but 3 labels were specified. The number of column labels must be smaller or equal to the number of expressions returned by the query.

--- a/ql/src/test/results/clientpositive/llap/cte_mat_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_1.q.out
@@ -1,7 +1,7 @@
 Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 with q1(srcKey, srcValue) as (select * from src where key= '5')
-select a.srcKey
+select a.srcKey, b.srcValue
 from q1 a join q1 b
 on a.srcKey=b.srcKey
 PREHOOK: type: QUERY
@@ -9,39 +9,420 @@ PREHOOK: Input: default@src
 #### A masked pattern was here ####
 POSTHOOK: query: explain
 with q1(srcKey, srcValue) as (select * from src where key= '5')
-select a.srcKey
+select a.srcKey, b.srcValue
 from q1 a join q1 b
 on a.srcKey=b.srcKey
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
-Plan optimized by CBO.
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
 
-Vertex dependency in root stage
-Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: (key = '5') (type: boolean)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key = '5') (type: boolean)
+                    Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: (key = '5') (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key = '5') (type: boolean)
+                    Statistics: Num rows: 2 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: value (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 182 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 2 Data size: 182 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 364 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: '5' (type: string), _col1 (type: string)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 4 Data size: 704 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 4 Data size: 704 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
-Stage-0
-  Fetch Operator
-    limit:-1
-    Stage-1
-      Reducer 2 llap
-      File Output Operator [FS_10]
-        Select Operator [SEL_9] (rows=4 width=85)
-          Output:["_col0"]
-          Merge Join Operator [MERGEJOIN_13] (rows=4 width=8)
-            Conds:(Inner)
-          <-Map 1 [XPROD_EDGE] vectorized, llap
-            XPROD_EDGE [RS_16]
-              Select Operator [SEL_15] (rows=2 width=8)
-                Filter Operator [FIL_14] (rows=2 width=87)
-                  predicate:(key = '5')
-                  TableScan [TS_0] (rows=500 width=87)
-                    default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
-          <-Map 3 [XPROD_EDGE] vectorized, llap
-            XPROD_EDGE [RS_19]
-              Select Operator [SEL_18] (rows=2 width=8)
-                Filter Operator [FIL_17] (rows=2 width=87)
-                  predicate:(key = '5')
-                  TableScan [TS_3] (rows=500 width=87)
-                    default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
 
+PREHOOK: query: explain
+with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey, b.srcValue
+from q1 a join q1 b
+on a.srcKey=b.srcKey
+PREHOOK: type: QUERY
+PREHOOK: Input: default@q1
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey, b.srcValue
+from q1 a join q1 b
+on a.srcKey=b.srcKey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@q1
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-4 depends on stages: Stage-2, Stage-0
+  Stage-0 depends on stages: Stage-1
+  Stage-3 depends on stages: Stage-4
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: (key = '5') (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key = '5') (type: boolean)
+                    Statistics: Num rows: 2 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: '5' (type: string), value (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat
+                            serde: org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe
+                            name: default.q1
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-4
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 3 <- Map 2 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  filterExpr: srckey is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: srckey is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: srckey (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 2 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs (cache only)
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: srckey is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: srckey is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: srckey (type: string), srcvalue (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs (cache only)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col2
+                Statistics: Num rows: 4 Data size: 704 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: string), _col2 (type: string)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 4 Data size: 704 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 4 Data size: 704 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Move Operator
+      files:
+          hdfs directory: true
+#### A masked pattern was here ####
+
+  Stage: Stage-3
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey, b.srcValue
+from q1 a join q1 b
+on a.srcKey=b.srcKey
+PREHOOK: type: QUERY
+PREHOOK: Input: default@q1
+PREHOOK: Input: default@src
+PREHOOK: Output: database:default
+PREHOOK: Output: default@q1
+#### A masked pattern was here ####
+POSTHOOK: query: with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey, b.srcValue
+from q1 a join q1 b
+on a.srcKey=b.srcKey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@q1
+POSTHOOK: Input: default@src
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@q1
+#### A masked pattern was here ####
+5	val_5
+5	val_5
+5	val_5
+5	val_5
+5	val_5
+5	val_5
+5	val_5
+5	val_5
+5	val_5
+PREHOOK: query: explain
+with q1(`srcKey`) as (select * from src where key= '5')
+select a.srcKey
+from q1 a join q1 b
+on a.srcKey=b.srcKey
+PREHOOK: type: QUERY
+PREHOOK: Input: default@q1
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+with q1(`srcKey`) as (select * from src where key= '5')
+select a.srcKey
+from q1 a join q1 b
+on a.srcKey=b.srcKey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@q1
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-4 depends on stages: Stage-2, Stage-0
+  Stage-0 depends on stages: Stage-1
+  Stage-3 depends on stages: Stage-4
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: (key = '5') (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key = '5') (type: boolean)
+                    Statistics: Num rows: 2 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: '5' (type: string), value (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat
+                            serde: org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe
+                            name: default.q1
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-4
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 3 <- Map 2 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  filterExpr: srckey is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: srckey is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: srckey (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 2 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs (cache only)
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: srckey is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: srckey is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: srckey (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 2 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs (cache only)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 4 Data size: 340 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 4 Data size: 340 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Move Operator
+      files:
+          hdfs directory: true
+#### A masked pattern was here ####
+
+  Stage: Stage-3
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: with q1(`srcKey`) as (select * from src where key= '5')
+select a.srcKey
+from q1 a join q1 b
+on a.srcKey=b.srcKey
+PREHOOK: type: QUERY
+PREHOOK: Input: default@q1
+PREHOOK: Input: default@src
+PREHOOK: Output: database:default
+PREHOOK: Output: default@q1
+#### A masked pattern was here ####
+POSTHOOK: query: with q1(`srcKey`) as (select * from src where key= '5')
+select a.srcKey
+from q1 a join q1 b
+on a.srcKey=b.srcKey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@q1
+POSTHOOK: Input: default@src
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@q1
+#### A masked pattern was here ####
+5
+5
+5
+5
+5
+5
+5
+5
+5


### PR DESCRIPTION
### What changes were proposed in this pull request?

ANSI SQL supports column aliases for CTEs. Hive also supports it but it fails when CTEs are materialized.

https://issues.apache.org/jira/browse/HIVE-28208

### Why are the changes needed?

This patch allows materialized CTEs to obey the standard.

### Does this PR introduce _any_ user-facing change?

No. The affected queries never succeed now.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

I added test queries to `cte_mat_1.q`.