### PR TITLE
HIVE-28353: Iceberg: Reading *Files Metadata table files if the column is of TIMESTAMP type.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInternalRecordWrapper.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInternalRecordWrapper.java
@@ -142,7 +142,7 @@ public class IcebergInternalRecordWrapper implements Record, StructLike {
   private static Function<Object, Object> converter(Type type) {
     switch (type.typeId()) {
       case TIMESTAMP:
-        return timestamp -> DateTimeUtil.timestamptzFromMicros((Long) timestamp);
+        return timestamp -> DateTimeUtil.timestampFromMicros((Long) timestamp);
       case DATE:
         return date -> DateTimeUtil.dateFromDays((Integer) date);
       case STRUCT:

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_metadata_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_metadata_table.q
@@ -1,3 +1,4 @@
+-- SORT_QUERY_RESULTS
 create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet tblproperties ('format-version'='2');
 insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp)), (2, cast('2023-07-20 00:00:00' as timestamp));
 select * from ice_ts_4;

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_metadata_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_metadata_table.q
@@ -1,3 +1,10 @@
-create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet;
-insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp));
-select readable_metrics from default.ice_ts_4.files;
+create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet tblproperties ('format-version'='2');
+insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp)), (2, cast('2023-07-20 00:00:00' as timestamp));
+select * from ice_ts_4;
+delete from ice_ts_4 where id = 2;
+select * from ice_ts_4;
+select readable_metrics from default.ice_ts_4.FILES;
+select readable_metrics from default.ice_ts_4.ALL_FILES;
+select readable_metrics from default.ice_ts_4.DATA_FILES;
+select readable_metrics from default.ice_ts_4.ALL_DATA_FILES;
+select readable_metrics from default.ice_ts_4.DELETE_FILES;

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_metadata_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_metadata_table.q
@@ -1,0 +1,3 @@
+create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet;
+insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp));
+select readable_metrics from default.ice_ts_4.files;

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_metadata_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_metadata_table.q.out
@@ -59,8 +59,8 @@ POSTHOOK: query: select readable_metrics from default.ice_ts_4.ALL_FILES
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@ice_ts_4
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-{"id":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null},"ts":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null}}
 {"id":{"column_size":46,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":2},"ts":{"column_size":76,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":"2023-07-20 00:00:00","upper_bound":"2023-07-20 00:00:00"}}
+{"id":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null},"ts":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null}}
 PREHOOK: query: select readable_metrics from default.ice_ts_4.DATA_FILES
 PREHOOK: type: QUERY
 PREHOOK: Input: default@ice_ts_4

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_metadata_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_metadata_table.q.out
@@ -1,0 +1,25 @@
+PREHOOK: query: create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_ts_4
+POSTHOOK: query: create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_ts_4
+PREHOOK: query: insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_ts_4
+POSTHOOK: query: insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_ts_4
+PREHOOK: query: select readable_metrics from default.ice_ts_4.files
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_ts_4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select readable_metrics from default.ice_ts_4.files
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_ts_4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"id":{"column_size":42,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":1},"ts":{"column_size":45,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":"2023-07-20 00:00:00","upper_bound":"2023-07-20 00:00:00"}}

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_metadata_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_metadata_table.q.out
@@ -1,25 +1,90 @@
-PREHOOK: query: create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet
+PREHOOK: query: create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet tblproperties ('format-version'='2')
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@ice_ts_4
-POSTHOOK: query: create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet
+POSTHOOK: query: create table ice_ts_4 (id int, ts timestamp ) stored by iceberg stored as parquet tblproperties ('format-version'='2')
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@ice_ts_4
-PREHOOK: query: insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp))
+PREHOOK: query: insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp)), (2, cast('2023-07-20 00:00:00' as timestamp))
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@ice_ts_4
-POSTHOOK: query: insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp))
+POSTHOOK: query: insert into ice_ts_4 values (1, cast('2023-07-20 00:00:00' as timestamp)), (2, cast('2023-07-20 00:00:00' as timestamp))
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@ice_ts_4
-PREHOOK: query: select readable_metrics from default.ice_ts_4.files
+PREHOOK: query: select * from ice_ts_4
 PREHOOK: type: QUERY
 PREHOOK: Input: default@ice_ts_4
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select readable_metrics from default.ice_ts_4.files
+POSTHOOK: query: select * from ice_ts_4
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@ice_ts_4
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-{"id":{"column_size":42,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":1},"ts":{"column_size":45,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":"2023-07-20 00:00:00","upper_bound":"2023-07-20 00:00:00"}}
+1	2023-07-20 00:00:00
+2	2023-07-20 00:00:00
+PREHOOK: query: delete from ice_ts_4 where id = 2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_ts_4
+PREHOOK: Output: default@ice_ts_4
+POSTHOOK: query: delete from ice_ts_4 where id = 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_ts_4
+POSTHOOK: Output: default@ice_ts_4
+PREHOOK: query: select * from ice_ts_4
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_ts_4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from ice_ts_4
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_ts_4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	2023-07-20 00:00:00
+PREHOOK: query: select readable_metrics from default.ice_ts_4.FILES
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_ts_4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select readable_metrics from default.ice_ts_4.FILES
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_ts_4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"id":{"column_size":46,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":2},"ts":{"column_size":76,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":"2023-07-20 00:00:00","upper_bound":"2023-07-20 00:00:00"}}
+{"id":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null},"ts":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null}}
+PREHOOK: query: select readable_metrics from default.ice_ts_4.ALL_FILES
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_ts_4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select readable_metrics from default.ice_ts_4.ALL_FILES
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_ts_4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"id":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null},"ts":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null}}
+{"id":{"column_size":46,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":2},"ts":{"column_size":76,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":"2023-07-20 00:00:00","upper_bound":"2023-07-20 00:00:00"}}
+PREHOOK: query: select readable_metrics from default.ice_ts_4.DATA_FILES
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_ts_4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select readable_metrics from default.ice_ts_4.DATA_FILES
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_ts_4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"id":{"column_size":46,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":2},"ts":{"column_size":76,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":"2023-07-20 00:00:00","upper_bound":"2023-07-20 00:00:00"}}
+PREHOOK: query: select readable_metrics from default.ice_ts_4.ALL_DATA_FILES
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_ts_4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select readable_metrics from default.ice_ts_4.ALL_DATA_FILES
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_ts_4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"id":{"column_size":46,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":2},"ts":{"column_size":76,"value_count":2,"null_value_count":0,"nan_value_count":null,"lower_bound":"2023-07-20 00:00:00","upper_bound":"2023-07-20 00:00:00"}}
+PREHOOK: query: select readable_metrics from default.ice_ts_4.DELETE_FILES
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_ts_4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select readable_metrics from default.ice_ts_4.DELETE_FILES
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_ts_4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"id":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null},"ts":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null}}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use the correct type while fetching Metadata Table, with tables having TIMESTAMP


### Why are the changes needed?

To fix reading Metadata Tables where the main table has a column of TIMESTAMP type

### Does this PR introduce _any_ user-facing change?

Yes, If the tables of TIMESTAMP data type, then *FILES Metadata tables can be read

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT
