### PR TITLE
HIVE-28321 Support select alias in the having clause for CBO

### DIFF
--- a/itests/hive-blobstore/src/test/queries/clientpositive/having.q
+++ b/itests/hive-blobstore/src/test/queries/clientpositive/having.q
@@ -1,4 +1,5 @@
 -- Test HAVING clause
+set hive.cbo.fallback.strategy=NEVER;
 
 DROP TABLE having_blobstore_test;
 CREATE TABLE having_blobstore_test(a int, b int, c string)

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/RowResolver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/RowResolver.java
@@ -125,6 +125,21 @@ public class RowResolver implements Serializable{
     return false;
   }
 
+  /**
+   * Puts a resolver entry corresponding to the expression and its
+   * column alias which is used for alias recognition in the latter constructs
+   * @param exprToColumnAlias
+   *          The map containing the expression to alias mapping
+   * @throws SemanticException
+   */
+  public void putAll(Map<ASTNode, String> exprToColumnAlias) throws SemanticException {
+    for (ASTNode astNode : exprToColumnAlias.keySet()) {
+      if (getExpression(astNode) != null) {
+        put("", exprToColumnAlias.get(astNode), getExpression(astNode));
+      }
+    }
+  }
+
   private void keepAmbiguousInfo(String col_alias, String tab_alias) {
     // we keep track of duplicate <tab alias, col alias> so that get can check
     // for ambiguity

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -3489,11 +3489,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     OpParseContext inputCtx = opParseCtx.get(input);
     RowResolver inputRR = inputCtx.getRowResolver();
     Map<ASTNode, String> exprToColumnAlias = qb.getParseInfo().getAllExprToColumnAlias();
-    for (ASTNode astNode : exprToColumnAlias.keySet()) {
-      if (inputRR.getExpression(astNode) != null) {
-        inputRR.put("", exprToColumnAlias.get(astNode), inputRR.getExpression(astNode));
-      }
-    }
+    inputRR.putAll(exprToColumnAlias);
     ASTNode condn = (ASTNode) havingExpr.getChild(0);
 
     if (!isCBOExecuted() && !qb.getParseInfo().getDestToGroupBy().isEmpty()) {

--- a/ql/src/test/queries/clientpositive/groupby_grouping_window.q
+++ b/ql/src/test/queries/clientpositive/groupby_grouping_window.q
@@ -1,4 +1,5 @@
 --! qt:dataset:src
+set hive.cbo.fallback.strategy=NEVER;
 create table t_n33(category int, live int, comments int);
 insert into table t_n33 select key, 0, 2 from src tablesample(3 rows);
 

--- a/ql/src/test/queries/clientpositive/having.q
+++ b/ql/src/test/queries/clientpositive/having.q
@@ -1,6 +1,7 @@
 --! qt:dataset:src
 set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
+set hive.cbo.fallback.strategy=NEVER;
 -- SORT_QUERY_RESULTS
 EXPLAIN SELECT count(value) AS c FROM src GROUP BY key HAVING c > 3;
 SELECT count(value) AS c FROM src GROUP BY key HAVING c > 3;
@@ -19,3 +20,6 @@ SELECT key, max(value) FROM src GROUP BY key HAVING max(value) > "val_255";
 
 EXPLAIN SELECT key, COUNT(value) FROM src GROUP BY key HAVING count(value) >= 4;
 SELECT key, COUNT(value) FROM src GROUP BY key HAVING count(value) >= 4;
+
+EXPLAIN CBO SELECT count(value) as c, max(key) as m from src GROUP BY key HAVING c > 3 and m > 400;
+SELECT count(value) as c, max(key) as m from src GROUP BY key HAVING c > 3 and m > 400;

--- a/ql/src/test/queries/clientpositive/limit_pushdown_negative.q
+++ b/ql/src/test/queries/clientpositive/limit_pushdown_negative.q
@@ -1,6 +1,7 @@
 --! qt:dataset:src
 set hive.mapred.mode=nonstrict;
 set hive.limit.pushdown.memory.usage=0.3f;
+set hive.cbo.fallback.strategy=NEVER;
 
 -- negative, RS + join
 explain select * from src a join src b on a.key=b.key limit 20;

--- a/ql/src/test/queries/clientpositive/prepare_plan.q
+++ b/ql/src/test/queries/clientpositive/prepare_plan.q
@@ -3,6 +3,7 @@
 --SORT_QUERY_RESULTS
 
 set hive.explain.user=false;
+set hive.cbo.fallback.strategy=NEVER;
 
 -- single param
 explain extended prepare pcount from select count(*) from src where key > ?;

--- a/ql/src/test/queries/clientpositive/vector_groupby_grouping_window.q
+++ b/ql/src/test/queries/clientpositive/vector_groupby_grouping_window.q
@@ -5,6 +5,7 @@ SET hive.vectorized.execution.reduce.enabled=true;
 set hive.vectorized.execution.ptf.enabled=true;
 set hive.fetch.task.conversion=none;
 set hive.cli.print.header=true;
+set hive.cbo.fallback.strategy=NEVER;
 
 create table t_n15(category int, live int, comments int) stored as orc;
 insert into table t_n15 select key, 0, 2 from src tablesample(3 rows);

--- a/ql/src/test/results/clientpositive/llap/groupby_grouping_window.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_grouping_window.q.out
@@ -60,7 +60,7 @@ STAGE PLANS:
                     Group By Operator
                       aggregations: max(live), max(comments)
                       keys: category (type: int), 0L (type: bigint)
-                      grouping sets: 1, 0
+                      grouping sets: 0, 1
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3

--- a/ql/src/test/results/clientpositive/llap/having.q.out
+++ b/ql/src/test/results/clientpositive/llap/having.q.out
@@ -1336,3 +1336,30 @@ POSTHOOK: Input: default@src
 468	4
 469	5
 489	4
+PREHOOK: query: EXPLAIN CBO SELECT count(value) as c, max(key) as m from src GROUP BY key HAVING c > 3 and m > 400
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT count(value) as c, max(key) as m from src GROUP BY key HAVING c > 3 and m > 400
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(c=[$1], m=[$2])
+  HiveFilter(condition=[AND(>($1, 3), >(CAST($2):DOUBLE, 400))])
+    HiveAggregate(group=[{0}], agg#0=[count($1)], agg#1=[max($0)])
+      HiveTableScan(table=[[default, src]], table:alias=[src])
+
+PREHOOK: query: SELECT count(value) as c, max(key) as m from src GROUP BY key HAVING c > 3 and m > 400
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT count(value) as c, max(key) as m from src GROUP BY key HAVING c > 3 and m > 400
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+4	406
+4	468
+4	489
+5	401
+5	469

--- a/ql/src/test/results/clientpositive/llap/prepare_plan.q.out
+++ b/ql/src/test/results/clientpositive/llap/prepare_plan.q.out
@@ -400,49 +400,49 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: alltypesorc
-                  filterExpr: ((cint <= $1) and (cbigint <= $2) and (cfloat <> $3)) (type: boolean)
+                  filterExpr: ((cint <= UDFToInteger($1)) and (cbigint <= UDFToLong($2)) and (cfloat <> UDFToFloat($3))) (type: boolean)
                   Statistics: Num rows: 12288 Data size: 183480 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((cint <= $1) and (cbigint <= $2) and (cfloat <> $3)) (type: boolean)
+                    predicate: ((cint <= UDFToInteger($1)) and (cbigint <= UDFToLong($2)) and (cfloat <> UDFToFloat($3))) (type: boolean)
                     Statistics: Num rows: 1365 Data size: 20400 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ctinyint (type: tinyint)
                       outputColumnNames: ctinyint
                       Statistics: Num rows: 1365 Data size: 20400 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
-                        aggregations: avg(ctinyint)
+                        aggregations: sum(ctinyint), count(ctinyint)
                         keys: ctinyint (type: tinyint)
                         minReductionHashAggr: 0.9062271
                         mode: hash
-                        outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 128 Data size: 10116 Basic stats: COMPLETE Column stats: COMPLETE
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 128 Data size: 2436 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: tinyint)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: tinyint)
-                          Statistics: Num rows: 128 Data size: 10116 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col1 (type: struct<count:bigint,sum:double,input:tinyint>)
+                          Statistics: Num rows: 128 Data size: 2436 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint), _col2 (type: bigint)
             Execution mode: llap
             LLAP IO: all inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: avg(VALUE._col0)
+                aggregations: sum(VALUE._col0), count(VALUE._col1)
                 keys: KEY._col0 (type: tinyint)
                 mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 128 Data size: 1412 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 128 Data size: 2436 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: double)
-                  outputColumnNames: _col1
-                  Statistics: Num rows: 128 Data size: 1024 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col1 (type: bigint), _col2 (type: bigint)
+                  outputColumnNames: _col1, _col2
+                  Statistics: Num rows: 128 Data size: 2048 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col1 < $4) (type: boolean)
-                    Statistics: Num rows: 42 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((UDFToDouble(_col1) / _col2) < UDFToDouble($4)) (type: boolean)
+                    Statistics: Num rows: 42 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: double)
+                      expressions: (UDFToDouble(_col1) / _col2) (type: double)
                       outputColumnNames: _col0
                       Statistics: Num rows: 42 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -485,49 +485,49 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: alltypesorc
-                  filterExpr: ((cint <= 100) and (cbigint <= 5000000) and (cfloat <> 0.023)) (type: boolean)
+                  filterExpr: ((cint <= UDFToInteger(100)) and (cbigint <= UDFToLong(5000000)) and (cfloat <> UDFToFloat(0.023))) (type: boolean)
                   Statistics: Num rows: 12288 Data size: 183480 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((cint <= 100) and (cbigint <= 5000000) and (cfloat <> 0.023)) (type: boolean)
-                    Statistics: Num rows: 3080 Data size: 46000 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((cint <= UDFToInteger(100)) and (cbigint <= UDFToLong(5000000)) and (cfloat <> UDFToFloat(0.023))) (type: boolean)
+                    Statistics: Num rows: 1365 Data size: 20400 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ctinyint (type: tinyint)
                       outputColumnNames: ctinyint
-                      Statistics: Num rows: 3080 Data size: 46000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1365 Data size: 20400 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
-                        aggregations: avg(ctinyint)
+                        aggregations: sum(ctinyint), count(ctinyint)
                         keys: ctinyint (type: tinyint)
-                        minReductionHashAggr: 0.95844156
+                        minReductionHashAggr: 0.9062271
                         mode: hash
-                        outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 128 Data size: 10116 Basic stats: COMPLETE Column stats: COMPLETE
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 128 Data size: 2436 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: tinyint)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: tinyint)
-                          Statistics: Num rows: 128 Data size: 10116 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col1 (type: struct<count:bigint,sum:double,input:tinyint>)
+                          Statistics: Num rows: 128 Data size: 2436 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: avg(VALUE._col0)
+                aggregations: sum(VALUE._col0), count(VALUE._col1)
                 keys: KEY._col0 (type: tinyint)
                 mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 128 Data size: 1412 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 128 Data size: 2436 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: double)
-                  outputColumnNames: _col1
-                  Statistics: Num rows: 128 Data size: 1024 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col1 (type: bigint), _col2 (type: bigint)
+                  outputColumnNames: _col1, _col2
+                  Statistics: Num rows: 128 Data size: 2048 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col1 < 0) (type: boolean)
-                    Statistics: Num rows: 42 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((UDFToDouble(_col1) / _col2) < UDFToDouble(0)) (type: boolean)
+                    Statistics: Num rows: 42 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: double)
+                      expressions: (UDFToDouble(_col1) / _col2) (type: double)
                       outputColumnNames: _col0
                       Statistics: Num rows: 42 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator

--- a/ql/src/test/results/clientpositive/llap/vector_groupby_grouping_window.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_groupby_grouping_window.q.out
@@ -81,7 +81,7 @@ STAGE PLANS:
                           vectorProcessingMode: HASH
                           projectedOutputColumnNums: [0, 1]
                       keys: category (type: int), 0L (type: bigint)
-                      grouping sets: 1, 0
+                      grouping sets: 0, 1
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Having clause CBO path of the queries should have visibility from the alias of the select expressions, as this is the case in the non-CBO path.

### Why are the changes needed?
In order to make the CBO path and non-CBO work the same way in terms of syntax and semantics of having clause


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Unit tests. Specifically mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=limit_pushdown_negative.q
