### PR TITLE
HIVE-28325: Slow compilation without owner information with Ranger au…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -12750,7 +12750,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
             List<String> colNames = new ArrayList<>();
             extractColumnInfos(table, colNames, new ArrayList<>());
 
-            basicInfos.put(new HivePrivilegeObject(table.getDbName(), table.getTableName(), colNames), null);
+            basicInfos.put(new HivePrivilegeObject(table.getDbName(), table.getTableName(), colNames,
+                table.getOwner(), table.getOwnerType()), null);
           }
         } else {
           List<String> colNames;
@@ -12766,7 +12767,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
             extractColumnInfos(table, colNames, colTypes);
           }
 
-          basicInfos.put(new HivePrivilegeObject(table.getDbName(), table.getTableName(), colNames),
+          basicInfos.put(new HivePrivilegeObject(table.getDbName(), table.getTableName(), colNames,
+              table.getOwner(), table.getOwnerType()),
               new MaskAndFilterInfo(colTypes, additionalTabInfo.toString(), alias, astNode, table.isView(), table.isNonNative()));
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/HivePrivilegeObject.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/HivePrivilegeObject.java
@@ -179,6 +179,12 @@ public class HivePrivilegeObject implements Comparable<HivePrivilegeObject> {
     this(HivePrivilegeObjectType.TABLE_OR_VIEW, dbname, objectName, null, columns, null);
   }
 
+  public HivePrivilegeObject(String dbname, String objectName, List<String> columns,
+      String ownerName, PrincipalType ownerType) {
+    this(HivePrivilegeObjectType.TABLE_OR_VIEW, dbname, objectName, null, columns,
+        HivePrivObjectActionType.OTHER, null, null, ownerName, ownerType);
+  }
+
   public HivePrivilegeObject(HivePrivilegeObjectType type, String dbname, String objectName, List<String> partKeys,
       List<String> columns, HivePrivObjectActionType actionType, List<String> commandParams, String className) {
     this(type, dbname, objectName, partKeys, columns, actionType, commandParams, className, null, null);

--- a/ql/src/test/results/clientpositive/llap/authorization_privilege_objects.q.out
+++ b/ql/src/test/results/clientpositive/llap/authorization_privilege_objects.q.out
@@ -50,7 +50,7 @@ POSTHOOK: Input: database:test_auth_obj_db
 test_privs
 test_privs2
 applyRowFilterAndColumnMasking:
-HIVE PRIVILEGE OBJECT { objectName: test_privs type: TABLE_OR_VIEW actionType: OTHER dbName: test_auth_obj_db columns: [i]}
+HIVE PRIVILEGE OBJECT { objectName: test_privs type: TABLE_OR_VIEW actionType: OTHER dbName: test_auth_obj_db OWNER: testuser OWNERTYPE: USER columns: [i]}
 inputHObjs:
 HIVE PRIVILEGE OBJECT { objectName: test_privs type: TABLE_OR_VIEW actionType: OTHER dbName: test_auth_obj_db OWNER: testuser OWNERTYPE: USER}
 PREHOOK: query: EXPLAIN SELECT * FROM test_auth_obj_db.test_privs
@@ -295,7 +295,7 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@ext_simple_derby_table_src
 applyRowFilterAndColumnMasking:
-HIVE PRIVILEGE OBJECT { objectName: ext_simple_derby_table_src type: TABLE_OR_VIEW actionType: OTHER dbName: default columns: [ikey, bkey, fkey, dkey]}
+HIVE PRIVILEGE OBJECT { objectName: ext_simple_derby_table_src type: TABLE_OR_VIEW actionType: OTHER dbName: default OWNER: hive_admin_user OWNERTYPE: USER columns: [ikey, bkey, fkey, dkey]}
 inputHObjs:
 HIVE PRIVILEGE OBJECT { objectName: ext_simple_derby_table_src type: TABLE_OR_VIEW actionType: OTHER dbName: default OWNER: hive_admin_user OWNERTYPE: USER columns: [bkey, dkey, fkey, ikey]}
 outputHObjs:
@@ -316,7 +316,7 @@ POSTHOOK: Lineage: ext_simple_derby_table_ctas.dkey SIMPLE [(ext_simple_derby_ta
 POSTHOOK: Lineage: ext_simple_derby_table_ctas.fkey SIMPLE [(ext_simple_derby_table_src)ext_simple_derby_table_src.FieldSchema(name:fkey, type:float, comment:from deserializer), ]
 POSTHOOK: Lineage: ext_simple_derby_table_ctas.ikey SIMPLE [(ext_simple_derby_table_src)ext_simple_derby_table_src.FieldSchema(name:ikey, type:int, comment:from deserializer), ]
 applyRowFilterAndColumnMasking:
-HIVE PRIVILEGE OBJECT { objectName: ext_simple_derby_table_ctas type: TABLE_OR_VIEW actionType: OTHER dbName: default columns: [bkey, dkey, fkey, ikey]}
+HIVE PRIVILEGE OBJECT { objectName: ext_simple_derby_table_ctas type: TABLE_OR_VIEW actionType: OTHER dbName: default OWNER: hive_admin_user OWNERTYPE: USER columns: [bkey, dkey, fkey, ikey]}
 inputHObjs:
 HIVE PRIVILEGE OBJECT { objectName: ext_simple_derby_table_ctas type: TABLE_OR_VIEW actionType: OTHER dbName: default OWNER: hive_admin_user OWNERTYPE: USER columns: [bkey, dkey, fkey, ikey]}
 outputHObjs:


### PR DESCRIPTION
…thorization

Added owner information to the HivePrivilegeObject created in the SemanticAnalyzer. The owner information is used by Ranger for filtering of objects. If the owner is not provided, it can slow down compilation.

This is related to HIVE-27285 and RANGER-3593.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Described in commit message


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Compilation becomes noticeably quicker when Ranger is provided owner information for the table 


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test changed and now shows owner information in the hook.
