### PR TITLE
HIVE-28401: Drop redundant XML test report post-processing from CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -376,8 +376,6 @@ tar -xzf packaging/target/apache-hive-*-nightly-*-src.tar.gz
                   RENAME_TMP=`echo \$a | sed s/TEST-//g`
                   mv \${RENAME_TMP/.xml/-output.txt} \${RENAME_TMP/.xml/-output-save.txt}
                 done
-                # removes all stdout and err for passed tests
-                xmlstarlet ed -L -d 'testsuite/testcase/system-out[count(../failure)=0]' -d 'testsuite/testcase/system-err[count(../failure)=0]' `find . -name 'TEST*xml' -path '*/surefire-reports/*'`
                 # remove all output.txt files
                 find . -name '*output.txt' -path '*/surefire-reports/*' -exec unlink "{}" \\;
               """


### PR DESCRIPTION
### Why are the changes needed?
The Maven Surefire Plugin (3.0.0-M4) does not store system-out and system-err in the XML report so the xmlstarlet post-processing step is redundant and can be removed.

1. Avoid `Huge input lookup` error thrown by `xmlstarlet` when XML input is large:
a. allow subsequent post-processing actions to complete (save disk space)
b. avoid Jenkins pipeline build failures confusing developers
2. Simplify the pipeline script and minor perf improvement

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Investigate the build artifacts generated by this PR and ensure that there is no system-out/system-err entries in XML files.