### PR TITLE
HIVE-28311: Backward compatibility of java.sql.Date and java.sql.Timestamp in hive-serde

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/type/Date.java
+++ b/common/src/java/org/apache/hadoop/hive/common/type/Date.java
@@ -190,6 +190,10 @@ public class Date implements Comparable<Date> {
     }
   }
 
+  public static Date valueOf(java.sql.Date d) {
+    return new Date(d.toLocalDate());
+  }
+
   public static Date ofEpochDay(int epochDay) {
     return new Date(LocalDate.ofEpochDay(epochDay));
   }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/JavaDateObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/JavaDateObjectInspector.java
@@ -33,6 +33,9 @@ public class JavaDateObjectInspector
   }
 
   public DateWritableV2 getPrimitiveWritableObject(Object o) {
+    if (o instanceof java.sql.Date) {
+      return new DateWritableV2(Date.valueOf((java.sql.Date) o));
+    }
     return o == null ? null : new DateWritableV2((Date) o);
   }
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/JavaTimestampObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/JavaTimestampObjectInspector.java
@@ -30,6 +30,9 @@ public class JavaTimestampObjectInspector
   }
 
   public TimestampWritableV2 getPrimitiveWritableObject(Object o) {
+    if (o instanceof java.sql.Timestamp) {
+      return new TimestampWritableV2(Timestamp.ofEpochMilli(((java.sql.Timestamp) o).getTime()));
+    }
     return o == null ? null : new TimestampWritableV2((Timestamp) o);
   }
 

--- a/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/primitive/TestPrimitiveObjectInspectorUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/primitive/TestPrimitiveObjectInspectorUtils.java
@@ -80,6 +80,20 @@ public class TestPrimitiveObjectInspectorUtils {
   }
 
   @Test
+  public void testGetDate() {
+    DateFormat gmtDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    gmtDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+    PrimitiveObjectInspector dateOI = PrimitiveObjectInspectorFactory
+        .getPrimitiveJavaObjectInspector(PrimitiveCategory.DATE);
+    assertEquals("1970-01-01", gmtDateFormat.format(PrimitiveObjectInspectorUtils.getDate(Date.ofEpochDay(0), dateOI).toEpochMilli()));
+    assertEquals("2024-06-07", gmtDateFormat.format(PrimitiveObjectInspectorUtils.getDate(Date.ofEpochMilli(1717752174344L), dateOI).toEpochMilli()));
+
+    // Test the compatibility of java.sql.Date that's removed in HIVE-20007
+    assertEquals("1970-01-01", gmtDateFormat.format(PrimitiveObjectInspectorUtils.getDate(java.sql.Date.valueOf("1970-01-01"), dateOI).toEpochMilli()));
+    assertEquals("2024-06-07", gmtDateFormat.format(PrimitiveObjectInspectorUtils.getDate(java.sql.Date.valueOf("2024-06-07"), dateOI).toEpochMilli()));
+  }
+
+  @Test
   public void testgetTimestampWithMillisecondsInt() {
     DateFormat gmtDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     gmtDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -148,6 +162,9 @@ public class TestPrimitiveObjectInspectorUtils {
     PrimitiveObjectInspector timestampOI = PrimitiveObjectInspectorFactory
         .getPrimitiveJavaObjectInspector(PrimitiveCategory.TIMESTAMP);
     assertEquals("2015-02-07 15:01:22.123", gmtDateFormat.format(PrimitiveObjectInspectorUtils.getTimestamp(Timestamp.ofEpochMilli(1423321282123L), timestampOI).toSqlTimestamp()));
+
+    // Test the compatibility of java.sql.Timestamp that's removed in HIVE-20007
+    assertEquals("2024-06-07 09:22:54.344", gmtDateFormat.format(PrimitiveObjectInspectorUtils.getTimestamp(new java.sql.Timestamp(1717752174344L), timestampOI).toSqlTimestamp()));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support `java.sql.Date` and `java.sql.Timestamp` objects in JavaXXXObjectInspector.


### Why are the changes needed?
The old clients before HIVE-20007 convert date value to `java.sql.Date` and timestamp value to `java.sql.Timestamp`, but the new HMS only accept internal `Date` and `Timestamp` while deserialize the expressions, which would cause `ClassCastException`.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Add new unit test:
```bash
mvn test -Dtest.groups= -Dtest=org.apache.hadoop.hive.serde2.objectinspector.primitive.TestPrimitiveObjectInspectorUtils -pl :hive-serde
```
