### PR TITLE
HIVE-28354: Rename NegativeLlapCliDriver to NegativeLlapCliConfig

### DIFF
--- a/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestNegativeLlapCliDriver.java
+++ b/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestNegativeLlapCliDriver.java
@@ -33,7 +33,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class TestNegativeLlapCliDriver {
 
-  static CliAdapter adapter = new CliConfigs.NegativeLlapCliDriver().getCliAdapter();
+  static CliAdapter adapter = new CliConfigs.NegativeLlapCliConfig().getCliAdapter();
 
   @Parameters(name = "{0}")
   public static List<Object[]> getParameters() throws Exception {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
@@ -361,8 +361,8 @@ public class CliConfigs {
     }
   }
 
-  public static class NegativeLlapCliDriver extends AbstractCliConfig {
-    public NegativeLlapCliDriver() {
+  public static class NegativeLlapCliConfig extends AbstractCliConfig {
+    public NegativeLlapCliConfig() {
       super(CoreNegativeCliDriver.class);
       try {
         setQueryDir("ql/src/test/queries/clientnegative");


### PR DESCRIPTION
Rename NegativeLlapCliDriver to NegativeLlapCliConfig


### Why are the changes needed?
Wrong naming

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Precommit tests