### PR TITLE
HIVE-26332: Test surefire upgrade to 3.1.3-SNAPSHOT for SUREFIRE-1934

### DIFF
--- a/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
+++ b/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
@@ -170,7 +170,7 @@ public class TestHiveCli {
   @Test
   public void testSqlFromCmdWithEmbeddedQuotes() {
     verifyCMD(null, "hive", out,
-        new String[] { "-e", "select \"hive\"" }, ERRNO_OK, true);
+        new String[] { "-e", "select \"hive\";" }, ERRNO_OK, true);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <maven.exec.plugin.version>3.1.0</maven.exec.plugin.version>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
     <maven.shade.plugin.version>3.5.0</maven.shade.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.3.1</maven.surefire.plugin.version>
     <maven.cyclonedx.plugin.version>2.7.10</maven.cyclonedx.plugin.version>
     <maven.license.plugin.version>2.3.0</maven.license.plugin.version>
     <!-- Library Dependency Versions -->
@@ -1734,6 +1734,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <enableOutErrElements>false</enableOutErrElements>
           <excludes>
             <exclude>**/TestSerDe.java</exclude>
             <exclude>**/TestHiveMetaStore.java</exclude>
@@ -1745,7 +1746,7 @@
           </excludes>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <reuseForks>false</reuseForks>
-          <failIfNoTests>false</failIfNoTests>
+          <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <argLine>${maven.test.jvm.args}</argLine>
           <trimStackTrace>false</trimStackTrace>
           <additionalClasspathElements>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -57,7 +57,7 @@
     <ant.contrib.version>1.0b3</ant.contrib.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.3.1</maven.surefire.plugin.version>
     <!-- Dependency versions -->
     <antlr.version>4.9.3</antlr.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
@@ -515,7 +515,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven.surefire.plugin.version}</version>
           <configuration>
-            <failIfNoTests>false</failIfNoTests>
+            <enableOutErrElements>false</enableOutErrElements>
+            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           </configuration>
         </plugin>
         <plugin>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -39,7 +39,7 @@
     <maven.cyclonedx.plugin.version>2.7.10</maven.cyclonedx.plugin.version>
     <checkstyle.conf.dir>${basedir}/checkstyle/</checkstyle.conf.dir>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.3.1</maven.surefire.plugin.version>
     <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
   <dependencies>
@@ -197,7 +197,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven.surefire.plugin.version}</version>
         <configuration>
           <reuseForks>false</reuseForks>
           <argLine>-Xmx3g</argLine>
@@ -205,6 +204,8 @@
           <systemPropertyVariables>
             <test.tmp.dir>${project.build.directory}/tmp</test.tmp.dir>
           </systemPropertyVariables>
+          <enableOutErrElements>false</enableOutErrElements>
+          <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade surefire plugin to 3.1.3-SNAPSHOT

### Why are the changes needed?
Test if failures related to SUREFIRE-1934 are resolved and what else remains to be done for upgrading

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
