### PR TITLE
HIVE-28377: Add support for hive.output.file.extension to HCatStorer

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/DynamicPartitionFileRecordWriterContainer.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/DynamicPartitionFileRecordWriterContainer.java
@@ -208,9 +208,10 @@ class DynamicPartitionFileRecordWriterContainer extends FileRecordWriterContaine
       baseOutputCommitter.setupTask(currTaskContext);
 
       Path parentDir = new Path(currTaskContext.getConfiguration().get("mapred.work.output.dir"));
+      String extension = HiveConf.getVar(currTaskContext.getConfiguration(), HiveConf.ConfVars.OUTPUT_FILE_EXTENSION, "");
       Path childPath =
           new Path(parentDir, FileOutputFormat.getUniqueFile(currTaskContext,
-              currTaskContext.getConfiguration().get("mapreduce.output.basename", "part"), ""));
+              currTaskContext.getConfiguration().get("mapreduce.output.basename", "part"), extension));
 
       RecordWriter baseRecordWriter =
           baseOF.getRecordWriter(parentDir.getFileSystem(currTaskContext.getConfiguration()),

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputFormatContainer.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputFormatContainer.java
@@ -97,8 +97,9 @@ class FileOutputFormatContainer extends OutputFormatContainer {
           (org.apache.hadoop.mapred.RecordWriter)null, context);
     } else {
       Path parentDir = new Path(context.getConfiguration().get("mapred.work.output.dir"));
+      String extension = HiveConf.getVar(context.getConfiguration(), HiveConf.ConfVars.OUTPUT_FILE_EXTENSION,"");
       Path childPath = new Path(parentDir,FileOutputFormat.getUniqueName(new JobConf(context.getConfiguration()),
-               context.getConfiguration().get("mapreduce.output.basename", "part")));
+               context.getConfiguration().get("mapreduce.output.basename", "part")) + extension);
 
       rw = new StaticPartitionFileRecordWriterContainer(
           getBaseOutputFormat().getRecordWriter(

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
@@ -334,9 +334,6 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
     job.setOutputFormatClass(HCatOutputFormat.class);
 
     OutputJobInfo outputJobInfo = OutputJobInfo.create(dbName, tableName, partitionValues);
-    /*if (customDynamicPathPattern != null) {
-      job.getConfiguration().set(HCatConstants.HCAT_DYNAMIC_CUSTOM_PATTERN, customDynamicPathPattern);
-    }*/
     HCatOutputFormat.setOutput(job, outputJobInfo);
 
     job.setMapOutputKeyClass(BytesWritable.class);

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
@@ -97,7 +97,7 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
   private static List<HCatRecord> writeRecords = new ArrayList<HCatRecord>();
   private static List<HCatRecord> readRecords = new ArrayList<HCatRecord>();
 
-  private static FileSystem fs;
+  protected static FileSystem fs;
   private String externalTableLocation = null;
   protected String tableName;
   protected String serdeClass;
@@ -282,7 +282,7 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
   Job runMRCreate(Map<String, String> partitionValues, List<HCatFieldSchema> partitionColumns,
       List<HCatRecord> records, int writeCount, boolean assertWrite) throws Exception {
     return runMRCreate(partitionValues, partitionColumns, records, writeCount, assertWrite,
-        true, null);
+        true, new HashMap<String, String>());
   }
 
   /**
@@ -298,12 +298,15 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
    */
   Job runMRCreate(Map<String, String> partitionValues, List<HCatFieldSchema> partitionColumns,
       List<HCatRecord> records, int writeCount, boolean assertWrite, boolean asSingleMapTask,
-      String customDynamicPathPattern) throws Exception {
+      Map<String, String> properties) throws Exception {
 
     writeRecords = records;
     MapCreate.writeCount = 0;
 
     Configuration conf = new Configuration();
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      conf.set(entry.getKey(), entry.getValue());
+    }
     Job job = new Job(conf, "hcat mapreduce write test");
     job.setJarByClass(this.getClass());
     job.setMapperClass(HCatMapReduceTest.MapCreate.class);
@@ -331,9 +334,9 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
     job.setOutputFormatClass(HCatOutputFormat.class);
 
     OutputJobInfo outputJobInfo = OutputJobInfo.create(dbName, tableName, partitionValues);
-    if (customDynamicPathPattern != null) {
+    /*if (customDynamicPathPattern != null) {
       job.getConfiguration().set(HCatConstants.HCAT_DYNAMIC_CUSTOM_PATTERN, customDynamicPathPattern);
-    }
+    }*/
     HCatOutputFormat.setOutput(job, outputJobInfo);
 
     job.setMapOutputKeyClass(BytesWritable.class);

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -282,7 +283,7 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
   Job runMRCreate(Map<String, String> partitionValues, List<HCatFieldSchema> partitionColumns,
       List<HCatRecord> records, int writeCount, boolean assertWrite) throws Exception {
     return runMRCreate(partitionValues, partitionColumns, records, writeCount, assertWrite,
-        true, new HashMap<String, String>());
+        true, Collections.emptyMap());
   }
 
   /**

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
@@ -21,6 +21,7 @@ package org.apache.hive.hcatalog.mapreduce;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
@@ -122,10 +123,14 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
   protected void runHCatDynamicPartitionedTable(boolean asSingleMapTask,
       String customDynamicPathPattern) throws Exception {
     generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
+    HashMap<String, String> properties = new HashMap<String, String>();
+    if (customDynamicPathPattern != null) {
+      properties.put(HCatConstants.HCAT_DYNAMIC_CUSTOM_PATTERN, customDynamicPathPattern);
+    }
     runMRCreate(null, dataColumns, writeRecords.subList(0,NUM_RECORDS/2), NUM_RECORDS/2,
-        true, asSingleMapTask, customDynamicPathPattern);
+        true, asSingleMapTask, properties);
     runMRCreate(null, dataColumns, writeRecords.subList(NUM_RECORDS/2,NUM_RECORDS), NUM_RECORDS/2,
-        true, asSingleMapTask, customDynamicPathPattern);
+        true, asSingleMapTask, properties);
 
     runMRRead(NUM_RECORDS);
 
@@ -149,7 +154,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
     try {
       generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
       Job job = runMRCreate(null, dataColumns, writeRecords, NUM_RECORDS, false,
-          true, customDynamicPathPattern);
+          true, properties);
 
       if (HCatUtil.isHadoop23()) {
         Assert.assertTrue(job.isSuccessful()==false);

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatExtension.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatExtension.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hive.hcatalog.mapreduce;
+
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hive.hcatalog.common.HCatException;
+import org.apache.hive.hcatalog.data.DefaultHCatRecord;
+import org.apache.hive.hcatalog.data.HCatRecord;
+import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
+import org.apache.hive.hcatalog.data.schema.HCatSchemaUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class TestHCatExtension extends HCatMapReduceTest {
+    private static List<HCatRecord> writeRecords;
+    private static List<HCatFieldSchema> dataColumns;
+    protected static final int NUM_RECORDS = 20;
+    protected static final int NUM_TOP_PARTITIONS = 5;
+
+    public TestHCatExtension(String formatName, String serdeClass, String inputFormatClass, String outputFormatClass) throws Exception {
+        super(formatName, serdeClass, inputFormatClass, outputFormatClass);
+        tableName = "testHCatExtension_" + formatName;
+        generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
+        generateDataColumns();
+    }
+
+    protected static void generateDataColumns() throws HCatException {
+        dataColumns = new ArrayList<HCatFieldSchema>();
+        dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("c1", serdeConstants.INT_TYPE_NAME, "")));
+        dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("c2", serdeConstants.STRING_TYPE_NAME, "")));
+        dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("p1", serdeConstants.STRING_TYPE_NAME, "")));
+        dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("p2", serdeConstants.STRING_TYPE_NAME, "")));
+
+    }
+
+    protected static void generateWriteRecords(int max, int mod, int offset) {
+        writeRecords = new ArrayList<HCatRecord>();
+
+        for (int i = 0; i < max; i++) {
+            List<Object> objList = new ArrayList<Object>();
+
+            objList.add(i);
+            objList.add("strvalue" + i);
+            objList.add(String.valueOf((i % mod) + offset));
+            objList.add(String.valueOf((i / (max / 2)) + offset));
+            writeRecords.add(new DefaultHCatRecord(objList));
+        }
+    }
+
+    @Override
+    protected List<FieldSchema> getPartitionKeys() {
+        List<FieldSchema> fields = new ArrayList<FieldSchema>();
+        fields.add(new FieldSchema("p1", serdeConstants.STRING_TYPE_NAME, ""));
+        fields.add(new FieldSchema("p2", serdeConstants.STRING_TYPE_NAME, ""));
+        return fields;
+    }
+
+    @Override
+    protected List<FieldSchema> getTableColumns() {
+        List<FieldSchema> fields = new ArrayList<FieldSchema>();
+        fields.add(new FieldSchema("c1", serdeConstants.INT_TYPE_NAME, ""));
+        fields.add(new FieldSchema("c2", serdeConstants.STRING_TYPE_NAME, ""));
+        return fields;
+    }
+
+    @Test
+    public void testHCatExtension() throws Exception {
+        HashMap<String, String> properties = new HashMap<String, String>();
+        properties.put(HiveConf.ConfVars.OUTPUT_FILE_EXTENSION.varname, ".test");
+        generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
+        runMRCreate(null, dataColumns, writeRecords.subList(0,NUM_RECORDS/2), NUM_RECORDS/2,
+                true, false, properties);
+        runMRCreate(null, dataColumns, writeRecords.subList(NUM_RECORDS/2,NUM_RECORDS), NUM_RECORDS/2,
+                true, false, properties);
+        String databaseName = (dbName == null) ? Warehouse.DEFAULT_DATABASE_NAME : dbName;
+        Table tbl = client.getTable(databaseName, tableName);
+        RemoteIterator<LocatedFileStatus> ls = fs.listFiles(new Path(tbl.getSd().getLocation()), true);
+        while (ls.hasNext()) {
+            LocatedFileStatus lfs = ls.next();
+            Assert.assertFalse(lfs.isFile() && lfs.getPath().getName().startsWith("part") && !lfs.getPath().toString().endsWith(".test"));
+        }
+    }
+}

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatExtension.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatExtension.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TestHCatExtension extends HCatMapReduceTest {
     private static List<HCatRecord> writeRecords;
@@ -93,7 +94,7 @@ public class TestHCatExtension extends HCatMapReduceTest {
 
     @Test
     public void testHCatExtension() throws Exception {
-        HashMap<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<String, String>();
         properties.put(HiveConf.ConfVars.OUTPUT_FILE_EXTENSION.varname, ".test");
         generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
         runMRCreate(null, dataColumns, writeRecords.subList(0,NUM_RECORDS/2), NUM_RECORDS/2,


### PR DESCRIPTION
### What changes were proposed in this pull request?
HCatStorer now respects hive.file.output.extension for the output files it writes.


### Why are the changes needed?
Brings HCatStorer's feature set more in line with Hive's.


### Does this PR introduce _any_ user-facing change?
Adds support for a property to HCatStorer that would previously have been ignored.

### Is the change a dependency upgrade?
No


### How was this patch tested?
TestHCatExtension was added.
