### PR TITLE
HIVE-28260: CreateTableEvent wrongly skips authorizing DFS_URI for managed table.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/events/CreateTableEvent.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/events/CreateTableEvent.java
@@ -82,7 +82,7 @@ public class CreateTableEvent extends HiveMetaStoreAuthorizableEvent {
     ret.add(getHivePrivilegeObject(database));
     ret.add(getHivePrivilegeObject(table));
 
-    if (StringUtils.isNotEmpty(uri) && table.getTableType() != TableType.EXTERNAL_TABLE.toString()) {
+    if (StringUtils.isNotEmpty(uri) && !TableType.EXTERNAL_TABLE.toString().equalsIgnoreCase(table.getTableType())) {
       ret.add(new HivePrivilegeObject(HivePrivilegeObjectType.DFS_URI, null, uri));
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct the check to restore proper behaviour 

### Why are the changes needed?

The check is wrong, the string needs to be compared using equals

### Does this PR introduce _any_ user-facing change?

Yes, the URI will be validated during create for managed table

### Is the change a dependency upgrade?

No

### How was this patch tested?

👀
