### PR TITLE
HIVE-28436: Fix Incorrect syntax in Hive schema file for table MIN_HISTORY_LEVEL

### DIFF
--- a/ql/src/test/queries/clientpositive/sysdb.q
+++ b/ql/src/test/queries/clientpositive/sysdb.q
@@ -124,6 +124,8 @@ select max(num_distincts) from sys.tab_col_stats;
 
 select * from compactions;
 
+select MHL_TXNID,MHL_MIN_OPEN_TXNID from MIN_HISTORY_LEVEL;
+
 use INFORMATION_SCHEMA;
 
 select count(*) from SCHEMATA;

--- a/ql/src/test/results/clientpositive/llap/sysdb.q.out
+++ b/ql/src/test/results/clientpositive/llap/sysdb.q.out
@@ -1643,6 +1643,14 @@ POSTHOOK: Input: sys@completed_compactions
 #### A masked pattern was here ####
 1	default	default	scr_txn	NULL	major	initiated	NULL	NULL	NULL	#Masked#	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	#Masked#	manual	4.1.0-SNAPSHOT	NULL	default	NULL	NULL
 2	default	default	scr_txn_2	NULL	minor	initiated	NULL	NULL	NULL	#Masked#	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	#Masked#	manual	4.1.0-SNAPSHOT	NULL	default	NULL	NULL
+PREHOOK: query: select MHL_TXNID,MHL_MIN_OPEN_TXNID from MIN_HISTORY_LEVEL
+PREHOOK: type: QUERY
+PREHOOK: Input: sys@min_history_level
+#### A masked pattern was here ####
+POSTHOOK: query: select MHL_TXNID,MHL_MIN_OPEN_TXNID from MIN_HISTORY_LEVEL
+POSTHOOK: type: QUERY
+POSTHOOK: Input: sys@min_history_level
+#### A masked pattern was here ####
 PREHOOK: query: use INFORMATION_SCHEMA
 PREHOOK: type: SWITCHDATABASE
 PREHOOK: Input: database:information_schema

--- a/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.0.0-alpha-2.hive.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.0.0-alpha-2.hive.sql
@@ -1510,7 +1510,7 @@ TBLPROPERTIES (
 "hive.sql.query" =
 "SELECT
     \"MHL_TXNID\",
-    \"MHL_MIN_OPEN_TXNID\",
+    \"MHL_MIN_OPEN_TXNID\"
 FROM \"MIN_HISTORY_LEVEL\""
 );
 

--- a/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.0.0-beta-1.hive.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.0.0-beta-1.hive.sql
@@ -1517,7 +1517,7 @@ TBLPROPERTIES (
 "hive.sql.query" =
 "SELECT
     \"MHL_TXNID\",
-    \"MHL_MIN_OPEN_TXNID\",
+    \"MHL_MIN_OPEN_TXNID\"
 FROM \"MIN_HISTORY_LEVEL\""
 );
 

--- a/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.0.0.hive.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.0.0.hive.sql
@@ -1517,7 +1517,7 @@ TBLPROPERTIES (
 "hive.sql.query" =
 "SELECT
     \"MHL_TXNID\",
-    \"MHL_MIN_OPEN_TXNID\",
+    \"MHL_MIN_OPEN_TXNID\"
 FROM \"MIN_HISTORY_LEVEL\""
 );
 

--- a/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.1.0.hive.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.1.0.hive.sql
@@ -1507,7 +1507,7 @@ TBLPROPERTIES (
 "hive.sql.query" =
 "SELECT
     \"MHL_TXNID\",
-    \"MHL_MIN_OPEN_TXNID\",
+    \"MHL_MIN_OPEN_TXNID\"
 FROM \"MIN_HISTORY_LEVEL\""
 );
 

--- a/standalone-metastore/metastore-server/src/main/sql/hive/upgrade-4.0.0-alpha-1-to-4.0.0-alpha-2.hive.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/hive/upgrade-4.0.0-alpha-1-to-4.0.0-alpha-2.hive.sql
@@ -12,7 +12,7 @@ TBLPROPERTIES (
 "hive.sql.query" =
 "SELECT
     \"MHL_TXNID\",
-    \"MHL_MIN_OPEN_TXNID\",
+    \"MHL_MIN_OPEN_TXNID\"
 FROM \"MIN_HISTORY_LEVEL\""
 );
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
Fixed syntax error in the sql

### Why are the changes needed?
Select query on the table is failing post Hive initSchema / upgradeSchema.


### Does this PR introduce _any_ user-facing change?
no

### Is the change a dependency upgrade?
no

### How was this patch tested?
Testcase scenario is added
