### PR TITLE
HIVE-28279: Output the database name for SHOW EXTENDED TABLES statement

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/tables/ShowTablesDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/tables/ShowTablesDesc.java
@@ -34,7 +34,7 @@ public class ShowTablesDesc implements DDLDesc, Serializable {
   private static final long serialVersionUID = 1L;
 
   private static final String TABLES_VIEWS_SCHEMA = "tab_name#string";
-  private static final String EXTENDED_TABLES_SCHEMA = "tab_name,table_type#string,string";
+  private static final String EXTENDED_TABLES_SCHEMA = "db_name,tab_name,table_type#string,string,string";
 
   private final String resFile;
   private final String dbName;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/tables/ShowTablesFormatter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/tables/ShowTablesFormatter.java
@@ -70,6 +70,7 @@ public abstract class ShowTablesFormatter {
       List<Map<String, Object>> tableDataList = new ArrayList<>();
       for (Table table : tables) {
         Map<String, Object> tableData = ImmutableMap.of(
+            "Database Name", table.getDbName(),
             "Table Name", table.getTableName(),
             "Table Type", table.getTableType().toString());
         tableDataList.add(tableData);
@@ -104,10 +105,10 @@ public abstract class ShowTablesFormatter {
       try {
         TextMetaDataTable mdt = new TextMetaDataTable();
         if (!SessionState.get().isHiveServerQuery()) {
-          mdt.addRow("# Table Name", "Table Type");
+          mdt.addRow("# Database Name", "Table Name", "Table Type");
         }
         for (Table table : tables) {
-          mdt.addRow(table.getTableName(), table.getTableType().toString());
+          mdt.addRow(table.getDbName(), table.getTableName(), table.getTableType().toString());
         }
         // In case the query is served by HiveServer2, don't pad it with spaces,
         // as HiveServer2 output is consumed by JDBC/ODBC clients.

--- a/ql/src/test/results/clientpositive/llap/show_json_format.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_json_format.q.out
@@ -31,7 +31,7 @@ PREHOOK: Input: database:default
 POSTHOOK: query: SHOW EXTENDED TABLES
 POSTHOOK: type: SHOWTABLES
 POSTHOOK: Input: database:default
-{"tables":[{"Table Name":"t","Table Type":"MANAGED_TABLE"}]}
+{"tables":[{"Database Name":"default","Table Name":"t","Table Type":"MANAGED_TABLE"}]}
 PREHOOK: query: SHOW TABLE EXTENDED LIKE 't'
 PREHOOK: type: SHOW_TABLESTATUS
 POSTHOOK: query: SHOW TABLE EXTENDED LIKE 't'

--- a/ql/src/test/results/clientpositive/llap/show_tables.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_tables.q.out
@@ -158,11 +158,11 @@ PREHOOK: Input: database:test_db
 POSTHOOK: query: SHOW EXTENDED TABLES FROM test_db
 POSTHOOK: type: SHOWTABLES
 POSTHOOK: Input: database:test_db
-# Table Name        	Table Type          
-bar_n0              	MANAGED_TABLE       
-baz                 	MANAGED_TABLE       
-foo_n4              	MANAGED_TABLE       
-test_view_n100      	VIRTUAL_VIEW        
+# Database Name     	Table Name          	Table Type          
+test_db             	bar_n0              	MANAGED_TABLE       
+test_db             	baz                 	MANAGED_TABLE       
+test_db             	foo_n4              	MANAGED_TABLE       
+test_db             	test_view_n100      	VIRTUAL_VIEW        
 PREHOOK: query: EXPLAIN SHOW TABLES IN test_db
 PREHOOK: type: SHOWTABLES
 PREHOOK: Input: database:test_db
@@ -222,11 +222,11 @@ PREHOOK: Input: database:test_db
 POSTHOOK: query: SHOW EXTENDED TABLES IN test_db
 POSTHOOK: type: SHOWTABLES
 POSTHOOK: Input: database:test_db
-# Table Name        	Table Type          
-bar_n0              	MANAGED_TABLE       
-baz                 	MANAGED_TABLE       
-foo_n4              	MANAGED_TABLE       
-test_view_n100      	VIRTUAL_VIEW        
+# Database Name     	Table Name          	Table Type          
+test_db             	bar_n0              	MANAGED_TABLE       
+test_db             	baz                 	MANAGED_TABLE       
+test_db             	foo_n4              	MANAGED_TABLE       
+test_db             	test_view_n100      	VIRTUAL_VIEW        
 PREHOOK: query: EXPLAIN SHOW TABLES IN test_db "test%"
 PREHOOK: type: SHOWTABLES
 PREHOOK: Input: database:test_db
@@ -344,8 +344,8 @@ PREHOOK: Input: database:test_db
 POSTHOOK: query: SHOW EXTENDED TABLES IN test_db WHERE `table_type` = "VIRTUAL_VIEW"
 POSTHOOK: type: SHOWTABLES
 POSTHOOK: Input: database:test_db
-# Table Name        	Table Type          
-test_view_n100      	VIRTUAL_VIEW        
+# Database Name     	Table Name          	Table Type          
+test_db             	test_view_n100      	VIRTUAL_VIEW        
 PREHOOK: query: SHOW TABLE EXTENDED IN test_db LIKE foo_n4
 PREHOOK: type: SHOW_TABLESTATUS
 POSTHOOK: query: SHOW TABLE EXTENDED IN test_db LIKE foo_n4


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HIVE-21301](https://issues.apache.org/jira/browse/HIVE-21301) introduced SHOW EXTENDED TABLES statement which output table name and table type while listing tables in a database.

In this patch, we aim to add a new output filed for database name.

### Why are the changes needed?
1. database name in `SHOW EXTENDED TABLES` statement is optional, output the database is informational in this case.
2. when statistic table names and database names by this statement for list of databases, the output result including database name is much more helpful.

### Does this PR introduce _any_ user-facing change?
Yes, `SHOW EXTENDED TABLES` will show database name now.

### Is the change a dependency upgrade?
No

### How was this patch tested?
Test in beeline:
```bash
0: jdbc:hive2://> show extended tables;
+----------+-----------+-----------------+
| db_name  | tab_name  |   table_type    |
+----------+-----------+-----------------+
| default  | tbl       | EXTERNAL_TABLE  |
| default  | tbl2      | EXTERNAL_TABLE  |
+----------+-----------+-----------------+
2 rows selected (1.519 seconds)
```
