### PR TITLE
HIVE-28407 Alter Table Rename should not require create database privilege

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLUtils.java
@@ -190,8 +190,6 @@ public final class DDLUtils {
 
   public static void addDbAndTableToOutputs(Database database, TableName tableName, TableType type, boolean isTemporary,
       Map<String, String> properties, Set<WriteEntity> outputs) {
-    outputs.add(new WriteEntity(database, WriteEntity.WriteType.DDL_SHARED));
-
     Table table = new Table(tableName.getDb(), tableName.getTable());
     table.setParameters(properties);
     table.setTableType(type);


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Currently we add the database object to the list of privilege objects required for authorization in the alter table rename set of queries. Ideally we only need a create table permission on the database and not a create database permission. 


### Why are the changes needed?
In order to alter table rename we need create database permission on the destination database, which is not required


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?

