### PR TITLE
HIVE-28276: Iceberg:Make Iceberg split threads configurable when table scanning

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -87,6 +87,8 @@ public class InputFormatConfig {
   public static final String CATALOG_DEFAULT_CONFIG_PREFIX = "iceberg.catalog-default.";
   public static final String QUERY_FILTERS = "iceberg.query.filters";
 
+  public static final String TABLE_PLAN_WORKER_POOL_SIZE = "iceberg.worker.num-threads";
+
   public enum InMemoryDataModel {
     PIG,
     HIVE,

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -87,8 +87,6 @@ public class InputFormatConfig {
   public static final String CATALOG_DEFAULT_CONFIG_PREFIX = "iceberg.catalog-default.";
   public static final String QUERY_FILTERS = "iceberg.query.filters";
 
-  public static final String TABLE_PLAN_WORKER_POOL_SIZE = "iceberg.worker.num-threads";
-
   public enum InMemoryDataModel {
     PIG,
     HIVE,

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -63,6 +63,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.SystemConfigs;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
@@ -211,7 +212,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
         });
     final ExecutorService workerPool =
         ThreadPools.newWorkerPool("iceberg-plan-worker-pool",
-            conf.getInt(InputFormatConfig.TABLE_PLAN_WORKER_POOL_SIZE, ThreadPools.WORKER_THREAD_POOL_SIZE));
+            conf.getInt(SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey(), ThreadPools.WORKER_THREAD_POOL_SIZE));
     try {
       return planInputSplits(table, conf, workerPool);
     } finally {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -218,7 +218,6 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     } finally {
       workerPool.shutdown();
     }
-
   }
 
   private List<InputSplit> planInputSplits(Table table, Configuration conf, ExecutorService workerPool) {
@@ -230,10 +229,11 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     long fromVersion = conf.getLong(InputFormatConfig.SNAPSHOT_ID_INTERVAL_FROM, -1);
     Scan<?, FileScanTask, CombinedScanTask> scan;
     if (fromVersion != -1) {
-      scan = applyConfig(conf, createIncrementalAppendScan(table, conf)).planWith(workerPool);
+      scan = applyConfig(conf, createIncrementalAppendScan(table, conf));
     } else {
-      scan = applyConfig(conf, createTableScan(table, conf)).planWith(workerPool);
+      scan = applyConfig(conf, createTableScan(table, conf));
     }
+    scan = (Scan<?, FileScanTask, CombinedScanTask>) scan.planWith(workerPool);
 
     boolean allowDataFilesWithinTableLocationOnly =
         conf.getBoolean(HiveConf.ConfVars.HIVE_ICEBERG_ALLOW_DATAFILES_IN_TABLE_LOCATION_ONLY.varname,

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -227,13 +227,13 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
         InputFormatConfig.InMemoryDataModel.GENERIC);
 
     long fromVersion = conf.getLong(InputFormatConfig.SNAPSHOT_ID_INTERVAL_FROM, -1);
-    Scan<?, FileScanTask, CombinedScanTask> scan;
+    Scan<? extends Scan, FileScanTask, CombinedScanTask> scan;
     if (fromVersion != -1) {
       scan = applyConfig(conf, createIncrementalAppendScan(table, conf));
     } else {
       scan = applyConfig(conf, createTableScan(table, conf));
     }
-    scan = (Scan<?, FileScanTask, CombinedScanTask>) scan.planWith(workerPool);
+    scan = scan.planWith(workerPool);
 
     boolean allowDataFilesWithinTableLocationOnly =
         conf.getBoolean(HiveConf.ConfVars.HIVE_ICEBERG_ALLOW_DATAFILES_IN_TABLE_LOCATION_ONLY.varname,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
I have noticed that if a iceberg table has lots of metadata/data files, iceberg will use many system cores to do scan planning, which may put some pressure on Tez AM memory/cpu.
We can try to make the thread pool size configurable, to avoid concurrency pressure on Tez AM.

Other OSS also did similar optimization, like FIink:
https://github.com/apache/iceberg/blob/cbb853073e681b4075d7c8707610dceecbee3a82/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java#L92-L100

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This can configure the icbeberg planning thread size, to reduce Tez AM memory/cpu pressure as well as reduce some pressure on operating system.
If we don't limit the thread pool size, it wii use a default value which is equal system cores when doing `scan.planTasks()`:, 
https://github.com/apache/iceberg/blob/9a5d24fee239352021a9a73f6a4cad8ecf464f01/core/src/main/java/org/apache/iceberg/SystemConfigs.java#L38-L43

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing test.