### PR TITLE
HIVE-28239: Fix bug on HMSHandler#checkLimitNumberOfPartitions

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -5562,32 +5562,32 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
   private void checkLimitNumberOfPartitionsByFilter(String catName, String dbName,
                                                     String tblName, String filterString,
-                                                    int maxParts) throws TException {
-    if (exceedsPartitionLimit(maxParts)) {
+                                                    int requestMax) throws TException {
+    if (exceedsPartitionFetchLimit(requestMax)) {
       checkLimitNumberOfPartitions(tblName, get_num_partitions_by_filter(prependCatalogToDbName(
           catName, dbName, conf), tblName, filterString));
     }
   }
 
   private void checkLimitNumberOfPartitionsByPs(String catName, String dbName, String tblName,
-                                                List<String> partVals, int maxParts)
+                                                List<String> partVals, int requestMax)
           throws TException {
-    if (exceedsPartitionLimit(maxParts)) {
+    if (exceedsPartitionFetchLimit(requestMax)) {
       checkLimitNumberOfPartitions(tblName, getNumPartitionsByPs(catName, dbName, tblName,
               partVals));
     }
   }
 
-  // Check input size exceeding partition limit iff:
+  // Check input count exceeding partition limit iff:
   //  1. partition limit is enabled.
-  //  2. input size is greater than the limit.
-  private boolean exceedsPartitionLimit(int size) {
+  //  2. input count is greater than the limit.
+  private boolean exceedsPartitionFetchLimit(int count) {
     int partitionLimit = MetastoreConf.getIntVar(conf, ConfVars.LIMIT_PARTITION_REQUEST);
-    return partitionLimit > -1 && (size < 0 || size > partitionLimit);
+    return partitionLimit > -1 && (count < 0 || count > partitionLimit);
   }
 
   private void checkLimitNumberOfPartitions(String tblName, int numPartitions) throws MetaException {
-    if (exceedsPartitionLimit(numPartitions)) {
+    if (exceedsPartitionFetchLimit(numPartitions)) {
       int partitionLimit = MetastoreConf.getIntVar(conf, ConfVars.LIMIT_PARTITION_REQUEST);
       String configName = ConfVars.LIMIT_PARTITION_REQUEST.toString();
       throw new MetaException(String.format(PARTITION_NUMBER_EXCEED_LIMIT_MSG, numPartitions,
@@ -7217,7 +7217,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     RawStore rs = getMS();
     try {
       authorizeTableForPartitionMetadata(catName, dbName, tblName);
-      if (exceedsPartitionLimit(args.getMax())) {
+      if (exceedsPartitionFetchLimit(args.getMax())) {
         // Since partition limit is configured, we need fetch at most (limit + 1) partition names
         int max = MetastoreConf.getIntVar(conf, ConfVars.LIMIT_PARTITION_REQUEST) + 1;
         args = new GetPartitionsArgs.GetPartitionsArgsBuilder(args).max(max).build();
@@ -7349,7 +7349,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     List<Partition> partitions = new LinkedList<>();
     boolean hasUnknownPartitions = false;
     RawStore rs = getMS();
-    if (exceedsPartitionLimit(args.getMax())) {
+    if (exceedsPartitionFetchLimit(args.getMax())) {
       // Since partition limit is configured, we need fetch at most (limit + 1) partition names
       int max = MetastoreConf.getIntVar(conf, ConfVars.LIMIT_PARTITION_REQUEST) + 1;
       List<String> partNames = rs.listPartitionNames(catName, dbName, tblName, args.getDefaultPartName(), args.getExpr(), null, max);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestListPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestListPartitions.java
@@ -203,6 +203,22 @@ public class TestListPartitions extends MetaStoreClientTest {
     return new ReturnTable(t, testValues);
   }
 
+  private ReturnTable createTableNParts(IMetaStoreClient client, boolean authOn, int nParts)
+      throws Exception {
+    Table t = createTestTable(client, DB_NAME, TABLE_NAME, Lists.newArrayList("yyyy", "mm", "dd"),
+            authOn);
+    List<List<String>> testValues = new ArrayList<>(nParts);
+    for (int i = 0; i < nParts; i++) {
+      testValues.add(Lists.newArrayList("2017", "01", String.valueOf(i)));
+    }
+
+    for(List<String> vals : testValues) {
+      addPartition(client, t, vals);
+    }
+
+    return new ReturnTable(t, testValues);
+  }
+
   protected ReturnTable createTable4PartColsParts(IMetaStoreClient client) throws
           Exception {
     return createTable4PartColsPartsGeneric(client, false);
@@ -324,7 +340,7 @@ public class TestListPartitions extends MetaStoreClientTest {
   @Test(expected = MetaException.class)
   @ConditionalIgnoreOnSessionHiveMetastoreClient
   public void testListPartitionsAllHighMaxParts() throws Exception {
-    createTable3PartCols1Part(client);
+    createTableNParts(client, false, 101);
     List<Partition> partitions = client.listPartitions(DB_NAME, TABLE_NAME, (short)101);
     assertTrue(partitions.isEmpty());
   }
@@ -496,7 +512,7 @@ public class TestListPartitions extends MetaStoreClientTest {
   @Test(expected = MetaException.class)
   @ConditionalIgnoreOnSessionHiveMetastoreClient
   public void testListPartitionSpecsHighMaxParts() throws Exception {
-    createTable4PartColsParts(client);
+    createTableNParts(client, false, 101);
     client.listPartitionSpecs(DB_NAME, TABLE_NAME, 101);
   }
 
@@ -562,7 +578,7 @@ public class TestListPartitions extends MetaStoreClientTest {
   @Test(expected = MetaException.class)
   @ConditionalIgnoreOnSessionHiveMetastoreClient
   public void testListPartitionsWithAuthHighMaxParts() throws Exception {
-    createTable4PartColsParts(client);
+    createTableNParts(client, false, 101);
     client.listPartitionsWithAuthInfo(DB_NAME, TABLE_NAME, (short)101, "", Lists.newArrayList());
   }
 
@@ -754,7 +770,7 @@ public class TestListPartitions extends MetaStoreClientTest {
   @Test(expected = MetaException.class)
   @ConditionalIgnoreOnSessionHiveMetastoreClient
   public void testListPartitionsWithAuthByValuesHighMaxParts() throws Exception {
-    createTable4PartColsParts(client);
+    createTableNParts(client, false, 101);
     client.listPartitionsWithAuthInfo(DB_NAME, TABLE_NAME, Lists
             .newArrayList("2017"), (short) 101, "", Lists.newArrayList());
   }
@@ -982,7 +998,7 @@ public class TestListPartitions extends MetaStoreClientTest {
   @Test(expected = MetaException.class)
   @ConditionalIgnoreOnSessionHiveMetastoreClient
   public void testListPartitionsByFilterHighMaxParts() throws Exception {
-    createTable4PartColsParts(client);
+    createTableNParts(client, false, 101);
     client.listPartitionsByFilter(DB_NAME, TABLE_NAME, "yyyy=\"2017\"", (short)101);
   }
 
@@ -1095,7 +1111,7 @@ public class TestListPartitions extends MetaStoreClientTest {
   @Test(expected = MetaException.class)
   @ConditionalIgnoreOnSessionHiveMetastoreClient
   public void testListPartitionSpecsByFilterHighMaxParts() throws Exception {
-    createTable4PartColsParts(client);
+    createTableNParts(client, false, 101);
     client.listPartitionSpecsByFilter(DB_NAME, TABLE_NAME, "yyyy=\"2017\"", 101);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the bug on `HMSHandler#checkLimitNumberOfPartitions`:
1. use maxParts to determine if need check partition limit
2. remove maxParts on `checkLimitNumberOfPartitions`

### Why are the changes needed?
Fix the bug, assume that HMS configure `metastore.limit.partition.request` as 100, the client calls `get_partitions_by_filter` with maxParts as 101, and the matching partition number is 50, in this case the HMS server should not throw `MetaException` by partition limit check.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Fix some unit tests.
