### PR TITLE
HIVE-28334 Support queries with function expression in the prepare execute workflow

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeGenericFuncDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeGenericFuncDesc.java
@@ -111,6 +111,9 @@ public class ExprNodeGenericFuncDesc extends ExprNodeDesc implements
 
   @Override
   public ObjectInspector getWritableObjectInspector() {
+    if (writableObjectInspector == null) {
+      writableObjectInspector = TypeInfoUtils.getStandardWritableObjectInspectorFromTypeInfo(typeInfo);
+    }
     return writableObjectInspector;
   }
 

--- a/ql/src/test/queries/clientpositive/prepare_plan_func_expr.q
+++ b/ql/src/test/queries/clientpositive/prepare_plan_func_expr.q
@@ -1,0 +1,9 @@
+--! qt:dataset:src
+--! qt:dataset:alltypesorc
+
+explain prepare pint from select sum(ctinyint)/count(ctinyint) as ag from alltypesorc where cint = ? group by cint;
+explain cbo prepare pint from select sum(ctinyint)/count(ctinyint) as ag from alltypesorc where cint = ? group by cint;
+prepare pint from select sum(ctinyint)/count(ctinyint) as ag from alltypesorc where cint = ? group by cint;
+
+execute pint using 1000828;
+

--- a/ql/src/test/results/clientpositive/llap/prepare_plan_func_expr.q.out
+++ b/ql/src/test/results/clientpositive/llap/prepare_plan_func_expr.q.out
@@ -1,0 +1,100 @@
+PREHOOK: query: explain prepare pint from select sum(ctinyint)/count(ctinyint) as ag from alltypesorc where cint = ? group by cint
+PREHOOK: type: QUERY
+PREHOOK: Input: default@alltypesorc
+#### A masked pattern was here ####
+POSTHOOK: query: explain prepare pint from select sum(ctinyint)/count(ctinyint) as ag from alltypesorc where cint = ? group by cint
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@alltypesorc
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: alltypesorc
+                  filterExpr: (cint = UDFToInteger($1)) (type: boolean)
+                  Statistics: Num rows: 12288 Data size: 73392 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (cint = UDFToInteger($1)) (type: boolean)
+                    Statistics: Num rows: 6144 Data size: 36696 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: ctinyint (type: tinyint)
+                      outputColumnNames: _col1
+                      Statistics: Num rows: 6144 Data size: 36696 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: sum(_col1), count(_col1)
+                        keys: null (type: int)
+                        minReductionHashAggr: 0.99
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: int)
+                          Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint), _col2 (type: bigint)
+            Execution mode: llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0), count(VALUE._col1)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: (UDFToDouble(_col1) / UDFToDouble(_col2)) (type: double)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain cbo prepare pint from select sum(ctinyint)/count(ctinyint) as ag from alltypesorc where cint = ? group by cint
+PREHOOK: type: QUERY
+PREHOOK: Input: default@alltypesorc
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo prepare pint from select sum(ctinyint)/count(ctinyint) as ag from alltypesorc where cint = ? group by cint
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@alltypesorc
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(ag=[/(CAST($1):DOUBLE, CAST($2):DOUBLE)])
+  HiveAggregate(group=[{0}], agg#0=[sum($1)], agg#1=[count($1)])
+    HiveProject($f0=[CAST(?1):INTEGER], $f1=[$0])
+      HiveFilter(condition=[=($2, CAST(?1):INTEGER)])
+        HiveTableScan(table=[[default, alltypesorc]], table:alias=[alltypesorc])
+
+PREHOOK: query: execute pint using 1000828
+PREHOOK: type: EXECUTE QUERY
+PREHOOK: Input: default@alltypesorc
+#### A masked pattern was here ####
+POSTHOOK: query: execute pint using 1000828
+POSTHOOK: type: EXECUTE QUERY
+POSTHOOK: Input: default@alltypesorc
+#### A masked pattern was here ####
+11.0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Queries with function expression throw error as their ObjectInspector is not initialized. As part of prepare execute execute workflow, we serialize and deserialize plan during execute analyzer. During this step, ExprNodeGenericFuncDesc's ObjectInspector field is not initialized as it is a transient field and is never part of the serialized byte array. Assuming it can be null, we try to populate the field when required.


### Why are the changes needed?
To make any queries with function expression work as part of the prepare execute workflow.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=prepare_plan_func_expr.q
