### PR TITLE
HIVE-28417: Bump Log4j2 to 2.24.1 to facilitate compilation of GraalVM Native Image

### DIFF
--- a/data/conf/hive-log4j2.properties
+++ b/data/conf/hive-log4j2.properties
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-status = INFO
 name = HiveLog4j2Test
-packages = org.apache.hadoop.hive.ql.log
 
 # list of properties
 property.hive.log.level = DEBUG
@@ -24,9 +22,6 @@ property.hive.root.logger = DRFA
 property.hive.log.dir = ${sys:test.tmp.dir}/log
 property.hive.log.file = hive.log
 property.hive.test.console.log.level = INFO
-
-# list of all appenders
-appenders = console, DRFA
 
 # console appender
 appender.console.type = Console
@@ -48,9 +43,6 @@ appender.DRFA.policies.time.interval = 1
 appender.DRFA.policies.time.modulate = true
 appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
-
-# list of all loggers
-loggers = HadoopIPC, HadoopSecurity, Hdfs, HdfsServer, HadoopMetrics2, Mortbay, Yarn, YarnServer, Tez, HadoopConf, Zookeeper, ServerCnxn, NIOServerCnxn, ClientCnxn, ClientCnxnSocket, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, Operator, Serde2Lazy, ObjectStore, CalcitePlanner, AmazonAws, ApacheHttp, Thrift, Jetty, BlockStateChange, swo, CBORuleLogger
 
 logger.HadoopIPC.name = org.apache.hadoop.ipc
 logger.HadoopIPC.level = WARN
@@ -128,7 +120,7 @@ logger.CBORuleLogger.filter.marker.type = MarkerFilter
 logger.CBORuleLogger.filter.marker.marker = FULL_PLAN
 # Change filter to ACCEPT, to see the produced plan after every rule invocation using the EXPLAIN CBO format
 logger.CBORuleLogger.filter.marker.onMatch = DENY
-logger.CBORuleLogger.filter.marker.onMisMatch = NEUTRAL
+logger.CBORuleLogger.filter.marker.onMismatch = NEUTRAL
 
 logger.AmazonAws.name=com.amazonaws
 logger.AmazonAws.level = INFO

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -367,9 +367,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <artifactId>log4j-core-test</artifactId>
       <version>${log4j2.version}</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryTracker.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryTracker.java
@@ -48,8 +48,9 @@ import org.apache.tez.common.security.JobTokenIdentifier;
 import org.apache.tez.common.security.TokenCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
 import org.slf4j.MDC;
+import org.slf4j.Marker;
+import org.slf4j.impl.StaticMarkerBinder;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -70,7 +71,7 @@ public class QueryTracker extends AbstractService {
 
   private static final Logger LOG = LoggerFactory.getLogger(QueryTracker.class);
   private static final Marker QUERY_COMPLETE_MARKER =
-      new Log4jMarker(new Log4jQueryCompleteMarker());
+      new Log4jMarker(StaticMarkerBinder.getSingleton().getMarkerFactory(), new Log4jQueryCompleteMarker());
 
   /// Shared singleton MetricsSource instance for all DAG locks
   private static final MetricsSource LOCK_METRICS;

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestLlapDaemonLogging.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestLlapDaemonLogging.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hive.testutils.junit.extensions.DoNothingTCPServer;
 import org.apache.hive.testutils.junit.extensions.DoNothingTCPServerExtension;
-import org.apache.logging.log4j.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.tez.common.security.TokenCache;
 
 import org.junit.jupiter.api.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.18.0</log4j2.version>
+    <log4j2.version>2.24.1</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.31</mysql.version>
@@ -1791,7 +1791,6 @@
             <log4j.configurationFile>${test.log4j.scheme}${test.conf.dir}/hive-log4j2.properties</log4j.configurationFile>
             <hive.test.console.log.level>${test.console.log.level}</hive.test.console.log.level>
             <hive.cluster.id>hive-test-cluster-id-cli</hive.cluster.id>
-            <log4j.debug>true</log4j.debug>
             <!-- don't dirty up /tmp -->
             <java.io.tmpdir>${test.tmp.dir}</java.io.tmpdir>
             <!-- Hadoop's minidfs class uses this -->

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -418,9 +418,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <artifactId>log4j-core-test</artifactId>
       <version>${log4j2.version}</version>
-      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.thrift.TException;
 import org.hamcrest.core.IsNot;
 import org.junit.After;

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -89,7 +89,7 @@
     <junit.vintage.version>5.6.3</junit.vintage.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.18.0</log4j2.version>
+    <log4j2.version>2.24.1</log4j2.version>
     <mockito-core.version>3.4.4</mockito-core.version>
     <orc.version>1.9.4</orc.version>
     <protobuf.version>3.24.4</protobuf.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Bump Log4j2 to 2.24.1 to facilitate compilation of GraalVM Native Image. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- This PR is aimed at ensuring that HiveServer2 JDBC Driver is compatible with future versions of LOG4J as much as possible. I created a unit test at https://github.com/linghengqian/log4j2-v2231-graalvm-native-image-test to prove that the HiveServer2 JDBC Driver using `apache/logging-log4j2:2.23.1` can be used under the GraalVM Native Image compiled by GraalVM CE For JDK 22.0.2.
```shell
sdk install java 8.0.422-tem
sdk install java 22.0.2-graalce
sdk use java 8.0.422-tem
sdk install maven
git clone git@github.com:linghengqian/hive.git -b log4j-bump
cd ./hive/
mvn clean install -DskipTests
mvn clean package -pl packaging -DskipTests -Pdocker
cd ../

git clone git@github.com:linghengqian/log4j2-v2231-graalvm-native-image-test.git
cd ./log4j2-v2231-graalvm-native-image-test/
sdk use java 22.0.2-graalce
./mvnw -PgenerateMetadata -DskipNativeTests -e -T1C clean test native:metadata-copy
./mvnw -PnativeTestInHive -T1C -e clean test
```

- See also https://github.com/apache/logging-log4j2/blob/rel/2.23.1/src/changelog/2.20.0/LOG4J2-3650_Move_tests.xml .

``` 
Moved `log4j-api` and `log4j-core` artifacts with classifier `tests` to `log4j-api-test` and `log4j-core-test` respectively. 
```

- See also https://github.com/apache/logging-log4j2/issues/1291#issuecomment-1450793036 .

```
I took care of the [release notes](https://logging.apache.org/log4j/2.x/release-notes/2.20.0.html).

The difference in dependencies is caused by Maven:

for the log4j-core artifact with tests classifier Maven pulled the wrong dependencies (compile scope instead of test scope),
for the log4j-core-test artifact the real dependencies are no longer hidden: the artifact mostly contains JUnit 4 and JUnit 5 extensions, so it depends on all those libraries.
```

- See also https://github.com/apache/logging-log4j2/pull/1032 . The constructor of `org.apache.logging.slf4j.Log4jMarker` has changed.
- See also https://github.com/apache/logging-log4j2/issues/2791 and https://github.com/apache/logging-log4j2/issues/2794 . The Log4j configuration file used by Hive contains deprecated properties .

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->

- Below is the output of `mvn dependency:tree > ./dependency-tree.txt`.

- [dependency-tree.txt](https://github.com/user-attachments/files/17350631/dependency-tree.txt)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

```shell
sdk install java 8.0.422-tem
sdk use java 8.0.422-tem
sdk install maven
mvn clean install -DskipTests
mvn test -Dtest=TestHplsqlLocal -pl hplsql
mvn test -Dtest=TestHplsqlOffline -pl hplsql
```