### PR TITLE
HIVE-28440: unblock hcatalog parquet project pushdown

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FosterStorageHandler.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FosterStorageHandler.java
@@ -135,7 +135,9 @@ public class FosterStorageHandler extends DefaultStorageHandler {
           typeNamesSb.append(dataField.getTypeString());
         }
         jobProperties.put(IOConstants.SCHEMA_EVOLUTION_COLUMNS, columnNamesSb.toString());
+        jobProperties.put(IOConstants.COLUMNS, columnNamesSb.toString());
         jobProperties.put(IOConstants.SCHEMA_EVOLUTION_COLUMNS_TYPES, typeNamesSb.toString());
+        jobProperties.put(IOConstants.COLUMNS_TYPES, typeNamesSb.toString());
 
         boolean isTransactionalTable = AcidUtils.isTablePropertyTransactional(tableProperties);
         AcidUtils.AcidOperationalProperties acidOperationalProperties =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
to unblock hcatloader parquet table project pushdown. HCatLoader sets the needed columns intending to be used for project/filter pushdown, however, org.apache.hadoop.hive.ql.io.parquet.read.DataWritableReadSupport#init ReadContext skips project/filter pushdown when job properties 'columns' is not set. This change sets the 'columns' property.


### Why are the changes needed?
to unblock hcatloader parquet table project pushdown

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
tested locally
