### PR TITLE
HIVE-28330: Fix a typo in the example output of UDFHex

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFHex.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFHex.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.io.Text;
     + "If the argument is a number or binary, returns the hexadecimal representation.\n"
     + "Example:\n"
     + "  > SELECT _FUNC_(17) FROM src LIMIT 1;\n"
-    + "  'H1'\n"
+    + "  '11'\n"
     + "  > SELECT _FUNC_('Facebook') FROM src LIMIT 1;\n"
     + "  '46616365626F6F6B'")
 @VectorizedExpressions({FuncHex.class})

--- a/ql/src/test/results/clientpositive/llap/udf_hex.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_hex.q.out
@@ -12,7 +12,7 @@ If the argument is a string, returns two hex digits for each character in the st
 If the argument is a number or binary, returns the hexadecimal representation.
 Example:
   > SELECT hex(17) FROM src LIMIT 1;
-  'H1'
+  '11'
   > SELECT hex('Facebook') FROM src LIMIT 1;
   '46616365626F6F6B'
 Function class:org.apache.hadoop.hive.ql.udf.UDFHex


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a typo in the example output of UDFHex


### Why are the changes needed?
doc fix


### Does this PR introduce _any_ user-facing change?
no

### Is the change a dependency upgrade?
no


### How was this patch tested?

I test this with 4.0.0
```
docker exec -it hiveserver2 beeline -u 'jdbc:hive2://localhost:10000/'  -e "select hex(17)"

+------+
| _c0  |
+------+
| 11   |
+------+
```