### PR TITLE
HIVE-28282: Merging into iceberg table fails with copy on write when values clause has a function call

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
@@ -15,18 +15,18 @@ explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
 when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c);
 
 -- insert clause with a column list
 explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
-when not matched then insert (a, b) values (src.a, src.b);
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'));
 
 merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
 when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c);
 
 select * from target_ice;
 

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
@@ -49,7 +49,7 @@ PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
 when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -58,7 +58,7 @@ POSTHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
 when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -239,12 +239,12 @@ STAGE PLANS:
                   predicate: _col4 is null (type: boolean)
                   Statistics: Num rows: 10 Data size: 1216 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col5 (type: int), concat(_col6, '-merge new') (type: string), _col7 (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 10 Data size: 1200 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 10 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 17 Data size: 3296 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17 Data size: 4784 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -266,7 +266,7 @@ STAGE PLANS:
                   Statistics: Num rows: 1 Data size: 302 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 17 Data size: 3296 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 17 Data size: 4784 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                         output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -308,7 +308,7 @@ STAGE PLANS:
                 Statistics: Num rows: 4 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 17 Data size: 3296 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 17 Data size: 4784 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -428,7 +428,7 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 17 Data size: 3296 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 17 Data size: 4784 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -457,7 +457,7 @@ STAGE PLANS:
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
-when not matched then insert (a, b) values (src.a, src.b)
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -465,7 +465,7 @@ PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
-when not matched then insert (a, b) values (src.a, src.b)
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -612,12 +612,12 @@ STAGE PLANS:
                   predicate: _col4 is null (type: boolean)
                   Statistics: Num rows: 10 Data size: 1200 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col5 (type: int), _col6 (type: string), null (type: int)
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col5 (type: int), concat(_col6, '-merge new 2') (type: string), null (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 10 Data size: 1188 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 10 Data size: 2676 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 13 Data size: 2085 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 13 Data size: 3573 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -659,7 +659,7 @@ STAGE PLANS:
                 Statistics: Num rows: 2 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 13 Data size: 2085 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 13 Data size: 3573 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -717,7 +717,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 299 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 13 Data size: 2085 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 13 Data size: 3573 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -808,7 +808,7 @@ STAGE PLANS:
 PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
 when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -816,7 +816,7 @@ PREHOOK: Output: default@target_ice
 POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
 when matched and t.a > 100 THEN DELETE
 when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -831,10 +831,10 @@ POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
 2	Merged	61
-3	three	52
+3	three-merge new	52
 333	two	56
-4	four	53
-5	five	54
+4	four-merge new	53
+5	five-merge new	54
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched then update set b = 'Merged', c = t.c - 10

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java
@@ -154,18 +154,17 @@ public class CopyOnWriteMergeRewriter extends MergeRewriter {
       }
       List<String> values = sqlGenerator.getDeleteValues(Context.Operation.MERGE);
       
-      if (insertClause.getColumnListText() != null) {
-        String[] columnNames = insertClause.getColumnListText()
-            .substring(1, insertClause.getColumnListText().length() - 1).split(",");
-        String[] columnValues = insertClause.getValuesClause().split(",");
+      if (insertClause.getColumnList() != null) {
+        List<String> columnNames = insertClause.getColumnList();
+        List<String> columnValues = insertClause.getValuesClause();
         
-        Map<String, String> columnMap = IntStream.range(0, columnNames.length).boxed().collect(
-            Collectors.toMap(i -> ParseUtils.stripIdentifierQuotes(columnNames[i].trim()), i -> columnValues[i]));
+        Map<String, String> columnMap = IntStream.range(0, columnNames.size()).boxed().collect(
+            Collectors.toMap(columnNames::get, columnValues::get));
         for (FieldSchema col : mergeStatement.getTargetTable().getAllCols()) {
           values.add(columnMap.getOrDefault(col.getName(), "null"));
         }
       } else {
-        values.add(insertClause.getValuesClause());
+        values.addAll(insertClause.getValuesClause());
       }
       sqlGenerator.append(StringUtils.join(values, ","));
       sqlGenerator.append("\nFROM " + mergeStatement.getSourceName());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
@@ -178,8 +178,8 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
     @Override
     public void appendWhenNotMatchedInsertClause(MergeStatement.InsertClause insertClause) {
       sqlGenerator.append("INSERT INTO ").append(mergeStatement.getTargetName());
-      if (insertClause.getColumnListText() != null) {
-        sqlGenerator.append(' ').append(insertClause.getColumnListText());
+      if (insertClause.getColumnList() != null) {
+        sqlGenerator.append(' ').append(String.join(",",insertClause.getColumnList()));
       }
 
       sqlGenerator.append("    -- insert clause\n  SELECT ");
@@ -188,7 +188,8 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
         hintStr = null;
       }
 
-      sqlGenerator.append(insertClause.getValuesClause()).append("\n   WHERE ").append(insertClause.getPredicate());
+      sqlGenerator.append(String.join(", ", insertClause.getValuesClause()));
+      sqlGenerator.append("\n   WHERE ").append(insertClause.getPredicate());
 
       if (insertClause.getExtraPredicate() != null) {
         //we have WHEN NOT MATCHED AND <boolean expr> THEN INSERT

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
@@ -179,7 +179,9 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
     public void appendWhenNotMatchedInsertClause(MergeStatement.InsertClause insertClause) {
       sqlGenerator.append("INSERT INTO ").append(mergeStatement.getTargetName());
       if (insertClause.getColumnList() != null) {
-        sqlGenerator.append(' ').append(String.join(",",insertClause.getColumnList()));
+        sqlGenerator.append(" (");
+        sqlGenerator.append(String.join(",",insertClause.getColumnList()));
+        sqlGenerator.append(')');
       }
 
       sqlGenerator.append("    -- insert clause\n  SELECT ");

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
@@ -180,7 +180,7 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
       sqlGenerator.append("INSERT INTO ").append(mergeStatement.getTargetName());
       if (insertClause.getColumnList() != null) {
         sqlGenerator.append(" (");
-        sqlGenerator.append(String.join(",",insertClause.getColumnList()));
+        sqlGenerator.append(String.join(",", insertClause.getColumnList()));
         sqlGenerator.append(')');
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeStatement.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeStatement.java
@@ -192,23 +192,23 @@ public class MergeStatement {
   }
 
   public static class InsertClause extends WhenClause {
-    private final String columnListText;
-    private final String valuesClause;
+    private final List<String> columnList;
+    private final List<String> valuesClause;
     private final String predicate;
 
 
-    public InsertClause(String columnListText, String valuesClause, String predicate, String extraPredicate) {
+    public InsertClause(List<String> columnList, List<String> valuesClause, String predicate, String extraPredicate) {
       super(extraPredicate);
       this.predicate = predicate;
-      this.columnListText = columnListText;
+      this.columnList = columnList;
       this.valuesClause = valuesClause;
     }
 
-    public String getColumnListText() {
-      return columnListText;
+    public List<String> getColumnList() {
+      return columnList;
     }
 
-    public String getValuesClause() {
+    public List<String> getValuesClause() {
       return valuesClause;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Hive rewrites merge statements to insert overwrite statements. When the target table is Iceberg with table property
```
'write.merge.mode'='copy-on-write'
```
The rewrite of
```
explain
merge into target_ice as t using source src ON t.a = src.a
when matched and t.a > 100 THEN DELETE
when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'));
```
should be
```
WITH `src` AS ( SELECT * FROM
(SELECT `PARTITION__SPEC__ID` AS `t__PARTITION__SPEC__ID`,`PARTITION__HASH` AS `t__PARTITION__HASH`,`FILE__PATH` AS `t__FILE__PATH`,`ROW__POSITION` AS `t__ROW__POSITION`,`a` AS `t__a`, `b` AS `t__b`, `c` AS `t__c` FROM `default`.`target_ice`) `t`
  FULL OUTER JOIN
  `default`.`source` `src`
  ON `t__a` = `src`.`a`
),
t AS (
  select `t__PARTITION__SPEC__ID`,`t__PARTITION__HASH`,`t__FILE__PATH`,-1,`t__a`,`t__b`,`t__c` from (
    select `t__PARTITION__SPEC__ID`,`t__PARTITION__HASH`,`t__FILE__PATH`,-1,`t__a`,`t__b`,`t__c`, row_number() OVER (partition by `t__FILE__PATH`) rn from `src`
    where `t__a` = `src`.`a` AND `t__a` > 100
  ) q
  where rn=1
)
INSERT INTO `default`.`target_ice`
    -- insert clause
SELECT `t__PARTITION__SPEC__ID`,`t__PARTITION__HASH`,`t__FILE__PATH`,`t__ROW__POSITION`,`src`.`a`,concat(`src`.`b`, '-merge new 2'),null
FROM `src`
   WHERE `t__a` IS NULL
union all
    -- delete clause
SELECT `t__PARTITION__SPEC__ID`,`t__PARTITION__HASH`,`t__FILE__PATH`,`t__ROW__POSITION`,`t__a`,`t__b`,`t__c`
FROM `src`  WHERE 
  ( NOT(`t__a` = `src`.`a` AND `t__a` > 100 OR `t__a` IS NULL) OR (`t__a` = `src`.`a` AND `t__a` > 100 OR `t__a` IS NULL) IS NULL )
  AND `t__FILE__PATH` IN ( select `t__FILE__PATH` from t )
union all
select * from t
```
however when the values clause in when not matched insert branch has a function call with more than one parameter the expressions in the values clause are malformed.
The values clause is treated as one string which contains all the value expressions delimited by `,` and it is passed to  `CopyOnWriteMergeRewriter` which generates the insert statement. The value expressions are extracted from the string by splitting it 
https://github.com/apache/hive/blob/3be197e2ca8ad819fd41c507936ef9327571f855/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java#L160
In our example
```
src.a, concat(src.b, '-merge new 2')
```
the function call
```
concat(src.b, '-merge new 2')
```
also contains a `,` and it is split. So we end up with the following value expressions
```
`src`.`a`
`concat`(`src`.`b`
'-merge new 2')
```
where
```
`concat`(`src`.`b`
'-merge new 2')
```
should remain
```
concat(`src`.`b`, '-merge new 2')
```
### Why are the changes needed?
Splitting value expressions leads to invalid value expression list hence malformed rewritten statement.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergCliDriver -Dqfile=merge_iceberg_copy_on_write_unpartitioned.q -pl itests/qtest-iceberg/ -Pitests,iceberg
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=insert_into_default_keyword.q,insert_into_default_keyword_2.q -pl itests/qtest -Pitests
```