### PR TITLE
HIVE-28275: Iceberg: Add support for 'If Not Exists' and 'or Replace' for Create Tag.

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/alter_table_create_tag.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/alter_table_create_tag.q
@@ -17,6 +17,15 @@ explain alter table iceTbl create tag test_tag_2 retain 5 days;
 alter table iceTbl create tag test_tag_2 retain 5 days;
 select name, max_reference_age_in_ms from default.iceTbl.refs where type='TAG';
 
+-- create a tag which already exists
+explain alter table iceTbl create tag if not exists test_tag_2;
+alter table iceTbl create tag if not exists test_tag_2;
+
+-- create or replace
+explain alter table iceTbl create or replace tag test_tag_1;
+alter table iceTbl create or replace tag test_tag_1;
+select * from default.iceTbl.tag_test_tag_1;
+
 -- drop a tag
 explain alter table iceTbl drop tag test_tag_2;
 alter table iceTbl drop tag test_tag_2;

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_table_create_tag.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_table_create_tag.q.out
@@ -83,6 +83,58 @@ POSTHOOK: Input: default@icetbl
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 test_tag_1	NULL
 test_tag_2	432000000
+PREHOOK: query: explain alter table iceTbl create tag if not exists test_tag_2
+PREHOOK: type: ALTERTABLE_CREATETAG
+PREHOOK: Input: default@icetbl
+POSTHOOK: query: explain alter table iceTbl create tag if not exists test_tag_2
+POSTHOOK: type: ALTERTABLE_CREATETAG
+POSTHOOK: Input: default@icetbl
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    SnapshotRef Operation
+      table name: default.iceTbl
+      spec: AlterTableSnapshotRefSpec{operationType=CREATE_TAG, operationParams=CreateSnapshotRefSpec{refName=test_tag_2, isReplace=false, ifNotExists=true}}
+
+PREHOOK: query: alter table iceTbl create tag if not exists test_tag_2
+PREHOOK: type: ALTERTABLE_CREATETAG
+PREHOOK: Input: default@icetbl
+POSTHOOK: query: alter table iceTbl create tag if not exists test_tag_2
+POSTHOOK: type: ALTERTABLE_CREATETAG
+POSTHOOK: Input: default@icetbl
+PREHOOK: query: explain alter table iceTbl create or replace tag test_tag_1
+PREHOOK: type: ALTERTABLE_CREATETAG
+PREHOOK: Input: default@icetbl
+POSTHOOK: query: explain alter table iceTbl create or replace tag test_tag_1
+POSTHOOK: type: ALTERTABLE_CREATETAG
+POSTHOOK: Input: default@icetbl
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    SnapshotRef Operation
+      table name: default.iceTbl
+      spec: AlterTableSnapshotRefSpec{operationType=CREATE_TAG, operationParams=CreateSnapshotRefSpec{refName=test_tag_1, isReplace=true, ifNotExists=false}}
+
+PREHOOK: query: alter table iceTbl create or replace tag test_tag_1
+PREHOOK: type: ALTERTABLE_CREATETAG
+PREHOOK: Input: default@icetbl
+POSTHOOK: query: alter table iceTbl create or replace tag test_tag_1
+POSTHOOK: type: ALTERTABLE_CREATETAG
+POSTHOOK: Input: default@icetbl
+PREHOOK: query: select * from default.iceTbl.tag_test_tag_1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@icetbl
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from default.iceTbl.tag_test_tag_1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@icetbl
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	jack
+2	bob
 PREHOOK: query: explain alter table iceTbl drop tag test_tag_2
 PREHOOK: type: ALTERTABLE_DROPTAG
 PREHOOK: Input: default@icetbl

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
@@ -75,6 +75,7 @@ alterTableStatementSuffix
     | alterStatementSuffixSetOwner
     | alterStatementSuffixSetPartSpec
     | alterStatementSuffixExecute
+    | (KW_CREATE KW_OR KW_REPLACE KW_TAG) => alterStatementSuffixCreateOrReplaceTag
     | alterStatementSuffixCreateBranch
     | alterStatementSuffixDropBranch
     | alterStatementSuffixCreateTag
@@ -582,9 +583,16 @@ alterStatementSuffixDropTag
 alterStatementSuffixCreateTag
 @init { gParent.pushMsg("alter table create tag", state); }
 @after { gParent.popMsg(state); }
-    : KW_CREATE KW_TAG tagName=identifier snapshotIdOfRef? refRetain?
-    -> ^(TOK_ALTERTABLE_CREATE_TAG $tagName snapshotIdOfRef? refRetain?)
+    : KW_CREATE KW_TAG ifNotExists? tagName=identifier snapshotIdOfRef? refRetain?
+    -> ^(TOK_ALTERTABLE_CREATE_TAG $tagName ifNotExists? snapshotIdOfRef? refRetain?)
     ;
+
+alterStatementSuffixCreateOrReplaceTag
+@init { gParent.pushMsg("alter table create tag", state); }
+@after { gParent.popMsg(state); }
+     : KW_CREATE KW_OR KW_REPLACE KW_TAG tagName=identifier snapshotIdOfRef? refRetain?
+     -> ^(TOK_ALTERTABLE_CREATE_TAG $tagName KW_REPLACE snapshotIdOfRef? refRetain?)
+     ;
 
 fileFormat
 @init { gParent.pushMsg("file format specification", state); }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add support for 'If Not Exist' & 'Or Replace' Clause while creating an iceberg tag 

### Why are the changes needed?

Better Usability

### Does this PR introduce _any_ user-facing change?

Yes, 'If Not Exists' & 'Or Replace' can be used while creating a Tag

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT
