### PR TITLE
HIVE-28264: OOM/slow compilation when query contains SELECT clauses with nested expressions

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/Bug.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/Bug.java
@@ -93,4 +93,9 @@ public final class Bug {
    * Whether <a href="https://issues.apache.org/jira/browse/CALCITE-5669">CALCITE-5985</a> is fixed.
    */
   public static final boolean CALCITE_5985_FIXED = false;
+
+  /**
+   * Whether <a href="https://issues.apache.org/jira/browse/CALCITE-6513">CALCITE-6513</a> is fixed.
+   */
+  public static final boolean CALCITE_6513_FIXED = false;
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelOptUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelOptUtil.java
@@ -727,6 +727,20 @@ public class HiveRelOptUtil extends RelOptUtil {
     return cannotExtract;
   }
 
+  public static RexNode pushPastProjectUnlessBloat(RexNode node, Project project, int bloat) {
+    if (Bug.CALCITE_6513_FIXED) {
+      throw new IllegalStateException("Method is redundant when the fix for CALCITE-6513 is merged into Calcite. " +
+          "Use RelOptUtil.pushPastProjectUnlessBloat");
+    }
+
+    List<RexNode> newConditions =
+        RelOptUtil.pushPastProjectUnlessBloat(Collections.singletonList(node), project, bloat);
+    if (newConditions == null || newConditions.size() != 1) {
+      return null;
+    }
+    return newConditions.get(0);
+  }
+
   public static class PKFKJoinInfo {
     public final boolean isPkFkJoin;
     public final Pair<ImmutableBitSet, ImmutableBitSet> pkFkJoinColumns;

--- a/ql/src/test/queries/clientpositive/subquery_nested_expressions.q
+++ b/ql/src/test/queries/clientpositive/subquery_nested_expressions.q
@@ -1,0 +1,10 @@
+CREATE TABLE t0 (`title` string);
+
+explain cbo
+SELECT x4 from
+    (SELECT concat_ws('L4',x3, x3, x3, x3) as x4 from
+        (SELECT concat_ws('L3',x2, x2, x2, x2) as x3 from
+            (SELECT concat_ws('L2',x1, x1, x1, x1) as x2 from
+                (SELECT concat_ws('L1',x0, x0, x0, x0) as x1 from
+                    (SELECT concat_ws('L0',title, title, title, title) as x0 from t0) t1) t2) t3) t4) t
+WHERE x4 = 'Something';

--- a/ql/src/test/results/clientpositive/llap/subquery_nested_expressions.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_nested_expressions.q.out
@@ -1,0 +1,36 @@
+PREHOOK: query: CREATE TABLE t0 (`title` string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t0
+POSTHOOK: query: CREATE TABLE t0 (`title` string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t0
+PREHOOK: query: explain cbo
+SELECT x4 from
+    (SELECT concat_ws('L4',x3, x3, x3, x3) as x4 from
+        (SELECT concat_ws('L3',x2, x2, x2, x2) as x3 from
+            (SELECT concat_ws('L2',x1, x1, x1, x1) as x2 from
+                (SELECT concat_ws('L1',x0, x0, x0, x0) as x1 from
+                    (SELECT concat_ws('L0',title, title, title, title) as x0 from t0) t1) t2) t3) t4) t
+WHERE x4 = 'Something'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t0
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+SELECT x4 from
+    (SELECT concat_ws('L4',x3, x3, x3, x3) as x4 from
+        (SELECT concat_ws('L3',x2, x2, x2, x2) as x3 from
+            (SELECT concat_ws('L2',x1, x1, x1, x1) as x2 from
+                (SELECT concat_ws('L1',x0, x0, x0, x0) as x1 from
+                    (SELECT concat_ws('L0',title, title, title, title) as x0 from t0) t1) t2) t3) t4) t
+WHERE x4 = 'Something'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t0
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(x4=[CAST(_UTF-16LE'Something':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
+  HiveFilter(condition=[=(concat_ws(_UTF-16LE'L4':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", concat_ws(_UTF-16LE'L3':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0)), concat_ws(_UTF-16LE'L3':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0)), concat_ws(_UTF-16LE'L3':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0)), concat_ws(_UTF-16LE'L3':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0))), _UTF-16LE'Something')])
+    HiveProject(x1=[concat_ws(_UTF-16LE'L1':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", concat_ws(_UTF-16LE'L0':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L0':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L0':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0), concat_ws(_UTF-16LE'L0':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $0, $0, $0, $0))])
+      HiveTableScan(table=[[default, t0]], table:alias=[t0])
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Apply changes in [CALCITE-6513](https://issues.apache.org/jira/browse/CALCITE-6513) into `HiveFilterProjectTransposeRule`.

### Why are the changes needed?
Applying the rule to nested project operators that contain nested expressions may cause OOM. Please see jira for details
[CALCITE-6513](https://issues.apache.org/jira/browse/CALCITE-6513)
[HIVE-28264](https://issues.apache.org/jira/browse/HIVE-28264)

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=subquery_nested_expressions.q -pl itests/qtest -Pitests
```