### PR TITLE
HIVE-27498: Support custom delimiter in SkippingTextInputFormat

### DIFF
--- a/data/files/header_footer_table_4/0003.txt
+++ b/data/files/header_footer_table_4/0003.txt
@@ -1,0 +1,2 @@
+Code	Name|A	AAAA|B	BBBB
+CCCC|C	DDDD

--- a/ql/src/test/queries/clientpositive/file_with_delimiter.q
+++ b/ql/src/test/queries/clientpositive/file_with_delimiter.q
@@ -1,0 +1,22 @@
+CREATE EXTERNAL TABLE test(code string,name string)
+ROW FORMAT SERDE
+   'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+ WITH SERDEPROPERTIES (
+   'field.delim'='\t')
+ STORED AS INPUTFORMAT
+   'org.apache.hadoop.mapred.TextInputFormat'
+ OUTPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+   location '${system:test.tmp.dir}/test'
+ TBLPROPERTIES (
+   'skip.header.line.count'='1',
+   'textinputformat.record.delimiter'='|');
+
+
+LOAD DATA LOCAL INPATH '../../data/files/header_footer_table_4/0003.txt' INTO TABLE test;
+
+
+SELECT COUNT(*) FROM test;
+
+
+SELECT * FROM test;

--- a/ql/src/test/results/clientpositive/llap/file_with_delimiter.q.out
+++ b/ql/src/test/results/clientpositive/llap/file_with_delimiter.q.out
@@ -1,0 +1,63 @@
+PREHOOK: query: CREATE EXTERNAL TABLE test(code string,name string)
+ROW FORMAT SERDE
+   'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+ WITH SERDEPROPERTIES (
+   'field.delim'='\t')
+ STORED AS INPUTFORMAT
+   'org.apache.hadoop.mapred.TextInputFormat'
+ OUTPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+#### A masked pattern was here ####
+ TBLPROPERTIES (
+   'skip.header.line.count'='1',
+   'textinputformat.record.delimiter'='|')
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test
+POSTHOOK: query: CREATE EXTERNAL TABLE test(code string,name string)
+ROW FORMAT SERDE
+   'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+ WITH SERDEPROPERTIES (
+   'field.delim'='\t')
+ STORED AS INPUTFORMAT
+   'org.apache.hadoop.mapred.TextInputFormat'
+ OUTPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+#### A masked pattern was here ####
+ TBLPROPERTIES (
+   'skip.header.line.count'='1',
+   'textinputformat.record.delimiter'='|')
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/header_footer_table_4/0003.txt' INTO TABLE test
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@test
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/header_footer_table_4/0003.txt' INTO TABLE test
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@test
+PREHOOK: query: SELECT COUNT(*) FROM test
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT COUNT(*) FROM test
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test
+#### A masked pattern was here ####
+3
+PREHOOK: query: SELECT * FROM test
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM test
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test
+#### A masked pattern was here ####
+A	AAAA
+B	BBBB
+CCCC
+C	DDDD


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added support for custom delimiter in SkippingTextInputFormat. The "Select count(*) from table" query does not return correct output when data file contains "row level delimiters". This PR fixes this problem.


### Why are the changes needed?
Bug fix


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Qtest
