### PR TITLE
HIVE-28358: Enable JDBC getClob retrieval from String columns

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveBaseResultSet.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveBaseResultSet.java
@@ -46,6 +46,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.sql.rowset.serial.SerialClob;
+
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.hive.common.type.HiveIntervalYearMonth;
 import org.apache.hadoop.hive.common.type.TimestampTZUtil;
@@ -309,12 +311,14 @@ public abstract class HiveBaseResultSet implements ResultSet {
 
   @Override
   public Clob getClob(int i) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
+    String str = getString(i);
+    return str == null ? null : new SerialClob(str.toCharArray());
   }
 
   @Override
   public Clob getClob(String colName) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
+    String str = getString(colName);
+    return str == null ? null : new SerialClob(str.toCharArray());
   }
 
   @Override

--- a/jdbc/src/test/org/apache/hive/jdbc/TestHiveBaseResultSet.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestHiveBaseResultSet.java
@@ -20,12 +20,17 @@ package org.apache.hive.jdbc;
 
 import static org.mockito.Mockito.when;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.sql.Clob;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hive.service.cli.TableSchema;
@@ -238,6 +243,49 @@ public class TestHiveBaseResultSet {
 
     Assert.assertEquals(true, resultSet.getBoolean(1));
     Assert.assertFalse(resultSet.wasNull());
+  }
+
+  /**
+   * HIVE-28358 getClob(int) != null
+   */
+  @Test
+  public void testGetClobString() throws SQLException, IOException {
+    FieldSchema fieldSchema = new FieldSchema();
+    fieldSchema.setType("varchar(64)");
+
+    List<FieldSchema> fieldSchemas = Arrays.asList(fieldSchema);
+    TableSchema schema = new TableSchema(fieldSchemas);
+
+    HiveBaseResultSet resultSet = Mockito.spy(HiveBaseResultSet.class);
+    resultSet.row = new Object[] {"ABC"};
+
+    when(resultSet.getSchema()).thenReturn(schema);
+    
+    Clob clob = resultSet.getClob(1);
+    try (Reader clobReader = clob.getCharacterStream()) {
+      Assert.assertEquals("ABC", new BufferedReader(clobReader).lines().collect(Collectors.joining(System.lineSeparator())));
+    }
+    Assert.assertFalse(resultSet.wasNull());
+  }
+
+  /**
+   * HIVE-28358 getClob(int) == null 
+   */
+  @Test
+  public void testGetClobNull() throws SQLException {
+    FieldSchema fieldSchema = new FieldSchema();
+    fieldSchema.setType("varchar(64)");
+
+    List<FieldSchema> fieldSchemas = Arrays.asList(fieldSchema);
+    TableSchema schema = new TableSchema(fieldSchemas);
+
+    HiveBaseResultSet resultSet = Mockito.spy(HiveBaseResultSet.class);
+    resultSet.row = new Object[] {null};
+
+    when(resultSet.getSchema()).thenReturn(schema);
+
+    Assert.assertNull(resultSet.getClob(1));
+    Assert.assertTrue(resultSet.wasNull());
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes an implementation for the getClob(int) and getClob(String) methods of [HiveBaseResultSet](https://github.com/apache/hive/blob/fe2e17c3ad4773a4b1066ac525f7de2a86572eca/jdbc/src/java/org/apache/hive/jdbc/HiveBaseResultSet.java).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
please see [HIVE-28358](https://issues.apache.org/jira/browse/HIVE-28358).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. The current getClob() methods of HiveBaseResultSet just throw an exception. The proposed change returns a [SerialClob](https://docs.oracle.com/javase/8/docs/api/javax/sql/rowset/serial/SerialClob.html) already initialized with a char array obtained from the corresponding getString() methods.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Testing was done inside the "poorly designed application". Other additional tests were not deemed useful since the functionality is not present in the master release.
