### PR TITLE
HIVE-28250: Add tez.task-specific configs into whitelist to modify at session level

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -6830,6 +6830,7 @@ public class HiveConf extends Configuration {
     "oozie\\..*",
     "tez\\.am\\..*",
     "tez\\.task\\..*",
+    "tez\\.task\\-.*",
     "tez\\.runtime\\..*",
     "tez\\.queue\\.name",
     "iceberg\\.mr\\..*"


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HIVE-28250](https://issues.apache.org/jira/browse/HIVE-28250): Refer the JIRA for error message


### Why are the changes needed?
For easier debugging tez jobs in cluster. **_tez.task-specific_** configs are used for debugging/profiling a particular vertex but we cannot set them at session level. 


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO

### How was this patch tested?
On local machine (single node setup)
