### PR TITLE
HIVE-28399: Improve the fetch size in HiveConnection

### DIFF
--- a/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
@@ -19,9 +19,11 @@ package org.apache.hive.jdbc;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.withSettings;
 
 import java.sql.SQLException;
 
@@ -47,7 +49,6 @@ import java.io.ByteArrayInputStream;
 
 public class TestHivePreparedStatement {
 
-  @Mock
   private HiveConnection connection;
   @Mock
   private Iface client;
@@ -65,6 +66,7 @@ public class TestHivePreparedStatement {
 
   @Before
   public void before() throws Exception {
+    connection = mock(HiveConnection.class, withSettings().useConstructor());
     MockitoAnnotations.initMocks(this);
     when(tExecStatementResp.getStatus()).thenReturn(tStatusSuccess);
     when(tExecStatementResp.getOperationHandle()).thenReturn(tOperationHandle);

--- a/jdbc/src/test/org/apache/hive/jdbc/TestHiveStatement.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestHiveStatement.java
@@ -19,6 +19,7 @@ package org.apache.hive.jdbc;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -39,7 +40,7 @@ public class TestHiveStatement {
    */
   @Test
   public void testSetFetchSize() throws SQLException {
-    final HiveConnection connection = mock(HiveConnection.class);
+    final HiveConnection connection = mock(HiveConnection.class, withSettings().useConstructor());
     final Iface iface = mock(Iface.class);
     final TSessionHandle handle = mock(TSessionHandle.class);
 
@@ -63,10 +64,11 @@ public class TestHiveStatement {
 
     // No hint specified and no default value passed in through the constructor,
     // so it falls-back to the configuration default value
+    int fetchSize = HiveConf.ConfVars.HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE.defaultIntVal;
+    connection.fetchSize = fetchSize;
     try (HiveStatement stmt = new HiveStatement(connection, iface, handle)) {
       stmt.setFetchSize(0);
-      assertEquals(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE.defaultIntVal,
-          stmt.getFetchSize());
+      assertEquals(fetchSize, stmt.getFetchSize());
     }
   }
 
@@ -83,10 +85,7 @@ public class TestHiveStatement {
     final Iface iface = mock(Iface.class);
     final TSessionHandle handle = mock(TSessionHandle.class);
 
-    // No hint specified and no default value passed in through the constructor,
-    // so it falls-back to a value 1000
-    try (HiveStatement stmt = new HiveStatement(connection, iface, handle, false, 0, 10)) {
-      stmt.setFetchSize(0);
+    try (HiveStatement stmt = new HiveStatement(connection, iface, handle, false, 10)) {
       assertEquals(10, stmt.getFetchSize());
     }
   }
@@ -106,7 +105,7 @@ public class TestHiveStatement {
     final Iface iface = mock(Iface.class);
     final TSessionHandle handle = mock(TSessionHandle.class);
 
-    try (HiveStatement stmt = new HiveStatement(connection, iface, handle, false, 4, 1000)) {
+    try (HiveStatement stmt = new HiveStatement(connection, iface, handle, false, 4)) {
       assertEquals(4, stmt.getFetchSize());
     }
   }
@@ -121,7 +120,7 @@ public class TestHiveStatement {
    */
   @Test(expected = SQLException.class)
   public void testSetFetchSizeNegativeValue() throws SQLException {
-    final HiveConnection connection = mock(HiveConnection.class);
+    final HiveConnection connection = mock(HiveConnection.class, withSettings().useConstructor());
     final Iface iface = mock(Iface.class);
     final TSessionHandle handle = mock(TSessionHandle.class);
 
@@ -132,7 +131,7 @@ public class TestHiveStatement {
 
   @Test(expected = SQLFeatureNotSupportedException.class)
   public void testaddBatch() throws SQLException {
-    final HiveConnection connection = mock(HiveConnection.class);
+    final HiveConnection connection = mock(HiveConnection.class, withSettings().useConstructor());
     final Iface iface = mock(Iface.class);
     final TSessionHandle handle = mock(TSessionHandle.class);
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
If the 4.x Hive Jdbc client connects to an older HS2 or other thrift implementations, it might throw the IllegalStateException: https://github.com/apache/hive/blob/master/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java#L1253-L1258, as the remote might haven't set the property:  
hive.server2.thrift.resultset.default.fetch.size back to the response of OpenSession request. It also introduces the confusing on what the real fetch size the connection is, as we have both initFetchSize and defaultFetchSize in this HiveConnection, the HiveStatement checks the initFetchSize, defaultFetchSize and 
HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE.defaultIntVal to obtain the real fetch size, we can make them one in HiveConnection, so every statement created from the connection uses this new fetch size.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
