### PR TITLE
HIVE-28286: Add filtering support for get_table_metas (Naveen Gangam)

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/HiveMetaStoreAuthorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/HiveMetaStoreAuthorizer.java
@@ -65,8 +65,11 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -216,44 +219,52 @@ public class HiveMetaStoreAuthorizer extends MetaStorePreEventListener implement
   @Deprecated
   public List<TableMeta> filterTableMetas(String catName, String dbName, List<TableMeta> tableMetas)
       throws MetaException {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("==> HiveMetaStoreAuthorizer.filterTableMetas()");
-    }
-    List<String> tableNames = new ArrayList<>();
-    List<TableMeta> filteredTableMetas = new ArrayList<>();
-    if (tableMetas != null) {
-      for (TableMeta tableMeta : tableMetas) {
+    LOG.debug("==> HiveMetaStoreAuthorizer.filterTableMetas()");
+    if (!CollectionUtils.isEmpty(tableMetas)) {
+      List<String> tableNames = new ArrayList<>();
+      tableMetas.forEach(tableMeta -> {
+        if (!tableMeta.getCatName().equalsIgnoreCase(catName) ||
+            !tableMeta.getDbName().equalsIgnoreCase(dbName)) {
+          throw new IllegalArgumentException(String.format("Table: %s doesn't belong to the catalog: %s, database: %s",
+              tableMeta.getCatName() + "." + tableMeta.getDbName() + "." + tableMeta.getTableName(), catName, dbName));
+        }
         tableNames.add(tableMeta.getTableName());
-      }
+      });
       TableFilterContext     tableFilterContext     = new TableFilterContext(dbName, tableNames);
       HiveMetaStoreAuthzInfo hiveMetaStoreAuthzInfo = tableFilterContext.getAuthzContext();
       final List<String>  filteredTableNames = filterTableNames(hiveMetaStoreAuthzInfo, dbName, tableNames);
-      if (CollectionUtils.isEmpty(filteredTableNames)) {
-        filteredTableMetas = Collections.emptyList();
-        if (LOG.isInfoEnabled()) {
-          LOG.info("<== HiveMetaStoreAuthorizer.filterTableMetas() : returning empty set");
-        }
-      } else {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("<== HiveMetaStoreAuthorizer.filterTableMetas() : " + filteredTableNames);
-        }
-        filteredTableMetas = tableMetas.stream().filter(tblMeta -> filteredTableNames.stream()
-            .anyMatch(tblName -> tblName.equals(tblMeta.getTableName()))).collect(Collectors.toList());
+      if (!CollectionUtils.isEmpty(filteredTableNames)) {
+        Set<String> filteredTabs = new HashSet<>(filteredTableNames);
+        LOG.debug("<== HiveMetaStoreAuthorizer.filterTableMetas() : {}", filteredTabs);
+        return tableMetas.stream().filter(tblMeta -> filteredTabs.contains(tblMeta.getTableName()))
+            .collect(Collectors.toList());
       }
     }
-    return filteredTableMetas;
+    LOG.info("<== HiveMetaStoreAuthorizer.filterTableMetas() : returning empty set");
+    return Collections.emptyList();
   }
 
   @Override
   public final List<TableMeta> filterTableMetas(List<TableMeta> tableMetas)
       throws MetaException {
-    String catName = null;
-    String dbName = null;
-    if (tableMetas != null) {
-      catName = tableMetas.get(0).getCatName();
-      dbName = tableMetas.get(0).getDbName();
+    LOG.debug("==> HiveMetaStoreAuthorizer.filterTableMetas()");
+    if (!CollectionUtils.isEmpty(tableMetas)) {
+      Map<String, List<TableMeta>> metaGroupByCatDb = new HashMap<>();
+      tableMetas.forEach(tableMeta -> {
+        String key = MetaStoreUtils.prependCatalogToDbName(tableMeta.getCatName(),
+            tableMeta.getDbName(), getConf()).toLowerCase();
+        metaGroupByCatDb.computeIfAbsent(key, s -> new ArrayList<>()).add(tableMeta);
+      });
+      List<TableMeta> filteredTabs = new ArrayList<>();
+      for (Map.Entry<String, List<TableMeta>> entry : metaGroupByCatDb.entrySet()) {
+        TableMeta firstTabMeta = entry.getValue().get(0);
+        filteredTabs.addAll(filterTableMetas(firstTabMeta.getCatName(),
+            firstTabMeta.getDbName(), entry.getValue()));
+      }
+      return filteredTabs;
     }
-    return filterTableMetas(catName, dbName, tableMetas);
+    LOG.info("<== HiveMetaStoreAuthorizer.filterTableMetas() : returning empty set");
+    return Collections.emptyList();
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently the filterTableMetas() method in the HiveMetastoreAuthorizer is a no-op. It returns the full set of tables that are passed into it. This prevents any filtering that is to be done.

This PR adds logic to be able to filter out the ones that the user does not have access to.

### Why are the changes needed?
To enhance security in HMS.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Tested manually in a Ranger enabled environment.
