### PR TITLE
HIVE-28042: DigestMD5 token expired or does not exist issue while opening connection to HMS 

### DIFF
--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestAuthWithDigestMD5.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestAuthWithDigestMD5.java
@@ -28,91 +28,49 @@ import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
-import org.junit.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
 public class TestAuthWithDigestMD5 {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TestAuthWithDigestMD5.class.getName());
-    protected static HiveMetaStoreClient client;
-    public static final String HS2TOKEN = "HiveServer2ImpersonationToken";
-
-    protected static String correctUser = "correct_user";
-    protected static String correctPassword = "correct_passwd";
-
-    protected static Configuration conf = null;
-
-    private static MiniHiveKdc miniKDC = null;
-    protected static Configuration clientConf;
-    protected static String hiveMetastorePrincipal;
-    protected static String hiveMetastoreKeytab;
-    private static boolean isServerStarted = false;
-    protected static int port;
+    MiniHiveKdc miniKDC = null;
+    private static HiveMetaStoreClient client;
+    private static final String HS2TOKEN = "HiveServer2ImpersonationToken";
+    private static Configuration conf = null;
+    private static int port;
 
     @Before
     public void setUp() throws Exception {
         miniKDC = new MiniHiveKdc();
-        hiveMetastorePrincipal =
-                miniKDC.getFullyQualifiedServicePrincipal(miniKDC.getHiveMetastoreServicePrincipal());
-        hiveMetastoreKeytab = miniKDC.getKeyTabFile(
+        String hiveMetastorePrincipal = miniKDC.getFullyQualifiedServicePrincipal(miniKDC.getHiveMetastoreServicePrincipal());
+        String hiveMetastoreKeytab = miniKDC.getKeyTabFile(
                 miniKDC.getServicePrincipalForUser(miniKDC.getHiveMetastoreServicePrincipal()));
+        conf = MetastoreConf.newMetastoreConf();
 
-        if (null == conf) {
-            conf = MetastoreConf.newMetastoreConf();
-        }
+        String correctUser = "correct_user";
+        String correctPassword = "correct_passwd";
 
         MetastoreConf.setBoolVar(conf, ConfVars.EXECUTE_SET_UGI, false);
-        clientConf = new Configuration(conf);
-
-        MetastoreConf.setVar(conf, ConfVars.THRIFT_METASTORE_AUTHENTICATION, "CONFIG");
         MetastoreConf.setVar(conf, ConfVars.THRIFT_AUTH_CONFIG_USERNAME, correctUser);
         MetastoreConf.setVar(conf, ConfVars.THRIFT_AUTH_CONFIG_PASSWORD, correctPassword);
         MetastoreConf.setBoolVar(conf, ConfVars.USE_THRIFT_SASL, true);
         MetastoreConf.setVar(conf, ConfVars.KERBEROS_PRINCIPAL, hiveMetastorePrincipal);
         MetastoreConf.setVar(conf, ConfVars.KERBEROS_KEYTAB_FILE, hiveMetastoreKeytab);
 
-        // set some values to use for getting conf. vars
-        MetastoreConf.setBoolVar(conf, ConfVars.METRICS_ENABLED, true);
-        conf.set("datanucleus.autoCreateTables", "false");
-        conf.set("hive.in.test", "true");
-        MetastoreConf.setVar(conf, ConfVars.METASTORE_METADATA_TRANSFORMER_CLASS, " ");
-
-        MetaStoreTestUtils.setConfForStandloneMode(conf);
-        MetastoreConf.setLongVar(conf, ConfVars.BATCH_RETRIEVE_MAX, 2);
-        MetastoreConf.setVar(conf, ConfVars.STORAGE_SCHEMA_READER_IMPL, "no.such.class");
-        MetastoreConf.setBoolVar(conf, ConfVars.INTEGER_JDO_PUSHDOWN, true);
         MetastoreConf.setTimeVar(conf, ConfVars.DELEGATION_TOKEN_RENEW_INTERVAL,10000, TimeUnit.MILLISECONDS);
         MetastoreConf.setTimeVar(conf, ConfVars.DELEGATION_TOKEN_GC_INTERVAL,3000, TimeUnit.MILLISECONDS);
 
-        if (isServerStarted) {
-            Assert.assertNotNull("Unable to connect to the MetaStore server", client);
-            return;
-        }
-        start();
-    }
-
-    protected void start() throws Exception {
         port = MetaStoreTestUtils.startMetaStoreWithRetry(HadoopThriftAuthBridge.getBridge(),
                 conf);
         System.out.println("Starting MetaStore Server on port " + port);
-        isServerStarted = true;
 
         MetastoreConf.setVar(conf, ConfVars.THRIFT_URIS, "thrift://localhost:" + port);
-        MetastoreConf.setBoolVar(conf, ConfVars.EXECUTE_SET_UGI, false);
-
-        client = createClient();
+        client = new HiveMetaStoreClient(conf);
     }
 
-    protected HiveMetaStoreClient createClient() throws Exception {
-        MetastoreConf.setVar(clientConf, ConfVars.KERBEROS_PRINCIPAL, hiveMetastorePrincipal);
-        MetastoreConf.setVar(clientConf, ConfVars.KERBEROS_KEYTAB_FILE, hiveMetastoreKeytab);
-        return new HiveMetaStoreClient(conf);
-    }
 
     @Test
     public void testPostRenewalTimeThreadKickedIn() throws Exception {
@@ -126,11 +84,15 @@ public class TestAuthWithDigestMD5 {
         delegationToken.setService(new Text(HS2TOKEN));
         UserGroupInformation.getCurrentUser().addToken(delegationToken);
 
-        LOG.info("Sleeping for 15 seconds");
         Thread.sleep(15000);
-        LOG.info("Waking Up");
-
         client = new HiveMetaStoreClient(conf);
+        client.close();
+    }
+
+    @After
+    public void tearDown() {
+        MetaStoreTestUtils.close(port);
+        miniKDC.shutDown();
     }
 
 }

--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestAuthWithDigestMD5.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestAuthWithDigestMD5.java
@@ -60,8 +60,8 @@ public class TestAuthWithDigestMD5 {
         MetastoreConf.setVar(conf, ConfVars.KERBEROS_PRINCIPAL, hiveMetastorePrincipal);
         MetastoreConf.setVar(conf, ConfVars.KERBEROS_KEYTAB_FILE, hiveMetastoreKeytab);
 
-        MetastoreConf.setTimeVar(conf, ConfVars.DELEGATION_TOKEN_RENEW_INTERVAL,10000, TimeUnit.MILLISECONDS);
-        MetastoreConf.setTimeVar(conf, ConfVars.DELEGATION_TOKEN_GC_INTERVAL,3000, TimeUnit.MILLISECONDS);
+        MetastoreConf.setTimeVar(conf, ConfVars.DELEGATION_TOKEN_RENEW_INTERVAL,2000, TimeUnit.MILLISECONDS);
+        MetastoreConf.setTimeVar(conf, ConfVars.DELEGATION_TOKEN_GC_INTERVAL,1000, TimeUnit.MILLISECONDS);
 
         port = MetaStoreTestUtils.startMetaStoreWithRetry(HadoopThriftAuthBridge.getBridge(),
                 conf);
@@ -84,7 +84,7 @@ public class TestAuthWithDigestMD5 {
         delegationToken.setService(new Text(HS2TOKEN));
         UserGroupInformation.getCurrentUser().addToken(delegationToken);
 
-        Thread.sleep(15000);
+        Thread.sleep(4000);
         client = new HiveMetaStoreClient(conf);
         client.close();
     }

--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestAuthWithDigestMD5.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestAuthWithDigestMD5.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.minikdc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
+import org.apache.hadoop.hive.metastore.security.DelegationTokenIdentifier;
+import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestAuthWithDigestMD5 {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestAuthWithDigestMD5.class.getName());
+    protected static HiveMetaStoreClient client;
+    public static final String HS2TOKEN = "HiveServer2ImpersonationToken";
+
+    protected static String correctUser = "correct_user";
+    protected static String correctPassword = "correct_passwd";
+
+    protected static Configuration conf = null;
+
+    private static MiniHiveKdc miniKDC = null;
+    protected static Configuration clientConf;
+    protected static String hiveMetastorePrincipal;
+    protected static String hiveMetastoreKeytab;
+    private static boolean isServerStarted = false;
+    protected static int port;
+
+    @Before
+    public void setUp() throws Exception {
+        miniKDC = new MiniHiveKdc();
+        hiveMetastorePrincipal =
+                miniKDC.getFullyQualifiedServicePrincipal(miniKDC.getHiveMetastoreServicePrincipal());
+        hiveMetastoreKeytab = miniKDC.getKeyTabFile(
+                miniKDC.getServicePrincipalForUser(miniKDC.getHiveMetastoreServicePrincipal()));
+
+        if (null == conf) {
+            conf = MetastoreConf.newMetastoreConf();
+        }
+
+        MetastoreConf.setBoolVar(conf, ConfVars.EXECUTE_SET_UGI, false);
+        clientConf = new Configuration(conf);
+
+        MetastoreConf.setVar(conf, ConfVars.THRIFT_METASTORE_AUTHENTICATION, "CONFIG");
+        MetastoreConf.setVar(conf, ConfVars.THRIFT_AUTH_CONFIG_USERNAME, correctUser);
+        MetastoreConf.setVar(conf, ConfVars.THRIFT_AUTH_CONFIG_PASSWORD, correctPassword);
+        MetastoreConf.setBoolVar(conf, ConfVars.USE_THRIFT_SASL, true);
+        MetastoreConf.setVar(conf, ConfVars.KERBEROS_PRINCIPAL, hiveMetastorePrincipal);
+        MetastoreConf.setVar(conf, ConfVars.KERBEROS_KEYTAB_FILE, hiveMetastoreKeytab);
+
+        // set some values to use for getting conf. vars
+        MetastoreConf.setBoolVar(conf, ConfVars.METRICS_ENABLED, true);
+        conf.set("datanucleus.autoCreateTables", "false");
+        conf.set("hive.in.test", "true");
+        MetastoreConf.setVar(conf, ConfVars.METASTORE_METADATA_TRANSFORMER_CLASS, " ");
+
+        MetaStoreTestUtils.setConfForStandloneMode(conf);
+        MetastoreConf.setLongVar(conf, ConfVars.BATCH_RETRIEVE_MAX, 2);
+        MetastoreConf.setVar(conf, ConfVars.STORAGE_SCHEMA_READER_IMPL, "no.such.class");
+        MetastoreConf.setBoolVar(conf, ConfVars.INTEGER_JDO_PUSHDOWN, true);
+        MetastoreConf.setTimeVar(conf, ConfVars.DELEGATION_TOKEN_RENEW_INTERVAL,10000, TimeUnit.MILLISECONDS);
+        MetastoreConf.setTimeVar(conf, ConfVars.DELEGATION_TOKEN_GC_INTERVAL,3000, TimeUnit.MILLISECONDS);
+
+        if (isServerStarted) {
+            Assert.assertNotNull("Unable to connect to the MetaStore server", client);
+            return;
+        }
+        start();
+    }
+
+    protected void start() throws Exception {
+        port = MetaStoreTestUtils.startMetaStoreWithRetry(HadoopThriftAuthBridge.getBridge(),
+                conf);
+        System.out.println("Starting MetaStore Server on port " + port);
+        isServerStarted = true;
+
+        MetastoreConf.setVar(conf, ConfVars.THRIFT_URIS, "thrift://localhost:" + port);
+        MetastoreConf.setBoolVar(conf, ConfVars.EXECUTE_SET_UGI, false);
+
+        client = createClient();
+    }
+
+    protected HiveMetaStoreClient createClient() throws Exception {
+        MetastoreConf.setVar(clientConf, ConfVars.KERBEROS_PRINCIPAL, hiveMetastorePrincipal);
+        MetastoreConf.setVar(clientConf, ConfVars.KERBEROS_KEYTAB_FILE, hiveMetastoreKeytab);
+        return new HiveMetaStoreClient(conf);
+    }
+
+    @Test
+    public void testPostRenewalTimeThreadKickedIn() throws Exception {
+        String token = client.getDelegationToken("hive","hive");
+        MetastoreConf.setVar(conf, ConfVars.TOKEN_SIGNATURE, HS2TOKEN);
+
+        client = new HiveMetaStoreClient(conf);
+
+        Token<DelegationTokenIdentifier> delegationToken = new Token<DelegationTokenIdentifier>();
+        delegationToken.decodeFromUrlString(token);
+        delegationToken.setService(new Text(HS2TOKEN));
+        UserGroupInformation.getCurrentUser().addToken(delegationToken);
+
+        LOG.info("Sleeping for 15 seconds");
+        Thread.sleep(15000);
+        LOG.info("Waking Up");
+
+        client = new HiveMetaStoreClient(conf);
+    }
+
+}

--- a/itests/hive-unit-hadoop2/src/test/java/org/apache/hadoop/hive/metastore/security/TestHadoopAuthBridge23.java
+++ b/itests/hive-unit-hadoop2/src/test/java/org/apache/hadoop/hive/metastore/security/TestHadoopAuthBridge23.java
@@ -204,13 +204,22 @@ public class TestHadoopAuthBridge23 {
       // expected
     }
 
-    // token expiration
+    // token Renewal
     MyTokenStore.TOKEN_STORE.addToken(d,
         new DelegationTokenInformation(0, t.getPassword()));
     Assert.assertNotNull(MyTokenStore.TOKEN_STORE.getToken(d));
     anotherManager.removeExpiredTokens();
+    Assert.assertTrue(MyTokenStore.TOKEN_STORE.getToken(d).getRenewDate() > 0);
+
+    // test Expiration
+    DelegationTokenIdentifier e = new DelegationTokenIdentifier();
+    e.setMaxDate(0);
+    MyTokenStore.TOKEN_STORE.addToken(e,
+            new DelegationTokenInformation(0, t.getPassword()));
+    Assert.assertNotNull(MyTokenStore.TOKEN_STORE.getToken(d));
+    anotherManager.removeExpiredTokens();
     Assert.assertNull("Expired token not removed",
-        MyTokenStore.TOKEN_STORE.getToken(d));
+        MyTokenStore.TOKEN_STORE.getToken(e));
 
     // key expiration - create an already expired key
     anotherManager.startThreads(); // generates initial key

--- a/itests/hive-unit-hadoop2/src/test/java/org/apache/hadoop/hive/metastore/security/TestHadoopAuthBridge23.java
+++ b/itests/hive-unit-hadoop2/src/test/java/org/apache/hadoop/hive/metastore/security/TestHadoopAuthBridge23.java
@@ -208,7 +208,7 @@ public class TestHadoopAuthBridge23 {
     MyTokenStore.TOKEN_STORE.addToken(d,
         new DelegationTokenInformation(0, t.getPassword()));
     Assert.assertNotNull(MyTokenStore.TOKEN_STORE.getToken(d));
-    anotherManager.removeExpiredTokens();
+    anotherManager.renewOrRemoveExpiredTokens();
     Assert.assertTrue(MyTokenStore.TOKEN_STORE.getToken(d).getRenewDate() > 0);
 
     // test Expiration
@@ -216,8 +216,8 @@ public class TestHadoopAuthBridge23 {
     e.setMaxDate(0);
     MyTokenStore.TOKEN_STORE.addToken(e,
             new DelegationTokenInformation(0, t.getPassword()));
-    Assert.assertNotNull(MyTokenStore.TOKEN_STORE.getToken(d));
-    anotherManager.removeExpiredTokens();
+    Assert.assertNotNull(MyTokenStore.TOKEN_STORE.getToken(e));
+    anotherManager.renewOrRemoveExpiredTokens();
     Assert.assertNull("Expired token not removed",
         MyTokenStore.TOKEN_STORE.getToken(e));
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/TokenStoreDelegationTokenSecretManager.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/TokenStoreDelegationTokenSecretManager.java
@@ -31,14 +31,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier;
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager;
 import org.apache.hadoop.security.token.delegation.DelegationKey;
 import org.apache.hadoop.security.token.delegation.MetastoreDelegationTokenSupport;
 import org.apache.hadoop.util.Daemon;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,6 +105,10 @@ public class TokenStoreDelegationTokenSecretManager extends DelegationTokenSecre
       if (info == null) {
           throw new InvalidToken("token expired or does not exist: " + identifier);
       }
+      renewIfRequired(System.currentTimeMillis(), identifier, info);
+      // we have to fetch the token again as it has been renewed and info still contains the previous renew time.
+      info = this.tokenStore.getToken(identifier);
+
       // must reuse super as info.getPassword is not accessible
       synchronized (this) {
         try {
@@ -163,8 +169,12 @@ public class TokenStoreDelegationTokenSecretManager extends DelegationTokenSecre
       try {
         long res = super.renewToken(token, renewer);
         this.tokenStore.removeToken(id);
-        this.tokenStore.addToken(id, super.currentTokens.get(id));
+        DelegationTokenInformation updatedToken = super.currentTokens.get(id);
+        this.tokenStore.addToken(id, updatedToken);
+        LOGGER.info("Successfully renewed token : " + id + ", Renewal time now is: " +
+                Time.formatTime(updatedToken.getRenewDate()));
         return res;
+
       } finally {
         super.currentTokens.remove(id);
       }
@@ -238,20 +248,33 @@ public class TokenStoreDelegationTokenSecretManager extends DelegationTokenSecre
    */
   protected void removeExpiredTokens() {
     long now = System.currentTimeMillis();
-    Iterator<DelegationTokenIdentifier> i = tokenStore.getAllDelegationTokenIdentifiers()
-        .iterator();
-    while (i.hasNext()) {
-      DelegationTokenIdentifier id = i.next();
+    for (DelegationTokenIdentifier id : tokenStore.getAllDelegationTokenIdentifiers()) {
       if (now > id.getMaxDate()) {
+        LOGGER.info("Expiry Thread removing expired token: " + id);
         this.tokenStore.removeToken(id); // no need to look at token info
       } else {
         // get token info to check renew date
-        DelegationTokenInformation tokenInfo = tokenStore.getToken(id);
-        if (tokenInfo != null) {
-          if (now > tokenInfo.getRenewDate()) {
-            this.tokenStore.removeToken(id);
-          }
+        renewIfRequired(now, id, tokenStore.getToken(id));
+      }
+    }
+  }
+
+  private void renewIfRequired(long currentTime, DelegationTokenIdentifier id, DelegationTokenInformation tokenInfo) {
+    if (tokenInfo != null) {
+      if (currentTime > tokenInfo.getRenewDate() && currentTime < id.getMaxDate()) {
+        // This will be the case when now > tokenInfo.getRenewDate() but less than the token expiration/max time.
+        LOGGER.info("Trying to renew the token: " + id);
+        try {
+          DelegationKey key = getDelegationKey(id.getMasterKeyId());
+          Token<DelegationTokenIdentifier> t = new Token<>(id.getBytes(), createPassword(id.getBytes(), key.getKey()),
+                  id.getKind(), new Text());
+          renewToken(t, UserGroupInformation.getCurrentUser().getShortUserName());
+        } catch (IOException e) {
+          throw new IllegalStateException("Unable to renew token: " + id);
         }
+      } else if (currentTime >= id.getMaxDate()) {
+        // In this case expiry time has passed and this token cannot be further renewed.
+        throw new IllegalStateException("Expiration time passed. Cannot renew the token.");
       }
     }
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/TokenStoreDelegationTokenSecretManager.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/TokenStoreDelegationTokenSecretManager.java
@@ -275,7 +275,7 @@ public class TokenStoreDelegationTokenSecretManager extends DelegationTokenSecre
                   id.getKind(), new Text());
           renewToken(t, UserGroupInformation.getCurrentUser().getShortUserName());
         } catch (IOException e) {
-          throw new InvalidToken("Unable to renew token: " + id);
+          throw new InvalidToken("Unable to renew token: " + id + " due to " + e.getMessage());
         }
       } else if (currentTime > id.getMaxDate()) {
         // In this case expiry time has passed and this token cannot be further renewed.

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/security/TestTokenStoreDelegationTokenSecretManager.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/security/TestTokenStoreDelegationTokenSecretManager.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
     long tokenRenewInterval = renewSecs * 1000;
     long tokenGcInterval = gcTime * 1000;
     return new TokenStoreDelegationTokenSecretManager(secretKeyInterval, tokenMaxLifetime,
-            tokenRenewInterval, tokenGcInterval, tokenStore);
+        tokenRenewInterval, tokenGcInterval, tokenStore);
   }
 
 
@@ -98,8 +98,8 @@ import java.util.concurrent.TimeUnit;
     try {
       mgr.startThreads();
       String tokenStr =
-              mgr.getDelegationToken(UserGroupInformation.getCurrentUser().getShortUserName(),
-                      UserGroupInformation.getCurrentUser().getShortUserName());
+          mgr.getDelegationToken(UserGroupInformation.getCurrentUser().getShortUserName(),
+              UserGroupInformation.getCurrentUser().getShortUserName());
       DelegationTokenIdentifier id = getID(tokenStr);
       Assert.assertNotNull(mgr.verifyDelegationToken(tokenStr));
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Adding two changes to fix this issue:
1. Rework expiry thread to not remove token after renewal time has passed for that particular token. It will actually try to renew the token in this case.
2. Individual calls to retrievePassword during the TSaslClientTransport auth will also try to renew the token if required before retrieving the password.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  4. If you fix some SQL features, you can provide some references of other DBMSes.
  5. If there is design documentation, please add the link.
  6. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Facing DigestMD5 token expiry issue in a session which has been open since a long time when a new new connection is opened to HMS using TSaslClientTransport with DigestMD5 based auth. This issue is happening due to the fact that the new connection is trying to authenticate using the token identifier which is removed by the expiry thread in the background.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
Added a test case to check the expiry thread renewing the token automatically after some time and removing a token automatically after the token has expired.
Tested the scenario on a machine with dedicated HMS, HS2 with Sasl enabled.
Added a test case to test the complete scenario of creating a new HMSClient after another.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
