### PR TITLE
HIVE-28181: Enable hive.server2.webui.explain.output

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3874,7 +3874,7 @@ public class HiveConf extends Configuration {
         "The maximum number of past queries to show in HiverSever2 WebUI."),
     HIVE_SERVER2_WEBUI_USE_PAM("hive.server2.webui.use.pam", false,
         "If true, the HiveServer2 WebUI will be secured with PAM."),
-    HIVE_SERVER2_WEBUI_EXPLAIN_OUTPUT("hive.server2.webui.explain.output", false,
+    HIVE_SERVER2_WEBUI_EXPLAIN_OUTPUT("hive.server2.webui.explain.output", true,
         "When set to true, the EXPLAIN output for every query is displayed"
             + " in the HS2 WebUI / Drilldown / Query Plan tab.\n"),
     HIVE_SERVER2_WEBUI_SHOW_GRAPH("hive.server2.webui.show.graph", false,


### PR DESCRIPTION
**What changes were proposed in this pull request?**

Enabled hive.server2.webui.explain.output

**Why are the changes needed?**

So that we can get the explain plan from the webUI

Does this PR introduce any user-facing change?
No

Is the change a dependency upgrade?
No

How was this patch tested?
We have manually tested using StartMiniHS2Cluster

mvn test -Dtest=StartMiniHS2Cluster -DminiHS2.clusterType=Tez -DminiHS2.run=true -DminiHS2.usePortsFromConf=true -Dpackaging.minimizeJar=false -T 1C -DskipShade -Dremoteresources.skip=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -pl itests/hive-unit -Pitests

Connected using beeline:
  beeline -u "jdbc:hive2://localhost:10000/default"

set hive.server2.webui.explain.output;
+-----------------------------------------+--+
|                   set                   |
+-----------------------------------------+--+
| hive.server2.webui.explain.output=true  |
+-----------------------------------------+--+