### PR TITLE
HIVE-28348: TransactionalKafkaWriterTest hangs in precommit

### DIFF
--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/TransactionalKafkaWriterTest.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/TransactionalKafkaWriterTest.java
@@ -58,6 +58,7 @@ import java.util.stream.IntStream;
 /**
  * Test Transactional Writer.
  */
+@Ignore("HIVE-28348: TransactionalKafkaWriterTest hangs in precommit")
 public class TransactionalKafkaWriterTest {
 
   private static final String TOPIC = "TOPIC_TEST";


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disable stuck unit test.

### Why are the changes needed?
To unblock precommit.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Locally, skipped.
