### PR TITLE
[hotfix][test] Initializing MiniDFSCluster avoid using deprecated methods.

### DIFF
--- a/hbase-handler/src/test/org/apache/hadoop/hive/hbase/TestHBaseSerDe.java
+++ b/hbase-handler/src/test/org/apache/hadoop/hive/hbase/TestHBaseSerDe.java
@@ -1273,7 +1273,8 @@ public class TestHBaseSerDe {
 
     try {
       // MiniDFSCluster litters files and folders all over the place.
-      miniDfs = new MiniDFSCluster(new Configuration(), 1, true, null);
+      miniDfs = new MiniDFSCluster.Builder(new Configuration()).numDataNodes(1).
+          format(true).racks(null).build();
 
       miniDfs.getFileSystem().mkdirs(new Path("/path/to/schema"));
       FSDataOutputStream out = miniDfs.getFileSystem().create(

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/MiniCluster.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/MiniCluster.java
@@ -65,7 +65,8 @@ public class MiniCluster {
       if(System.getProperty("hadoop.log.dir") == null) {
         System.setProperty("hadoop.log.dir", "target/tmp/logs/");
       }
-      m_dfs = new MiniDFSCluster(config, dataNodes, true, null);
+      m_dfs = new MiniDFSCluster.Builder(config).numDataNodes(dataNodes).format(true)
+          .racks(null).build();
 
       m_fileSys = m_dfs.getFileSystem();
       m_mr = new MiniMRCluster(taskTrackers, m_fileSys.getUri().toString(), 1);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestDDLWithRemoteMetastoreSecondNamenode.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestDDLWithRemoteMetastoreSecondNamenode.java
@@ -92,7 +92,8 @@ public class TestDDLWithRemoteMetastoreSecondNamenode {
       // Initialize second mocked filesystem (implement only necessary stuff)
       // Physical files are resides in local file system in the similar location
       jobConf = new HiveConf(conf);
-      miniDfs = new MiniDFSCluster(new Configuration(), 1, true, null);
+      miniDfs = new MiniDFSCluster.Builder(new Configuration()).numDataNodes(1).format(true)
+          .racks(null).build();
       fs2 = miniDfs.getFileSystem();
       try {
         fs2.delete(tmppathFs2, true);

--- a/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroSerdeUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroSerdeUtils.java
@@ -208,7 +208,8 @@ public class TestAvroSerdeUtils {
     MiniDFSCluster miniDfs = null;
     try {
       // MiniDFSCluster litters files and folders all over the place.
-      miniDfs = new MiniDFSCluster(new Configuration(), 1, true, null);
+      miniDfs = new MiniDFSCluster.Builder(new Configuration()).numDataNodes(1).format(true)
+          .racks(null).build();
 
       miniDfs.getFileSystem().mkdirs(new Path("/path/to/schema"));
       FSDataOutputStream out = miniDfs.getFileSystem()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

I have been recently tracking the issue of upgrading Hadoop from 3.3.6 to 3.4.0. During this process, I identified an improvement point: we are using deprecated methods while initializing MiniDFSCluster. Currently, four unit tests utilize deprecated methods, while others use the recommended ones. Instead of creating a JIRA ticket, I am attempting to fix it directly using a hotfix approach.

### Why are the changes needed?

It is better to use the recommended method.

### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

This pr is upgrading the code for unit tests, and the upgraded code won't introduce any other issues.