### PR TITLE
HIVE-28456: ObjectStore updatePartitionColumnStatisticsInBatch can ca…

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdatePart.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdatePart.java
@@ -478,48 +478,52 @@ class DirectSqlUpdatePart {
                                                       List<TransactionalMetaStoreEventListener> transactionalListeners)
           throws MetaException {
 
-    JDOConnection jdoConn = null;
     Transaction tx = pm.currentTransaction();
     try {
       dbType.lockInternal();
       tx.begin();
-      jdoConn = pm.getDataStoreConnection();
-      Connection dbConn = (Connection) jdoConn.getNativeConnection();
-      setAnsiQuotes(dbConn);
+      JDOConnection jdoConn = null;
+      Map<String, Map<String, String>> result;
+      try {
+        jdoConn = pm.getDataStoreConnection();
+        Connection dbConn = (Connection) jdoConn.getNativeConnection();
+        setAnsiQuotes(dbConn);
 
-      Map<PartitionInfo, ColumnStatistics> partitionInfoMap = getPartitionInfo(dbConn, tbl.getId(), partColStatsMap);
+        Map<PartitionInfo, ColumnStatistics> partitionInfoMap = getPartitionInfo(dbConn, tbl.getId(), partColStatsMap);
 
-      Map<String, Map<String, String>> result =
-              updatePartitionParamTable(dbConn, partitionInfoMap, validWriteIds, writeId, TxnUtils.isAcidTable(tbl));
+        result = updatePartitionParamTable(dbConn, partitionInfoMap, validWriteIds,
+            writeId, TxnUtils.isAcidTable(tbl));
 
-      Map<PartColNameInfo, MPartitionColumnStatistics> insertMap = new HashMap<>();
-      Map<PartColNameInfo, MPartitionColumnStatistics> updateMap = new HashMap<>();
-      populateInsertUpdateMap(partitionInfoMap, updateMap, insertMap, dbConn, tbl);
+        Map<PartColNameInfo, MPartitionColumnStatistics> insertMap = new HashMap<>();
+        Map<PartColNameInfo, MPartitionColumnStatistics> updateMap = new HashMap<>();
+        populateInsertUpdateMap(partitionInfoMap, updateMap, insertMap, dbConn, tbl);
 
-      LOG.info("Number of stats to insert  " + insertMap.size() + " update " + updateMap.size());
+        LOG.info("Number of stats to insert  " + insertMap.size() + " update " + updateMap.size());
 
-      if (insertMap.size() != 0) {
-        insertIntoPartColStatTable(insertMap, csId, dbConn);
-      }
-
-      if (updateMap.size() != 0) {
-        updatePartColStatTable(updateMap, dbConn);
-      }
-
-      if (transactionalListeners != null) {
-        UpdatePartitionColumnStatEventBatch eventBatch = new UpdatePartitionColumnStatEventBatch(null);
-        for (Map.Entry entry : result.entrySet()) {
-          Map<String, String> parameters = (Map<String, String>) entry.getValue();
-          ColumnStatistics colStats = partColStatsMap.get(entry.getKey());
-          List<String> partVals = getPartValsFromName(tbl, colStats.getStatsDesc().getPartName());
-          UpdatePartitionColumnStatEvent event = new UpdatePartitionColumnStatEvent(colStats, partVals, parameters,
-                  tbl, writeId, null);
-          eventBatch.addPartColStatEvent(event);
+        if (insertMap.size() != 0) {
+          insertIntoPartColStatTable(insertMap, csId, dbConn);
         }
-        MetaStoreListenerNotifier.notifyEventWithDirectSql(transactionalListeners,
-                EventMessage.EventType.UPDATE_PARTITION_COLUMN_STAT_BATCH, eventBatch, dbConn, sqlGenerator);
+
+        if (updateMap.size() != 0) {
+          updatePartColStatTable(updateMap, dbConn);
+        }
+
+        if (transactionalListeners != null) {
+          UpdatePartitionColumnStatEventBatch eventBatch = new UpdatePartitionColumnStatEventBatch(null);
+          for (Map.Entry entry : result.entrySet()) {
+            Map<String, String> parameters = (Map<String, String>) entry.getValue();
+            ColumnStatistics colStats = partColStatsMap.get(entry.getKey());
+            List<String> partVals = getPartValsFromName(tbl, colStats.getStatsDesc().getPartName());
+            UpdatePartitionColumnStatEvent event = new UpdatePartitionColumnStatEvent(colStats, partVals, parameters,
+                tbl, writeId, null);
+            eventBatch.addPartColStatEvent(event);
+          }
+          MetaStoreListenerNotifier.notifyEventWithDirectSql(transactionalListeners,
+              EventMessage.EventType.UPDATE_PARTITION_COLUMN_STAT_BATCH, eventBatch, dbConn, sqlGenerator);
+        }
+      } finally {
+        closeDbConn(jdoConn);
       }
-      closeDbConn(jdoConn);
       tx.commit();
       return result;
     } catch (Exception e) {
@@ -528,7 +532,6 @@ class DirectSqlUpdatePart {
               + " due to: "  + e.getMessage());
     } finally {
       if (tx.isActive()) {
-        closeDbConn(jdoConn);
         tx.rollback();
       }
       dbType.unlockInternal();
@@ -541,60 +544,59 @@ class DirectSqlUpdatePart {
    */
   public long getNextCSIdForMPartitionColumnStatistics(long numStats) throws MetaException {
     long maxCsId = 0;
-    JDOConnection jdoConn = null;
     Transaction tx = pm.currentTransaction();
     try {
       dbType.lockInternal();
       tx.begin();
-      jdoConn = pm.getDataStoreConnection();
-      Connection dbConn = (Connection) jdoConn.getNativeConnection();
+      JDOConnection jdoConn = null;
+      try {
+        jdoConn = pm.getDataStoreConnection();
+        Connection dbConn = (Connection) jdoConn.getNativeConnection();
 
-      setAnsiQuotes(dbConn);
+        setAnsiQuotes(dbConn);
 
-      // This loop will be iterated at max twice. If there is no records, it will first insert and then do a select.
-      // We are not using any upsert operations as select for update and then update is required to make sure that
-      // the caller gets a reserved range for CSId not used by any other thread.
-      boolean insertDone = false;
-      while (maxCsId == 0) {
-        String query = sqlGenerator.addForUpdateClause("SELECT \"NEXT_VAL\" FROM \"SEQUENCE_TABLE\" "
-                + "WHERE \"SEQUENCE_NAME\"= "
-                + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics"));
-        LOG.debug("Execute query: " + query);
-        try (Statement statement = dbConn.createStatement();
-             ResultSet rs = statement.executeQuery(query)) {
-          if (rs.next()) {
-            maxCsId = rs.getLong(1);
-          } else if (insertDone) {
-            throw new MetaException("Invalid state of SEQUENCE_TABLE for MPartitionColumnStatistics");
-          } else {
-            insertDone = true;
-            query = "INSERT INTO \"SEQUENCE_TABLE\" (\"SEQUENCE_NAME\", \"NEXT_VAL\")  VALUES ( "
-                    + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics") + "," + 1
-                    + ")";
-            try {
-              statement.executeUpdate(query);
-            } catch (SQLException e) {
-              // If the record is already inserted by some other thread continue to select.
-              if (dbType.isDuplicateKeyError(e)) {
-                continue;
+        // This loop will be iterated at max twice. If there is no records, it will first insert and then do a select.
+        // We are not using any upsert operations as select for update and then update is required to make sure that
+        // the caller gets a reserved range for CSId not used by any other thread.
+        boolean insertDone = false;
+        while (maxCsId == 0) {
+          String query = sqlGenerator.addForUpdateClause(
+              "SELECT \"NEXT_VAL\" FROM \"SEQUENCE_TABLE\" " + "WHERE \"SEQUENCE_NAME\"= " + quoteString(
+                  "org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics"));
+          LOG.debug("Execute query: " + query);
+          try (Statement statement = dbConn.createStatement(); ResultSet rs = statement.executeQuery(query)) {
+            if (rs.next()) {
+              maxCsId = rs.getLong(1);
+            } else if (insertDone) {
+              throw new MetaException("Invalid state of SEQUENCE_TABLE for MPartitionColumnStatistics");
+            } else {
+              insertDone = true;
+              query = "INSERT INTO \"SEQUENCE_TABLE\" (\"SEQUENCE_NAME\", \"NEXT_VAL\")  VALUES ( " + quoteString(
+                  "org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics") + "," + 1 + ")";
+              try {
+                statement.executeUpdate(query);
+              } catch (SQLException e) {
+                // If the record is already inserted by some other thread continue to select.
+                if (dbType.isDuplicateKeyError(e)) {
+                  continue;
+                }
+                LOG.error("Unable to insert into SEQUENCE_TABLE for MPartitionColumnStatistics.", e);
+                throw e;
               }
-              LOG.error("Unable to insert into SEQUENCE_TABLE for MPartitionColumnStatistics.", e);
-              throw e;
             }
           }
         }
-      }
 
-      long nextMaxCsId = maxCsId + numStats + 1;
-      String query = "UPDATE \"SEQUENCE_TABLE\" SET \"NEXT_VAL\" = "
-              + nextMaxCsId
-              + " WHERE \"SEQUENCE_NAME\" = "
-              + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics");
+        long nextMaxCsId = maxCsId + numStats + 1;
+        String query = "UPDATE \"SEQUENCE_TABLE\" SET \"NEXT_VAL\" = " + nextMaxCsId + " WHERE \"SEQUENCE_NAME\" = " + quoteString(
+            "org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics");
 
-      try (Statement statement = dbConn.createStatement()) {
-        statement.executeUpdate(query);
+        try (Statement statement = dbConn.createStatement()) {
+          statement.executeUpdate(query);
+        }
+      } finally {
+        closeDbConn(jdoConn);
       }
-      closeDbConn(jdoConn);
       tx.commit();
       return maxCsId;
     } catch (Exception e) {
@@ -603,7 +605,6 @@ class DirectSqlUpdatePart {
               + " due to: " + e.getMessage());
     } finally {
       if (tx.isActive()) {
-        closeDbConn(jdoConn);
         tx.rollback();
       }
       dbType.unlockInternal();


### PR DESCRIPTION
…use connection starvation

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Make the time consuming API request the connection from primary connection pool
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Since [HIVE-26419](https://issues.apache.org/jira/browse/HIVE-26419), we have a secondary connection pool for schema generation, and for value generation operations, the size of this pool is 2. However, based on DataNucleus documentation on datanucleus.ConnectionFactory2, link:
https://www.datanucleus.org/products/accessplatform_5_0/jdo/persistence.html
the secondary pool also serves for nontransactional connections(effectively "auto-commit" mode), which makes the ObjectStore updatePartitionColumnStatisticsInBatch request the connection from this pool, as it doesn't open a transaction explicitly. If there is a slow on inserting or updating the column statistics, the pool will become unavailable quickly(the pool reaches its maximum size), the ObjectStore cloud see the "Connection is not available, request timed out" under such a situation.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
