### PR TITLE
HIVE-28273: Avoid getting NegativeArraySizeException in HIVE-28249 related tests

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampsHive2Compatibility.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampsHive2Compatibility.java
@@ -26,12 +26,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.google.common.base.Strings;
+
 import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
@@ -258,45 +261,16 @@ class TestParquetTimestampsHive2Compatibility {
   }
 
   private static Stream<String> generateJulianLeapYearTimestamps() {
-    return Stream.concat(Stream.generate(new Supplier<String>() {
-          int i = 0;
-
-          @Override
-          public String get() {
-            StringBuilder sb = new StringBuilder(29);
-            int year = ((i % 9999) + 1) * 100;
-            sb.append(zeros(4 - digits(year)));
-            sb.append(year);
-            sb.append("-03-01 00:00:00.000000001");
-            i++;
-            return sb.toString();
-          }
-        })
-        // Exclude dates falling in the default Gregorian change date since legacy code does not handle that interval
-        // gracefully. It is expected that these do not work well when legacy APIs are in use. 0200-03-01 01:01:01.000000001
-        .filter(s -> !s.startsWith("1582-10")).limit(3000), Stream.of("9999-12-31 23:59:59.999"));
+    return IntStream.range(1, 100)
+    .mapToObj(value -> Strings.padStart(String.valueOf(value * 100), 4, '0'))
+    .map(value -> value + "-03-01 00:00:00.000000001");
   }
 
   private static Stream<String> generateJulianLeapYearTimestamps28thFeb() {
-    return Stream.concat(Stream.generate(new Supplier<String>() {
-          int i = 0;
-
-          @Override
-          public String get() {
-            StringBuilder sb = new StringBuilder(29);
-            int year = ((i % 9999) + 1) * 100;
-            sb.append(zeros(4 - digits(year)));
-            sb.append(year);
-            sb.append("-02-28 00:00:00.000000001");
-            i++;
-            return sb.toString();
-          }
-        })
-        // Exclude dates falling in the default Gregorian change date since legacy code does not handle that interval
-        // gracefully. It is expected that these do not work well when legacy APIs are in use. 0200-03-01 01:01:01.000000001
-        .filter(s -> !s.startsWith("1582-10")).limit(3000), Stream.of("9999-12-31 23:59:59.999"));
+    return IntStream.range(1, 100)
+    .mapToObj(value -> Strings.padStart(String.valueOf(value * 100), 4, '0'))
+    .map(value -> value + "-02-28 00:00:00.000000001");
   }
-
 
   private static int digits(int number) {
     int digits = 0;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This change refactors how timestamps are generated for the following tests in TestParquetTimestampsHive2Compatibility:
- testWriteHive2ReadHive4UsingLegacyConversionWithJulianLeapYears
- testWriteHive2ReadHive4UsingLegacyConversionWithJulianLeapYearsFor28thFeb


### Why are the changes needed?
generateJulianLeapYearTimestamps and generateJulianLeapYearTimestamps28thFeb are throwing NegativeArraySizeException once the base value equals or is over 999

This is caused by the below code, supplying a negative value (when digits return a value larger than 4) to zeros, which in turn is used to create a new char array.

```
StringBuilder sb = new StringBuilder(29);
int year = ((i % 9999) + 1) * 100;
sb.append(zeros(4 - digits(year)));
```


When the tests are run using maven, the error in the generation function is caught but never rethrown or reported and the build is reported successful. For example running
TestParquetTimestampsHive2Compatibility#testWriteHive2ReadHive4UsingLegacyConversionWithJulianLeapYearsFor28thFeb has the result:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hive.ql.io.parquet.serde.TestParquetTimestampsHive2Compatibility
[INFO] Tests run: 396, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.723 s - in org.apache.hadoop.hive.ql.io.parquet.serde.TestParquetTimestampsHive2Compatibility
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 396, Failures: 0, Errors: 0, Skipped: 0

...

[INFO] BUILD SUCCESS
```
When the test is run through an IDE (eg VSCode), the failure is reported properly.

Full stack trace:
```
java.lang.NegativeArraySizeException
 at org.apache.hadoop.hive.ql.io.parquet.serde.TestParquetTimestampsHive2Compatibility.zeros(TestParquetTimestampsHive2Compatibility.java:334)
 at org.apache.hadoop.hive.ql.io.parquet.serde.TestParquetTimestampsHive2Compatibility.access$1(TestParquetTimestampsHive2Compatibility.java:333)
 at org.apache.hadoop.hive.ql.io.parquet.serde.TestParquetTimestampsHive2Compatibility$3.get(TestParquetTimestampsHive2Compatibility.java:311)
 at org.apache.hadoop.hive.ql.io.parquet.serde.TestParquetTimestampsHive2Compatibility$3.get(TestParquetTimestampsHive2Compatibility.java:1)
 at java.util.stream.StreamSpliterators$InfiniteSupplyingSpliterator$OfRef.tryAdvance(StreamSpliterators.java:1361)
 at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
 at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
 at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
 at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
 at java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:313)
 at java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:742)
 at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
 at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
 at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
 at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
 at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
 at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
 at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:272)
 at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
 at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
 at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
 at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
 at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
 at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
 at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
 at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
 at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
 at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:272)
 at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
 at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
 at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
 at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
 at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
 at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
 at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
 at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
 at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
 at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
 at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:272)
 at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
 at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
 at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
 at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
 at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
 at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
 at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
 at java.util.ArrayList.forEach(ArrayList.java:1257)
 at java.util.ArrayList.forEach(ArrayList.java:1257)
```

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This change refactors existing tests. Running those tests is sufficient.