### PR TITLE
HIVE-28438: Remove commons-pool2 as an explicit dependency & upgrade commons-dbcp2 to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,9 @@
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-exec.version>1.1</commons-exec.version>
     <commons-io.version>2.12.0</commons-io.version>
-    <commons-pool2.version>2.11.1</commons-pool2.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
-    <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
+    <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <commons-text.version>1.10.0</commons-text.version>
     <derby.version>10.14.2.0</derby.version>
     <dropwizard.version>3.1.0</dropwizard.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -91,11 +91,6 @@
       <artifactId>commons-math3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-pool2</artifactId>
-      <version>${commons-pool2.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-vector-code-gen</artifactId>
       <version>${project.version}</version>

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
@@ -85,16 +85,16 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
     boolean testOnBorrow = hdpConfig.getBoolean(CONNECTION_TEST_BORROW_PROPERTY,
         BaseObjectPoolConfig.DEFAULT_TEST_ON_BORROW);
     long evictionTimeMillis = hdpConfig.getLong(CONNECTION_MIN_EVICT_MILLIS_PROPERTY,
-        BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME.toMillis());
+        BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_DURATION.toMillis());
     boolean testWhileIdle = hdpConfig.getBoolean(CONNECTION_TEST_IDLEPROPERTY,
         BaseObjectPoolConfig.DEFAULT_TEST_WHILE_IDLE);
     long timeBetweenEvictionRuns = hdpConfig.getLong(CONNECTION_TIME_BETWEEN_EVICTION_RUNS_MILLIS,
-        BaseObjectPoolConfig.DEFAULT_TIME_BETWEEN_EVICTION_RUNS.toMillis());
+        BaseObjectPoolConfig.DEFAULT_DURATION_BETWEEN_EVICTION_RUNS.toMillis());
     int numTestsPerEvictionRun = hdpConfig.getInt(CONNECTION_NUM_TESTS_PER_EVICTION_RUN,
         BaseObjectPoolConfig.DEFAULT_NUM_TESTS_PER_EVICTION_RUN);
     boolean testOnReturn = hdpConfig.getBoolean(CONNECTION_TEST_ON_RETURN, BaseObjectPoolConfig.DEFAULT_TEST_ON_RETURN);
     long softMinEvictableIdleTimeMillis = hdpConfig.getLong(CONNECTION_SOFT_MIN_EVICTABLE_IDLE_TIME,
-        BaseObjectPoolConfig.DEFAULT_SOFT_MIN_EVICTABLE_IDLE_TIME.toMillis());
+        BaseObjectPoolConfig.DEFAULT_SOFT_MIN_EVICTABLE_IDLE_DURATION.toMillis());
     boolean lifo = hdpConfig.getBoolean(CONNECTION_LIFO, BaseObjectPoolConfig.DEFAULT_LIFO);
 
     ConnectionFactory connFactory = new DataSourceConnectionFactory(dbcpDs);
@@ -102,16 +102,16 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
 
     GenericObjectPool objectPool = new GenericObjectPool(poolableConnFactory);
     objectPool.setMaxTotal(maxPoolSize);
-    objectPool.setMaxWaitMillis(connectionTimeout);
+    objectPool.setMaxWait(Duration.ofMillis(connectionTimeout));
     objectPool.setMaxIdle(connectionMaxIlde);
     objectPool.setMinIdle(connectionMinIlde);
     objectPool.setTestOnBorrow(testOnBorrow);
     objectPool.setTestWhileIdle(testWhileIdle);
-    objectPool.setMinEvictableIdleTime(Duration.ofMillis(evictionTimeMillis));
-    objectPool.setTimeBetweenEvictionRuns(Duration.ofMillis(timeBetweenEvictionRuns));
+    objectPool.setMinEvictableIdleDuration(Duration.ofMillis(evictionTimeMillis));
+    objectPool.setDurationBetweenEvictionRuns(Duration.ofMillis(timeBetweenEvictionRuns));
     objectPool.setNumTestsPerEvictionRun(numTestsPerEvictionRun);
     objectPool.setTestOnReturn(testOnReturn);
-    objectPool.setSoftMinEvictableIdleTime(Duration.ofMillis(softMinEvictableIdleTimeMillis));
+    objectPool.setSoftMinEvictableIdleDuration(Duration.ofMillis(softMinEvictableIdleTimeMillis));
     objectPool.setLifo(lifo);
 
     // Enable TxnHandler#connPoolMutex to release the idle connection if possible,
@@ -121,10 +121,10 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
     if ("mutex".equalsIgnoreCase(poolName)) {
       if (timeBetweenEvictionRuns < 0) {
         // When timeBetweenEvictionRunsMillis non-positive, no idle object evictor thread runs
-        objectPool.setTimeBetweenEvictionRuns(Duration.ofMillis(30 * 1000));
+        objectPool.setDurationBetweenEvictionRuns(Duration.ofMillis(30 * 1000));
       }
       if (softMinEvictableIdleTimeMillis < 0) {
-        objectPool.setSoftMinEvictableIdleTime(Duration.ofMillis(600 * 1000));
+        objectPool.setSoftMinEvictableIdleDuration(Duration.ofMillis(600 * 1000));
       }
     }
     String stmt = dbProduct.getPrepareTxnStmt();

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -63,7 +63,7 @@
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
-    <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
+    <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <datasketches.version>1.2.0</datasketches.version>
     <datanucleus-api-jdo.version>5.2.8</datanucleus-api-jdo.version>
     <datanucleus-core.version>5.2.10</datanucleus-core.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrade commons-dbcp2 and commons-pool2 to 2.12.0


### Why are the changes needed?
To fix multiple CVEs and make commons-pool2 version consistent across complete project.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes
New dependency tree: 
[dpn.txt](https://github.com/user-attachments/files/16570391/dpn.txt)



### How was this patch tested?
Manually triggered some CRUD operations after dependency upgrade. Rest relying on precommit tests.
