### PR TITLE
HIVE-28303: Develocity integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ on:
     branches:
       - 'master'
 
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+
 jobs:
   macos-jdk8:
     name: 'macOS (JDK 8)'

--- a/.github/workflows/docker-GA-images.yml
+++ b/.github/workflows/docker-GA-images.yml
@@ -36,7 +36,8 @@ on:
         required: true
         default: '0.10.2'
 
-
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
 jobs:
   buildFromArchive:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ kafka-handler/src/test/gen
 **/.vscode/
 /.recommenders/
 dependency-reduced-pom.xml
+**/.mvn/.develocity*

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://ge.apache.org</url>
+    <allowUntrusted>false</allowUntrusted>
+  </server>
+  <buildScan>
+    <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>
+    <obfuscation>
+      <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>#{isFalse(env['GITHUB_ACTIONS'])}</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<extensions>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>1.21.4</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>2.0</version>
+  </extension>
+</extensions>


### PR DESCRIPTION
@simhadri-g, it was nice meeting you at Community over Code yesterday. This PR will enable you to publish Build Scans to [ge.apache.org](https://ge.apache.org/) as discussed.

https://issues.apache.org/jira/browse/HIVE-28303

### What changes were proposed in this pull request?
This PR publishes a build scan for every CI build and for every local build from an authenticated Apache committer. The build will not fail if publishing fails. Local caching on CI and remote caching was left disabled on this PR by design so that the build is not affected by this change.

The build scans of the Apache Hive project are published to the Develocity instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Apache Hive project and all other Apache projects.

On this Develocity instance, Apache Hive will have access not only to all of the published build scans but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

A licensing agreement between ASF and Gradle is already in place, covering the contribution. For more information, you can reach out to the ASF Infra team.

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

