### PR TITLE
HIVE-28245. Upgrade Spring to 5.3.27 due to CVE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
     <aws-java-sdk.version>1.12.499</aws-java-sdk.version>
     <jansi.version>2.4.0</jansi.version>
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
-    <spring.version>5.3.21</spring.version>
+    <spring.version>5.3.27</spring.version>
     <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
   <repositories>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -112,7 +112,7 @@
     <jetty.version>9.4.45.v20220203</jetty.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
-    <spring.version>5.3.21</spring.version>
+    <spring.version>5.3.27</spring.version>
     <!-- Thrift properties -->
     <thrift.home>you-must-set-this-to-run-thrift</thrift.home>
     <thrift.gen.dir>${basedir}/src/gen/thrift</thrift.gen.dir>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

JIRA: HIVE-28245. Upgrade Spring to 5.3.27 due to CVE.

I found that there are 2 CVE issues in the current Spring version, CVE-2023-20863 and CVE-2023-20861; we can upgrade the Spring version to 5.3.27 to solve this issue.

[CVE-2023-20861](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20861)

[CVE-2023-20863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20863)

### Why are the changes needed?

We need to upgrade to resolve CVE Issue.

### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

Compile locally