### PR TITLE
HIVE-28435: Upgrade cron-utils to 9.2.1

### DIFF
--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -114,6 +114,10 @@
           <groupId>io.netty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.glassfish</groupId>
+          <artifactId>javax.el</artifactId>
+        </exclusion>
       </exclusions>
       <optional>true</optional>
     </dependency>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -102,7 +102,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <curator.version>5.2.0</curator.version>
     <zookeeper.version>3.8.4</zookeeper.version>
-    <cron-utils.version>9.1.6</cron-utils.version>
+    <cron-utils.version>9.2.1</cron-utils.version>
     <spotbugs.version>4.0.3</spotbugs.version>
     <caffeine.version>2.8.4</caffeine.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrade Cron-utils to 9.2.1 and remove one instance of older version coming in transitively.


### Why are the changes needed?
fix CVE-2021-28170


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes 
[dpn.txt](https://github.com/user-attachments/files/16498615/dpn.txt)



### How was this patch tested?
Manually triggered some CRUD operations after dependency upgrade. Rest relying on precommit tests.
