### PR TITLE
HIVE-28359: Discard old builds in Jenkins to avoid disk space exhaustion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ if (env.BRANCH_NAME != 'master') {
   discardNumToKeep = '5'
 }
 properties([
-    buildDiscarder(logRotator(daysToKeepStr: discardDaysToKeep, numToKeepStr: discardNumToKeep))
+    buildDiscarder(logRotator(daysToKeepStr: discardDaysToKeep, numToKeepStr: discardNumToKeep)),
     // max 5 build/branch/day
     rateLimitBuilds(throttle: [count: 5, durationName: 'day', userBoost: true]),
     // do not run multiple testruns on the same branch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,10 +16,14 @@
  * limitations under the License.
  */
 
+def discardDaysToKeep = '365'
+def discardNumToKeep = '' // Unlimited
+if (env.BRANCH_NAME != 'master') {
+  discardDaysToKeep = '60'
+  discardNumToKeep = '5'
+}
 properties([
-    // For master keep all builds for one year
-    // For other branches/PRs keep at most 5 builds for at most two months
-    buildDiscarder(logRotator(daysToKeepStr: env.BRANCH_NAME=='master'?'365':'60', numToKeepStr: env.BRANCH_NAME=='master'?'':'5')),
+    buildDiscarder(logRotator(daysToKeepStr: discardDaysToKeep, numToKeepStr: discardNumToKeep))
     // max 5 build/branch/day
     rateLimitBuilds(throttle: [count: 5, durationName: 'day', userBoost: true]),
     // do not run multiple testruns on the same branch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,9 @@
  */
 
 properties([
+    // For master keep all builds for one year
+    // For other branches/PRs keep at most 5 builds for at most two months
+    buildDiscarder(logRotator(daysToKeepStr: env.BRANCH_NAME=='master'?'365':'60', numToKeepStr: env.BRANCH_NAME=='master'?'':'5')),
     // max 5 build/branch/day
     rateLimitBuilds(throttle: [count: 5, durationName: 'day', userBoost: true]),
     // do not run multiple testruns on the same branch


### PR DESCRIPTION
### Why are the changes needed?
Currently Jenkins retains the builds from all active branches/PRs leading to disk space exhaustion and CI failures requiring manual intervention to restore the services.

### Does this PR introduce _any_ user-facing change?
Developers will not be able to access discarded builds. 

### Is the change a dependency upgrade?
No

### How was this patch tested?
Inspect job configuration generated by this PR (https://ci.hive.apache.org/job/hive-precommit/job/PR-5332/configure).