### PR TITLE
HIVE-28324: HIVE_CLUSTER_ID in env: unified way to mark a cluster - addendum empty string default

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ServiceContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ServiceContext.java
@@ -38,12 +38,21 @@ public class ServiceContext {
   }
 
   /**
-   * Logic for finding cluster id if any. Can be used as a utility.
+   * Logic for finding cluster id if any. Default value is empty string instead of null to stay safe
+   * with HiveConf.set().
+   * Precedence order: cli opt, env var, empty string
+   * Can be used as a utility.
    *
    * @return cluster id found from environment of system props
    */
   public static String findClusterId() {
-    return System.getProperty(Constants.CLUSTER_ID_CLI_OPT_NAME, System.getenv(Constants.CLUSTER_ID_ENV_VAR_NAME));
+    return System.getProperty(Constants.CLUSTER_ID_CLI_OPT_NAME,
+        getClusterIdFromEnv());
+  }
+
+  private static String getClusterIdFromEnv() {
+    return System.getenv(Constants.CLUSTER_ID_ENV_VAR_NAME) == null ? "" : System.getenv(
+        Constants.CLUSTER_ID_ENV_VAR_NAME);
   }
 
   public void setClusterIdInConf(HiveConf hiveConf) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Backward-compatible null safe default value for cluster id.

### Why are the changes needed?
To prevent issues like below:
```
2024-06-18T20:37:43,031  WARN [main] server.HiveServer2: Error starting HiveServer2 on attempt 1, will retry in 60000ms
java.lang.IllegalArgumentException: The value of property hive.cluster.id must not be null
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:217) ~[guava-28.2-jre.jar:?]
        at org.apache.hadoop.conf.Configuration.set(Configuration.java:1421) ~[hadoop-common-3.1.1.7.2.18.0-641.jar:?]
        at org.apache.hadoop.conf.Configuration.set(Configuration.java:1402) ~[hadoop-common-3.1.1.7.2.18.0-641.jar:?]
        at org.apache.hadoop.hive.ql.ServiceContext.setClusterIdInConf(ServiceContext.java:50) ~[hive-exec-3.1.3000.2024.0.19.0-97.jar:3.1.3000.2024.0.19.0-97]
        at org.apache.hive.service.server.HiveServer2.init(HiveServer2.java:259) ~[hive-service-3.1.3000.2024.0.19.0-97.jar:3.1.3000.2024.0.19.0-97]
        at org.apache.hive.service.server.HiveServer2.startHiveServer2(HiveServer2.java:1167) ~[hive-service-3.1.3000.2024.0.19.0-97.jar:3.1.3000.2024.0.19.0-97]
...

```


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Tested downstream where the abovementioned exception happened.
