### PR TITLE
HIVE-28441: NPE in ORC tables when hive.orc.splits.include.file.footer is enabled

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -11,6 +11,7 @@ minitez.query.files.shared=\
   empty_skip_header_footer_aggr.q,\
   hybridgrace_hashjoin_1.q,\
   hybridgrace_hashjoin_2.q,\
+  orc_footer_enabled.q,\
   substr_estimate_range.q
 
 # NOTE: Add tests to minitez only if it is very

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/OrcEncodedDataReader.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/OrcEncodedDataReader.java
@@ -546,13 +546,6 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
     LlapIoImpl.ORC_LOGGER.trace("Creating reader for {} ({})", path, split.getPath());
     long startTime = counters.startTimeCounter();
     ReaderOptions opts = EncodedOrcFile.readerOptions(jobConf).filesystem(fsSupplier).fileMetadata(fileMetadata);
-    if (split instanceof OrcSplit) {
-      OrcTail orcTail = ((OrcSplit) split).getOrcTail();
-      if (orcTail != null) {
-        LlapIoImpl.ORC_LOGGER.debug("Setting OrcTail. path={}", path);
-        opts.orcTail(orcTail);
-      }
-    }
     orcReader = EncodedOrcFile.createReader(path, opts);
     counters.incrWallClockCounter(LlapIOCounters.HDFS_TIME_NS, startTime);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcNewSplit.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcNewSplit.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.ql.io.AcidInputFormat;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.orc.OrcProto;
+import org.apache.orc.impl.BufferChunk;
 import org.apache.orc.impl.OrcTail;
 
 /**
@@ -101,7 +102,7 @@ public class OrcNewSplit extends FileSplit {
       byte[] tailBuffer = new byte[tailLen];
       in.readFully(tailBuffer);
       OrcProto.FileTail fileTail = OrcProto.FileTail.parseFrom(tailBuffer);
-      orcTail = new OrcTail(fileTail, null);
+      orcTail = new OrcTail(fileTail, new BufferChunk(0, 0), -1);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcSplit.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcSplit.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.orc.OrcProto;
+import org.apache.orc.impl.BufferChunk;
 import org.apache.orc.impl.OrcTail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -227,7 +228,7 @@ public class OrcSplit extends FileSplit implements ColumnarSplit, LlapAwareSplit
       byte[] tailBuffer = new byte[tailLen];
       in.readFully(tailBuffer);
       OrcProto.FileTail fileTail = OrcProto.FileTail.parseFrom(tailBuffer);
-      orcTail = new OrcTail(fileTail, null);
+      orcTail = new OrcTail(fileTail, new BufferChunk(0, 0), -1);
     }
     if (hasLongFileId) {
       fileKey = in.readLong();

--- a/ql/src/test/queries/clientpositive/orc_footer_enabled.q
+++ b/ql/src/test/queries/clientpositive/orc_footer_enabled.q
@@ -1,0 +1,6 @@
+set hive.orc.splits.include.file.footer=true;
+set hive.fetch.task.conversion=none;
+
+CREATE TABLE tbl (id INT, name STRING) STORED AS ORC;
+INSERT INTO tbl VALUES (1, 'abc');
+SELECT * FROM tbl;

--- a/ql/src/test/results/clientpositive/llap/orc_footer_enabled.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_footer_enabled.q.out
@@ -1,0 +1,27 @@
+PREHOOK: query: CREATE TABLE tbl (id INT, name STRING) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: CREATE TABLE tbl (id INT, name STRING) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+PREHOOK: query: INSERT INTO tbl VALUES (1, 'abc')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl
+POSTHOOK: query: INSERT INTO tbl VALUES (1, 'abc')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl
+POSTHOOK: Lineage: tbl.id SCRIPT []
+POSTHOOK: Lineage: tbl.name SCRIPT []
+PREHOOK: query: SELECT * FROM tbl
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM tbl
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl
+#### A masked pattern was here ####
+1	abc

--- a/ql/src/test/results/clientpositive/tez/orc_footer_enabled.q.out
+++ b/ql/src/test/results/clientpositive/tez/orc_footer_enabled.q.out
@@ -1,0 +1,27 @@
+PREHOOK: query: CREATE TABLE tbl (id INT, name STRING) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: CREATE TABLE tbl (id INT, name STRING) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+PREHOOK: query: INSERT INTO tbl VALUES (1, 'abc')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl
+POSTHOOK: query: INSERT INTO tbl VALUES (1, 'abc')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl
+POSTHOOK: Lineage: tbl.id SCRIPT []
+POSTHOOK: Lineage: tbl.name SCRIPT []
+PREHOOK: query: SELECT * FROM tbl
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT * FROM tbl
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	abc


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-28441](https://issues.apache.org/jira/browse/HIVE-28441) for steps to reproduce this issue and stacktrace


### Why are the changes needed?
NullPointerException is thrown when hive.orc.splits.include.file.footer is enabled in ORC tables


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO


### How was this patch tested?
Using a q file present in the commits.
```
mvn clean test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=orc_footer_enabled.q -pl itests/qtest -Pitests -Dtest.output.overwrite=true
mvn clean test -Dtest=TestMiniTezCliDriver -Dqfile=orc_footer_enabled.q -pl itests/qtest -Pitests -Dtest.output.overwrite=true
```
