### PR TITLE
HIVE-28209: Allow the use of a proxy user

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -255,7 +255,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       LOG.info(HADOOP_PROXY_USER + " is set. Using delegation "
           + "token for HiveMetaStore connection.");
       try {
-        UserGroupInformation.getLoginUser().getRealUser().doAs(
+        UserGroupInformation.getLoginUser().doAs(
             new PrivilegedExceptionAction<Void>() {
               @Override
               public Void run() throws Exception {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -255,7 +255,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       LOG.info(HADOOP_PROXY_USER + " is set. Using delegation "
           + "token for HiveMetaStore connection.");
       try {
-        UserGroupInformation.getLoginUser().doAs(
+        UserGroupInformation.getRealUserOrSelf(UserGroupInformation.getLoginUser()).doAs(
             new PrivilegedExceptionAction<Void>() {
               @Override
               public Void run() throws Exception {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow delegation for HiveMetaStore connections

### Why are the changes needed?

The log message indicates that `HADOOP_PROXY_USER` is set, but then doesn't allow its use by calling `getRealUser()` which will be `null`.  This change allows delegation for HiveMetaStore connections by using either the real user or self.  The code for this is coming from Hadoop 3.3.6.

### Does this PR introduce _any_ user-facing change?

Allows proxying instead of throwing an exception.

### Is the change a dependency upgrade?

No

### How was this patch tested?

Local builds which have removed `getRealUser()` to allow the use of delegation work as expected.  Running the existing code always fail because `getRealUser()` will always return `null`.