### PR TITLE
HIVE-28237: Add a default tez-site.xml to data/conf

### DIFF
--- a/data/conf/tez-site.xml
+++ b/data/conf/tez-site.xml
@@ -1,0 +1,1 @@
+tez/tez-site.xml


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added a tez-site.xml file to data/conf: symlinked from data/conf/tez and added a typical test scenario setting as below:
```
  <property>
    <name>tez.local.mode</name>
    <value>true</value>
  </property>
```


### Why are the changes needed?
As described on jira, users of StartMiniHS2Cluster might find it confusing where to set tez configs, not even defined without this patch.


### Does this PR introduce _any_ user-facing change?
No.


### Is the change a dependency upgrade?
No.



### How was this patch tested?
With StartMiniHS2Cluster, tez.local.mode=true was kicking in with the patch, this log line below was found in the log file of StartMiniHS2Cluster, so it created a LocalClient as expected
```
2024-04-30T02:55:14,168  INFO [DAGAppMaster Thread] client.LocalClient: Using working directory: /tmp/hive/scratch/laszlobodor/_tez_session_dir/7c9b847c-9d48-469a-a1e7-fa4d29b3148f/.tez/application_1714470913855_0001_wd
```