### PR TITLE
HIVE-28244: Add SBOM for storage-api and standalone-metastore modules

### DIFF
--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -40,6 +40,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
+    <maven.cyclonedx.plugin.version>2.7.10</maven.cyclonedx.plugin.version>
     <maven.repo.local>${settings.localRepository}</maven.repo.local>
     <maven.exec.plugin.version>3.1.0</maven.exec.plugin.version>
     <checkstyle.conf.dir>${basedir}/${standalone.metastore.path.to.root}/checkstyle</checkstyle.conf.dir>
@@ -658,6 +659,26 @@
           </plugin>
         </plugins>
       </reporting>
+    </profile>
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>${maven.cyclonedx.plugin.version}</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>makeBom</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -36,6 +36,7 @@
     <junit.vintage.version>5.6.3</junit.vintage.version>
     <slf4j.version>1.7.30</slf4j.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
+    <maven.cyclonedx.plugin.version>2.7.10</maven.cyclonedx.plugin.version>
     <checkstyle.conf.dir>${basedir}/checkstyle/</checkstyle.conf.dir>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
@@ -216,4 +217,26 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>${maven.cyclonedx.plugin.version}</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>makeBom</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
### What changes were proposed in this pull request?
-Pdist profile present in parent pom.xml doesn't come into effect for storage-api module and standalone-metastore module.

### Why are the changes needed?
Publish SBOM for standalone-metastore and storage-api module



### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO


### How was this patch tested?
Tested via my local .m2 repository cache. After the fix, it is creating the "-cyclonedx.json" and "-cyclonedx.xml" for storage-api and standalone-metastore.
