### PR TITLE
HIVE-28328:Hive Compilation Failed Due to License-Maven-Plugin URL Mismatch Error

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -153,7 +153,15 @@
               </licenseUrlReplacements>
               <licenseUrlFileNames>
                 <APACHE-2.0>
-                  https?://www\.apache\.org/licenses/LICENSE-2\.0.*
+                  http://apache.org/licenses/LICENSE-2.0.txt
+                  \Qhttp://www.apache.org/licenses/LICENSE-2.0
+                  \Qhttps://www.apache.org/licenses/LICENSE-2.0.txt
+                  \Qhttp://www.apache.org/licenses/LICENSE-2.0.txt
+                  \Qhttp://www.apache.org/licenses/LICENSE-2.0.html
+                  \Qhttps://www.apache.org/licenses/LICENSE-2.0
+                  \Qhttps://www.apache.org/licenses/LICENSE-2.0
+                  \Qhttps://aws.amazon.com/apache2.0
+                  \Qhttps?://www.apache.org/licenses/LICENSE-2.0.*
                   \Qhttps://aws.amazon.com/apache2.0\E
                   \Qhttps://opensource.org/licenses/Apache-2.0\E
                   \Qhttp://www.apache.org/licenses/\E
@@ -163,6 +171,7 @@
                   https?://(www\.)?opensource.org/licenses/BSD-2-Clause
                 </BSD-2-CLAUSE>
                 <BSD-3-CLAUSE>
+		  https?://(www\.)?eclipse.org/org/documents/edl-v10.php
                   https?://(www\.)?opensource.org/licenses/BSD-3-Clause
                 </BSD-3-CLAUSE>
                 <LGPL-3.0-only>

--- a/packaging/src/main/assembly/bin.xml
+++ b/packaging/src/main/assembly/bin.xml
@@ -39,11 +39,11 @@
       <useStrictFiltering>false</useStrictFiltering>
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <excludes>
-        <exclude>org.apache.calcite:*</exclude>
+        <!--exclude>org.apache.calcite:*</exclude-->
         <exclude>org.apache.hadoop:*</exclude>
         <exclude>org.apache.hive.hcatalog:*</exclude>
         <exclude>org.slf4j:*</exclude>
-        <exclude>log4j:*</exclude>
+        <!--exclude>log4j:*</exclude-->
         <exclude>ch.qos.reload4j:*</exclude>
         <exclude>junit:*</exclude>
         <exclude>commons-configuration:commons-configuration</exclude>
@@ -103,7 +103,7 @@
       <excludes>
         <exclude>org.apache.hadoop:*</exclude>
         <exclude>org.apache.hive:hive-jdbc:jar:standalone</exclude>
-        <exclude>org.apache.httpcomponents:*</exclude>
+        <!--exclude>org.apache.httpcomponents:*</exclude-->
       </excludes>
       <includes>
         <include>org.apache.hive.hcatalog:hive-webhcat:*</include>

--- a/packaging/src/main/assembly/bin.xml
+++ b/packaging/src/main/assembly/bin.xml
@@ -39,11 +39,11 @@
       <useStrictFiltering>false</useStrictFiltering>
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <excludes>
-        <!--exclude>org.apache.calcite:*</exclude-->
+        <exclude>org.apache.calcite:*</exclude>
         <exclude>org.apache.hadoop:*</exclude>
         <exclude>org.apache.hive.hcatalog:*</exclude>
         <exclude>org.slf4j:*</exclude>
-        <!--exclude>log4j:*</exclude-->
+        <exclude>log4j:*</exclude>
         <exclude>ch.qos.reload4j:*</exclude>
         <exclude>junit:*</exclude>
         <exclude>commons-configuration:commons-configuration</exclude>
@@ -103,7 +103,7 @@
       <excludes>
         <exclude>org.apache.hadoop:*</exclude>
         <exclude>org.apache.hive:hive-jdbc:jar:standalone</exclude>
-        <!--exclude>org.apache.httpcomponents:*</exclude-->
+        <exclude>org.apache.httpcomponents:*</exclude>
       </excludes>
       <includes>
         <include>org.apache.hive.hcatalog:hive-webhcat:*</include>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
[HIVE-28328](https://issues.apache.org/jira/browse/HIVE-28328)
as per the above jira, hive compilation is failing on both master and branch-4.0 with the mentioned failures. This PR handles the failures.


### Why are the changes needed?
HIve compilation is failing with **branch-4.0** and **master** master too.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
compiled with the patch, it went well.
