### PR TITLE
HIVE-28305: ProfileServlet: add html to output formats and prepare for profiler 3.0

### DIFF
--- a/common/src/java/org/apache/hive/http/ProfileServlet.java
+++ b/common/src/java/org/apache/hive/http/ProfileServlet.java
@@ -17,6 +17,9 @@ package org.apache.hive.http;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -45,19 +48,19 @@ import com.google.common.base.Joiner;
  * //  -m method         fully qualified method name: 'ClassName.methodName'
  * //  -t                profile different threads separately
  * //  -s                simple class names instead of FQN
- * //  -o fmt[,fmt...]   output format: summary|traces|flat|collapsed|svg|tree|jfr
+ * //  -o fmt[,fmt...]   output format: summary|traces|flat|collapsed|svg|tree|jfr|html
  * //  --width px        SVG width pixels (integer)
  * //  --height px       SVG frame height pixels (integer)
  * //  --minwidth px     skip frames smaller than px (double)
  * //  --reverse         generate stack-reversed FlameGraph / Call tree
  * Example:
- * - To collect 30 second CPU profile of current process (returns FlameGraph svg)
+ * - To collect 10 second CPU profile of current process (returns FlameGraph html)
  * curl "http://localhost:10002/prof"
  * - To collect 1 minute CPU profile of current process and output in tree format (html)
  * curl "http://localhost:10002/prof?output=tree&amp;duration=60"
- * - To collect 30 second heap allocation profile of current process (returns FlameGraph svg)
+ * - To collect 10 second heap allocation profile of current process (returns FlameGraph html)
  * curl "http://localhost:10002/prof?event=alloc"
- * - To collect lock contention profile of current process (returns FlameGraph svg)
+ * - To collect lock contention profile of current process (returns FlameGraph html)
  * curl "http://localhost:10002/prof?event=lock"
  * Following event types are supported (default is 'cpu') (NOTE: not all OS'es support all events)
  * // Perf events:
@@ -89,7 +92,6 @@ public class ProfileServlet extends HttpServlet {
   private static final String CONTENT_TYPE_TEXT = "text/plain; charset=utf-8";
   private static final String ASYNC_PROFILER_HOME_ENV = "ASYNC_PROFILER_HOME";
   private static final String ASYNC_PROFILER_HOME_SYSTEM_PROPERTY = "async.profiler.home";
-  private static final String PROFILER_SCRIPT = "/profiler.sh";
   private static final int DEFAULT_DURATION_SECONDS = 10;
   private static final AtomicInteger ID_GEN = new AtomicInteger(0);
   static final String OUTPUT_DIR = System.getProperty("java.io.tmpdir") + "/prof-output";
@@ -141,7 +143,8 @@ public class ProfileServlet extends HttpServlet {
     COLLAPSED,
     SVG,
     TREE,
-    JFR
+    JFR,
+    HTML
   }
 
   private Lock profilerLock = new ReentrantLock();
@@ -213,7 +216,7 @@ public class ProfileServlet extends HttpServlet {
               (method == null ? event.name().toLowerCase() : method) + "-" + ID_GEN.incrementAndGet() + "." +
               output.name().toLowerCase());
             List<String> cmd = new ArrayList<>();
-            cmd.add(asyncProfilerHome + PROFILER_SCRIPT);
+            cmd.add(getProfilerScriptPath());
             cmd.add("-e");
             cmd.add(method == null ? event.getInternalName() : method);
             cmd.add("-d");
@@ -293,6 +296,16 @@ public class ProfileServlet extends HttpServlet {
     }
   }
 
+  /**
+   * Get the path of the profiler script to be executed.
+   * Before async-profiler 3.0, the script was named profiler.sh, and after 3.0 it's bin/asprof
+   * @return
+   */
+  private String getProfilerScriptPath() {
+    Path defaultPath = Paths.get(asyncProfilerHome + "/bin/asprof");
+    return Files.exists(defaultPath)? defaultPath.toString() : asyncProfilerHome + "/profiler.sh";
+  }
+
   private Integer getInteger(final HttpServletRequest req, final String param, final Integer defaultValue) {
     final String value = req.getParameter(param);
     if (value != null) {
@@ -344,10 +357,11 @@ public class ProfileServlet extends HttpServlet {
       try {
         return Output.valueOf(outputArg.trim().toUpperCase());
       } catch (IllegalArgumentException e) {
-        return Output.SVG;
+        LOG.warn("Output format value is invalid, returning with default HTML");
+        return Output.HTML;
       }
     }
-    return Output.SVG;
+    return Output.HTML;
   }
 
   private void setResponseHeader(final HttpServletResponse response) {

--- a/common/src/java/org/apache/hive/http/ProfileServlet.java
+++ b/common/src/java/org/apache/hive/http/ProfileServlet.java
@@ -353,11 +353,12 @@ public class ProfileServlet extends HttpServlet {
 
   private Output getOutput(final HttpServletRequest req) {
     final String outputArg = req.getParameter("output");
+    String outputFormat = outputArg.trim().toUpperCase();
     if (req.getParameter("output") != null) {
       try {
-        return Output.valueOf(outputArg.trim().toUpperCase());
+        return Output.valueOf(outputFormat);
       } catch (IllegalArgumentException e) {
-        LOG.warn("Output format value is invalid, returning with default HTML");
+        LOG.warn("Output format value '{}' is invalid, returning with default HTML", outputFormat);
         return Output.HTML;
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added HTML format support to ProfileServlet.


### Why are the changes needed?
Because HTML is the default format for creating flamegraphs.


### Does this PR introduce _any_ user-facing change?
No, profile servlet is more like a dev tool.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
set web port for hs2 in hive-site.xml
```
+<property>
+  <name>hive.server2.webui.port</name>
+  <value>10003</value>
+</property>
```

```
#tried with both 2.9 and 3.0
export ASYNC_PROFILER_HOME=/Users/laszlobodor/Downloads/async-profiler-2.9-macos
export ASYNC_PROFILER_HOME=/Users/laszlobodor/Downloads/async-profiler-3.0-macos

 mvn install -Dtest=StartMiniHS2Cluster -DminiHS2.clusterType=llap -DminiHS2.conf="target/testconf/llap/hive-site.xml"  -DminiHS2.run=true -DminiHS2.usePortsFromConf=true -Dpackaging.minimizeJar=false -T 1C -DskipShade -Dremoteresources.skip=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -pl itests/hive-unit -Pitests -nsu
```

called localhost:10003/prof and get the flamegraph successfully
https://issues.apache.org/jira/secure/attachment/13069348/async-prof-pid-21327-cpu-2.html
