### PR TITLE
HIVE-28345: Avoid redundant HiveConf creation in MiniHS2.Builder

### DIFF
--- a/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
+++ b/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
@@ -97,7 +97,7 @@ public class MiniHS2 extends AbstractHiveService {
   }
 
   public static class Builder {
-    private HiveConf hiveConf = new HiveConf();
+    private HiveConf hiveConf = null;
     private MiniClusterType miniClusterType = MiniClusterType.LOCALFS_ONLY;
     private boolean useMiniKdc = false;
     private String serverPrincipal;
@@ -193,6 +193,9 @@ public class MiniHS2 extends AbstractHiveService {
     public MiniHS2 build() throws Exception {
       if (miniClusterType == MiniClusterType.MR && useMiniKdc) {
         throw new IOException("Can't create secure miniMr ... yet");
+      }
+      if (hiveConf == null) {
+        this.hiveConf = new HiveConf();
       }
       Iterator<Map.Entry<String, String>> iter = hiveConf.iterator();
       while (iter.hasNext()) {


### PR DESCRIPTION
### Why are the changes needed?
Every creation of a MiniHS2.Builder object triggers the creation  of a HiveConf object. In many cases this new configuration object is thrown away and replaced by another conf object via the withConf method.

Creating a HiveConf object is computationally heavy so for performance reasons its best to avoid it when possible.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Existing tests