### PR TITLE
HIVE-28324: HIVE_CLUSTER_ID in env: unified way to mark a cluster

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/Constants.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/Constants.java
@@ -109,4 +109,8 @@ public class Constants {
       "position_delete_record_count,position_delete_file_count,equality_delete_record_count," +
       "equality_delete_file_count,last_updated_at,total_data_file_size_in_bytes,last_updated_snapshot_id";
   public static final String DELIMITED_JSON_SERDE = "org.apache.hadoop.hive.serde2.DelimitedJSONSerDe";
+
+  public static final String CLUSTER_ID_ENV_VAR_NAME = "HIVE_CLUSTER_ID";
+  public static final String CLUSTER_ID_CLI_OPT_NAME = "hive.cluster.id";
+  public static final String CLUSTER_ID_HIVE_CONF_PROP = "hive.cluster.id";
 }

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/StartMiniHS2Cluster.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/StartMiniHS2Cluster.java
@@ -23,8 +23,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.ql.ServiceContext;
 import org.apache.hive.jdbc.miniHS2.MiniHS2.MiniClusterType;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -64,6 +66,7 @@ public class StartMiniHS2Cluster {
     HiveConf conf = new HiveConf();
     conf.setBoolVar(ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
     conf.setBoolVar(HiveConf.ConfVars.HIVE_RPC_QUERY_PLAN, true);
+    conf.set(Constants.CLUSTER_ID_HIVE_CONF_PROP, ServiceContext.findClusterId());
 
     for (; idx < confFiles.length; ++idx) {
       String confFile = confFiles[idx];

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.JvmPauseMonitor;
 import org.apache.hadoop.hive.common.LogUtils;
 import org.apache.hadoop.hive.common.UgiFactory;
+import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.llap.DaemonId;
@@ -73,6 +74,7 @@ import org.apache.hadoop.hive.llap.security.LlapUgiFactoryFactory;
 import org.apache.hadoop.hive.llap.security.LlapTokenIdentifier;
 import org.apache.hadoop.hive.llap.security.SecretManager;
 import org.apache.hadoop.hive.llap.shufflehandler.ShuffleHandler;
+import org.apache.hadoop.hive.ql.ServiceContext;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.exec.UDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
@@ -619,6 +621,8 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
       long ioMemoryBytes = LlapDaemonInfo.INSTANCE.getCacheSize();
       boolean isDirectCache = LlapDaemonInfo.INSTANCE.isDirectCache();
       boolean isLlapIo = LlapDaemonInfo.INSTANCE.isLlapIo();
+
+      daemonConf.set(Constants.CLUSTER_ID_HIVE_CONF_PROP, ServiceContext.findClusterId());
 
       LlapDaemon.initializeLogging(daemonConf);
       llapDaemon =

--- a/pom.xml
+++ b/pom.xml
@@ -1728,6 +1728,7 @@
             <additionalClasspathElement>${basedir}/${hive.path.to.root}/conf</additionalClasspathElement>
           </additionalClasspathElements>
           <environmentVariables>
+            <HIVE_CLUSTER_ID>hive-test-cluster-id-env</HIVE_CLUSTER_ID>
             <TZ>US/Pacific</TZ>
             <LANG>en_US.UTF-8</LANG>
             <HADOOP_CLASSPATH>${test.conf.dir}:${basedir}/${hive.path.to.root}/conf</HADOOP_CLASSPATH>
@@ -1751,6 +1752,7 @@
             <mapred.job.tracker>local</mapred.job.tracker>
             <log4j.configurationFile>${test.log4j.scheme}${test.conf.dir}/hive-log4j2.properties</log4j.configurationFile>
             <hive.test.console.log.level>${test.console.log.level}</hive.test.console.log.level>
+            <hive.cluster.id>hive-test-cluster-id-cli</hive.cluster.id>
             <log4j.debug>true</log4j.debug>
             <!-- don't dirty up /tmp -->
             <java.io.tmpdir>${test.tmp.dir}</java.io.tmpdir>

--- a/ql/src/java/org/apache/hadoop/hive/ql/ServiceContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ServiceContext.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql;
+
+import org.apache.hadoop.hive.conf.Constants;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+import java.util.function.Supplier;
+
+/**
+ * Information context about the service, most probably HiveServer2.
+ */
+public class ServiceContext {
+
+  private final String clusterId;
+  private final Supplier<String> host;
+  private final Supplier<Integer> port;
+
+  public ServiceContext(Supplier<String> host, Supplier<Integer> port) {
+    this.host = host;
+    this.port = port;
+    this.clusterId = findClusterId();
+  }
+
+  /**
+   * Logic for finding cluster id if any. Can be used as a utility.
+   *
+   * @return cluster id found from environment of system props
+   */
+  public static String findClusterId() {
+    return System.getProperty(Constants.CLUSTER_ID_CLI_OPT_NAME, System.getenv(Constants.CLUSTER_ID_ENV_VAR_NAME));
+  }
+
+  public void setClusterIdInConf(HiveConf hiveConf) {
+    hiveConf.set(Constants.CLUSTER_ID_HIVE_CONF_PROP, clusterId);
+  }
+
+  public String getHost() {
+    return host.get();
+  }
+
+  public int getPort() {
+    return port.get();
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestServiceContext.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestServiceContext.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql;
+
+import org.apache.hadoop.hive.conf.Constants;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestServiceContext {
+
+  @Test
+  public void testInit() {
+    ServiceContext serviceContext = new ServiceContext(() -> "testhost", () -> 1234);
+    Assert.assertEquals("testhost", serviceContext.getHost());
+    Assert.assertEquals(1234, serviceContext.getPort());
+  }
+
+  @Test
+  public void testClusterId() {
+    // 1. find cli arg value (defined in root pom.xml)
+    ServiceContext serviceContext = new ServiceContext(null, null);
+    Assert.assertEquals("hive-test-cluster-id-cli", serviceContext.getClusterId());
+
+    // 2. if cli arg value is not present, find in env (defined in root pom.xml)
+    System.getProperties().remove(Constants.CLUSTER_ID_CLI_OPT_NAME);
+    serviceContext = new ServiceContext(null, null);
+    Assert.assertEquals("hive-test-cluster-id-env", serviceContext.getClusterId());
+  }
+}

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.hive.metastore.api.WMFullResourcePlan;
 import org.apache.hadoop.hive.metastore.api.WMPool;
 import org.apache.hadoop.hive.metastore.api.WMResourcePlan;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.ql.ServiceContext;
 import org.apache.hadoop.hive.ql.cache.results.QueryResultsCache;
 import org.apache.hadoop.hive.ql.exec.tez.TezSessionPoolManager;
 import org.apache.hadoop.hive.ql.exec.tez.WorkloadManager;
@@ -171,6 +172,7 @@ public class HiveServer2 extends CompositeService {
   private SettableFuture<Boolean> notLeaderTestFuture = SettableFuture.create();
   private ZooKeeperHiveHelper zooKeeperHelper = null;
   private ScheduledQueryExecutionService scheduledQueryService;
+  private ServiceContext serviceContext;
 
   public HiveServer2() {
     super(HiveServer2.class.getSimpleName());
@@ -239,6 +241,10 @@ public class HiveServer2 extends CompositeService {
     }
 
     super.init(hiveConf);
+    this.serviceContext = new ServiceContext(() -> thriftCLIService.getServerIPAddress().getCanonicalHostName(),
+        () -> thriftCLIService.getPortNumber());
+    serviceContext.setClusterIdInConf(hiveConf);
+
     // Set host name in conf
     try {
       hiveConf.set(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_BIND_HOST.varname, getServerHost());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce logic for parsing a specific cluster id in hive, that can be used by the environment. 

### Why are the changes needed?
Hive doesn't have any control over how its environment (kubernetes, yarn, onprem, cloud, whatever) identifies a specific hive compute instance.

### Does this PR introduce _any_ user-facing change?
No. This env/cli property is optional to use, hive takes care of putting it into the conf (hive.cluster.id) if found.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
1. test class for ServiceContext
2. with mini hs2 cluster:
```
mvn install -Dtest=StartMiniHS2Cluster -DminiHS2.clusterType=llap -DminiHS2.conf="target/testconf/llap/hive-site.xml"  -DminiHS2.run=true -DminiHS2.usePortsFromConf=true -Dpackaging.minimizeJar=false -T 1C -DskipShade -Dremoteresources.skip=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -pl itests/hive-unit -Pitests -nsu -Dhive.cluster.id=hello-cluster

#connected with beeline
beeline -u "jdbc:hive2://localhost:10000/default" -n $USER

0: jdbc:hive2://localhost:10000/default> set hive.cluster.id;
+--------------------------------+
|              set               |
+--------------------------------+
| hive.cluster.id=hello-cluster  |
+--------------------------------+


# from env
export HIVE_CLUSTER_ID=hello-cluster-env

# temporarily deleted the value "hive-test-cluster-id-cli" from pom.xml because it was propagated

0: jdbc:hive2://localhost:10000/default> set hive.cluster.id;
+------------------------------------+
|                set                 |
+------------------------------------+
| hive.cluster.id=hello-cluster-env  |
+------------------------------------+

```