### PR TITLE
HIVE-28367: Bump org.xerial.snappy:snappy-java from 1.1.10.4 to 1.1.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
     <tez.version>0.10.3</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
     <tempus-fugit.version>1.1</tempus-fugit.version>
-    <snappy.version>1.1.10.4</snappy.version>
+    <snappy.version>1.1.10.5</snappy.version>
     <wadl-resourcedoc-doclet.version>1.4</wadl-resourcedoc-doclet.version>
     <velocity.version>2.3</velocity.version>
     <xerces.version>2.12.2</xerces.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -95,6 +95,7 @@
     <protobuf.version>3.24.4</protobuf.version>
     <io.grpc.version>1.51.0</io.grpc.version>
     <sqlline.version>1.9.0</sqlline.version>
+    <snappy.version>1.1.10.5</snappy.version>
     <jline.version>2.14.6</jline.version>
     <ST4.version>4.0.4</ST4.version>
     <storage-api.version>4.1.0-SNAPSHOT</storage-api.version>
@@ -364,6 +365,11 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
         <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>${snappy.version}</version>
       </dependency>
       <!-- JDBC drivers -->
       <dependency>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -34,6 +34,7 @@
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.6.3</junit.jupiter.version>
     <junit.vintage.version>5.6.3</junit.vintage.version>
+    <snappy.version>1.1.10.5</snappy.version>
     <slf4j.version>1.7.30</slf4j.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.cyclonedx.plugin.version>2.7.10</maven.cyclonedx.plugin.version>
@@ -114,6 +115,10 @@
           <groupId>org.apache.curator</groupId>
           <artifactId>curator-recipes</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -126,6 +131,12 @@
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- test inter-project -->
     <dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrade snappy-java from version 1.1.10.4 to 1.1.10.5
Have also made changes to make snappy-java version consistent throughout hive, which varied across modules earlier.

### Why are the changes needed?
[https://github.com/xerial/snappy-java/releases/tag/v1.1.10.5](https://github.com/xerial/snappy-java/releases/tag/v1.1.10.5)


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes
Dependency Tree: [dpn.txt](https://github.com/user-attachments/files/16175382/dpn.txt)


### How was this patch tested?
Manually tested by triggering basic queries in hive after making the change.
