### PR TITLE
HIVE-28291: Fix Partition spec is incorrect in getPartitionsByFilter RPC

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -1551,9 +1551,11 @@ class MetaStoreDirectSql {
               : tableValue + " " + node.operator.getSqlOp() + " " + nodeValue0;
       // For equals and not-equals filter, we can add partition name filter to improve performance.
       boolean isOpEquals = Operator.isEqualOperator(node.operator);
-      if (isOpEquals || Operator.isNotEqualOperator(node.operator)) {
+      boolean isOpNotEqual = Operator.isNotEqualOperator(node.operator);
+      String nodeValueStr = node.value.toString();
+      if (StringUtils.isNotEmpty(nodeValueStr) && (isOpEquals || isOpNotEqual)) {
         Map<String, String> partKeyToVal = new HashMap<>();
-        partKeyToVal.put(partCol.getName(), node.value.toString());
+        partKeyToVal.put(partCol.getName(), nodeValueStr);
         String escapedNameFragment = Warehouse.makePartName(partKeyToVal, false);
         if (colType == FilterType.Date) {
           // Some engines like Pig will record both date and time values, in which case we need

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -566,6 +566,14 @@ public class TestObjectStore {
     }
     Assert.assertEquals(1, partNames.size());
     Assert.assertEquals("country=US/state=MA", partNames.get(0));
+
+    try (AutoCloseable c = deadline()) {
+      partNames = objectStore.listPartitionNamesByFilter(DEFAULT_CATALOG_NAME, DB1, TABLE1,
+          new GetPartitionsArgs.GetPartitionsArgsBuilder().filter("Country != ''").build());
+    }
+    Assert.assertEquals(2, partNames.size());
+    Assert.assertEquals("country=US/state=CA", partNames.get(0));
+    Assert.assertEquals("country=US/state=MA", partNames.get(1));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix Partition spec is incorrect in getPartitionsByFilter RPC.


### Why are the changes needed?
`Warehouse.makePartName` throws an exception because value is null, causing getPartitionsByFilter call to fail.

```sql
select * from foo where d=''
```

```
2024-05-30T16:21:57,490 ERROR [Metastore-Handler-Pool: Thread-30] metastore.RetryingHMSHandler: MetaException(message:Partition spec is incorrect. {d=})
	at org.apache.hadoop.hive.metastore.Warehouse.makePartNameUtil(Warehouse.java:590)
	at org.apache.hadoop.hive.metastore.Warehouse.makePartName(Warehouse.java:620)
	at org.apache.hadoop.hive.metastore.MetaStoreDirectSql$PartitionFilterGenerator.visit(MetaStoreDirectSql.java:1557)
	at org.apache.hadoop.hive.metastore.parser.ExpressionTree$LeafNode.accept(ExpressionTree.java:255)
	at org.apache.hadoop.hive.metastore.parser.ExpressionTree.accept(ExpressionTree.java:551)
	at org.apache.hadoop.hive.metastore.MetaStoreDirectSql$PartitionFilterGenerator.generateSqlFilter(MetaStoreDirectSql.java:1350)
	at org.apache.hadoop.hive.metastore.MetaStoreDirectSql$PartitionFilterGenerator.access$1000(MetaStoreDirectSql.java:1293)
	at org.apache.hadoop.hive.metastore.MetaStoreDirectSql.generateSqlFilterForPushdown(MetaStoreDirectSql.java:887)
	at org.apache.hadoop.hive.metastore.ObjectStore$18.canUseDirectSql(ObjectStore.java:4778)
	at org.apache.hadoop.hive.metastore.ObjectStore$GetHelper.start(ObjectStore.java:4517)
	at org.apache.hadoop.hive.metastore.ObjectStore$GetHelper.run(ObjectStore.java:4481)
	at org.apache.hadoop.hive.metastore.ObjectStore.getPartitionsByFilterInternal(ObjectStore.java:4792)
	at org.apache.hadoop.hive.metastore.ObjectStore.getPartitionsByFilter(ObjectStore.java:4417)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.hive.metastore.RawStoreProxy.invoke(RawStoreProxy.java:97)
	at com.sun.proxy.$Proxy33.getPartitionsByFilter(Unknown Source)
	at org.apache.hadoop.hive.metastore.HMSHandler.get_partitions_by_filter_internal(HMSHandler.java:7229)
	at org.apache.hadoop.hive.metastore.HMSHandler.get_partitions_by_filter(HMSHandler.java:7206)
```

https://github.com/apache/hive/blob/e7de9164557e6029fd845b8da0f78a6021e965bb/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java#L585-L591

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
local test & add UT
