### PR TITLE
HIVE-28431 Fix RexLiteral to ExprNode conversion if the literal is an empty string

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/ExprNodeConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/ExprNodeConverter.java
@@ -361,6 +361,9 @@ public class ExprNodeConverter extends RexVisitorImpl<ExprNodeDesc> {
             "char values must use NlsString for correctness");
         int precision = lType.getPrecision();
         HiveChar value = new HiveChar((String) literal.getValue3(), precision);
+        if (value.getCharacterLength() == 0) {
+          return new ExprNodeConstantDesc(TypeInfoFactory.stringTypeInfo, null);
+        }
         return new ExprNodeConstantDesc(new CharTypeInfo(precision), value);
       }
       case VARCHAR: {

--- a/ql/src/test/queries/clientpositive/filter_emptyliteral.q
+++ b/ql/src/test/queries/clientpositive/filter_emptyliteral.q
@@ -1,0 +1,4 @@
+create table employee(firstname varchar(255), lastname char(25), id int);
+
+explain cbo SELECT id FROM employee where firstname = '';
+explain cbo SELECT id FROM employee where lastname = '';

--- a/ql/src/test/results/clientpositive/llap/filter_emptyliteral.q.out
+++ b/ql/src/test/results/clientpositive/llap/filter_emptyliteral.q.out
@@ -1,0 +1,34 @@
+PREHOOK: query: create table employee(firstname varchar(255), lastname char(25), id int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@employee
+POSTHOOK: query: create table employee(firstname varchar(255), lastname char(25), id int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@employee
+PREHOOK: query: explain cbo SELECT id FROM employee where firstname = ''
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo SELECT id FROM employee where firstname = ''
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(id=[$2])
+  HiveFilter(condition=[=($0, _UTF-16LE'')])
+    HiveTableScan(table=[[default, employee]], table:alias=[employee])
+
+PREHOOK: query: explain cbo SELECT id FROM employee where lastname = ''
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo SELECT id FROM employee where lastname = ''
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(id=[$2])
+  HiveFilter(condition=[=($1, _UTF-16LE'                         ')])
+    HiveTableScan(table=[[default, employee]], table:alias=[employee])
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
An empty literal in the filter should still produce a valid RexNode.
### Why are the changes needed?
Currently conversion from RexLiteral to ExprNode fail if the literal is an empty string. This causes the CBO to fail for such queries with this filter.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=filter_emptyliteral.q
