### PR TITLE
HIVE-28266: Iceberg: select count(*) from data_files metadata tables …

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -48,6 +48,7 @@ public class IcebergAcidUtil {
   private static final Types.NestedField PARTITION_STRUCT_META_COL = null; // placeholder value in the map
   private static final Map<Types.NestedField, Integer> FILE_READ_META_COLS = Maps.newLinkedHashMap();
   private static final Map<String, Types.NestedField> VIRTUAL_COLS_TO_META_COLS = Maps.newLinkedHashMap();
+  public static final String META_TABLE_PROPERTY = "metaTable";
 
   static {
     FILE_READ_META_COLS.put(MetadataColumns.SPEC_ID, 0);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
@@ -99,7 +99,7 @@ public class IcebergTableUtil {
    * @return an Iceberg table
    */
   static Table getTable(Configuration configuration, Properties properties, boolean skipCache) {
-    String metaTable = properties.getProperty("metaTable");
+    String metaTable = properties.getProperty(IcebergAcidUtil.META_TABLE_PROPERTY);
     String tableName = properties.getProperty(Catalogs.NAME);
     String location = properties.getProperty(Catalogs.LOCATION);
     if (metaTable != null) {

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_major_compaction_query_metadata.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_major_compaction_query_metadata.q
@@ -1,0 +1,43 @@
+-- Mask random uuid
+--! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask a random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\S+(\s*)/$1#Masked#/
+-- Mask current-snapshot-timestamp-ms
+--! qt:replace:/(\s+current-snapshot-timestamp-ms\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask added file size
+--! qt:replace:/(\S\"added-files-size\\\":\\\")(\d+)(\\\")/$1#Masked#$3/
+-- Mask total file size
+--! qt:replace:/(\S\"total-files-size\\\":\\\")(\d+)(\\\")/$1#Masked#$3/
+-- Mask show compactions fields that change across runs
+--! qt:replace:/(MAJOR\s+succeeded\s+)[a-zA-Z0-9\-\.\s+]+(\s+manual)/$1#Masked#$2/
+
+set hive.llap.io.enabled=true;
+set hive.vectorized.execution.enabled=true;
+set hive.optimize.shared.work.merge.ts.schema=true;
+set iceberg.mr.schema.auto.conversion=true;
+
+CREATE TABLE x (name VARCHAR(50), age TINYINT, num_clicks BIGINT) 
+stored by iceberg stored as orc 
+TBLPROPERTIES ('external.table.purge'='true','format-version'='2');
+
+insert into x values 
+('amy', 35, 123412344),
+('adxfvy', 36, 123412534),
+('amsdfyy', 37, 123417234),
+('asafmy', 38, 123412534);
+
+insert into x values 
+('amerqwy', 39, 123441234),
+('amyxzcv', 40, 123341234),
+('erweramy', 45, 122341234);
+
+select * from default.x.data_files;
+select count(*) from default.x.data_files;
+
+alter table x compact 'major' and wait;
+
+show compactions;
+desc formatted x;
+
+select * from default.x.data_files;
+select count(*) from default.x.data_files;

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_major_compaction_query_metadata.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_major_compaction_query_metadata.q.out
@@ -1,0 +1,142 @@
+PREHOOK: query: CREATE TABLE x (name VARCHAR(50), age TINYINT, num_clicks BIGINT) 
+stored by iceberg stored as orc 
+TBLPROPERTIES ('external.table.purge'='true','format-version'='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@x
+POSTHOOK: query: CREATE TABLE x (name VARCHAR(50), age TINYINT, num_clicks BIGINT) 
+stored by iceberg stored as orc 
+TBLPROPERTIES ('external.table.purge'='true','format-version'='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@x
+PREHOOK: query: insert into x values 
+('amy', 35, 123412344),
+('adxfvy', 36, 123412534),
+('amsdfyy', 37, 123417234),
+('asafmy', 38, 123412534)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@x
+POSTHOOK: query: insert into x values 
+('amy', 35, 123412344),
+('adxfvy', 36, 123412534),
+('amsdfyy', 37, 123417234),
+('asafmy', 38, 123412534)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@x
+PREHOOK: query: insert into x values 
+('amerqwy', 39, 123441234),
+('amyxzcv', 40, 123341234),
+('erweramy', 45, 122341234)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@x
+POSTHOOK: query: insert into x values 
+('amerqwy', 39, 123441234),
+('amyxzcv', 40, 123341234),
+('erweramy', 45, 122341234)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@x
+PREHOOK: query: select * from default.x.data_files
+PREHOOK: type: QUERY
+PREHOOK: Input: default@x
+#### A masked pattern was here ####
+POSTHOOK: query: select * from default.x.data_files
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@x
+#### A masked pattern was here ####
+PREHOOK: query: select count(*) from default.x.data_files
+PREHOOK: type: QUERY
+PREHOOK: Input: default@x
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from default.x.data_files
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@x
+#### A masked pattern was here ####
+2
+PREHOOK: query: alter table x compact 'major' and wait
+PREHOOK: type: ALTERTABLE_COMPACT
+PREHOOK: Input: default@x
+PREHOOK: Output: default@x
+POSTHOOK: query: alter table x compact 'major' and wait
+POSTHOOK: type: ALTERTABLE_COMPACT
+POSTHOOK: Input: default@x
+POSTHOOK: Output: default@x
+PREHOOK: query: show compactions
+PREHOOK: type: SHOW COMPACTIONS
+POSTHOOK: query: show compactions
+POSTHOOK: type: SHOW COMPACTIONS
+CompactionId	Database	Table	Partition	Type	State	Worker host	Worker	Enqueue Time	Start Time	Duration(ms)	HadoopJobId	Error message	Initiator host	Initiator	Pool name	TxnId	Next TxnId	Commit Time	Highest WriteId
+1	default	x	 --- 	MAJOR	succeeded	#Masked#	manual	default	0	0	0	 --- 
+PREHOOK: query: desc formatted x
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@x
+POSTHOOK: query: desc formatted x
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@x
+# col_name            	data_type           	comment             
+name                	string              	                    
+age                 	int                 	                    
+num_clicks          	bigint              	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"age\":\"true\",\"name\":\"true\",\"num_clicks\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	current-schema      	{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"name\",\"required\":false,\"type\":\"string\"},{\"id\":2,\"name\":\"age\",\"required\":false,\"type\":\"int\"},{\"id\":3,\"name\":\"num_clicks\",\"required\":false,\"type\":\"long\"}]}
+	current-snapshot-id 	#Masked#
+	current-snapshot-summary	{\"replace-partitions\":\"true\",\"added-data-files\":\"1\",\"added-records\":\"7\",\"added-files-size\":\"#Masked#\",\"changed-partition-count\":\"1\",\"total-records\":\"7\",\"total-files-size\":\"#Masked#\",\"total-data-files\":\"1\",\"total-delete-files\":\"0\",\"total-position-deletes\":\"0\",\"total-equality-deletes\":\"0\"}
+	current-snapshot-timestamp-ms	#Masked#       
+	external.table.purge	true                
+	format-version      	2                   
+	iceberg.orc.files.only	true                
+#### A masked pattern was here ####
+	numFiles            	1                   
+	numRows             	7                   
+	parquet.compression 	zstd                
+#### A masked pattern was here ####
+	rawDataSize         	0                   
+	serialization.format	1                   
+	snapshot-count      	4                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	#Masked#
+#### A masked pattern was here ####
+	uuid                	#Masked#
+	write.delete.mode   	merge-on-read       
+	write.format.default	orc                 
+	write.merge.mode    	merge-on-read       
+	write.update.mode   	merge-on-read       
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: select * from default.x.data_files
+PREHOOK: type: QUERY
+PREHOOK: Input: default@x
+#### A masked pattern was here ####
+POSTHOOK: query: select * from default.x.data_files
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@x
+#### A masked pattern was here ####
+PREHOOK: query: select count(*) from default.x.data_files
+PREHOOK: type: QUERY
+PREHOOK: Input: default@x
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from default.x.data_files
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@x
+#### A masked pattern was here ####
+1

--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -422,6 +422,7 @@ iceberg.llap.query.files=\
 iceberg.llap.query.compactor.files=\
   iceberg_major_compaction_partition_evolution.q,\
   iceberg_major_compaction_partitioned.q,\
+  iceberg_major_compaction_query_metadata.q,\
   iceberg_major_compaction_schema_evolution.q,\
   iceberg_major_compaction_single_partition.q,\
   iceberg_major_compaction_unpartitioned.q,\


### PR DESCRIPTION
…gives wrong result

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Modified Iceberg method "canComputeQueryUsingStats" to return false for queries over metadata tables to make Hive execute query over metadata table instead of getting the result from statistics.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Presently, when running a SELECT COUNT(*) query over an Iceberg table X.data_files where X is a data table, the result returns number of records in X rather than in X.data_files.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New query test added