### PR TITLE
HIVE-28362: Fail to materialize a CTE with VOID

### DIFF
--- a/ql/src/test/queries/clientpositive/cte_mat_12.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_12.q
@@ -1,0 +1,9 @@
+set hive.optimize.cte.materialize.full.aggregate.only=false;
+set hive.optimize.cte.materialize.threshold=2;
+
+EXPLAIN
+WITH x AS (SELECT null AS null_value, 1 AS non_null_value)
+SELECT *, TYPEOF(null_value) FROM x UNION ALL SELECT *, TYPEOF(null_value) FROM x;
+
+WITH x AS (SELECT null AS null_value, 1 AS non_null_value)
+SELECT *, TYPEOF(null_value) FROM x UNION ALL SELECT *, TYPEOF(null_value) FROM x;

--- a/ql/src/test/results/clientpositive/llap/cte_mat_12.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_12.q.out
@@ -1,0 +1,133 @@
+PREHOOK: query: EXPLAIN
+WITH x AS (SELECT null AS null_value, 1 AS non_null_value)
+SELECT *, TYPEOF(null_value) FROM x UNION ALL SELECT *, TYPEOF(null_value) FROM x
+PREHOOK: type: QUERY
+PREHOOK: Input: default@x
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+WITH x AS (SELECT null AS null_value, 1 AS non_null_value)
+SELECT *, TYPEOF(null_value) FROM x UNION ALL SELECT *, TYPEOF(null_value) FROM x
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@x
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-4 depends on stages: Stage-2, Stage-0
+  Stage-0 depends on stages: Stage-1
+  Stage-3 depends on stages: Stage-4
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: _dummy_table
+                  Row Limit Per Split: 1
+                  Statistics: Num rows: 1 Data size: 10 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: null (type: void), 1 (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.TextInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          name: default.x
+            Execution mode: llap
+            LLAP IO: no inputs
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-4
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 2 <- Union 3 (CONTAINS)
+        Map 4 <- Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: x
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: non_null_value (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: null (type: void), _col0 (type: int), 'void' (type: string)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: x
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: non_null_value (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: null (type: void), _col0 (type: int), 'void' (type: string)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-0
+    Move Operator
+      files:
+          hdfs directory: true
+#### A masked pattern was here ####
+
+  Stage: Stage-3
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: WITH x AS (SELECT null AS null_value, 1 AS non_null_value)
+SELECT *, TYPEOF(null_value) FROM x UNION ALL SELECT *, TYPEOF(null_value) FROM x
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Input: default@x
+PREHOOK: Output: database:default
+PREHOOK: Output: default@x
+#### A masked pattern was here ####
+POSTHOOK: query: WITH x AS (SELECT null AS null_value, 1 AS non_null_value)
+SELECT *, TYPEOF(null_value) FROM x UNION ALL SELECT *, TYPEOF(null_value) FROM x
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Input: default@x
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@x
+#### A masked pattern was here ####
+NULL	1	void
+NULL	1	void


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow materialized CTEs to hold NULL literals.
https://issues.apache.org/jira/browse/HIVE-28362

### Why are the changes needed?

Materialized CTEs should keep the original semantics of the CTEs. Regular CTEs allow a VOID type, then materialized CTEs also allow it.

### Does this PR introduce _any_ user-facing change?

No

### Is the change a dependency upgrade?

No

### How was this patch tested?

Tested by the new qtest.