### PR TITLE
HIVE-28271: DirectSql fails for AlterPartitions.

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdatePart.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdatePart.java
@@ -72,6 +72,7 @@ import java.util.stream.Collectors;
 import static org.apache.hadoop.hive.common.StatsSetupConst.COLUMN_STATS_ACCURATE;
 import static org.apache.hadoop.hive.metastore.HMSHandler.getPartValsFromName;
 import static org.apache.hadoop.hive.metastore.MetastoreDirectSqlUtils.executeWithArray;
+import static org.apache.hadoop.hive.metastore.MetastoreDirectSqlUtils.extractSqlClob;
 import static org.apache.hadoop.hive.metastore.MetastoreDirectSqlUtils.extractSqlInt;
 import static org.apache.hadoop.hive.metastore.MetastoreDirectSqlUtils.extractSqlLong;
 
@@ -755,8 +756,8 @@ class DirectSqlUpdatePart {
           List<Object[]> sqlResult = executeWithArray(query.getInnerQuery(), null, queryText);
           for (Object[] row : sqlResult) {
             Long id = extractSqlLong(row[0]);
-            String paramKey = (String) row[1];
-            String paramVal = (String) row[2];
+            String paramKey = extractSqlClob(row[1]);
+            String paramVal = extractSqlClob(row[2]);
             idToParams.computeIfAbsent(id, key -> new HashMap<>()).put(paramKey, paramVal);
           }
         }
@@ -930,8 +931,8 @@ class DirectSqlUpdatePart {
               StorageDescriptor sd = idToSd.get(sdId);
               statement.setLong(1, idToCdId.get(sdId));
               statement.setString(2, sd.getInputFormat());
-              statement.setBoolean(3, sd.isCompressed());
-              statement.setBoolean(4, sd.isStoredAsSubDirectories());
+              statement.setObject(3, dbType.getBoolean(sd.isCompressed()));
+              statement.setObject(4, dbType.getBoolean(sd.isStoredAsSubDirectories()));
               statement.setString(5, sd.getLocation());
               statement.setInt(6, sd.getNumBuckets());
               statement.setString(7, sd.getOutputFormat());
@@ -1234,9 +1235,9 @@ class DirectSqlUpdatePart {
           List<Object[]> sqlResult = executeWithArray(query.getInnerQuery(), null, queryText);
           for (Object[] row : sqlResult) {
             Long id = extractSqlLong(row[0]);
-            String comment = (String) row[1];
-            String name = (String) row[2];
-            String type = (String) row[3];
+            String comment = extractSqlClob(row[1]);
+            String name = extractSqlClob(row[2]);
+            String type = extractSqlClob(row[3]);
             int index = extractSqlInt(row[4]);
             FieldSchema field = new FieldSchema(name, type, comment);
             cdIdToColIdxPair.computeIfAbsent(id, k -> new ArrayList<>()).add(Pair.of(index, field));

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -548,6 +548,16 @@ class MetaStoreDirectSql {
    */
   public List<Partition> alterPartitions(MTable table, List<String> partNames,
                                          List<Partition> newParts, String queryWriteIdList) throws MetaException {
+
+    for (Partition tmpPart : newParts) {
+      if (!tmpPart.getDbName().equalsIgnoreCase(table.getDatabase().getName())) {
+        throw new MetaException("Invalid DB name : " + tmpPart.getDbName());
+      }
+
+      if (!tmpPart.getTableName().equalsIgnoreCase(table.getTableName())) {
+        throw new MetaException("Invalid table name : " + tmpPart.getDbName());
+      }
+    }
     List<Object[]> rows = Batchable.runBatched(batchSize, partNames, new Batchable<String, Object[]>() {
       @Override
       public List<Object[]> run(List<String> input) throws Exception {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -548,16 +548,6 @@ class MetaStoreDirectSql {
    */
   public List<Partition> alterPartitions(MTable table, List<String> partNames,
                                          List<Partition> newParts, String queryWriteIdList) throws MetaException {
-
-    for (Partition tmpPart : newParts) {
-      if (!tmpPart.getDbName().equalsIgnoreCase(table.getDatabase().getName())) {
-        throw new MetaException("Invalid DB name : " + tmpPart.getDbName());
-      }
-
-      if (!tmpPart.getTableName().equalsIgnoreCase(table.getTableName())) {
-        throw new MetaException("Invalid table name : " + tmpPart.getDbName());
-      }
-    }
     List<Object[]> rows = Batchable.runBatched(batchSize, partNames, new Batchable<String, Object[]>() {
       @Override
       public List<Object[]> run(List<String> input) throws Exception {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -5364,6 +5364,16 @@ public class ObjectStore implements RawStore, Configurable {
         partNames.add(Warehouse.makePartName(partCols, partVal));
       }
 
+      for (Partition tmpPart : newParts) {
+        if (!tmpPart.getDbName().equalsIgnoreCase(table.getDatabase().getName())) {
+          throw new MetaException("Invalid DB name : " + tmpPart.getDbName());
+        }
+
+        if (!tmpPart.getTableName().equalsIgnoreCase(table.getTableName())) {
+          throw new MetaException("Invalid table name : " + tmpPart.getDbName());
+        }
+      }
+
       results = new GetListHelper<Partition>(catName, dbName, tblName, true, true) {
         @Override
         protected List<Partition> getSqlResult(GetHelper<List<Partition>> ctx)
@@ -5420,14 +5430,6 @@ public class ObjectStore implements RawStore, Configurable {
       Set<MColumnDescriptor> oldCds = new HashSet<>();
       Ref<MColumnDescriptor> oldCdRef = new Ref<>();
       for (Partition tmpPart : newParts) {
-        if (!tmpPart.getDbName().equalsIgnoreCase(dbName)) {
-          throw new MetaException("Invalid DB name : " + tmpPart.getDbName());
-        }
-
-        if (!tmpPart.getTableName().equalsIgnoreCase(tblName)) {
-          throw new MetaException("Invalid table   name : " + tmpPart.getDbName());
-        }
-
         oldCdRef.t = null;
         Partition result = alterPartitionNoTxn(catName, dbName, tblName,
             mPartsMap.get(tmpPart.getValues()), tmpPart, queryWriteIdList, oldCdRef, table);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix DirectSql for AlterPartitions for some DB

### Why are the changes needed?

To fix directSql for alter partions


### Does this PR introduce _any_ user-facing change?

No

### Is the change a dependency upgrade?

No

### How was this patch tested?

Checked Logs to see no direct sql related exception where they were present earlier
