### PR TITLE
HIVE-28340: Test concurrent JDBC connections with Kerberized cluster, impersonation, and HTTP transport

### DIFF
--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/MiniHiveKdc.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/MiniHiveKdc.java
@@ -194,9 +194,6 @@ public class MiniHiveKdc {
                                               .withConf(hiveConf)
                                               .withMiniKdc(hivePrincipal, hiveKeytab)
                                               .withAuthenticationType(authType);
-    if (HiveServer2.isHttpTransportMode(hiveConf)) {
-      miniHS2Builder.withHTTPTransport();
-    }
     return miniHS2Builder.build();
  }
 

--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/MiniHiveKdc.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/MiniHiveKdc.java
@@ -194,6 +194,9 @@ public class MiniHiveKdc {
                                               .withConf(hiveConf)
                                               .withMiniKdc(hivePrincipal, hiveKeytab)
                                               .withAuthenticationType(authType);
+    if (HiveServer2.isHttpTransportMode(hiveConf)) {
+      miniHS2Builder.withHTTPTransport();
+    }
     return miniHS2Builder.build();
  }
 
@@ -235,10 +238,13 @@ public class MiniHiveKdc {
     String hiveMetastoreKeytab = miniHiveKdc.getKeyTabFile(
         miniHiveKdc.getServicePrincipalForUser(MiniHiveKdc.HIVE_METASTORE_SERVICE_PRINCIPAL));
 
-    return new MiniHS2.Builder().withTransactionalTables(false).withConf(hiveConf)
+    MiniHS2.Builder b = new MiniHS2.Builder().withTransactionalTables(false).withConf(hiveConf)
         .withSecureRemoteMetastore(hiveMetastorePrincipal, hiveMetastoreKeytab).
-            withMiniKdc(hivePrincipal, hiveKeytab).withAuthenticationType(authenticationType)
-        .build();
+            withMiniKdc(hivePrincipal, hiveKeytab).withAuthenticationType(authenticationType);
+    if(HiveServer2.isHttpTransportMode(hiveConf)){
+      b.withHTTPTransport();
+    }
+    return b.build();
   }
 
   /**

--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestJdbcWithMiniKdcDoAsHttp.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestJdbcWithMiniKdcDoAsHttp.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.minikdc;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hive.jdbc.miniHS2.MiniHS2;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class TestJdbcWithMiniKdcDoAsHttp {
+
+  private static MiniHS2 hs2;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    MiniHiveKdc kdc = new MiniHiveKdc();
+    HiveConf conf = new HiveConf();
+    // Set connection retries to 1 to fail fast.
+    conf.setIntVar(HiveConf.ConfVars.METASTORE_THRIFT_CONNECTION_RETRIES, 1);
+    conf.setVar(HiveConf.ConfVars.HIVE_SERVER2_TRANSPORT_MODE, "http");
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS, true);
+    hs2 = MiniHiveKdc.getMiniHS2WithKerbWithRemoteHMSWithKerb(kdc, conf);
+    hs2.start(Collections.emptyMap());
+    kdc.loginUser(MiniHiveKdc.HIVE_TEST_USER_1);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    if (hs2 != null) {
+      hs2.cleanup();
+      hs2.stop();
+      hs2 = null;
+    }
+  }
+
+  @Test
+  public void testConcurrentConnectionsWithSessionOverlapNoSaslException() throws Exception {
+    ExecutorService service = Executors.newFixedThreadPool(2);
+    // Open, close, client connections repeatedly till interrupted; essentially leading to many HS2 sessions.
+    // Simulate a client application that uses many short-lived connections.
+    Future<Boolean> openCloseConnectionTask = service.submit(() -> {
+      do {
+        try (Connection c = DriverManager.getConnection(hs2.getJdbcURL())) {
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      } while (!Thread.interrupted());
+      return true;
+    });
+    // Open connection, execute a fixed amount of queries, and close; the HS2 session will remain open for the whole period.
+    // Simulate a client that uses long-lived connections with many queries per connection.
+    Future<Boolean> executeQueryTask = service.submit(() -> {
+      try (Connection c = DriverManager.getConnection(hs2.getJdbcURL())) {
+        for (int i = 0; i < 20; i++) {
+          try (Statement s = c.createStatement()) {
+            try (ResultSet r = s.executeQuery("show databases")) {
+            }
+          }
+        }
+        return true;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    try {
+      // Wait till all the queries are executed, or an exception is thrown
+      executeQueryTask.get();
+    } finally {
+      openCloseConnectionTask.cancel(true);
+      service.shutdown();
+      service.awaitTermination(1, TimeUnit.MINUTES);
+    }
+  }
+}

--- a/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
+++ b/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
@@ -201,8 +201,6 @@ public class MiniHS2 extends AbstractHiveService {
       }
       if (isHTTPTransMode) {
         hiveConf.setVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE, HS2_HTTP_MODE);
-      } else {
-        hiveConf.setVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE, HS2_BINARY_MODE);
       }
       return new MiniHS2(hiveConf, miniClusterType, useMiniKdc, serverPrincipal, serverKeytab,
           isMetastoreRemote, createTransactionalTables, usePortsFromConf, authType, isHA, cleanupLocalDirOnStartup,

--- a/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
+++ b/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
@@ -201,6 +201,8 @@ public class MiniHS2 extends AbstractHiveService {
       }
       if (isHTTPTransMode) {
         hiveConf.setVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE, HS2_HTTP_MODE);
+      } else {
+        hiveConf.setVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE, HS2_BINARY_MODE);
       }
       return new MiniHS2(hiveConf, miniClusterType, useMiniKdc, serverPrincipal, serverKeytab,
           isMetastoreRemote, createTransactionalTables, usePortsFromConf, authType, isHA, cleanupLocalDirOnStartup,


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. New test case simulating JDBC clients concurrently accessing a Kerberized cluster, with impersonation and HTTP transport.
2. Set transport mode based on configuration when creating MiniHS2 from `MiniHiveKdc#getMiniHS2WithKerbWithRemoteHMSWithKerb`.

### Why are the changes needed?
Increase test coverage and guard against regressions. More info under HIVE-28340.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
```
mvn test -Dtest=TestJdbcWithMiniKdcDoAsHttp -pl itests/hive-minikdc -Pitests
```