### PR TITLE
HIVE-28338: Client connection count is not correct in HiveMetaStore#close

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -445,6 +445,11 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     return transport;
   }
 
+  @VisibleForTesting
+  public static AtomicInteger getConnCount() {
+    return connCount;
+  }
+
   @Override
   public boolean isLocalMetaStore() {
     return localMetaStore;
@@ -1007,17 +1012,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     try {
       if (null != client) {
         client.shutdown();
-        if ((transport == null) || !transport.isOpen()) {
-          final int newCount = connCount.decrementAndGet();
-          LOG.info("Closed a connection to metastore, current connections: {}",
-                  newCount);
-        }
       }
     } catch (TException e) {
       LOG.debug("Unable to shutdown metastore client. Will try closing transport directly.", e);
     }
-    // Transport would have got closed via client.shutdown(), so we dont need this, but
-    // just in case, we make this call.
     if ((transport != null) && transport.isOpen()) {
       transport.close();
       final int newCount = connCount.decrementAndGet();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -616,15 +616,10 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
     try {
       if (null != client) {
         client.shutdown();
-        if ((transport == null) || !transport.isOpen()) {
-          LOG.info("Closed a connection to metastore, current connections: " + connCount.decrementAndGet());
-        }
       }
     } catch (TException e) {
       LOG.debug("Unable to shutdown metastore client. Will try closing transport directly.", e);
     }
-    // Transport would have got closed via client.shutdown(), so we dont need this, but
-    // just in case, we make this call.
     if ((transport != null) && transport.isOpen()) {
       transport.close();
       LOG.info("Closed a connection to metastore, current connections: " + connCount.decrementAndGet());

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestHiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestHiveMetaStoreClient.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.client;
+
+import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.minihms.AbstractMetaStoreService;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Connection related tests for HiveMetaStoreClient.
+ */
+@RunWith(Parameterized.class)
+@Category(MetastoreCheckinTest.class)
+public class TestHiveMetaStoreClient extends MetaStoreClientTest {
+  private boolean isRemote;
+  private AbstractMetaStoreService metaStore;
+
+  public TestHiveMetaStoreClient(String name, AbstractMetaStoreService metaStore) {
+    this.isRemote = name.equals("Remote");
+    this.metaStore = metaStore;
+  }
+
+  @After
+  public void cleanUp() throws Exception {
+    HiveMetaStoreClient.getConnCount().set(0);
+  }
+
+  @Test
+  public void testTTransport() throws MetaException {
+    HiveMetaStoreClient client = metaStore.getClient();
+    assertTrue(isRemote ? client.getTTransport().isOpen() : client.getTTransport() == null);
+
+    client.close();
+    assertTrue(isRemote ? !client.getTTransport().isOpen() : client.getTTransport() == null);
+  }
+
+  @Test
+  public void testReconnect() throws MetaException {
+    HiveMetaStoreClient client = metaStore.getClient();
+    assertEquals(isRemote ? 1 : 0, HiveMetaStoreClient.getConnCount().get());
+
+    try {
+      client.reconnect();
+    } catch (MetaException e) {
+      // expected in local metastore
+      assertFalse(isRemote);
+    }
+    assertEquals(isRemote ? 1 : 0, HiveMetaStoreClient.getConnCount().get());
+
+    client.close();
+    assertEquals(0, HiveMetaStoreClient.getConnCount().get());
+  }
+
+  @Test
+  public void testCloseClient() throws MetaException {
+    HiveMetaStoreClient client1 = metaStore.getClient();
+    assertEquals(isRemote ? 1 : 0, HiveMetaStoreClient.getConnCount().get());
+
+    HiveMetaStoreClient client2 = metaStore.getClient();
+    assertEquals(isRemote ? 2 : 0, HiveMetaStoreClient.getConnCount().get());
+
+    client1.close();
+    assertEquals(isRemote ? 1 : 0, HiveMetaStoreClient.getConnCount().get());
+
+    client1.close();
+    assertEquals(isRemote ? 1 : 0, HiveMetaStoreClient.getConnCount().get());
+
+    client2.close();
+    assertEquals(0, HiveMetaStoreClient.getConnCount().get());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Revert [#1655](https://github.com/apache/hive/pull/1655).
2. Add a test class for `HiveMetaStoreClient` connections.


### Why are the changes needed?
Bug fix, connection counts is used in remote metastore with `TTransport`, so we cannot decrease counts when transport is null.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
New test class:
```bash
mvn test -Dtest.groups= -Dtest=org.apache.hadoop.hive.metastore.client.TestHiveMetaStoreClient  -pl :hive-standalone-metastore-server
```
