### PR TITLE
HIVE-28656: Improve HPL/SQL tests

### DIFF
--- a/hplsql/src/test/java/org/apache/hive/hplsql/TestConsole.java
+++ b/hplsql/src/test/java/org/apache/hive/hplsql/TestConsole.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.hplsql;
+
+import java.util.regex.Pattern;
+
+/**
+ * {@link Console} implementation used in tests to capture the output of the {@link Exec} class.
+ */
+class TestConsole implements Console {
+
+    StringBuilder out = new StringBuilder();
+    StringBuilder err = new StringBuilder();
+    private final Pattern ignorePattern;
+
+    TestConsole(String ignorePattern) {
+        this.ignorePattern = Pattern.compile(ignorePattern);
+    }
+
+    private boolean isNotIgnored(String msg) {
+        return msg == null || !ignorePattern.matcher(msg).matches();
+    }
+
+    @Override
+    public void print(String msg) {
+        if (isNotIgnored(msg)) {
+            out.append(msg);
+        }
+    }
+
+    @Override
+    public void printLine(String msg) {
+        if (isNotIgnored(msg)) {
+            out.append(msg).append("\n");
+        }
+    }
+
+    @Override
+    public void printError(String msg) {
+        if (isNotIgnored(msg)) {
+            err.append(msg).append("\n");
+        }
+    }
+}

--- a/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlLocal.java
+++ b/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlLocal.java
@@ -18,10 +18,7 @@
 
 package org.apache.hive.hplsql;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.StringReader;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,10 +28,7 @@ import org.junit.Test;
  */
 public class TestHplsqlLocal {
 
-  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
-  private final ByteArrayOutputStream err = new ByteArrayOutputStream();
-
-  @Test
+    @Test
   public void testAdd() throws Exception {
     run("add");
   }
@@ -468,38 +462,18 @@ public class TestHplsqlLocal {
    * Run a test file
    */
   void run(String testFile) throws Exception {
-    System.setOut(new PrintStream(out));
-    System.setErr(new PrintStream(err));
+    TestConsole console = new TestConsole("(Configuration file|Parser tree):.*");
     Exec exec = new Exec();
+    exec.console = console;
+
     String[] args = { "-f", "src/test/queries/local/" + testFile + ".sql", "-trace" };
     exec.run(args);
-    String sout = getTestOutput(out.toString());
-    String serr = getTestOutput(err.toString());
+    String sout = console.out.toString();
+    String serr = console.err.toString();
     String output = (sout + (serr.isEmpty() ? "" : serr));
     FileUtils.writeStringToFile(new java.io.File("target/tmp/log/" + testFile + ".out.txt"), output);
     String t = FileUtils.readFileToString(new java.io.File("src/test/results/local/" + testFile + ".out.txt"), "utf-8");
-    System.setOut(null);
     Assert.assertEquals(t, output);
   }
 
-  /**
-   * Get test output
-   */
-  String getTestOutput(String s) throws Exception {
-    StringBuilder sb = new StringBuilder();
-    BufferedReader reader = new BufferedReader(new StringReader(s));
-    String line = null;
-    while ((line = reader.readLine()) != null) {
-      if (!line.startsWith("log4j:")
-              && !line.contains("INFO Log4j")
-              && !line.startsWith("SLF4J")
-              && !line.contains(" StatusLogger ")
-              && !line.contains("Configuration file: ")
-              && !line.contains("Parser tree: ")) {
-        sb.append(line);
-        sb.append("\n");
-      }
-    }
-    return sb.toString();
-  }
 }

--- a/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlLocal.java
+++ b/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlLocal.java
@@ -18,7 +18,6 @@
 
 package org.apache.hive.hplsql;
 
-import java.io.ByteArrayOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;

--- a/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlLocal.java
+++ b/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlLocal.java
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class TestHplsqlLocal {
 
-    @Test
+  @Test
   public void testAdd() throws Exception {
     run("add");
   }

--- a/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlOffline.java
+++ b/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlOffline.java
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class TestHplsqlOffline {
 
-    @Test
+  @Test
   public void testCreateTable() throws Exception {
     run("create_table");
   }
@@ -36,17 +36,17 @@ public class TestHplsqlOffline {
   public void testCreateTableDb2() throws Exception {
     run("create_table_db2");
   }
-  
+
   @Test
   public void testCreateTableMssql() throws Exception {
     run("create_table_mssql");
   }
-  
+
   @Test
   public void testCreateTableMssql2() throws Exception {
     run("create_table_mssql2");
   }
-  
+
   @Test
   public void testCreateTableMysql() throws Exception {
     run("create_table_mysql");
@@ -56,27 +56,27 @@ public class TestHplsqlOffline {
   public void testCreateTableOra() throws Exception {
     run("create_table_ora");
   }
-  
+
   @Test
   public void testCreateTableOra2() throws Exception {
     run("create_table_ora2");
   }
-  
+
   @Test
   public void testCreateTablePg() throws Exception {
     run("create_table_pg");
   }
-  
+
   @Test
   public void testCreateTableTd() throws Exception {
     run("create_table_td");
   }
-  
+
   @Test
   public void testDeleteAll() throws Exception {
     run("delete_all");
   }
-  
+
   @Test
   public void testInsertMysql() throws Exception {
     run("insert_mysql");
@@ -86,17 +86,17 @@ public class TestHplsqlOffline {
   public void testSelect() throws Exception {
     run("select");
   }
-  
+
   @Test
   public void testSelectDb2() throws Exception {
     run("select_db2");
   }
-  
+
   @Test
   public void testSelectTeradata() throws Exception {
     run("select_teradata");
   }
-  
+
   @Test
   public void testUpdate() throws Exception {
     run("update");

--- a/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlOffline.java
+++ b/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlOffline.java
@@ -18,7 +18,6 @@
 
 package org.apache.hive.hplsql;
 
-import java.io.ByteArrayOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;

--- a/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlOffline.java
+++ b/hplsql/src/test/java/org/apache/hive/hplsql/TestHplsqlOffline.java
@@ -18,10 +18,7 @@
 
 package org.apache.hive.hplsql;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.StringReader;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,9 +28,7 @@ import org.junit.Test;
  */
 public class TestHplsqlOffline {
 
-  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-  @Test
+    @Test
   public void testCreateTable() throws Exception {
     run("create_table");
   }
@@ -112,30 +107,16 @@ public class TestHplsqlOffline {
    * Run a test file
    */
   void run(String testFile) throws Exception {
-    System.setOut(new PrintStream(out));
+    TestConsole console = new TestConsole("(Configuration file|Parser tree):.*");
     Exec exec = new Exec();
+    exec.console = console;
+
     String[] args = { "-f", "src/test/queries/offline/" + testFile + ".sql", "-trace", "-offline" };
     exec.run(args);
-    String s = getTestOutput(out.toString()).trim();
+    String s = console.out.toString().trim();
     FileUtils.writeStringToFile(new java.io.File("target/tmp/log/" + testFile + ".out.txt"), s);
     String t = FileUtils.readFileToString(new java.io.File("src/test/results/offline/" + testFile + ".out.txt"), "utf-8").trim();
-    System.setOut(null);
     Assert.assertEquals(t, s);
   }
 
-  /**
-   * Get test output
-   */
-  String getTestOutput(String s) throws Exception {
-    StringBuilder sb = new StringBuilder();
-    BufferedReader reader = new BufferedReader(new StringReader(s));
-    String line = null;
-    while ((line = reader.readLine()) != null) {
-      if (!line.startsWith("log4j:") && !line.contains("INFO Log4j")) {
-        sb.append(line);
-        sb.append("\n");
-      }
-    }
-    return sb.toString();
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces a custom `Console` implementation to capture the output of two `hplsql` tests and make them independent from whatever is printed to `System.out` and `System.err`.


### Why are the changes needed?

Two tests in `hplsql` module (`TestHplsqlLocal` and `TestHplsqlOffline`) make assertions on the output to `System.out` and `System.err`. This makes the tests fragile to any other output that might appear there (see apache/logging-log4j2#2791 for example) and prevents them from running in parallel.

### Does this PR introduce _any_ user-facing change?

No, no changes to the main code are introduced.

### Is the change a dependency upgrade?

No.

