### PR TITLE
HIVE-28411: Bucket Map Join on Iceberg tables

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -39,6 +39,7 @@ public class InputFormatConfig {
   public static final String SKIP_RESIDUAL_FILTERING = "skip.residual.filtering";
   public static final String AS_OF_TIMESTAMP = "iceberg.mr.as.of.time";
   public static final String FILTER_EXPRESSION = "iceberg.mr.filter.expression";
+  public static final String GROUPING_PARTITION_COLUMNS = "iceberg.mr.grouping.partition.columns";
   public static final String IN_MEMORY_DATA_MODEL = "iceberg.mr.in.memory.data.model";
   public static final String READ_SCHEMA = "iceberg.mr.read.schema";
   public static final String SNAPSHOT_ID = "iceberg.mr.snapshot.id";

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -154,6 +154,7 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
     }
 
     job.set(InputFormatConfig.SELECTED_COLUMNS, job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, ""));
+    job.set(InputFormatConfig.GROUPING_PARTITION_COLUMNS, job.get(TableScanDesc.GROUPING_PARTITION_COLUMNS, ""));
     job.setBoolean(InputFormatConfig.FETCH_VIRTUAL_COLUMNS,
             job.getBoolean(ColumnProjectionUtils.FETCH_VIRTUAL_COLUMNS_CONF_STR, false));
     job.set(InputFormatConfig.AS_OF_TIMESTAMP, job.get(TableScanDesc.AS_OF_TIMESTAMP, "-1"));
@@ -162,8 +163,9 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
     job.set(InputFormatConfig.OUTPUT_TABLE_SNAPSHOT_REF, job.get(TableScanDesc.SNAPSHOT_REF, ""));
 
     String location = job.get(InputFormatConfig.TABLE_LOCATION);
+    int numBuckets = job.getInt(TableScanDesc.GROUPING_NUM_BUCKETS, -1);
     return Arrays.stream(super.getSplits(job, numSplits))
-                 .map(split -> new HiveIcebergSplit((IcebergSplit) split, location))
+                 .map(split -> new HiveIcebergSplit((IcebergSplit) split, location, numBuckets))
                  .toArray(InputSplit[]::new);
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -25,6 +25,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.OptionalInt;
+import java.util.stream.IntStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.tez.HashableInputSplit;
 import org.apache.hadoop.hive.ql.io.PartitionAwareSplit;
@@ -101,11 +102,10 @@ public class HiveIcebergSplit extends FileSplit
     if (key.size() == 0) {
       return OptionalInt.empty();
     }
-    final int numBucketKeys = key.size();
-    final int[] bucketIds = new int[numBucketKeys];
-    for (int i = 0; i < numBucketKeys; i++) {
-      bucketIds[i] = key.get(i, Integer.class);
-    }
+    final int[] bucketIds = IntStream
+        .range(0, key.size())
+        .map(i -> key.get(i, Integer.class))
+        .toArray();
     return OptionalInt.of(IcebergBucketFunction.getHashCode(bucketIds));
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.tez.HashableInputSplit;
 import org.apache.hadoop.hive.ql.io.PartitionAwareSplit;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.StructLike;
@@ -97,7 +98,7 @@ public class HiveIcebergSplit extends FileSplit
   }
 
   @Override
-  public OptionalInt getBucketHashCode() {
+  public OptionalInt getBucketId() {
     final StructLike key = innerSplit.taskGroup().groupingKey();
     if (key.size() == 0) {
       return OptionalInt.empty();
@@ -106,12 +107,8 @@ public class HiveIcebergSplit extends FileSplit
         .range(0, key.size())
         .map(i -> key.get(i, Integer.class))
         .toArray();
-    return OptionalInt.of(IcebergBucketFunction.getHashCode(bucketIds));
-  }
-
-  @Override
-  public int getNumBuckets() {
-    return numBuckets;
+    final int hashCode = IcebergBucketFunction.getHashCode(bucketIds);
+    return OptionalInt.of(ObjectInspectorUtils.getBucketNumber(hashCode, numBuckets));
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -83,7 +83,7 @@ public class HiveIcebergSplit extends FileSplit
 
   @Override
   public byte[] getBytesForHash() {
-    Collection<FileScanTask> fileScanTasks = innerSplit.task().tasks();
+    Collection<FileScanTask> fileScanTasks = innerSplit.taskGroup().tasks();
 
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       for (FileScanTask task : fileScanTasks) {
@@ -98,7 +98,7 @@ public class HiveIcebergSplit extends FileSplit
 
   @Override
   public OptionalInt getBucketHashCode() {
-    final StructLike key = innerSplit.task().groupingKey();
+    final StructLike key = innerSplit.taskGroup().groupingKey();
     if (key.size() == 0) {
       return OptionalInt.empty();
     }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.ql.io.PartitionAwareSplit;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.mr.hive.plan.IcebergBucketFunction;
 import org.apache.iceberg.mr.mapreduce.IcebergSplit;
 import org.apache.iceberg.mr.mapreduce.IcebergSplitContainer;
 import org.apache.iceberg.relocated.com.google.common.primitives.Longs;

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -776,7 +776,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     }
     final List<TransformSpec> specs = getPartitionTransformSpec(table);
     // Currently, we support the only bucket transform
-    return specs.stream().anyMatch(HiveIcebergStorageHandler::isBucket);
+    return specs.stream().anyMatch(IcebergTableUtil::isBucket);
   }
 
   @Override
@@ -785,7 +785,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     // Currently, we support the only bucket transform
     final List<String> bucketColumnNames = Lists.newArrayList();
     final List<Integer> numBuckets = Lists.newArrayList();
-    getPartitionTransformSpec(table).stream().filter(HiveIcebergStorageHandler::isBucket).forEach(spec -> {
+    getPartitionTransformSpec(table).stream().filter(IcebergTableUtil::isBucket).forEach(spec -> {
       bucketColumnNames.add(spec.getColumnName());
       numBuckets.add(spec.getTransformParam().get());
     });
@@ -795,10 +795,6 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     }
     final IcebergBucketFunction bucketFunction = new IcebergBucketFunction(bucketColumnNames, numBuckets);
     return new PartitionAwareOptimizationCtx(bucketFunction);
-  }
-
-  private static boolean isBucket(TransformSpec spec) {
-    return spec.getTransformType() == TransformSpec.TransformType.BUCKET && spec.getTransformParam().isPresent();
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -114,6 +114,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.FileSinkDesc;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
 import org.apache.hadoop.hive.ql.plan.MergeTaskProperties;
+import org.apache.hadoop.hive.ql.plan.PartitionAwareOptimizationCtx;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider;
 import org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandlerUtils;
@@ -764,6 +765,39 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     customSortExprs.addAll(transformSpecs.stream().map(spec ->
         IcebergTransformSortFunctionUtil.getCustomSortExprs(spec, fieldOrderMap.get(spec.getColumnName()) + offset)
     ).collect(Collectors.toList()));
+  }
+
+  @Override
+  public boolean supportsPartitionAwareOptimization(org.apache.hadoop.hive.ql.metadata.Table table) {
+    if (hasUndergonePartitionEvolution(table)) {
+      // Don't support complex cases yet
+      return false;
+    }
+    final List<TransformSpec> specs = getPartitionTransformSpec(table);
+    // Currently, we support the only bucket transform
+    return specs.stream().anyMatch(HiveIcebergStorageHandler::isBucket);
+  }
+
+  @Override
+  public PartitionAwareOptimizationCtx createPartitionAwareOptimizationContext(
+      org.apache.hadoop.hive.ql.metadata.Table table) {
+    // Currently, we support the only bucket transform
+    final List<String> bucketColumnNames = Lists.newArrayList();
+    final List<Integer> numBuckets = Lists.newArrayList();
+    getPartitionTransformSpec(table).stream().filter(HiveIcebergStorageHandler::isBucket).forEach(spec -> {
+      bucketColumnNames.add(spec.getColumnName());
+      numBuckets.add(spec.getTransformParam().get());
+    });
+
+    if (bucketColumnNames.isEmpty()) {
+      return null;
+    }
+    final IcebergBucketFunction bucketFunction = new IcebergBucketFunction(bucketColumnNames, numBuckets);
+    return new PartitionAwareOptimizationCtx(bucketFunction);
+  }
+
+  private static boolean isBucket(TransformSpec spec) {
+    return spec.getTransformType() == TransformSpec.TransformType.BUCKET && spec.getTransformParam().isPresent();
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -185,6 +185,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.actions.HiveIcebergDeleteOrphanFiles;
+import org.apache.iceberg.mr.hive.plan.IcebergBucketFunction;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.BlobMetadata;
 import org.apache.iceberg.puffin.Puffin;

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergBucketFunction.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergBucketFunction.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.CustomBucketFunction;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.iceberg.mr.hive.udf.GenericUDFIcebergBucket;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public class IcebergBucketFunction implements CustomBucketFunction {
+  private static final class SettableDeferredObject implements DeferredObject {
+    private Object value;
+
+    @Override
+    public void prepare(int i) {
+      throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public Object get() {
+      return value;
+    }
+
+    void set(Object object) {
+      this.value = object;
+    }
+  }
+
+  private static final long serialVersionUID = 1L;
+
+  private final List<String> sourceColumnNames;
+  private final List<Integer> numBuckets;
+
+  private transient List<GenericUDFIcebergBucket> bucketUdfs;
+  private transient List<IntObjectInspector> bucketIdInspectors;
+  private transient SettableDeferredObject[] deferredObjects;
+
+  public IcebergBucketFunction(List<String> sourceColumnNames, List<Integer> numBuckets) {
+    Objects.requireNonNull(sourceColumnNames);
+    Objects.requireNonNull(numBuckets);
+    Preconditions.checkArgument(sourceColumnNames.size() == numBuckets.size());
+    Preconditions.checkArgument(!sourceColumnNames.isEmpty());
+    this.sourceColumnNames = sourceColumnNames;
+    this.numBuckets = numBuckets;
+  }
+
+  @Override
+  public Optional<CustomBucketFunction> select(boolean[] retainedColumns) {
+    Preconditions.checkArgument(retainedColumns.length == numBuckets.size());
+    Preconditions.checkState(bucketUdfs == null);
+    Preconditions.checkState(bucketIdInspectors == null);
+    Preconditions.checkState(deferredObjects == null);
+
+    final List<String> newSourceColumnNames = Lists.newArrayList();
+    final List<Integer> newNumBuckets = Lists.newArrayList();
+    for (int i = 0; i < retainedColumns.length; i++) {
+      if (retainedColumns[i]) {
+        newSourceColumnNames.add(sourceColumnNames.get(i));
+        newNumBuckets.add(numBuckets.get(i));
+      }
+    }
+
+    if (newSourceColumnNames.isEmpty()) {
+      return Optional.empty();
+    }
+
+    final IcebergBucketFunction newBucketFunction = new IcebergBucketFunction(newSourceColumnNames, newNumBuckets);
+    return Optional.of(newBucketFunction);
+  }
+
+  @Override
+  public void initialize(ObjectInspector[] objectInspectors) {
+    Preconditions.checkArgument(objectInspectors.length == numBuckets.size());
+    bucketIdInspectors = Lists.newArrayList();
+    bucketUdfs = Lists.newArrayList();
+    for (int i = 0; i < objectInspectors.length; i++) {
+      final GenericUDFIcebergBucket udf = new GenericUDFIcebergBucket();
+      final ObjectInspector numBucketInspector = PrimitiveObjectInspectorFactory
+          .getPrimitiveWritableConstantObjectInspector(
+              TypeInfoFactory.intTypeInfo,
+              new IntWritable(numBuckets.get(i)));
+      final ObjectInspector[] args = { objectInspectors[i], numBucketInspector };
+      try {
+        final ObjectInspector inspector = udf.initialize(args);
+        Preconditions.checkState(inspector.getCategory() == Category.PRIMITIVE);
+        final PrimitiveObjectInspector primitiveInspector = (PrimitiveObjectInspector) inspector;
+        Preconditions.checkState(primitiveInspector.getPrimitiveCategory() == PrimitiveCategory.INT);
+        bucketIdInspectors.add((IntObjectInspector) primitiveInspector);
+      } catch (UDFArgumentException e) {
+        throw new IllegalArgumentException("The given object inspector is illegal", e);
+      }
+      bucketUdfs.add(udf);
+    }
+    deferredObjects = new SettableDeferredObject[1];
+    deferredObjects[0] = new SettableDeferredObject();
+
+    Preconditions.checkState(bucketIdInspectors.size() == numBuckets.size());
+    Preconditions.checkState(bucketUdfs.size() == numBuckets.size());
+  }
+
+  @Override
+  public List<String> getSourceColumnNames() {
+    return sourceColumnNames;
+  }
+
+  @Override
+  public int getNumBuckets() {
+    return numBuckets.stream().reduce(1, (a, b) -> a * b);
+  }
+
+  @Override
+  public int getBucketHashCode(Object[] bucketFields) {
+    final int[] bucketIds = new int[numBuckets.size()];
+    for (int i = 0; i < bucketUdfs.size(); i++) {
+      deferredObjects[0].set(bucketFields[i]);
+      try {
+        final Object bucketId = bucketUdfs.get(i).evaluate(deferredObjects);
+        bucketIds[i] = bucketIdInspectors.get(i).get(bucketId);
+      } catch (HiveException e) {
+        throw new IllegalArgumentException("Failed to evaluate the given objects", e);
+      }
+    }
+    return getHashCode(bucketIds);
+  }
+
+  static int getHashCode(int[] bucketIds) {
+    int hashCode = 0;
+    for (int bucketId : bucketIds) {
+      hashCode = 31 * hashCode + bucketId;
+    }
+    return hashCode;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("IcebergBucketFunction{sourceColumnNames=%s,numBuckets=%s}",
+        sourceColumnNames, numBuckets);
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.TransformSpec;
+import org.apache.hadoop.hive.ql.parse.TransformSpec.TransformType;
 import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.hive.ql.session.SessionStateUtil;
 import org.apache.iceberg.DataFile;
@@ -269,6 +270,11 @@ public class IcebergTableUtil {
 
   public static boolean isBucketed(Table table) {
     return table.spec().fields().stream().anyMatch(f -> f.transform().toString().startsWith("bucket["));
+  }
+
+  public static boolean isBucket(TransformSpec spec) {
+    // Iceberg's bucket transform requires a bucket number to be specified
+    return spec.getTransformType() == TransformType.BUCKET && spec.getTransformParam().isPresent();
   }
 
   /**

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/plan/IcebergBucketFunction.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/plan/IcebergBucketFunction.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.CustomBucketFunction;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.SettableDeferredJavaObject;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
@@ -38,24 +38,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 public class IcebergBucketFunction implements CustomBucketFunction {
-  private static final class SettableDeferredObject implements DeferredObject {
-    private Object value;
-
-    @Override
-    public void prepare(int i) {
-      throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public Object get() {
-      return value;
-    }
-
-    void set(Object object) {
-      this.value = object;
-    }
-  }
-
   private static final long serialVersionUID = 1L;
 
   private final List<String> sourceColumnNames;
@@ -63,7 +45,7 @@ public class IcebergBucketFunction implements CustomBucketFunction {
 
   private transient List<GenericUDFIcebergBucket> bucketUdfs;
   private transient List<IntObjectInspector> bucketIdInspectors;
-  private transient SettableDeferredObject[] deferredObjects;
+  private transient SettableDeferredJavaObject[] deferredObjects;
 
   public IcebergBucketFunction(List<String> sourceColumnNames, List<Integer> numBuckets) {
     Objects.requireNonNull(sourceColumnNames);
@@ -121,8 +103,8 @@ public class IcebergBucketFunction implements CustomBucketFunction {
       }
       bucketUdfs.add(udf);
     }
-    deferredObjects = new SettableDeferredObject[1];
-    deferredObjects[0] = new SettableDeferredObject();
+    deferredObjects = new SettableDeferredJavaObject[1];
+    deferredObjects[0] = new SettableDeferredJavaObject();
 
     Preconditions.checkState(bucketIdInspectors.size() == numBuckets.size());
     Preconditions.checkState(bucketUdfs.size() == numBuckets.size());

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/plan/IcebergBucketFunction.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/plan/IcebergBucketFunction.java
@@ -135,7 +135,7 @@ public class IcebergBucketFunction implements CustomBucketFunction {
 
   @Override
   public int getNumBuckets() {
-    return numBuckets.stream().reduce(1, (a, b) -> a * b);
+    return numBuckets.stream().reduce(1, Math::multiplyExact);
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/plan/IcebergBucketFunction.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/plan/IcebergBucketFunction.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.iceberg.mr.hive;
+package org.apache.iceberg.mr.hive.plan;
 
 import java.util.List;
 import java.util.Objects;
@@ -153,7 +153,7 @@ public class IcebergBucketFunction implements CustomBucketFunction {
     return getHashCode(bucketIds);
   }
 
-  static int getHashCode(int[] bucketIds) {
+  public static int getHashCode(int[] bucketIds) {
     int hashCode = 0;
     for (int bucketId : bucketIds) {
       hashCode = 31 * hashCode + bucketId;

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -44,7 +45,9 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataTableScan;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Scan;
+import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.SystemConfigs;
@@ -58,7 +61,9 @@ import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.HiveIcebergStorageHandler;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.SerializationUtil;
+import org.apache.iceberg.util.TableScanUtil;
 import org.apache.iceberg.util.ThreadPools;
 
 /**
@@ -205,22 +210,18 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
             HiveConf.ConfVars.HIVE_ICEBERG_ALLOW_DATAFILES_IN_TABLE_LOCATION_ONLY.defaultBoolVal);
     Path tableLocation = new Path(conf.get(InputFormatConfig.TABLE_LOCATION));
 
-
-    try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
-      tasksIterable.forEach(task -> {
-        if (applyResidual && (model == InputFormatConfig.InMemoryDataModel.HIVE ||
-            model == InputFormatConfig.InMemoryDataModel.PIG)) {
-          // TODO: We do not support residual evaluation for HIVE and PIG in memory data model yet
-          checkResiduals(task);
-        }
-        if (allowDataFilesWithinTableLocationOnly) {
-          validateFileLocations(task, tableLocation);
-        }
-        splits.add(new IcebergSplit(conf, task));
-      });
-    } catch (IOException e) {
-      throw new UncheckedIOException(String.format("Failed to close table scan: %s", scan), e);
-    }
+    String[] groupingPartitionColumns = conf.getStrings(InputFormatConfig.GROUPING_PARTITION_COLUMNS);
+    generateInputSplits(scan, table, groupingPartitionColumns, task -> {
+      if (applyResidual && (model == InputFormatConfig.InMemoryDataModel.HIVE ||
+          model == InputFormatConfig.InMemoryDataModel.PIG)) {
+        // TODO: We do not support residual evaluation for HIVE and PIG in memory data model yet
+        checkResiduals(task);
+      }
+      if (allowDataFilesWithinTableLocationOnly) {
+        validateFileLocations(task, tableLocation);
+      }
+      splits.add(new IcebergSplit(conf, task));
+    });
 
     // If enabled, do not serialize FileIO hadoop config to decrease split size
     // However, do not skip serialization for metatable queries, because some metadata tasks cache the IO object and we
@@ -232,16 +233,43 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     return splits;
   }
 
-  private static void validateFileLocations(CombinedScanTask split, Path tableLocation) {
-    for (FileScanTask fileScanTask : split.files()) {
+  private static void validateFileLocations(ScanTaskGroup<FileScanTask> split, Path tableLocation) {
+    for (FileScanTask fileScanTask : split.tasks()) {
       if (!FileUtils.isPathWithinSubtree(new Path(fileScanTask.file().path().toString()), tableLocation)) {
         throw new AuthorizationException("The table contains paths which are outside the table location");
       }
     }
   }
 
-  private static void checkResiduals(CombinedScanTask task) {
-    task.files().forEach(fileScanTask -> {
+  private static void generateInputSplits(Scan<?, FileScanTask, CombinedScanTask> scan, Table table,
+      String[] groupingPartitionColumns, Consumer<ScanTaskGroup<FileScanTask>> consumer) {
+    if (groupingPartitionColumns == null) {
+      try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
+        tasksIterable.forEach(consumer);
+      } catch (IOException e) {
+        throw new UncheckedIOException(String.format("Failed to close table scan: %s", scan), e);
+      }
+    } else {
+      final StructType groupingKeyType = Partitioning.groupingKeyType(
+          table.schema().select(groupingPartitionColumns), table.specs().values());
+      try (CloseableIterable<FileScanTask> taskIterable = scan.planFiles()) {
+        final List<FileScanTask> tasks = Lists.newArrayList(taskIterable);
+        final List<ScanTaskGroup<FileScanTask>> partitionScanTaskGroups =
+            TableScanUtil.planTaskGroups(
+                tasks,
+                scan.targetSplitSize(),
+                scan.splitLookback(),
+                scan.splitOpenFileCost(),
+                groupingKeyType);
+        partitionScanTaskGroups.forEach(consumer);
+      } catch (IOException e) {
+        throw new UncheckedIOException(String.format("Failed to close table scan: %s", scan), e);
+      }
+    }
+  }
+
+  private static void checkResiduals(ScanTaskGroup<FileScanTask> task) {
+    task.tasks().forEach(fileScanTask -> {
       Expression residual = fileScanTask.residual();
       if (residual != null && !residual.equals(Expressions.alwaysTrue())) {
         throw new UnsupportedOperationException(
@@ -256,5 +284,4 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
   public RecordReader<Void, T> createRecordReader(InputSplit split, TaskAttemptContext context) {
     return split instanceof IcebergMergeSplit ? new IcebergMergeRecordReader<>() : new IcebergRecordReader<>();
   }
-
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -211,16 +211,16 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     Path tableLocation = new Path(conf.get(InputFormatConfig.TABLE_LOCATION));
 
     String[] groupingPartitionColumns = conf.getStrings(InputFormatConfig.GROUPING_PARTITION_COLUMNS);
-    generateInputSplits(scan, table, groupingPartitionColumns, task -> {
+    generateInputSplits(scan, table, groupingPartitionColumns, taskGroup -> {
       if (applyResidual && (model == InputFormatConfig.InMemoryDataModel.HIVE ||
           model == InputFormatConfig.InMemoryDataModel.PIG)) {
         // TODO: We do not support residual evaluation for HIVE and PIG in memory data model yet
-        checkResiduals(task);
+        checkResiduals(taskGroup);
       }
       if (allowDataFilesWithinTableLocationOnly) {
-        validateFileLocations(task, tableLocation);
+        validateFileLocations(taskGroup, tableLocation);
       }
-      splits.add(new IcebergSplit(conf, task));
+      splits.add(new IcebergSplit(conf, taskGroup));
     });
 
     // If enabled, do not serialize FileIO hadoop config to decrease split size

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergRecordReader.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergRecordReader.java
@@ -99,7 +99,7 @@ public final class IcebergRecordReader<T> extends AbstractIcebergRecordReader<T>
   public void initialize(InputSplit split, TaskAttemptContext newContext) {
     // For now IcebergInputFormat does its own split planning and does not accept FileSplit instances
     super.initialize(split, newContext);
-    ScanTaskGroup<FileScanTask> task = ((IcebergSplit) split).task();
+    ScanTaskGroup<FileScanTask> task = ((IcebergSplit) split).taskGroup();
     this.tasks = task.tasks();
     this.currentIterator = nextTask();
   }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergRecordReader.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergRecordReader.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataTask;
 import org.apache.iceberg.FileFormat;
@@ -39,6 +38,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
+import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.avro.Avro;
@@ -99,8 +99,8 @@ public final class IcebergRecordReader<T> extends AbstractIcebergRecordReader<T>
   public void initialize(InputSplit split, TaskAttemptContext newContext) {
     // For now IcebergInputFormat does its own split planning and does not accept FileSplit instances
     super.initialize(split, newContext);
-    CombinedScanTask task = ((IcebergSplit) split).task();
-    this.tasks = task.files();
+    ScanTaskGroup<FileScanTask> task = ((IcebergSplit) split).task();
+    this.tasks = task.tasks();
     this.currentIterator = nextTask();
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -22,21 +22,29 @@ package org.apache.iceberg.mr.mapreduce;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.hadoop.Util;
+import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.SerializationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // Since this class extends `mapreduce.InputSplit and implements `mapred.InputSplit`, it can be returned by both MR v1
 // and v2 file formats.
 public class IcebergSplit extends InputSplit implements IcebergSplitContainer {
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergSplit.class);
 
   public static final String[] ANYWHERE = new String[]{"*"};
 
-  private CombinedScanTask task;
+  private ScanTaskGroup<FileScanTask> task;
 
   private transient String[] locations;
   private transient Configuration conf;
@@ -45,12 +53,12 @@ public class IcebergSplit extends InputSplit implements IcebergSplitContainer {
   public IcebergSplit() {
   }
 
-  IcebergSplit(Configuration conf, CombinedScanTask task) {
+  IcebergSplit(Configuration conf, ScanTaskGroup<FileScanTask> task) {
     this.task = task;
     this.conf = conf;
   }
 
-  public CombinedScanTask task() {
+  public ScanTaskGroup<FileScanTask> task() {
     return task;
   }
 
@@ -61,7 +69,7 @@ public class IcebergSplit extends InputSplit implements IcebergSplitContainer {
 
   @Override
   public long getLength() {
-    return task.files().stream().mapToLong(FileScanTask::length).sum();
+    return task.tasks().stream().mapToLong(FileScanTask::length).sum();
   }
 
   @Override
@@ -70,12 +78,29 @@ public class IcebergSplit extends InputSplit implements IcebergSplitContainer {
     // getLocations() won't be accurate when called on worker nodes and will always return "*"
     if (locations == null && conf != null) {
       boolean localityPreferred = conf.getBoolean(InputFormatConfig.LOCALITY, false);
-      locations = localityPreferred ? Util.blockLocations(task, conf) : ANYWHERE;
+      locations = localityPreferred ? blockLocations(task, conf) : ANYWHERE;
     } else {
       locations = ANYWHERE;
     }
 
     return locations;
+  }
+
+  private static String[] blockLocations(ScanTaskGroup<FileScanTask> task, Configuration conf) {
+    final Set<String> locationSets = Sets.newHashSet();
+    task.tasks().forEach(fileScanTask -> {
+      final Path path = new Path(fileScanTask.file().path().toString());
+      try {
+        final FileSystem fs = path.getFileSystem(conf);
+        for (BlockLocation location : fs.getFileBlockLocations(path, fileScanTask.start(), fileScanTask.length())) {
+          locationSets.addAll(Arrays.asList(location.getHosts()));
+        }
+      } catch (IOException e) {
+        LOG.warn("Failed to get block locations for path {}", path, e);
+      }
+    });
+
+    return locationSets.toArray(new String[0]);
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -86,6 +86,8 @@ public class IcebergSplit extends InputSplit implements IcebergSplitContainer {
     return locations;
   }
 
+  // TODO: We should move to Util.blockLocations once the following PR is merged and shipped
+  // https://github.com/apache/iceberg/pull/11053
   private static String[] blockLocations(ScanTaskGroup<FileScanTask> task, Configuration conf) {
     final Set<String> locationSets = Sets.newHashSet();
     task.tasks().forEach(fileScanTask -> {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -86,7 +86,7 @@ public class IcebergSplit extends InputSplit implements IcebergSplitContainer {
     return locations;
   }
 
-  // TODO: We should move to Util.blockLocations once the following PR is merged and shipped
+  // We should move to Util.blockLocations once the following PR is merged and shipped
   // https://github.com/apache/iceberg/pull/11053
   private static String[] blockLocations(ScanTaskGroup<FileScanTask> task, Configuration conf) {
     final Set<String> locationSets = Sets.newHashSet();

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_1.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_1.q
@@ -1,0 +1,127 @@
+-- Copied from bucket_map_join_tez3.q
+set hive.explain.user=true;
+
+create table target_table(date_col date, string_col string, decimal_col decimal(38,0)) partitioned by spec (bucket(7, decimal_col)) stored by iceberg;
+insert into table target_table values
+('2017-05-17', 'pipeline', '50000000000000000000441610525'),
+('2018-12-20', 'pipeline', '50000000000000000001048981030'),
+('2020-06-30', 'pipeline', '50000000000000000002332575516'),
+('2021-08-16', 'pipeline', '50000000000000000003897973989'),
+('2017-06-06', 'pipeline', '50000000000000000000449148729'),
+('2017-09-08', 'pipeline', '50000000000000000000525378314'),
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2018-05-03', 'pipeline', '50000000000000000000750826355'),
+('2020-01-10', 'pipeline', '50000000000000000001816579677'),
+('2021-11-01', 'pipeline', '50000000000000000004269423714'),
+('2017-11-07', 'pipeline', '50000000000000000000585901787'),
+('2019-10-15', 'pipeline', '50000000000000000001598843430'),
+('2020-04-01', 'pipeline', '50000000000000000002035795461'),
+('2020-02-24', 'pipeline', '50000000000000000001932600185'),
+('2020-04-27', 'pipeline', '50000000000000000002108160849'),
+('2016-07-05', 'pipeline', '50000000000000000000054405114'),
+('2020-06-02', 'pipeline', '50000000000000000002234387967'),
+('2020-08-21', 'pipeline', '50000000000000000002529168758'),
+('2021-02-17', 'pipeline', '50000000000000000003158511687');
+
+create table source_table(date_col date, string_col string, decimal_col decimal(38,0)) partitioned by spec (bucket(7, decimal_col)) stored by iceberg;
+insert into table source_table values
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2022-09-01', 'pipeline', '50000000000000000006008686831'),
+('2022-08-30', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992621067'),
+('2022-08-30', 'pipeline', '50000000000000000005992621067');
+
+
+-- Test 2 queries in 4 configs.
+
+-- Each query has 1 join that can be converted to bucket join.
+-- One of the query receives the small table from Map vertex while the other recives it from Reducer vertex.
+
+-- 4 configs enfoce MapJoin to be converted to one of the following joins:
+-- 1. BucketMapJoin, 2. MapJoin, 3. VectorBucketMapJoin, 4. VectorMapJoin
+
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+
+-- 1. BucketMapJoin
+set hive.convert.join.bucket.mapjoin.tez=true;
+set hive.vectorized.execution.enabled=false;
+
+explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+-- 2. MapJoin
+set hive.convert.join.bucket.mapjoin.tez=false;
+set hive.vectorized.execution.enabled=false;
+
+explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+-- 3. VectorBucketMapJoin
+set hive.convert.join.bucket.mapjoin.tez=true;
+set hive.vectorized.execution.enabled=true;
+
+explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+-- 4. VectorMapJoin
+set hive.convert.join.bucket.mapjoin.tez=false;
+set hive.vectorized.execution.enabled=true;
+
+explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_2.q
@@ -1,0 +1,95 @@
+-- Copied from bucketmapjoin5.q
+set hive.explain.user=true;
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+
+CREATE TABLE srcbucket_mapjoin_n0_tmp(key int, value string) STORED AS TEXTFILE;
+load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_n0_tmp;
+load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_n0_tmp;
+CREATE TABLE srcbucket_mapjoin_n0(key int, value string) PARTITIONED BY SPEC (bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_n0 SELECT * FROM srcbucket_mapjoin_n0_tmp;
+
+CREATE TABLE srcbucket_mapjoin_part_n0_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE;
+load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08');
+load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08');
+load data local inpath '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08');
+load data local inpath '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08');
+load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09');
+load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09');
+load data local inpath '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09');
+load data local inpath '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09');
+CREATE TABLE srcbucket_mapjoin_part_n0 (key int, value string, ds string) partitioned by spec (ds, bucket(4, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_n0 SELECT * FROM srcbucket_mapjoin_part_n0_tmp;
+
+CREATE TABLE srcbucket_mapjoin_part_2_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE;
+load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-08');
+load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-08');
+load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-09');
+load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-09');
+CREATE TABLE srcbucket_mapjoin_part_2 (key int, value string, ds string) partitioned by spec (ds, bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_2 SELECT * FROM srcbucket_mapjoin_part_2_tmp;
+
+create table bucketmapjoin_hash_result_1 (key bigint , value1 bigint, value2 bigint);
+create table bucketmapjoin_hash_result_2 (key bigint , value1 bigint, value2 bigint);
+set hive.convert.join.bucket.mapjoin.tez=true;
+create table bucketmapjoin_tmp_result (key string , value1 string, value2 string);
+
+explain
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key;
+
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key;
+
+select count(1) from bucketmapjoin_tmp_result;
+insert overwrite table bucketmapjoin_hash_result_1
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result;
+
+set hive.convert.join.bucket.mapjoin.tez=false;
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key;
+
+select count(1) from bucketmapjoin_tmp_result;
+insert overwrite table bucketmapjoin_hash_result_2
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result;
+
+select a.key-b.key, a.value1-b.value1, a.value2-b.value2
+from bucketmapjoin_hash_result_1 a left outer join bucketmapjoin_hash_result_2 b
+on a.key = b.key;
+
+
+set hive.convert.join.bucket.mapjoin.tez=true;
+explain
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key;
+
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key;
+
+select count(1) from bucketmapjoin_tmp_result;
+insert overwrite table bucketmapjoin_hash_result_1
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result;
+
+set hive.convert.join.bucket.mapjoin.tez=false;
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key;
+
+select count(1) from bucketmapjoin_tmp_result;
+insert overwrite table bucketmapjoin_hash_result_2
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result;
+
+select a.key-b.key, a.value1-b.value1, a.value2-b.value2
+from bucketmapjoin_hash_result_1 a left outer join bucketmapjoin_hash_result_2 b
+on a.key = b.key;

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_3.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_3.q
@@ -1,0 +1,47 @@
+-- Copied from bucketmapjoin8.q
+set hive.explain.user=true;
+
+--! qt:dataset:part
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+
+CREATE TABLE srcbucket_mapjoin_part_1_n1_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n1_tmp PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n1_tmp PARTITION (part='1');
+CREATE TABLE srcbucket_mapjoin_part_1_n1 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_1_n1 SELECT * FROM srcbucket_mapjoin_part_1_n1_tmp;
+
+CREATE TABLE srcbucket_mapjoin_part_2_n4_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n4_tmp PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n4_tmp PARTITION (part='1');
+CREATE TABLE srcbucket_mapjoin_part_2_n4 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_2_n4 SELECT * FROM srcbucket_mapjoin_part_2_n4_tmp;
+
+ALTER TABLE srcbucket_mapjoin_part_2_n4 SET PARTITION SPEC (part, bucket(3, key));
+
+set hive.convert.join.bucket.mapjoin.tez=true;
+-- The partition bucketing metadata match but the tables have different numbers of buckets, bucket map join should still be used
+
+EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1';
+
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1';
+
+ALTER TABLE srcbucket_mapjoin_part_2_n4 SET PARTITION SPEC (part, bucket(2, value));
+
+-- The partition bucketing metadata match but the tables are bucketed on different columns, bucket map join should still be used
+
+EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1';
+
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1';

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_4.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_4.q
@@ -1,0 +1,60 @@
+-- Copied from bucketmapjoin11.q
+set hive.explain.user=true;
+
+--! qt:dataset:part
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+
+CREATE TABLE srcbucket_mapjoin_part_1_n2_tmp1 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp1 PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp1 PARTITION (part='1');
+CREATE TABLE srcbucket_mapjoin_part_1_n2 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_1_n2 SELECT * FROM srcbucket_mapjoin_part_1_n2_tmp1;
+
+ALTER TABLE srcbucket_mapjoin_part_1_n2 SET PARTITION SPEC (part, bucket(4, key));
+CREATE TABLE srcbucket_mapjoin_part_1_n2_tmp2 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2');
+INSERT INTO srcbucket_mapjoin_part_1_n2 SELECT * FROM srcbucket_mapjoin_part_1_n2_tmp2;
+
+CREATE TABLE srcbucket_mapjoin_part_2_n6_tmp1 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1');
+CREATE TABLE srcbucket_mapjoin_part_2_n6 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(4, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_2_n6 SELECT * FROM srcbucket_mapjoin_part_2_n6_tmp1;
+
+ALTER TABLE srcbucket_mapjoin_part_2_n6 SET PARTITION SPEC (part, bucket(2, key));
+CREATE TABLE srcbucket_mapjoin_part_2_n6_tmp2 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp2 PARTITION (part='2');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp2 PARTITION (part='2');
+INSERT INTO srcbucket_mapjoin_part_2_n6 SELECT * FROM srcbucket_mapjoin_part_2_n6_tmp2;
+
+set hive.convert.join.bucket.mapjoin.tez=true;
+
+-- The partition spec has been changed. This pattern is not supported yet
+
+EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part IS NOT NULL AND b.part IS NOT NULL;
+
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part IS NOT NULL AND b.part IS NOT NULL;
+
+EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part = b.part AND a.part IS NOT NULL AND b.part IS NOT NULL;
+
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part = b.part AND a.part IS NOT NULL AND b.part IS NOT NULL;

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_5.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_5.q
@@ -1,0 +1,54 @@
+-- Copied from bucketmapjoin12.q
+set hive.explain.user=true;
+
+--! qt:dataset:part
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+
+CREATE TABLE srcbucket_mapjoin_part_1_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_tmp PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_tmp PARTITION (part='1');
+CREATE TABLE srcbucket_mapjoin_part_1 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_1 SELECT * FROM srcbucket_mapjoin_part_1_tmp;
+
+CREATE TABLE srcbucket_mapjoin_part_2_n0_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n0_tmp PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n0_tmp PARTITION (part='1');
+CREATE TABLE srcbucket_mapjoin_part_2_n0 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_2_n0 SELECT * FROM srcbucket_mapjoin_part_2_n0_tmp;
+
+ALTER TABLE srcbucket_mapjoin_part_2_n0 SET PARTITION SPEC (part);
+
+CREATE TABLE srcbucket_mapjoin_part_3_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE;
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_3_tmp PARTITION (part='1');
+LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_3_tmp PARTITION (part='1');
+CREATE TABLE srcbucket_mapjoin_part_3 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_3 SELECT * FROM srcbucket_mapjoin_part_3_tmp;
+
+ALTER TABLE srcbucket_mapjoin_part_3 SET PARTITION SPEC (part, bucket(2, key));
+set hive.convert.join.bucket.mapjoin.tez=true;
+
+-- The partition bucketing metadata match but one table is not bucketed, bucket map join should still be used
+
+EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_2_n0 b
+ON a.key = b.key AND a.part = '1' and b.part = '1';
+
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_2_n0 b
+ON a.key = b.key AND a.part = '1' and b.part = '1';
+
+-- The table bucketing metadata match and one partition is not bucketed, bucket map join should be used
+
+EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_3 b
+ON a.key = b.key AND a.part = '1' and b.part = '1';
+
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_3 b
+ON a.key = b.key AND a.part = '1' and b.part = '1';

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_6.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_6.q
@@ -1,0 +1,27 @@
+-- Copied from bucketmapjoin_negative2.q
+set hive.explain.user=true;
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+
+CREATE TABLE srcbucket_mapjoin_n5_tmp(key int, value string) STORED AS TEXTFILE;
+load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_n5_tmp;
+load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_n5_tmp;
+CREATE TABLE srcbucket_mapjoin_n5(key int, value string) PARTITIONED BY SPEC(bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_n5 SELECT * FROM srcbucket_mapjoin_n5_tmp;
+
+CREATE TABLE srcbucket_mapjoin_part_2_n7_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE;
+load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-08');
+load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-08');
+load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-09');
+load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-09');
+CREATE TABLE srcbucket_mapjoin_part_2_n7 (key int, value string, ds string) partitioned by spec (ds, bucket(2, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_mapjoin_part_2_n7 SELECT * FROM srcbucket_mapjoin_part_2_n7_tmp;
+
+set hive.convert.join.bucket.mapjoin.tez=true;
+create table bucketmapjoin_tmp_result_n3 (key string , value1 string, value2 string);
+
+explain
+insert overwrite table bucketmapjoin_tmp_result_n3
+select /*+mapjoin(b)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n5 a join srcbucket_mapjoin_part_2_n7 b
+on a.key=b.key;

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_7.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_7.q
@@ -1,0 +1,128 @@
+--! qt:dataset:src
+set hive.explain.user=true;
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+set hive.convert.join.bucket.mapjoin.tez=true;
+
+CREATE TABLE srcbucket_big(key1 string, key2 string, value string)
+PARTITIONED BY SPEC(bucket(4, key1), bucket(2, key2)) STORED BY ICEBERG;
+INSERT INTO srcbucket_big
+SELECT key AS key1, value AS key2, value FROM src;
+
+-- Using both key1 and key2
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20;
+
+-- Using both key1 and key2, with a predicate
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20;
+
+-- Using only key1
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+ORDER BY a.key1
+LIMIT 20;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+ORDER BY a.key1
+LIMIT 20;
+
+-- Using only key1, with a predicate with key1
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20;
+
+-- Using only key1, with a predicate with key2
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key2 NOT IN ('val_0', 'val_100')
+ORDER BY a.key1
+LIMIT 20;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key2 NOT IN ('val_0', 'val_100')
+ORDER BY a.key1
+LIMIT 20;
+
+-- Using only key2
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20;
+
+-- Using both key1, key2, and an additional column
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value AND a.value = b.value
+ORDER BY a.key1
+LIMIT 20;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value AND a.value = b.value
+ORDER BY a.key1
+LIMIT 20;
+
+-- Using only a non bucketing column
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.value = b.value
+ORDER BY a.key1
+LIMIT 20;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.value = b.value
+ORDER BY a.key1
+LIMIT 20;

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_8.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_8.q
@@ -1,0 +1,50 @@
+--! qt:dataset:src
+set hive.explain.user=true;
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+set hive.convert.join.bucket.mapjoin.tez=true;
+
+CREATE TABLE srcbucket_big(key int, value string, id int)
+PARTITIONED BY SPEC(bucket(4, key)) STORED BY ICEBERG;
+INSERT INTO srcbucket_big VALUES
+(101, 'val_101', 1),
+(null, 'val_102', 2),
+(103, 'val_103', 3),
+(104, null, 4),
+(105, 'val_105', 5),
+(null, null, 6);
+
+CREATE TABLE src_small(key int, value string);
+INSERT INTO src_small VALUES
+(101, 'val_101'),
+(null, 'val_102'),
+(103, 'val_103'),
+(104, null),
+(105, 'val_105'),
+(null, null);
+
+SELECT * FROM srcbucket_big ORDER BY id;
+
+-- Using the bucket column
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.key = b.key
+ORDER BY a.id;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.key = b.key
+ORDER BY a.id;
+
+-- Using a non-bucket column
+EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.value = b.value
+ORDER BY a.id;
+
+SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.value = b.value
+ORDER BY a.id;

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_1.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_1.q.out
@@ -1,0 +1,614 @@
+PREHOOK: query: create table target_table(date_col date, string_col string, decimal_col decimal(38,0)) partitioned by spec (bucket(7, decimal_col)) stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@target_table
+POSTHOOK: query: create table target_table(date_col date, string_col string, decimal_col decimal(38,0)) partitioned by spec (bucket(7, decimal_col)) stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@target_table
+PREHOOK: query: insert into table target_table values
+('2017-05-17', 'pipeline', '50000000000000000000441610525'),
+('2018-12-20', 'pipeline', '50000000000000000001048981030'),
+('2020-06-30', 'pipeline', '50000000000000000002332575516'),
+('2021-08-16', 'pipeline', '50000000000000000003897973989'),
+('2017-06-06', 'pipeline', '50000000000000000000449148729'),
+('2017-09-08', 'pipeline', '50000000000000000000525378314'),
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2018-05-03', 'pipeline', '50000000000000000000750826355'),
+('2020-01-10', 'pipeline', '50000000000000000001816579677'),
+('2021-11-01', 'pipeline', '50000000000000000004269423714'),
+('2017-11-07', 'pipeline', '50000000000000000000585901787'),
+('2019-10-15', 'pipeline', '50000000000000000001598843430'),
+('2020-04-01', 'pipeline', '50000000000000000002035795461'),
+('2020-02-24', 'pipeline', '50000000000000000001932600185'),
+('2020-04-27', 'pipeline', '50000000000000000002108160849'),
+('2016-07-05', 'pipeline', '50000000000000000000054405114'),
+('2020-06-02', 'pipeline', '50000000000000000002234387967'),
+('2020-08-21', 'pipeline', '50000000000000000002529168758'),
+('2021-02-17', 'pipeline', '50000000000000000003158511687')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@target_table
+POSTHOOK: query: insert into table target_table values
+('2017-05-17', 'pipeline', '50000000000000000000441610525'),
+('2018-12-20', 'pipeline', '50000000000000000001048981030'),
+('2020-06-30', 'pipeline', '50000000000000000002332575516'),
+('2021-08-16', 'pipeline', '50000000000000000003897973989'),
+('2017-06-06', 'pipeline', '50000000000000000000449148729'),
+('2017-09-08', 'pipeline', '50000000000000000000525378314'),
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2018-05-03', 'pipeline', '50000000000000000000750826355'),
+('2020-01-10', 'pipeline', '50000000000000000001816579677'),
+('2021-11-01', 'pipeline', '50000000000000000004269423714'),
+('2017-11-07', 'pipeline', '50000000000000000000585901787'),
+('2019-10-15', 'pipeline', '50000000000000000001598843430'),
+('2020-04-01', 'pipeline', '50000000000000000002035795461'),
+('2020-02-24', 'pipeline', '50000000000000000001932600185'),
+('2020-04-27', 'pipeline', '50000000000000000002108160849'),
+('2016-07-05', 'pipeline', '50000000000000000000054405114'),
+('2020-06-02', 'pipeline', '50000000000000000002234387967'),
+('2020-08-21', 'pipeline', '50000000000000000002529168758'),
+('2021-02-17', 'pipeline', '50000000000000000003158511687')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@target_table
+PREHOOK: query: create table source_table(date_col date, string_col string, decimal_col decimal(38,0)) partitioned by spec (bucket(7, decimal_col)) stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source_table
+POSTHOOK: query: create table source_table(date_col date, string_col string, decimal_col decimal(38,0)) partitioned by spec (bucket(7, decimal_col)) stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source_table
+PREHOOK: query: insert into table source_table values
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2022-09-01', 'pipeline', '50000000000000000006008686831'),
+('2022-08-30', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992621067'),
+('2022-08-30', 'pipeline', '50000000000000000005992621067')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source_table
+POSTHOOK: query: insert into table source_table values
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2022-09-01', 'pipeline', '50000000000000000006008686831'),
+('2022-08-30', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992621067'),
+('2022-08-30', 'pipeline', '50000000000000000005992621067')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source_table
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 2 (BROADCAST_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 llap
+      File Output Operator [FS_10]
+        Select Operator [SEL_9] (rows=30 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_45] (rows=30 width=336)
+            Conds:SEL_2._col0, _col1=RS_7._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Map 2 [BROADCAST_EDGE] llap
+            BROADCAST [RS_7]
+              PartitionCols:_col0, _col1
+              Select Operator [SEL_5] (rows=3 width=168)
+                Output:["_col0","_col1"]
+                Filter Operator [FIL_14] (rows=3 width=168)
+                  predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                  TableScan [TS_3] (rows=7 width=168)
+                    default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_2] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_13] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Reducer 3 (BROADCAST_EDGE)
+Reducer 3 <- Map 2 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 llap
+      File Output Operator [FS_14]
+        Select Operator [SEL_13] (rows=10 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_49] (rows=10 width=336)
+            Conds:SEL_2._col0, _col1=RS_11._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Reducer 3 [BROADCAST_EDGE] llap
+            BROADCAST [RS_11]
+              PartitionCols:_col0, _col1
+              Group By Operator [GBY_8] (rows=1 width=168)
+                Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+              <-Map 2 [SIMPLE_EDGE] llap
+                SHUFFLE [RS_7]
+                  PartitionCols:_col0, _col1
+                  Group By Operator [GBY_6] (rows=1 width=168)
+                    Output:["_col0","_col1"],keys:date_col, decimal_col
+                    Filter Operator [FIL_18] (rows=3 width=168)
+                      predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                      TableScan [TS_3] (rows=7 width=168)
+                        default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_2] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_17] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 2 (BROADCAST_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 llap
+      File Output Operator [FS_10]
+        Select Operator [SEL_9] (rows=30 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_45] (rows=30 width=336)
+            Conds:SEL_2._col0, _col1=RS_7._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Map 2 [BROADCAST_EDGE] llap
+            BROADCAST [RS_7]
+              PartitionCols:_col0, _col1
+              Select Operator [SEL_5] (rows=3 width=168)
+                Output:["_col0","_col1"]
+                Filter Operator [FIL_14] (rows=3 width=168)
+                  predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                  TableScan [TS_3] (rows=7 width=168)
+                    default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_2] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_13] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Reducer 3 (BROADCAST_EDGE)
+Reducer 3 <- Map 2 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 llap
+      File Output Operator [FS_14]
+        Select Operator [SEL_13] (rows=10 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_49] (rows=10 width=336)
+            Conds:SEL_2._col0, _col1=RS_11._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Reducer 3 [BROADCAST_EDGE] llap
+            BROADCAST [RS_11]
+              PartitionCols:_col0, _col1
+              Group By Operator [GBY_8] (rows=1 width=168)
+                Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+              <-Map 2 [SIMPLE_EDGE] llap
+                SHUFFLE [RS_7]
+                  PartitionCols:_col0, _col1
+                  Group By Operator [GBY_6] (rows=1 width=168)
+                    Output:["_col0","_col1"],keys:date_col, decimal_col
+                    Filter Operator [FIL_18] (rows=3 width=168)
+                      predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                      TableScan [TS_3] (rows=7 width=168)
+                        default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_2] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_17] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 2 (BROADCAST_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 vectorized, llap
+      File Output Operator [FS_54]
+        Select Operator [SEL_53] (rows=30 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_52] (rows=30 width=336)
+            Conds:SEL_51._col0, _col1=RS_49._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Map 2 [BROADCAST_EDGE] vectorized, llap
+            BROADCAST [RS_49]
+              PartitionCols:_col0, _col1
+              Select Operator [SEL_48] (rows=3 width=168)
+                Output:["_col0","_col1"]
+                Filter Operator [FIL_47] (rows=3 width=168)
+                  predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                  TableScan [TS_3] (rows=7 width=168)
+                    default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_51] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_50] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Reducer 3 (BROADCAST_EDGE)
+Reducer 3 <- Map 2 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 vectorized, llap
+      File Output Operator [FS_60]
+        Select Operator [SEL_59] (rows=10 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_58] (rows=10 width=336)
+            Conds:SEL_57._col0, _col1=RS_55._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Reducer 3 [BROADCAST_EDGE] vectorized, llap
+            BROADCAST [RS_55]
+              PartitionCols:_col0, _col1
+              Group By Operator [GBY_54] (rows=1 width=168)
+                Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+              <-Map 2 [SIMPLE_EDGE] vectorized, llap
+                SHUFFLE [RS_53]
+                  PartitionCols:_col0, _col1
+                  Group By Operator [GBY_52] (rows=1 width=168)
+                    Output:["_col0","_col1"],keys:date_col, decimal_col
+                    Filter Operator [FIL_51] (rows=3 width=168)
+                      predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                      TableScan [TS_3] (rows=7 width=168)
+                        default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_57] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_56] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 2 (BROADCAST_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 vectorized, llap
+      File Output Operator [FS_54]
+        Select Operator [SEL_53] (rows=30 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_52] (rows=30 width=336)
+            Conds:SEL_51._col0, _col1=RS_49._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Map 2 [BROADCAST_EDGE] vectorized, llap
+            BROADCAST [RS_49]
+              PartitionCols:_col0, _col1
+              Select Operator [SEL_48] (rows=3 width=168)
+                Output:["_col0","_col1"]
+                Filter Operator [FIL_47] (rows=3 width=168)
+                  predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                  TableScan [TS_3] (rows=7 width=168)
+                    default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_51] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_50] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Reducer 3 (BROADCAST_EDGE)
+Reducer 3 <- Map 2 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 vectorized, llap
+      File Output Operator [FS_60]
+        Select Operator [SEL_59] (rows=10 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_58] (rows=10 width=336)
+            Conds:SEL_57._col0, _col1=RS_55._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Reducer 3 [BROADCAST_EDGE] vectorized, llap
+            BROADCAST [RS_55]
+              PartitionCols:_col0, _col1
+              Group By Operator [GBY_54] (rows=1 width=168)
+                Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+              <-Map 2 [SIMPLE_EDGE] vectorized, llap
+                SHUFFLE [RS_53]
+                  PartitionCols:_col0, _col1
+                  Group By Operator [GBY_52] (rows=1 width=168)
+                    Output:["_col0","_col1"],keys:date_col, decimal_col
+                    Filter Operator [FIL_51] (rows=3 width=168)
+                      predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                      TableScan [TS_3] (rows=7 width=168)
+                        default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_57] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_56] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_1.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_1.q.out
@@ -103,6 +103,138 @@ POSTHOOK: Input: default@target_table
 Plan optimized by CBO.
 
 Vertex dependency in root stage
+Map 1 <- Map 2 (CUSTOM_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 llap
+      File Output Operator [FS_10]
+        Select Operator [SEL_9] (rows=30 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_45] (rows=30 width=336)
+            BucketMapJoin:true,Conds:SEL_2._col0, _col1=RS_7._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Map 2 [CUSTOM_EDGE] llap
+            MULTICAST [RS_7]
+              PartitionCols:_col1
+              Select Operator [SEL_5] (rows=3 width=168)
+                Output:["_col0","_col1"]
+                Filter Operator [FIL_14] (rows=3 width=168)
+                  predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                  TableScan [TS_3] (rows=7 width=168)
+                    default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_2] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_13] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:7,Grouping Partition Columns:["decimal_col"],Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Reducer 3 (CUSTOM_EDGE)
+Reducer 3 <- Map 2 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Map 1 llap
+      File Output Operator [FS_14]
+        Select Operator [SEL_13] (rows=10 width=520)
+          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
+          Map Join Operator [MAPJOIN_49] (rows=10 width=336)
+            BucketMapJoin:true,Conds:SEL_2._col0, _col1=RS_11._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Reducer 3 [CUSTOM_EDGE] llap
+            MULTICAST [RS_11]
+              PartitionCols:_col1
+              Group By Operator [GBY_8] (rows=1 width=168)
+                Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+              <-Map 2 [SIMPLE_EDGE] llap
+                SHUFFLE [RS_7]
+                  PartitionCols:_col0, _col1
+                  Group By Operator [GBY_6] (rows=1 width=168)
+                    Output:["_col0","_col1"],keys:date_col, decimal_col
+                    Filter Operator [FIL_18] (rows=3 width=168)
+                      predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                      TableScan [TS_3] (rows=7 width=168)
+                        default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
+          <-Select Operator [SEL_2] (rows=10 width=168)
+              Output:["_col0","_col1"]
+              Filter Operator [FIL_17] (rows=10 width=260)
+                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
+                TableScan [TS_0] (rows=20 width=260)
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:7,Grouping Partition Columns:["decimal_col"],Output:["date_col","string_col","decimal_col"]
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
 Map 1 <- Map 2 (BROADCAST_EDGE)
 
 Stage-0
@@ -235,139 +367,7 @@ POSTHOOK: Input: default@target_table
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 2 (BROADCAST_EDGE)
-
-Stage-0
-  Fetch Operator
-    limit:-1
-    Stage-1
-      Map 1 llap
-      File Output Operator [FS_10]
-        Select Operator [SEL_9] (rows=30 width=520)
-          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-          Map Join Operator [MAPJOIN_45] (rows=30 width=336)
-            Conds:SEL_2._col0, _col1=RS_7._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
-          <-Map 2 [BROADCAST_EDGE] llap
-            BROADCAST [RS_7]
-              PartitionCols:_col0, _col1
-              Select Operator [SEL_5] (rows=3 width=168)
-                Output:["_col0","_col1"]
-                Filter Operator [FIL_14] (rows=3 width=168)
-                  predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
-                  TableScan [TS_3] (rows=7 width=168)
-                    default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
-          <-Select Operator [SEL_2] (rows=10 width=168)
-              Output:["_col0","_col1"]
-              Filter Operator [FIL_13] (rows=10 width=260)
-                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
-                TableScan [TS_0] (rows=20 width=260)
-                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
-
-PREHOOK: query: select * from target_table inner join
-(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
-on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source_table
-PREHOOK: Input: default@target_table
-#### A masked pattern was here ####
-POSTHOOK: query: select * from target_table inner join
-(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
-on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source_table
-POSTHOOK: Input: default@target_table
-#### A masked pattern was here ####
-2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
-select * from target_table inner join
-(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
-on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source_table
-PREHOOK: Input: default@target_table
-#### A masked pattern was here ####
-POSTHOOK: query: explain
-select * from target_table inner join
-(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
-on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source_table
-POSTHOOK: Input: default@target_table
-#### A masked pattern was here ####
-Plan optimized by CBO.
-
-Vertex dependency in root stage
-Map 1 <- Reducer 3 (BROADCAST_EDGE)
-Reducer 3 <- Map 2 (SIMPLE_EDGE)
-
-Stage-0
-  Fetch Operator
-    limit:-1
-    Stage-1
-      Map 1 llap
-      File Output Operator [FS_14]
-        Select Operator [SEL_13] (rows=10 width=520)
-          Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-          Map Join Operator [MAPJOIN_49] (rows=10 width=336)
-            Conds:SEL_2._col0, _col1=RS_11._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
-          <-Reducer 3 [BROADCAST_EDGE] llap
-            BROADCAST [RS_11]
-              PartitionCols:_col0, _col1
-              Group By Operator [GBY_8] (rows=1 width=168)
-                Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-              <-Map 2 [SIMPLE_EDGE] llap
-                SHUFFLE [RS_7]
-                  PartitionCols:_col0, _col1
-                  Group By Operator [GBY_6] (rows=1 width=168)
-                    Output:["_col0","_col1"],keys:date_col, decimal_col
-                    Filter Operator [FIL_18] (rows=3 width=168)
-                      predicate:(if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
-                      TableScan [TS_3] (rows=7 width=168)
-                        default@source_table,source_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","decimal_col"]
-          <-Select Operator [SEL_2] (rows=10 width=168)
-              Output:["_col0","_col1"]
-              Filter Operator [FIL_17] (rows=10 width=260)
-                predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
-                TableScan [TS_0] (rows=20 width=260)
-                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
-
-PREHOOK: query: select * from target_table inner join
-(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
-on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source_table
-PREHOOK: Input: default@target_table
-#### A masked pattern was here ####
-POSTHOOK: query: select * from target_table inner join
-(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
-on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source_table
-POSTHOOK: Input: default@target_table
-#### A masked pattern was here ####
-2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
-select * from target_table inner join
-(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
-on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source_table
-PREHOOK: Input: default@target_table
-#### A masked pattern was here ####
-POSTHOOK: query: explain
-select * from target_table inner join
-(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
-on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source_table
-POSTHOOK: Input: default@target_table
-#### A masked pattern was here ####
-Plan optimized by CBO.
-
-Vertex dependency in root stage
-Map 1 <- Map 2 (BROADCAST_EDGE)
+Map 1 <- Map 2 (CUSTOM_EDGE)
 
 Stage-0
   Fetch Operator
@@ -378,10 +378,10 @@ Stage-0
         Select Operator [SEL_53] (rows=30 width=520)
           Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
           Map Join Operator [MAPJOIN_52] (rows=30 width=336)
-            Conds:SEL_51._col0, _col1=RS_49._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
-          <-Map 2 [BROADCAST_EDGE] vectorized, llap
-            BROADCAST [RS_49]
-              PartitionCols:_col0, _col1
+            BucketMapJoin:true,Conds:SEL_51._col0, _col1=RS_49._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Map 2 [CUSTOM_EDGE] vectorized, llap
+            MULTICAST [RS_49]
+              PartitionCols:_col1
               Select Operator [SEL_48] (rows=3 width=168)
                 Output:["_col0","_col1"]
                 Filter Operator [FIL_47] (rows=3 width=168)
@@ -393,7 +393,7 @@ Stage-0
               Filter Operator [FIL_50] (rows=10 width=260)
                 predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
                 TableScan [TS_0] (rows=20 width=260)
-                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:7,Grouping Partition Columns:["decimal_col"],Output:["date_col","string_col","decimal_col"]
 
 PREHOOK: query: select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
@@ -430,7 +430,7 @@ POSTHOOK: Input: default@target_table
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Reducer 3 (BROADCAST_EDGE)
+Map 1 <- Reducer 3 (CUSTOM_EDGE)
 Reducer 3 <- Map 2 (SIMPLE_EDGE)
 
 Stage-0
@@ -442,10 +442,10 @@ Stage-0
         Select Operator [SEL_59] (rows=10 width=520)
           Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
           Map Join Operator [MAPJOIN_58] (rows=10 width=336)
-            Conds:SEL_57._col0, _col1=RS_55._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
-          <-Reducer 3 [BROADCAST_EDGE] vectorized, llap
-            BROADCAST [RS_55]
-              PartitionCols:_col0, _col1
+            BucketMapJoin:true,Conds:SEL_57._col0, _col1=RS_55._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3"]
+          <-Reducer 3 [CUSTOM_EDGE] vectorized, llap
+            MULTICAST [RS_55]
+              PartitionCols:_col1
               Group By Operator [GBY_54] (rows=1 width=168)
                 Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
               <-Map 2 [SIMPLE_EDGE] vectorized, llap
@@ -462,7 +462,7 @@ Stage-0
               Filter Operator [FIL_56] (rows=10 width=260)
                 predicate:((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null)
                 TableScan [TS_0] (rows=20 width=260)
-                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Output:["date_col","string_col","decimal_col"]
+                  default@target_table,target_table,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:7,Grouping Partition Columns:["decimal_col"],Output:["date_col","string_col","decimal_col"]
 
 PREHOOK: query: select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_2.q.out
@@ -1,0 +1,548 @@
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_n0_tmp(key int, value string) STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_n0_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_n0_tmp(key int, value string) STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_n0_tmp
+PREHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_n0_tmp
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_n0_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_n0_tmp
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_n0_tmp
+PREHOOK: query: load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_n0_tmp
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_n0_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_n0_tmp
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_n0_tmp
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_n0(key int, value string) PARTITIONED BY SPEC (bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_n0
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_n0(key int, value string) PARTITIONED BY SPEC (bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_n0
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_n0 SELECT * FROM srcbucket_mapjoin_n0_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n0_tmp
+PREHOOK: Output: default@srcbucket_mapjoin_n0
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_n0 SELECT * FROM srcbucket_mapjoin_n0_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n0_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_n0
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_n0_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_n0_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp
+PREHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+PREHOOK: query: load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+PREHOOK: query: load data local inpath '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+PREHOOK: query: load data local inpath '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-08')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+PREHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+PREHOOK: query: load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+PREHOOK: query: load data local inpath '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+PREHOOK: query: load data local inpath '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_n0_tmp partition(ds='2008-04-09')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_n0 (key int, value string, ds string) partitioned by spec (ds, bucket(4, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_n0 (key int, value string, ds string) partitioned by spec (ds, bucket(4, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_n0 SELECT * FROM srcbucket_mapjoin_part_n0_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_n0_tmp
+PREHOOK: Input: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+PREHOOK: Input: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+PREHOOK: Output: default@srcbucket_mapjoin_part_n0
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_n0 SELECT * FROM srcbucket_mapjoin_part_n0_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_n0_tmp
+POSTHOOK: Input: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-08
+POSTHOOK: Input: default@srcbucket_mapjoin_part_n0_tmp@ds=2008-04-09
+POSTHOOK: Output: default@srcbucket_mapjoin_part_n0
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_tmp
+PREHOOK: query: load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-08')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-08')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-08
+PREHOOK: query: load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-08')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-08
+POSTHOOK: query: load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-08')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-08
+PREHOOK: query: load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-09')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-09')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-09
+PREHOOK: query: load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-09')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-09
+POSTHOOK: query: load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_tmp partition(ds='2008-04-09')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-09
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2 (key int, value string, ds string) partitioned by spec (ds, bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2 (key int, value string, ds string) partitioned by spec (ds, bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_2 SELECT * FROM srcbucket_mapjoin_part_2_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_tmp
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-08
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-09
+PREHOOK: Output: default@srcbucket_mapjoin_part_2
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_2 SELECT * FROM srcbucket_mapjoin_part_2_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_tmp
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-08
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_tmp@ds=2008-04-09
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2
+PREHOOK: query: create table bucketmapjoin_hash_result_1 (key bigint , value1 bigint, value2 bigint)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@bucketmapjoin_hash_result_1
+POSTHOOK: query: create table bucketmapjoin_hash_result_1 (key bigint , value1 bigint, value2 bigint)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@bucketmapjoin_hash_result_1
+PREHOOK: query: create table bucketmapjoin_hash_result_2 (key bigint , value1 bigint, value2 bigint)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@bucketmapjoin_hash_result_2
+POSTHOOK: query: create table bucketmapjoin_hash_result_2 (key bigint , value1 bigint, value2 bigint)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@bucketmapjoin_hash_result_2
+PREHOOK: query: create table bucketmapjoin_tmp_result (key string , value1 string, value2 string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: query: create table bucketmapjoin_tmp_result (key string , value1 string, value2 string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@bucketmapjoin_tmp_result
+PREHOOK: query: explain
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n0
+PREHOOK: Input: default@srcbucket_mapjoin_part_n0
+PREHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: query: explain
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n0
+POSTHOOK: Input: default@srcbucket_mapjoin_part_n0
+POSTHOOK: Output: default@bucketmapjoin_tmp_result
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 2 <- Map 1 (BROADCAST_EDGE)
+Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE)
+
+Stage-3
+  Stats Work{}
+    Stage-0
+      Move Operator
+        table:{"name:":"default.bucketmapjoin_tmp_result"}
+        Stage-2
+          Dependency Collection{}
+            Stage-1
+              Reducer 3 vectorized, llap
+              File Output Operator [FS_48]
+                Select Operator [SEL_47] (rows=1 width=798)
+                  Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17"]
+                  Group By Operator [GBY_46] (rows=1 width=500)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(VALUE._col0)","avg(VALUE._col1)","count(VALUE._col2)","count(VALUE._col3)","compute_bit_vector_hll(VALUE._col4)","max(VALUE._col5)","avg(VALUE._col6)","count(VALUE._col7)","compute_bit_vector_hll(VALUE._col8)","max(VALUE._col9)","avg(VALUE._col10)","count(VALUE._col11)","compute_bit_vector_hll(VALUE._col12)"]
+                  <-Map 2 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+                    File Output Operator [FS_42]
+                      table:{"name:":"default.bucketmapjoin_tmp_result"}
+                      Select Operator [SEL_41] (rows=785 width=366)
+                        Output:["_col0","_col1","_col2"]
+                        Map Join Operator [MAPJOIN_40] (rows=785 width=186)
+                          Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
+                        <-Map 1 [BROADCAST_EDGE] vectorized, llap
+                          BROADCAST [RS_37]
+                            PartitionCols:_col0
+                            Select Operator [SEL_36] (rows=238 width=95)
+                              Output:["_col0","_col1"]
+                              Filter Operator [FIL_35] (rows=238 width=95)
+                                predicate:key is not null
+                                TableScan [TS_0] (rows=238 width=95)
+                                  default@srcbucket_mapjoin_n0,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                        <-Select Operator [SEL_39] (rows=1000 width=95)
+                            Output:["_col0","_col1"]
+                            Filter Operator [FIL_38] (rows=1000 width=95)
+                              predicate:key is not null
+                              TableScan [TS_3] (rows=1000 width=95)
+                                default@srcbucket_mapjoin_part_n0,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                    PARTITION_ONLY_SHUFFLE [RS_45]
+                      Group By Operator [GBY_44] (rows=1 width=704)
+                        Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(length(key))","avg(COALESCE(length(key),0))","count(1)","count(key)","compute_bit_vector_hll(key)","max(length(value1))","avg(COALESCE(length(value1),0))","count(value1)","compute_bit_vector_hll(value1)","max(length(value2))","avg(COALESCE(length(value2),0))","count(value2)","compute_bit_vector_hll(value2)"]
+                        Select Operator [SEL_43] (rows=785 width=366)
+                          Output:["key","value1","value2"]
+                           Please refer to the previous Select Operator [SEL_41]
+
+PREHOOK: query: insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n0
+PREHOOK: Input: default@srcbucket_mapjoin_part_n0
+PREHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: query: insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n0
+POSTHOOK: Input: default@srcbucket_mapjoin_part_n0
+POSTHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.key EXPRESSION [(srcbucket_mapjoin_n0)a.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.value1 SIMPLE [(srcbucket_mapjoin_n0)a.FieldSchema(name:value, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.value2 SIMPLE [(srcbucket_mapjoin_part_n0)b.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: select count(1) from bucketmapjoin_tmp_result
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_tmp_result
+#### A masked pattern was here ####
+POSTHOOK: query: select count(1) from bucketmapjoin_tmp_result
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_tmp_result
+#### A masked pattern was here ####
+928
+PREHOOK: query: insert overwrite table bucketmapjoin_hash_result_1
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_tmp_result
+PREHOOK: Output: default@bucketmapjoin_hash_result_1
+POSTHOOK: query: insert overwrite table bucketmapjoin_hash_result_1
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_tmp_result
+POSTHOOK: Output: default@bucketmapjoin_hash_result_1
+POSTHOOK: Lineage: bucketmapjoin_hash_result_1.key EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:key, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_hash_result_1.value1 EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:value1, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_hash_result_1.value2 EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:value2, type:string, comment:null), ]
+PREHOOK: query: insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n0
+PREHOOK: Input: default@srcbucket_mapjoin_part_n0
+PREHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: query: insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_n0 b
+on a.key=b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n0
+POSTHOOK: Input: default@srcbucket_mapjoin_part_n0
+POSTHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.key EXPRESSION [(srcbucket_mapjoin_n0)a.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.value1 SIMPLE [(srcbucket_mapjoin_n0)a.FieldSchema(name:value, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.value2 SIMPLE [(srcbucket_mapjoin_part_n0)b.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: select count(1) from bucketmapjoin_tmp_result
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_tmp_result
+#### A masked pattern was here ####
+POSTHOOK: query: select count(1) from bucketmapjoin_tmp_result
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_tmp_result
+#### A masked pattern was here ####
+928
+PREHOOK: query: insert overwrite table bucketmapjoin_hash_result_2
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_tmp_result
+PREHOOK: Output: default@bucketmapjoin_hash_result_2
+POSTHOOK: query: insert overwrite table bucketmapjoin_hash_result_2
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_tmp_result
+POSTHOOK: Output: default@bucketmapjoin_hash_result_2
+POSTHOOK: Lineage: bucketmapjoin_hash_result_2.key EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:key, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_hash_result_2.value1 EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:value1, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_hash_result_2.value2 EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:value2, type:string, comment:null), ]
+PREHOOK: query: select a.key-b.key, a.value1-b.value1, a.value2-b.value2
+from bucketmapjoin_hash_result_1 a left outer join bucketmapjoin_hash_result_2 b
+on a.key = b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_hash_result_1
+PREHOOK: Input: default@bucketmapjoin_hash_result_2
+#### A masked pattern was here ####
+POSTHOOK: query: select a.key-b.key, a.value1-b.value1, a.value2-b.value2
+from bucketmapjoin_hash_result_1 a left outer join bucketmapjoin_hash_result_2 b
+on a.key = b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_hash_result_1
+POSTHOOK: Input: default@bucketmapjoin_hash_result_2
+#### A masked pattern was here ####
+0	0	0
+PREHOOK: query: explain
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n0
+PREHOOK: Input: default@srcbucket_mapjoin_part_2
+PREHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: query: explain
+insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n0
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2
+POSTHOOK: Output: default@bucketmapjoin_tmp_result
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 2 <- Map 1 (BROADCAST_EDGE)
+Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE)
+
+Stage-3
+  Stats Work{}
+    Stage-0
+      Move Operator
+        table:{"name:":"default.bucketmapjoin_tmp_result"}
+        Stage-2
+          Dependency Collection{}
+            Stage-1
+              Reducer 3 vectorized, llap
+              File Output Operator [FS_48]
+                Select Operator [SEL_47] (rows=1 width=798)
+                  Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17"]
+                  Group By Operator [GBY_46] (rows=1 width=500)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(VALUE._col0)","avg(VALUE._col1)","count(VALUE._col2)","count(VALUE._col3)","compute_bit_vector_hll(VALUE._col4)","max(VALUE._col5)","avg(VALUE._col6)","count(VALUE._col7)","compute_bit_vector_hll(VALUE._col8)","max(VALUE._col9)","avg(VALUE._col10)","count(VALUE._col11)","compute_bit_vector_hll(VALUE._col12)"]
+                  <-Map 2 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+                    File Output Operator [FS_42]
+                      table:{"name:":"default.bucketmapjoin_tmp_result"}
+                      Select Operator [SEL_41] (rows=809 width=366)
+                        Output:["_col0","_col1","_col2"]
+                        Map Join Operator [MAPJOIN_40] (rows=809 width=186)
+                          Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
+                        <-Map 1 [BROADCAST_EDGE] vectorized, llap
+                          BROADCAST [RS_37]
+                            PartitionCols:_col0
+                            Select Operator [SEL_36] (rows=238 width=95)
+                              Output:["_col0","_col1"]
+                              Filter Operator [FIL_35] (rows=238 width=95)
+                                predicate:key is not null
+                                TableScan [TS_0] (rows=238 width=95)
+                                  default@srcbucket_mapjoin_n0,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                        <-Select Operator [SEL_39] (rows=524 width=95)
+                            Output:["_col0","_col1"]
+                            Filter Operator [FIL_38] (rows=524 width=95)
+                              predicate:key is not null
+                              TableScan [TS_3] (rows=524 width=95)
+                                default@srcbucket_mapjoin_part_2,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                    PARTITION_ONLY_SHUFFLE [RS_45]
+                      Group By Operator [GBY_44] (rows=1 width=704)
+                        Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(length(key))","avg(COALESCE(length(key),0))","count(1)","count(key)","compute_bit_vector_hll(key)","max(length(value1))","avg(COALESCE(length(value1),0))","count(value1)","compute_bit_vector_hll(value1)","max(length(value2))","avg(COALESCE(length(value2),0))","count(value2)","compute_bit_vector_hll(value2)"]
+                        Select Operator [SEL_43] (rows=809 width=366)
+                          Output:["key","value1","value2"]
+                           Please refer to the previous Select Operator [SEL_41]
+
+PREHOOK: query: insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n0
+PREHOOK: Input: default@srcbucket_mapjoin_part_2
+PREHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: query: insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n0
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2
+POSTHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.key EXPRESSION [(srcbucket_mapjoin_n0)a.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.value1 SIMPLE [(srcbucket_mapjoin_n0)a.FieldSchema(name:value, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.value2 SIMPLE [(srcbucket_mapjoin_part_2)b.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: select count(1) from bucketmapjoin_tmp_result
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_tmp_result
+#### A masked pattern was here ####
+POSTHOOK: query: select count(1) from bucketmapjoin_tmp_result
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_tmp_result
+#### A masked pattern was here ####
+0
+PREHOOK: query: insert overwrite table bucketmapjoin_hash_result_1
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_tmp_result
+PREHOOK: Output: default@bucketmapjoin_hash_result_1
+POSTHOOK: query: insert overwrite table bucketmapjoin_hash_result_1
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_tmp_result
+POSTHOOK: Output: default@bucketmapjoin_hash_result_1
+POSTHOOK: Lineage: bucketmapjoin_hash_result_1.key EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:key, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_hash_result_1.value1 EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:value1, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_hash_result_1.value2 EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:value2, type:string, comment:null), ]
+PREHOOK: query: insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n0
+PREHOOK: Input: default@srcbucket_mapjoin_part_2
+PREHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: query: insert overwrite table bucketmapjoin_tmp_result
+select /*+mapjoin(a)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n0 a join srcbucket_mapjoin_part_2 b
+on a.key=b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n0
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2
+POSTHOOK: Output: default@bucketmapjoin_tmp_result
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.key EXPRESSION [(srcbucket_mapjoin_n0)a.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.value1 SIMPLE [(srcbucket_mapjoin_n0)a.FieldSchema(name:value, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_tmp_result.value2 SIMPLE [(srcbucket_mapjoin_part_2)b.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: select count(1) from bucketmapjoin_tmp_result
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_tmp_result
+#### A masked pattern was here ####
+POSTHOOK: query: select count(1) from bucketmapjoin_tmp_result
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_tmp_result
+#### A masked pattern was here ####
+0
+PREHOOK: query: insert overwrite table bucketmapjoin_hash_result_2
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_tmp_result
+PREHOOK: Output: default@bucketmapjoin_hash_result_2
+POSTHOOK: query: insert overwrite table bucketmapjoin_hash_result_2
+select sum(hash(key)), sum(hash(value1)), sum(hash(value2)) from bucketmapjoin_tmp_result
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_tmp_result
+POSTHOOK: Output: default@bucketmapjoin_hash_result_2
+POSTHOOK: Lineage: bucketmapjoin_hash_result_2.key EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:key, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_hash_result_2.value1 EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:value1, type:string, comment:null), ]
+POSTHOOK: Lineage: bucketmapjoin_hash_result_2.value2 EXPRESSION [(bucketmapjoin_tmp_result)bucketmapjoin_tmp_result.FieldSchema(name:value2, type:string, comment:null), ]
+PREHOOK: query: select a.key-b.key, a.value1-b.value1, a.value2-b.value2
+from bucketmapjoin_hash_result_1 a left outer join bucketmapjoin_hash_result_2 b
+on a.key = b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@bucketmapjoin_hash_result_1
+PREHOOK: Input: default@bucketmapjoin_hash_result_2
+#### A masked pattern was here ####
+POSTHOOK: query: select a.key-b.key, a.value1-b.value1, a.value2-b.value2
+from bucketmapjoin_hash_result_1 a left outer join bucketmapjoin_hash_result_2 b
+on a.key = b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@bucketmapjoin_hash_result_1
+POSTHOOK: Input: default@bucketmapjoin_hash_result_2
+#### A masked pattern was here ####
+NULL	NULL	NULL

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_2.q.out
@@ -239,7 +239,7 @@ POSTHOOK: Output: default@bucketmapjoin_tmp_result
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 2 <- Map 1 (BROADCAST_EDGE)
+Map 2 <- Map 1 (CUSTOM_EDGE)
 Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE)
 
 Stage-3
@@ -262,9 +262,9 @@ Stage-3
                       Select Operator [SEL_41] (rows=785 width=366)
                         Output:["_col0","_col1","_col2"]
                         Map Join Operator [MAPJOIN_40] (rows=785 width=186)
-                          Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
-                        <-Map 1 [BROADCAST_EDGE] vectorized, llap
-                          BROADCAST [RS_37]
+                          BucketMapJoin:true,Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
+                        <-Map 1 [CUSTOM_EDGE] vectorized, llap
+                          MULTICAST [RS_37]
                             PartitionCols:_col0
                             Select Operator [SEL_36] (rows=238 width=95)
                               Output:["_col0","_col1"]
@@ -277,7 +277,7 @@ Stage-3
                             Filter Operator [FIL_38] (rows=1000 width=95)
                               predicate:key is not null
                               TableScan [TS_3] (rows=1000 width=95)
-                                default@srcbucket_mapjoin_part_n0,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                                default@srcbucket_mapjoin_part_n0,b,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:4,Grouping Partition Columns:["key"],Output:["key","value"]
                     PARTITION_ONLY_SHUFFLE [RS_45]
                       Group By Operator [GBY_44] (rows=1 width=704)
                         Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(length(key))","avg(COALESCE(length(key),0))","count(1)","count(key)","compute_bit_vector_hll(key)","max(length(value1))","avg(COALESCE(length(value1),0))","count(value1)","compute_bit_vector_hll(value1)","max(length(value2))","avg(COALESCE(length(value2),0))","count(value2)","compute_bit_vector_hll(value2)"]
@@ -403,7 +403,7 @@ POSTHOOK: Output: default@bucketmapjoin_tmp_result
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 2 <- Map 1 (BROADCAST_EDGE)
+Map 2 <- Map 1 (CUSTOM_EDGE)
 Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE)
 
 Stage-3
@@ -426,9 +426,9 @@ Stage-3
                       Select Operator [SEL_41] (rows=809 width=366)
                         Output:["_col0","_col1","_col2"]
                         Map Join Operator [MAPJOIN_40] (rows=809 width=186)
-                          Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
-                        <-Map 1 [BROADCAST_EDGE] vectorized, llap
-                          BROADCAST [RS_37]
+                          BucketMapJoin:true,Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
+                        <-Map 1 [CUSTOM_EDGE] vectorized, llap
+                          MULTICAST [RS_37]
                             PartitionCols:_col0
                             Select Operator [SEL_36] (rows=238 width=95)
                               Output:["_col0","_col1"]
@@ -441,7 +441,7 @@ Stage-3
                             Filter Operator [FIL_38] (rows=524 width=95)
                               predicate:key is not null
                               TableScan [TS_3] (rows=524 width=95)
-                                default@srcbucket_mapjoin_part_2,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                                default@srcbucket_mapjoin_part_2,b,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:2,Grouping Partition Columns:["key"],Output:["key","value"]
                     PARTITION_ONLY_SHUFFLE [RS_45]
                       Group By Operator [GBY_44] (rows=1 width=704)
                         Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(length(key))","avg(COALESCE(length(key),0))","count(1)","count(key)","compute_bit_vector_hll(key)","max(length(value1))","avg(COALESCE(length(value1),0))","count(value1)","compute_bit_vector_hll(value1)","max(length(value2))","avg(COALESCE(length(value2),0))","count(value2)","compute_bit_vector_hll(value2)"]

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_3.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_3.q.out
@@ -1,0 +1,238 @@
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n1_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n1_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n1_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n1_tmp
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n1_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n1_tmp
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n1_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n1_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n1_tmp@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n1_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n1_tmp@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n1_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n1_tmp@part=1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n1 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n1
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n1 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n1
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_1_n1 SELECT * FROM srcbucket_mapjoin_part_1_n1_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n1_tmp
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n1_tmp@part=1
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n1
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_1_n1 SELECT * FROM srcbucket_mapjoin_part_1_n1_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n1_tmp
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n1_tmp@part=1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n4_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n4_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n4_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n4_tmp
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n4_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n4_tmp
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n4_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n4_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n4_tmp@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n4_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n4_tmp@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n4_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n4_tmp@part=1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n4 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n4
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n4 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n4
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n4 SELECT * FROM srcbucket_mapjoin_part_2_n4_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n4_tmp
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n4_tmp@part=1
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n4
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n4 SELECT * FROM srcbucket_mapjoin_part_2_n4_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4_tmp
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4_tmp@part=1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n4
+PREHOOK: query: ALTER TABLE srcbucket_mapjoin_part_2_n4 SET PARTITION SPEC (part, bucket(3, key))
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+POSTHOOK: query: ALTER TABLE srcbucket_mapjoin_part_2_n4 SET PARTITION SPEC (part, bucket(3, key))
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n4
+PREHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n1
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_40]
+        Group By Operator [GBY_39] (rows=1 width=8)
+          Output:["_col0"],aggregations:["count(VALUE._col0)"]
+        <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+          PARTITION_ONLY_SHUFFLE [RS_38]
+            Group By Operator [GBY_37] (rows=1 width=8)
+              Output:["_col0"],aggregations:["count()"]
+              Map Join Operator [MAPJOIN_36] (rows=372 width=8)
+                Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                BROADCAST [RS_33]
+                  PartitionCols:_col0
+                  Select Operator [SEL_32] (rows=238 width=4)
+                    Output:["_col0"]
+                    Filter Operator [FIL_31] (rows=238 width=89)
+                      predicate:((part = '1') and key is not null)
+                      TableScan [TS_3] (rows=238 width=89)
+                        default@srcbucket_mapjoin_part_2_n4,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+              <-Select Operator [SEL_35] (rows=238 width=4)
+                  Output:["_col0"]
+                  Filter Operator [FIL_34] (rows=238 width=89)
+                    predicate:((part = '1') and key is not null)
+                    TableScan [TS_0] (rows=238 width=89)
+                      default@srcbucket_mapjoin_part_1_n1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+
+PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n1
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+#### A masked pattern was here ####
+464
+PREHOOK: query: ALTER TABLE srcbucket_mapjoin_part_2_n4 SET PARTITION SPEC (part, bucket(2, value))
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+POSTHOOK: query: ALTER TABLE srcbucket_mapjoin_part_2_n4 SET PARTITION SPEC (part, bucket(2, value))
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n4
+PREHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n1
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_40]
+        Group By Operator [GBY_39] (rows=1 width=8)
+          Output:["_col0"],aggregations:["count(VALUE._col0)"]
+        <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+          PARTITION_ONLY_SHUFFLE [RS_38]
+            Group By Operator [GBY_37] (rows=1 width=8)
+              Output:["_col0"],aggregations:["count()"]
+              Map Join Operator [MAPJOIN_36] (rows=372 width=8)
+                Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                BROADCAST [RS_33]
+                  PartitionCols:_col0
+                  Select Operator [SEL_32] (rows=238 width=4)
+                    Output:["_col0"]
+                    Filter Operator [FIL_31] (rows=238 width=89)
+                      predicate:((part = '1') and key is not null)
+                      TableScan [TS_3] (rows=238 width=89)
+                        default@srcbucket_mapjoin_part_2_n4,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+              <-Select Operator [SEL_35] (rows=238 width=4)
+                  Output:["_col0"]
+                  Filter Operator [FIL_34] (rows=238 width=89)
+                    predicate:((part = '1') and key is not null)
+                    TableScan [TS_0] (rows=238 width=89)
+                      default@srcbucket_mapjoin_part_1_n1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+
+PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n1
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4
+#### A masked pattern was here ####
+464

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_3.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_3.q.out
@@ -114,7 +114,7 @@ POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
@@ -130,9 +130,9 @@ Stage-0
             Group By Operator [GBY_37] (rows=1 width=8)
               Output:["_col0"],aggregations:["count()"]
               Map Join Operator [MAPJOIN_36] (rows=372 width=8)
-                Conds:SEL_35._col0=RS_33._col0(Inner)
-              <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                BROADCAST [RS_33]
+                BucketMapJoin:true,Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                MULTICAST [RS_33]
                   PartitionCols:_col0
                   Select Operator [SEL_32] (rows=238 width=4)
                     Output:["_col0"]
@@ -145,7 +145,7 @@ Stage-0
                   Filter Operator [FIL_34] (rows=238 width=89)
                     predicate:((part = '1') and key is not null)
                     TableScan [TS_0] (rows=238 width=89)
-                      default@srcbucket_mapjoin_part_1_n1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+                      default@srcbucket_mapjoin_part_1_n1,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:2,Grouping Partition Columns:["key"],Output:["key","part"]
 
 PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
 FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b
@@ -188,7 +188,7 @@ POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n4
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
@@ -204,9 +204,9 @@ Stage-0
             Group By Operator [GBY_37] (rows=1 width=8)
               Output:["_col0"],aggregations:["count()"]
               Map Join Operator [MAPJOIN_36] (rows=372 width=8)
-                Conds:SEL_35._col0=RS_33._col0(Inner)
-              <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                BROADCAST [RS_33]
+                BucketMapJoin:true,Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                MULTICAST [RS_33]
                   PartitionCols:_col0
                   Select Operator [SEL_32] (rows=238 width=4)
                     Output:["_col0"]
@@ -219,7 +219,7 @@ Stage-0
                   Filter Operator [FIL_34] (rows=238 width=89)
                     predicate:((part = '1') and key is not null)
                     TableScan [TS_0] (rows=238 width=89)
-                      default@srcbucket_mapjoin_part_1_n1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+                      default@srcbucket_mapjoin_part_1_n1,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:2,Grouping Partition Columns:["key"],Output:["key","part"]
 
 PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
 FROM srcbucket_mapjoin_part_1_n1 a JOIN srcbucket_mapjoin_part_2_n4 b

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_4.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_4.q.out
@@ -1,0 +1,350 @@
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n2_tmp1 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp1
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n2_tmp1 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp1 PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp1 PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp1@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp1 PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp1@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp1 PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp1@part=1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n2 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n2 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_1_n2 SELECT * FROM srcbucket_mapjoin_part_1_n2_tmp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2_tmp1
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2_tmp1@part=1
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_1_n2 SELECT * FROM srcbucket_mapjoin_part_1_n2_tmp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2_tmp1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2_tmp1@part=1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2
+PREHOOK: query: ALTER TABLE srcbucket_mapjoin_part_1_n2 SET PARTITION SPEC (part, bucket(4, key))
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: query: ALTER TABLE srcbucket_mapjoin_part_1_n2 SET PARTITION SPEC (part, bucket(4, key))
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n2_tmp2 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_n2_tmp2 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_1_n2_tmp2 PARTITION (part='2')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_1_n2 SELECT * FROM srcbucket_mapjoin_part_1_n2_tmp2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2_tmp2
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_1_n2 SELECT * FROM srcbucket_mapjoin_part_1_n2_tmp2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2_tmp2
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2_tmp2@part=2
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_n2
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n6_tmp1 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n6_tmp1 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000002_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000003_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp1 PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n6 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(4, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n6 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(4, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n6 SELECT * FROM srcbucket_mapjoin_part_2_n6_tmp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6_tmp1
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n6 SELECT * FROM srcbucket_mapjoin_part_2_n6_tmp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6_tmp1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6_tmp1@part=1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6
+PREHOOK: query: ALTER TABLE srcbucket_mapjoin_part_2_n6 SET PARTITION SPEC (part, bucket(2, key))
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+POSTHOOK: query: ALTER TABLE srcbucket_mapjoin_part_2_n6 SET PARTITION SPEC (part, bucket(2, key))
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n6_tmp2 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp2
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n6_tmp2 (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp2
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp2 PARTITION (part='2')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp2
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp2 PARTITION (part='2')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp2
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp2@part=2
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp2 PARTITION (part='2')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp2@part=2
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n6_tmp2 PARTITION (part='2')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6_tmp2@part=2
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n6 SELECT * FROM srcbucket_mapjoin_part_2_n6_tmp2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6_tmp2
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6_tmp2@part=2
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n6
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n6 SELECT * FROM srcbucket_mapjoin_part_2_n6_tmp2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6_tmp2
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6_tmp2@part=2
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n6
+PREHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part IS NOT NULL AND b.part IS NOT NULL
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part IS NOT NULL AND b.part IS NOT NULL
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_40]
+        Group By Operator [GBY_39] (rows=1 width=8)
+          Output:["_col0"],aggregations:["count(VALUE._col0)"]
+        <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+          PARTITION_ONLY_SHUFFLE [RS_38]
+            Group By Operator [GBY_37] (rows=1 width=8)
+              Output:["_col0"],aggregations:["count()"]
+              Map Join Operator [MAPJOIN_36] (rows=1797 width=8)
+                Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                BROADCAST [RS_33]
+                  PartitionCols:_col0
+                  Select Operator [SEL_32] (rows=738 width=4)
+                    Output:["_col0"]
+                    Filter Operator [FIL_31] (rows=738 width=89)
+                      predicate:(part is not null and key is not null)
+                      TableScan [TS_3] (rows=738 width=89)
+                        default@srcbucket_mapjoin_part_2_n6,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+              <-Select Operator [SEL_35] (rows=738 width=4)
+                  Output:["_col0"]
+                  Filter Operator [FIL_34] (rows=738 width=89)
+                    predicate:(part is not null and key is not null)
+                    TableScan [TS_0] (rows=738 width=89)
+                      default@srcbucket_mapjoin_part_1_n2,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+
+PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part IS NOT NULL AND b.part IS NOT NULL
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part IS NOT NULL AND b.part IS NOT NULL
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+#### A masked pattern was here ####
+2420
+PREHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part = b.part AND a.part IS NOT NULL AND b.part IS NOT NULL
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part = b.part AND a.part IS NOT NULL AND b.part IS NOT NULL
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_49]
+        Group By Operator [GBY_48] (rows=1 width=8)
+          Output:["_col0"],aggregations:["count(VALUE._col0)"]
+        <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+          PARTITION_ONLY_SHUFFLE [RS_47]
+            Group By Operator [GBY_46] (rows=1 width=8)
+              Output:["_col0"],aggregations:["count()"]
+              Map Join Operator [MAPJOIN_45] (rows=1797 width=8)
+                Conds:SEL_44._col0, _col1=RS_39._col0, _col1(Inner)
+              <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                BROADCAST [RS_39]
+                  PartitionCols:_col0, _col1
+                  Select Operator [SEL_38] (rows=738 width=89)
+                    Output:["_col0","_col1"]
+                    Filter Operator [FIL_37] (rows=738 width=89)
+                      predicate:(part is not null and key is not null)
+                      TableScan [TS_3] (rows=738 width=89)
+                        default@srcbucket_mapjoin_part_2_n6,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+                Dynamic Partitioning Event Operator [EVENT_42] (rows=2 width=85)
+                  Group By Operator [GBY_41] (rows=2 width=85)
+                    Output:["_col0"],keys:_col0
+                    Select Operator [SEL_40] (rows=738 width=85)
+                      Output:["_col0"]
+                       Please refer to the previous Select Operator [SEL_38]
+              <-Select Operator [SEL_44] (rows=738 width=89)
+                  Output:["_col0","_col1"]
+                  Filter Operator [FIL_43] (rows=738 width=89)
+                    predicate:(part is not null and key is not null)
+                    TableScan [TS_0] (rows=738 width=89)
+                      default@srcbucket_mapjoin_part_1_n2,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+
+PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part = b.part AND a.part IS NOT NULL AND b.part IS NOT NULL
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1_n2 a JOIN srcbucket_mapjoin_part_2_n6 b
+ON a.key = b.key AND a.part = b.part AND a.part IS NOT NULL AND b.part IS NOT NULL
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_n2
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n6
+#### A masked pattern was here ####
+928

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_5.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_5.q.out
@@ -166,7 +166,7 @@ POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n0
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
@@ -182,9 +182,9 @@ Stage-0
             Group By Operator [GBY_37] (rows=1 width=8)
               Output:["_col0"],aggregations:["count()"]
               Map Join Operator [MAPJOIN_36] (rows=372 width=8)
-                Conds:SEL_35._col0=RS_33._col0(Inner)
-              <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                BROADCAST [RS_33]
+                BucketMapJoin:true,Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                MULTICAST [RS_33]
                   PartitionCols:_col0
                   Select Operator [SEL_32] (rows=238 width=4)
                     Output:["_col0"]
@@ -197,7 +197,7 @@ Stage-0
                   Filter Operator [FIL_34] (rows=238 width=89)
                     predicate:((part = '1') and key is not null)
                     TableScan [TS_0] (rows=238 width=89)
-                      default@srcbucket_mapjoin_part_1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+                      default@srcbucket_mapjoin_part_1,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:2,Grouping Partition Columns:["key"],Output:["key","part"]
 
 PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
 FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_2_n0 b
@@ -233,7 +233,7 @@ POSTHOOK: Input: default@srcbucket_mapjoin_part_3
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
@@ -249,9 +249,9 @@ Stage-0
             Group By Operator [GBY_37] (rows=1 width=8)
               Output:["_col0"],aggregations:["count()"]
               Map Join Operator [MAPJOIN_36] (rows=372 width=8)
-                Conds:SEL_35._col0=RS_33._col0(Inner)
-              <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                BROADCAST [RS_33]
+                BucketMapJoin:true,Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                MULTICAST [RS_33]
                   PartitionCols:_col0
                   Select Operator [SEL_32] (rows=238 width=4)
                     Output:["_col0"]
@@ -264,7 +264,7 @@ Stage-0
                   Filter Operator [FIL_34] (rows=238 width=89)
                     predicate:((part = '1') and key is not null)
                     TableScan [TS_0] (rows=238 width=89)
-                      default@srcbucket_mapjoin_part_1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+                      default@srcbucket_mapjoin_part_1,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:2,Grouping Partition Columns:["key"],Output:["key","part"]
 
 PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
 FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_3 b

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_5.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_5.q.out
@@ -1,0 +1,283 @@
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_tmp
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_tmp
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_1_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_tmp@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_1_tmp@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_1_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1_tmp@part=1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_1
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_1 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_1 SELECT * FROM srcbucket_mapjoin_part_1_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_tmp
+PREHOOK: Input: default@srcbucket_mapjoin_part_1_tmp@part=1
+PREHOOK: Output: default@srcbucket_mapjoin_part_1
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_1 SELECT * FROM srcbucket_mapjoin_part_1_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_tmp
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1_tmp@part=1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n0_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n0_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n0_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n0_tmp
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n0_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n0_tmp
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n0_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n0_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n0_tmp@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n0_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n0_tmp@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n0_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n0_tmp@part=1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n0 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n0
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n0 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part, bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n0
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n0 SELECT * FROM srcbucket_mapjoin_part_2_n0_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n0_tmp
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n0_tmp@part=1
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n0
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n0 SELECT * FROM srcbucket_mapjoin_part_2_n0_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n0_tmp
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n0_tmp@part=1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n0
+PREHOOK: query: ALTER TABLE srcbucket_mapjoin_part_2_n0 SET PARTITION SPEC (part)
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n0
+POSTHOOK: query: ALTER TABLE srcbucket_mapjoin_part_2_n0 SET PARTITION SPEC (part)
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n0
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n0
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_3_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_3_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_3_tmp (key INT, value STRING) PARTITIONED BY (part STRING)
+STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_3_tmp
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_3_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_3_tmp
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_part_3_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_3_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_3_tmp@part=1
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_3_tmp PARTITION (part='1')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_3_tmp@part=1
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_part_3_tmp PARTITION (part='1')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_3_tmp@part=1
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_3 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_3
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_3 (key INT, value STRING, part STRING) PARTITIONED BY SPEC (part) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_3
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_3 SELECT * FROM srcbucket_mapjoin_part_3_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_3_tmp
+PREHOOK: Input: default@srcbucket_mapjoin_part_3_tmp@part=1
+PREHOOK: Output: default@srcbucket_mapjoin_part_3
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_3 SELECT * FROM srcbucket_mapjoin_part_3_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_3_tmp
+POSTHOOK: Input: default@srcbucket_mapjoin_part_3_tmp@part=1
+POSTHOOK: Output: default@srcbucket_mapjoin_part_3
+PREHOOK: query: ALTER TABLE srcbucket_mapjoin_part_3 SET PARTITION SPEC (part, bucket(2, key))
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@srcbucket_mapjoin_part_3
+POSTHOOK: query: ALTER TABLE srcbucket_mapjoin_part_3 SET PARTITION SPEC (part, bucket(2, key))
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@srcbucket_mapjoin_part_3
+POSTHOOK: Output: default@srcbucket_mapjoin_part_3
+PREHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_2_n0 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n0
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_2_n0 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n0
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_40]
+        Group By Operator [GBY_39] (rows=1 width=8)
+          Output:["_col0"],aggregations:["count(VALUE._col0)"]
+        <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+          PARTITION_ONLY_SHUFFLE [RS_38]
+            Group By Operator [GBY_37] (rows=1 width=8)
+              Output:["_col0"],aggregations:["count()"]
+              Map Join Operator [MAPJOIN_36] (rows=372 width=8)
+                Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                BROADCAST [RS_33]
+                  PartitionCols:_col0
+                  Select Operator [SEL_32] (rows=238 width=4)
+                    Output:["_col0"]
+                    Filter Operator [FIL_31] (rows=238 width=89)
+                      predicate:((part = '1') and key is not null)
+                      TableScan [TS_3] (rows=238 width=89)
+                        default@srcbucket_mapjoin_part_2_n0,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+              <-Select Operator [SEL_35] (rows=238 width=4)
+                  Output:["_col0"]
+                  Filter Operator [FIL_34] (rows=238 width=89)
+                    predicate:((part = '1') and key is not null)
+                    TableScan [TS_0] (rows=238 width=89)
+                      default@srcbucket_mapjoin_part_1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+
+PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_2_n0 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n0
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_2_n0 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n0
+#### A masked pattern was here ####
+464
+PREHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_3 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1
+PREHOOK: Input: default@srcbucket_mapjoin_part_3
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_3 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_3
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_40]
+        Group By Operator [GBY_39] (rows=1 width=8)
+          Output:["_col0"],aggregations:["count(VALUE._col0)"]
+        <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+          PARTITION_ONLY_SHUFFLE [RS_38]
+            Group By Operator [GBY_37] (rows=1 width=8)
+              Output:["_col0"],aggregations:["count()"]
+              Map Join Operator [MAPJOIN_36] (rows=372 width=8)
+                Conds:SEL_35._col0=RS_33._col0(Inner)
+              <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                BROADCAST [RS_33]
+                  PartitionCols:_col0
+                  Select Operator [SEL_32] (rows=238 width=4)
+                    Output:["_col0"]
+                    Filter Operator [FIL_31] (rows=238 width=89)
+                      predicate:((part = '1') and key is not null)
+                      TableScan [TS_3] (rows=238 width=89)
+                        default@srcbucket_mapjoin_part_3,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+              <-Select Operator [SEL_35] (rows=238 width=4)
+                  Output:["_col0"]
+                  Filter Operator [FIL_34] (rows=238 width=89)
+                    predicate:((part = '1') and key is not null)
+                    TableScan [TS_0] (rows=238 width=89)
+                      default@srcbucket_mapjoin_part_1,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","part"]
+
+PREHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_3 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_1
+PREHOOK: Input: default@srcbucket_mapjoin_part_3
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT /*+ MAPJOIN(b) */ count(*)
+FROM srcbucket_mapjoin_part_1 a JOIN srcbucket_mapjoin_part_3 b
+ON a.key = b.key AND a.part = '1' and b.part = '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_1
+POSTHOOK: Input: default@srcbucket_mapjoin_part_3
+#### A masked pattern was here ####
+464

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_6.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_6.q.out
@@ -129,7 +129,7 @@ POSTHOOK: Output: default@bucketmapjoin_tmp_result_n3
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 2 <- Map 1 (BROADCAST_EDGE)
+Map 2 <- Map 1 (CUSTOM_EDGE)
 Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE)
 
 Stage-3
@@ -152,9 +152,9 @@ Stage-3
                       Select Operator [SEL_41] (rows=809 width=366)
                         Output:["_col0","_col1","_col2"]
                         Map Join Operator [MAPJOIN_40] (rows=809 width=186)
-                          Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
-                        <-Map 1 [BROADCAST_EDGE] vectorized, llap
-                          BROADCAST [RS_37]
+                          BucketMapJoin:true,Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
+                        <-Map 1 [CUSTOM_EDGE] vectorized, llap
+                          MULTICAST [RS_37]
                             PartitionCols:_col0
                             Select Operator [SEL_36] (rows=238 width=95)
                               Output:["_col0","_col1"]
@@ -167,7 +167,7 @@ Stage-3
                             Filter Operator [FIL_38] (rows=524 width=95)
                               predicate:key is not null
                               TableScan [TS_3] (rows=524 width=95)
-                                default@srcbucket_mapjoin_part_2_n7,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                                default@srcbucket_mapjoin_part_2_n7,b,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:2,Grouping Partition Columns:["key"],Output:["key","value"]
                     PARTITION_ONLY_SHUFFLE [RS_45]
                       Group By Operator [GBY_44] (rows=1 width=704)
                         Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(length(key))","avg(COALESCE(length(key),0))","count(1)","count(key)","compute_bit_vector_hll(key)","max(length(value1))","avg(COALESCE(length(value1),0))","count(value1)","compute_bit_vector_hll(value1)","max(length(value2))","avg(COALESCE(length(value2),0))","count(value2)","compute_bit_vector_hll(value2)"]

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_6.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_6.q.out
@@ -1,0 +1,177 @@
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_n5_tmp(key int, value string) STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_n5_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_n5_tmp(key int, value string) STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_n5_tmp
+PREHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_n5_tmp
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_n5_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE srcbucket_mapjoin_n5_tmp
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_n5_tmp
+PREHOOK: query: load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_n5_tmp
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_n5_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj/000001_0' INTO TABLE srcbucket_mapjoin_n5_tmp
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_n5_tmp
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_n5(key int, value string) PARTITIONED BY SPEC(bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_n5
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_n5(key int, value string) PARTITIONED BY SPEC(bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_n5
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_n5 SELECT * FROM srcbucket_mapjoin_n5_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n5_tmp
+PREHOOK: Output: default@srcbucket_mapjoin_n5
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_n5 SELECT * FROM srcbucket_mapjoin_n5_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n5_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_n5
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n7_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n7_tmp (key int, value string) partitioned by (ds string) STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp
+PREHOOK: query: load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-08')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-08')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-08
+PREHOOK: query: load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-08')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-08
+POSTHOOK: query: load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-08')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-08
+PREHOOK: query: load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-09')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp
+POSTHOOK: query: load data local inpath '../../data/files/bmj2/000000_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-09')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-09
+PREHOOK: query: load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-09')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-09
+POSTHOOK: query: load data local inpath '../../data/files/bmj2/000001_0' INTO TABLE srcbucket_mapjoin_part_2_n7_tmp partition(ds='2008-04-09')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-09
+PREHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n7 (key int, value string, ds string) partitioned by spec (ds, bucket(2, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n7
+POSTHOOK: query: CREATE TABLE srcbucket_mapjoin_part_2_n7 (key int, value string, ds string) partitioned by spec (ds, bucket(2, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7
+PREHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n7 SELECT * FROM srcbucket_mapjoin_part_2_n7_tmp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n7_tmp
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-08
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-09
+PREHOOK: Output: default@srcbucket_mapjoin_part_2_n7
+POSTHOOK: query: INSERT INTO srcbucket_mapjoin_part_2_n7 SELECT * FROM srcbucket_mapjoin_part_2_n7_tmp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n7_tmp
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-08
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n7_tmp@ds=2008-04-09
+POSTHOOK: Output: default@srcbucket_mapjoin_part_2_n7
+PREHOOK: query: create table bucketmapjoin_tmp_result_n3 (key string , value1 string, value2 string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@bucketmapjoin_tmp_result_n3
+POSTHOOK: query: create table bucketmapjoin_tmp_result_n3 (key string , value1 string, value2 string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@bucketmapjoin_tmp_result_n3
+PREHOOK: query: explain
+insert overwrite table bucketmapjoin_tmp_result_n3
+select /*+mapjoin(b)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n5 a join srcbucket_mapjoin_part_2_n7 b
+on a.key=b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_mapjoin_n5
+PREHOOK: Input: default@srcbucket_mapjoin_part_2_n7
+PREHOOK: Output: default@bucketmapjoin_tmp_result_n3
+POSTHOOK: query: explain
+insert overwrite table bucketmapjoin_tmp_result_n3
+select /*+mapjoin(b)*/ a.key, a.value, b.value
+from srcbucket_mapjoin_n5 a join srcbucket_mapjoin_part_2_n7 b
+on a.key=b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_mapjoin_n5
+POSTHOOK: Input: default@srcbucket_mapjoin_part_2_n7
+POSTHOOK: Output: default@bucketmapjoin_tmp_result_n3
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 2 <- Map 1 (BROADCAST_EDGE)
+Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE)
+
+Stage-3
+  Stats Work{}
+    Stage-0
+      Move Operator
+        table:{"name:":"default.bucketmapjoin_tmp_result_n3"}
+        Stage-2
+          Dependency Collection{}
+            Stage-1
+              Reducer 3 vectorized, llap
+              File Output Operator [FS_48]
+                Select Operator [SEL_47] (rows=1 width=798)
+                  Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17"]
+                  Group By Operator [GBY_46] (rows=1 width=500)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(VALUE._col0)","avg(VALUE._col1)","count(VALUE._col2)","count(VALUE._col3)","compute_bit_vector_hll(VALUE._col4)","max(VALUE._col5)","avg(VALUE._col6)","count(VALUE._col7)","compute_bit_vector_hll(VALUE._col8)","max(VALUE._col9)","avg(VALUE._col10)","count(VALUE._col11)","compute_bit_vector_hll(VALUE._col12)"]
+                  <-Map 2 [CUSTOM_SIMPLE_EDGE] vectorized, llap
+                    File Output Operator [FS_42]
+                      table:{"name:":"default.bucketmapjoin_tmp_result_n3"}
+                      Select Operator [SEL_41] (rows=809 width=366)
+                        Output:["_col0","_col1","_col2"]
+                        Map Join Operator [MAPJOIN_40] (rows=809 width=186)
+                          Conds:RS_37._col0=SEL_39._col0(Inner),Output:["_col0","_col1","_col3"]
+                        <-Map 1 [BROADCAST_EDGE] vectorized, llap
+                          BROADCAST [RS_37]
+                            PartitionCols:_col0
+                            Select Operator [SEL_36] (rows=238 width=95)
+                              Output:["_col0","_col1"]
+                              Filter Operator [FIL_35] (rows=238 width=95)
+                                predicate:key is not null
+                                TableScan [TS_0] (rows=238 width=95)
+                                  default@srcbucket_mapjoin_n5,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                        <-Select Operator [SEL_39] (rows=524 width=95)
+                            Output:["_col0","_col1"]
+                            Filter Operator [FIL_38] (rows=524 width=95)
+                              predicate:key is not null
+                              TableScan [TS_3] (rows=524 width=95)
+                                default@srcbucket_mapjoin_part_2_n7,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                    PARTITION_ONLY_SHUFFLE [RS_45]
+                      Group By Operator [GBY_44] (rows=1 width=704)
+                        Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"],aggregations:["max(length(key))","avg(COALESCE(length(key),0))","count(1)","count(key)","compute_bit_vector_hll(key)","max(length(value1))","avg(COALESCE(length(value1),0))","count(value1)","compute_bit_vector_hll(value1)","max(length(value2))","avg(COALESCE(length(value2),0))","count(value2)","compute_bit_vector_hll(value2)"]
+                        Select Operator [SEL_43] (rows=809 width=366)
+                          Output:["key","value1","value2"]
+                           Please refer to the previous Select Operator [SEL_41]
+

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_7.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_7.q.out
@@ -41,7 +41,7 @@ POSTHOOK: Input: default@srcbucket_big
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
@@ -59,9 +59,9 @@ Stage-0
               Top N Key Operator [TNK_57] (rows=791 width=447)
                 keys:_col0,top n:20
                 Map Join Operator [MAPJOIN_56] (rows=791 width=447)
-                  Conds:SEL_55._col0, _col1=RS_53._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
-                <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                  BROADCAST [RS_53]
+                  BucketMapJoin:true,Conds:SEL_55._col0, _col1=RS_53._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                  MULTICAST [RS_53]
                     PartitionCols:_col0, _col1
                     Select Operator [SEL_52] (rows=500 width=178)
                       Output:["_col0","_col1"]
@@ -74,7 +74,7 @@ Stage-0
                     Filter Operator [FIL_54] (rows=500 width=269)
                       predicate:(key1 is not null and key2 is not null)
                       TableScan [TS_0] (rows=500 width=269)
-                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:8,Grouping Partition Columns:["key1","key2"],Output:["key1","key2","value"]
 
 PREHOOK: query: SELECT *
 FROM srcbucket_big a
@@ -139,7 +139,7 @@ POSTHOOK: Input: default@srcbucket_big
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
@@ -157,9 +157,9 @@ Stage-0
               Top N Key Operator [TNK_57] (rows=791 width=447)
                 keys:_col0,top n:20
                 Map Join Operator [MAPJOIN_56] (rows=791 width=447)
-                  Conds:SEL_55._col0, _col1=RS_53._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
-                <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                  BROADCAST [RS_53]
+                  BucketMapJoin:true,Conds:SEL_55._col0, _col1=RS_53._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                  MULTICAST [RS_53]
                     PartitionCols:_col0, _col1
                     Select Operator [SEL_52] (rows=500 width=178)
                       Output:["_col0","_col1"]
@@ -172,7 +172,7 @@ Stage-0
                     Filter Operator [FIL_54] (rows=500 width=269)
                       predicate:((key1 <> '0') and (key1 <> '100') and key2 is not null)
                       TableScan [TS_0] (rows=500 width=269)
-                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:8,Grouping Partition Columns:["key1","key2"],Output:["key1","key2","value"]
 
 PREHOOK: query: SELECT *
 FROM srcbucket_big a
@@ -237,7 +237,7 @@ POSTHOOK: Input: default@srcbucket_big
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
@@ -255,9 +255,9 @@ Stage-0
               Top N Key Operator [TNK_37] (rows=791 width=447)
                 keys:_col0,top n:20
                 Map Join Operator [MAPJOIN_36] (rows=791 width=447)
-                  Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
-                <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                  BROADCAST [RS_33]
+                  BucketMapJoin:true,Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                  MULTICAST [RS_33]
                     PartitionCols:_col0
                     Select Operator [SEL_32] (rows=500 width=178)
                       Output:["_col0","_col1"]
@@ -270,7 +270,7 @@ Stage-0
                     Filter Operator [FIL_34] (rows=500 width=269)
                       predicate:key1 is not null
                       TableScan [TS_0] (rows=500 width=269)
-                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:4,Grouping Partition Columns:["key1"],Output:["key1","key2","value"]
 
 PREHOOK: query: SELECT *
 FROM srcbucket_big a
@@ -335,7 +335,7 @@ POSTHOOK: Input: default@srcbucket_big
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
@@ -353,9 +353,9 @@ Stage-0
               Top N Key Operator [TNK_37] (rows=791 width=447)
                 keys:_col0,top n:20
                 Map Join Operator [MAPJOIN_36] (rows=791 width=447)
-                  Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
-                <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                  BROADCAST [RS_33]
+                  BucketMapJoin:true,Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                  MULTICAST [RS_33]
                     PartitionCols:_col0
                     Select Operator [SEL_32] (rows=500 width=178)
                       Output:["_col0","_col1"]
@@ -368,7 +368,7 @@ Stage-0
                     Filter Operator [FIL_34] (rows=500 width=269)
                       predicate:((key1 <> '0') and (key1 <> '100'))
                       TableScan [TS_0] (rows=500 width=269)
-                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:4,Grouping Partition Columns:["key1"],Output:["key1","key2","value"]
 
 PREHOOK: query: SELECT *
 FROM srcbucket_big a
@@ -435,7 +435,7 @@ POSTHOOK: Input: default@srcbucket_big
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
@@ -453,9 +453,9 @@ Stage-0
               Top N Key Operator [TNK_37] (rows=791 width=447)
                 keys:_col0,top n:20
                 Map Join Operator [MAPJOIN_36] (rows=791 width=447)
-                  Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
-                <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                  BROADCAST [RS_33]
+                  BucketMapJoin:true,Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                  MULTICAST [RS_33]
                     PartitionCols:_col0
                     Select Operator [SEL_32] (rows=500 width=178)
                       Output:["_col0","_col1"]
@@ -468,7 +468,7 @@ Stage-0
                     Filter Operator [FIL_34] (rows=500 width=269)
                       predicate:((key2 <> 'val_0') and (key2 <> 'val_100') and key1 is not null)
                       TableScan [TS_0] (rows=500 width=269)
-                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:4,Grouping Partition Columns:["key1"],Output:["key1","key2","value"]
 
 PREHOOK: query: SELECT *
 FROM srcbucket_big a
@@ -629,7 +629,7 @@ POSTHOOK: Input: default@srcbucket_big
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
@@ -647,10 +647,10 @@ Stage-0
               Top N Key Operator [TNK_62] (rows=791 width=447)
                 keys:_col0,top n:20
                 Map Join Operator [MAPJOIN_61] (rows=791 width=447)
-                  Conds:SEL_60._col0, _col1, _col2=RS_58._col0, _col1, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
-                <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                  BROADCAST [RS_58]
-                    PartitionCols:_col0, _col1, _col1
+                  BucketMapJoin:true,Conds:SEL_60._col0, _col1, _col2=RS_58._col0, _col1, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [CUSTOM_EDGE] vectorized, llap
+                  MULTICAST [RS_58]
+                    PartitionCols:_col0, _col1
                     Select Operator [SEL_57] (rows=500 width=178)
                       Output:["_col0","_col1"]
                       Filter Operator [FIL_56] (rows=500 width=178)
@@ -662,7 +662,7 @@ Stage-0
                     Filter Operator [FIL_59] (rows=500 width=269)
                       predicate:(key1 is not null and key2 is not null and value is not null)
                       TableScan [TS_0] (rows=500 width=269)
-                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:8,Grouping Partition Columns:["key1","key2"],Output:["key1","key2","value"]
 
 PREHOOK: query: SELECT *
 FROM srcbucket_big a

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_7.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_7.q.out
@@ -1,0 +1,800 @@
+PREHOOK: query: CREATE TABLE srcbucket_big(key1 string, key2 string, value string)
+PARTITIONED BY SPEC(bucket(4, key1), bucket(2, key2)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_big
+POSTHOOK: query: CREATE TABLE srcbucket_big(key1 string, key2 string, value string)
+PARTITIONED BY SPEC(bucket(4, key1), bucket(2, key2)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_big
+PREHOOK: query: INSERT INTO srcbucket_big
+SELECT key AS key1, value AS key2, value FROM src
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@srcbucket_big
+POSTHOOK: query: INSERT INTO srcbucket_big
+SELECT key AS key1, value AS key2, value FROM src
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@srcbucket_big
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:20
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_61]
+        Limit [LIM_60] (rows=20 width=447)
+          Number of rows:20
+          Select Operator [SEL_59] (rows=791 width=447)
+            Output:["_col0","_col1","_col2","_col3","_col4"]
+          <-Map 1 [SIMPLE_EDGE] vectorized, llap
+            SHUFFLE [RS_58]
+              Top N Key Operator [TNK_57] (rows=791 width=447)
+                keys:_col0,top n:20
+                Map Join Operator [MAPJOIN_56] (rows=791 width=447)
+                  Conds:SEL_55._col0, _col1=RS_53._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                  BROADCAST [RS_53]
+                    PartitionCols:_col0, _col1
+                    Select Operator [SEL_52] (rows=500 width=178)
+                      Output:["_col0","_col1"]
+                      Filter Operator [FIL_51] (rows=500 width=178)
+                        predicate:(key is not null and value is not null)
+                        TableScan [TS_3] (rows=500 width=178)
+                          default@src,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_55] (rows=500 width=269)
+                    Output:["_col0","_col1","_col2"]
+                    Filter Operator [FIL_54] (rows=500 width=269)
+                      predicate:(key1 is not null and key2 is not null)
+                      TableScan [TS_0] (rows=500 width=269)
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+10	val_10	val_10	10	val_10
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:20
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_61]
+        Limit [LIM_60] (rows=20 width=447)
+          Number of rows:20
+          Select Operator [SEL_59] (rows=791 width=447)
+            Output:["_col0","_col1","_col2","_col3","_col4"]
+          <-Map 1 [SIMPLE_EDGE] vectorized, llap
+            SHUFFLE [RS_58]
+              Top N Key Operator [TNK_57] (rows=791 width=447)
+                keys:_col0,top n:20
+                Map Join Operator [MAPJOIN_56] (rows=791 width=447)
+                  Conds:SEL_55._col0, _col1=RS_53._col0, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                  BROADCAST [RS_53]
+                    PartitionCols:_col0, _col1
+                    Select Operator [SEL_52] (rows=500 width=178)
+                      Output:["_col0","_col1"]
+                      Filter Operator [FIL_51] (rows=500 width=178)
+                        predicate:((key <> '0') and (key <> '100') and value is not null)
+                        TableScan [TS_3] (rows=500 width=178)
+                          default@src,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_55] (rows=500 width=269)
+                    Output:["_col0","_col1","_col2"]
+                    Filter Operator [FIL_54] (rows=500 width=269)
+                      predicate:((key1 <> '0') and (key1 <> '100') and key2 is not null)
+                      TableScan [TS_0] (rows=500 width=269)
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+10	val_10	val_10	10	val_10
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+105	val_105	val_105	105	val_105
+11	val_11	val_11	11	val_11
+111	val_111	val_111	111	val_111
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+114	val_114	val_114	114	val_114
+116	val_116	val_116	116	val_116
+118	val_118	val_118	118	val_118
+118	val_118	val_118	118	val_118
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:20
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_41]
+        Limit [LIM_40] (rows=20 width=447)
+          Number of rows:20
+          Select Operator [SEL_39] (rows=791 width=447)
+            Output:["_col0","_col1","_col2","_col3","_col4"]
+          <-Map 1 [SIMPLE_EDGE] vectorized, llap
+            SHUFFLE [RS_38]
+              Top N Key Operator [TNK_37] (rows=791 width=447)
+                keys:_col0,top n:20
+                Map Join Operator [MAPJOIN_36] (rows=791 width=447)
+                  Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                  BROADCAST [RS_33]
+                    PartitionCols:_col0
+                    Select Operator [SEL_32] (rows=500 width=178)
+                      Output:["_col0","_col1"]
+                      Filter Operator [FIL_31] (rows=500 width=178)
+                        predicate:key is not null
+                        TableScan [TS_3] (rows=500 width=178)
+                          default@src,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_35] (rows=500 width=269)
+                    Output:["_col0","_col1","_col2"]
+                    Filter Operator [FIL_34] (rows=500 width=269)
+                      predicate:key1 is not null
+                      TableScan [TS_0] (rows=500 width=269)
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+10	val_10	val_10	10	val_10
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:20
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_41]
+        Limit [LIM_40] (rows=20 width=447)
+          Number of rows:20
+          Select Operator [SEL_39] (rows=791 width=447)
+            Output:["_col0","_col1","_col2","_col3","_col4"]
+          <-Map 1 [SIMPLE_EDGE] vectorized, llap
+            SHUFFLE [RS_38]
+              Top N Key Operator [TNK_37] (rows=791 width=447)
+                keys:_col0,top n:20
+                Map Join Operator [MAPJOIN_36] (rows=791 width=447)
+                  Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                  BROADCAST [RS_33]
+                    PartitionCols:_col0
+                    Select Operator [SEL_32] (rows=500 width=178)
+                      Output:["_col0","_col1"]
+                      Filter Operator [FIL_31] (rows=500 width=178)
+                        predicate:((key <> '0') and (key <> '100'))
+                        TableScan [TS_3] (rows=500 width=178)
+                          default@src,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_35] (rows=500 width=269)
+                    Output:["_col0","_col1","_col2"]
+                    Filter Operator [FIL_34] (rows=500 width=269)
+                      predicate:((key1 <> '0') and (key1 <> '100'))
+                      TableScan [TS_0] (rows=500 width=269)
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key1 NOT IN ('0', '100')
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+10	val_10	val_10	10	val_10
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+105	val_105	val_105	105	val_105
+11	val_11	val_11	11	val_11
+111	val_111	val_111	111	val_111
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+114	val_114	val_114	114	val_114
+116	val_116	val_116	116	val_116
+118	val_118	val_118	118	val_118
+118	val_118	val_118	118	val_118
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key2 NOT IN ('val_0', 'val_100')
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key2 NOT IN ('val_0', 'val_100')
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:20
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_41]
+        Limit [LIM_40] (rows=20 width=447)
+          Number of rows:20
+          Select Operator [SEL_39] (rows=791 width=447)
+            Output:["_col0","_col1","_col2","_col3","_col4"]
+          <-Map 1 [SIMPLE_EDGE] vectorized, llap
+            SHUFFLE [RS_38]
+              Top N Key Operator [TNK_37] (rows=791 width=447)
+                keys:_col0,top n:20
+                Map Join Operator [MAPJOIN_36] (rows=791 width=447)
+                  Conds:SEL_35._col0=RS_33._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                  BROADCAST [RS_33]
+                    PartitionCols:_col0
+                    Select Operator [SEL_32] (rows=500 width=178)
+                      Output:["_col0","_col1"]
+                      Filter Operator [FIL_31] (rows=500 width=178)
+                        predicate:key is not null
+                        TableScan [TS_3] (rows=500 width=178)
+                          default@src,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_35] (rows=500 width=269)
+                    Output:["_col0","_col1","_col2"]
+                    Filter Operator [FIL_34] (rows=500 width=269)
+                      predicate:((key2 <> 'val_0') and (key2 <> 'val_100') and key1 is not null)
+                      TableScan [TS_0] (rows=500 width=269)
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key2 NOT IN ('val_0', 'val_100')
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key
+WHERE a.key2 NOT IN ('val_0', 'val_100')
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+10	val_10	val_10	10	val_10
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+105	val_105	val_105	105	val_105
+11	val_11	val_11	11	val_11
+111	val_111	val_111	111	val_111
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+113	val_113	val_113	113	val_113
+114	val_114	val_114	114	val_114
+116	val_116	val_116	116	val_116
+118	val_118	val_118	118	val_118
+118	val_118	val_118	118	val_118
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:20
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_41]
+        Limit [LIM_40] (rows=20 width=447)
+          Number of rows:20
+          Select Operator [SEL_39] (rows=814 width=447)
+            Output:["_col0","_col1","_col2","_col3","_col4"]
+          <-Map 1 [SIMPLE_EDGE] vectorized, llap
+            SHUFFLE [RS_38]
+              Top N Key Operator [TNK_37] (rows=814 width=447)
+                keys:_col0,top n:20
+                Map Join Operator [MAPJOIN_36] (rows=814 width=447)
+                  Conds:SEL_35._col1=RS_33._col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                  BROADCAST [RS_33]
+                    PartitionCols:_col1
+                    Select Operator [SEL_32] (rows=500 width=178)
+                      Output:["_col0","_col1"]
+                      Filter Operator [FIL_31] (rows=500 width=178)
+                        predicate:value is not null
+                        TableScan [TS_3] (rows=500 width=178)
+                          default@src,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_35] (rows=500 width=269)
+                    Output:["_col0","_col1","_col2"]
+                    Filter Operator [FIL_34] (rows=500 width=269)
+                      predicate:key2 is not null
+                      TableScan [TS_0] (rows=500 width=269)
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key2 = b.value
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+10	val_10	val_10	10	val_10
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value AND a.value = b.value
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value AND a.value = b.value
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:20
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_66]
+        Limit [LIM_65] (rows=20 width=447)
+          Number of rows:20
+          Select Operator [SEL_64] (rows=791 width=447)
+            Output:["_col0","_col1","_col2","_col3","_col4"]
+          <-Map 1 [SIMPLE_EDGE] vectorized, llap
+            SHUFFLE [RS_63]
+              Top N Key Operator [TNK_62] (rows=791 width=447)
+                keys:_col0,top n:20
+                Map Join Operator [MAPJOIN_61] (rows=791 width=447)
+                  Conds:SEL_60._col0, _col1, _col2=RS_58._col0, _col1, _col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                  BROADCAST [RS_58]
+                    PartitionCols:_col0, _col1, _col1
+                    Select Operator [SEL_57] (rows=500 width=178)
+                      Output:["_col0","_col1"]
+                      Filter Operator [FIL_56] (rows=500 width=178)
+                        predicate:(key is not null and value is not null)
+                        TableScan [TS_3] (rows=500 width=178)
+                          default@src,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_60] (rows=500 width=269)
+                    Output:["_col0","_col1","_col2"]
+                    Filter Operator [FIL_59] (rows=500 width=269)
+                      predicate:(key1 is not null and key2 is not null and value is not null)
+                      TableScan [TS_0] (rows=500 width=269)
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value AND a.value = b.value
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.key1 = b.key AND a.key2 = b.value AND a.value = b.value
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+10	val_10	val_10	10	val_10
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.value = b.value
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.value = b.value
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:20
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_41]
+        Limit [LIM_40] (rows=20 width=447)
+          Number of rows:20
+          Select Operator [SEL_39] (rows=814 width=447)
+            Output:["_col0","_col1","_col2","_col3","_col4"]
+          <-Map 1 [SIMPLE_EDGE] vectorized, llap
+            SHUFFLE [RS_38]
+              Top N Key Operator [TNK_37] (rows=814 width=447)
+                keys:_col0,top n:20
+                Map Join Operator [MAPJOIN_36] (rows=814 width=447)
+                  Conds:SEL_35._col2=RS_33._col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+                <-Map 3 [BROADCAST_EDGE] vectorized, llap
+                  BROADCAST [RS_33]
+                    PartitionCols:_col1
+                    Select Operator [SEL_32] (rows=500 width=178)
+                      Output:["_col0","_col1"]
+                      Filter Operator [FIL_31] (rows=500 width=178)
+                        predicate:value is not null
+                        TableScan [TS_3] (rows=500 width=178)
+                          default@src,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_35] (rows=500 width=269)
+                    Output:["_col0","_col1","_col2"]
+                    Filter Operator [FIL_34] (rows=500 width=269)
+                      predicate:value is not null
+                      TableScan [TS_0] (rows=500 width=269)
+                        default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key1","key2","value"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.value = b.value
+ORDER BY a.key1
+LIMIT 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src b ON a.value = b.value
+ORDER BY a.key1
+LIMIT 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+0	val_0	val_0	0	val_0
+10	val_10	val_10	10	val_10
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+100	val_100	val_100	100	val_100
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+103	val_103	val_103	103	val_103
+104	val_104	val_104	104	val_104
+104	val_104	val_104	104	val_104

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_8.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_8.q.out
@@ -1,0 +1,218 @@
+PREHOOK: query: CREATE TABLE srcbucket_big(key int, value string, id int)
+PARTITIONED BY SPEC(bucket(4, key)) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@srcbucket_big
+POSTHOOK: query: CREATE TABLE srcbucket_big(key int, value string, id int)
+PARTITIONED BY SPEC(bucket(4, key)) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@srcbucket_big
+PREHOOK: query: INSERT INTO srcbucket_big VALUES
+(101, 'val_101', 1),
+(null, 'val_102', 2),
+(103, 'val_103', 3),
+(104, null, 4),
+(105, 'val_105', 5),
+(null, null, 6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@srcbucket_big
+POSTHOOK: query: INSERT INTO srcbucket_big VALUES
+(101, 'val_101', 1),
+(null, 'val_102', 2),
+(103, 'val_103', 3),
+(104, null, 4),
+(105, 'val_105', 5),
+(null, null, 6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@srcbucket_big
+PREHOOK: query: CREATE TABLE src_small(key int, value string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@src_small
+POSTHOOK: query: CREATE TABLE src_small(key int, value string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@src_small
+PREHOOK: query: INSERT INTO src_small VALUES
+(101, 'val_101'),
+(null, 'val_102'),
+(103, 'val_103'),
+(104, null),
+(105, 'val_105'),
+(null, null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@src_small
+POSTHOOK: query: INSERT INTO src_small VALUES
+(101, 'val_101'),
+(null, 'val_102'),
+(103, 'val_103'),
+(104, null),
+(105, 'val_105'),
+(null, null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@src_small
+POSTHOOK: Lineage: src_small.key SCRIPT []
+POSTHOOK: Lineage: src_small.value SCRIPT []
+PREHOOK: query: SELECT * FROM srcbucket_big ORDER BY id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM srcbucket_big ORDER BY id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+101	val_101	1
+NULL	val_102	2
+103	val_103	3
+104	NULL	4
+105	val_105	5
+NULL	NULL	6
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.key = b.key
+ORDER BY a.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_small
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.key = b.key
+ORDER BY a.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_small
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_37]
+        Select Operator [SEL_36] (rows=4 width=190)
+          Output:["_col0","_col1","_col2","_col3","_col4"]
+        <-Map 1 [SIMPLE_EDGE] vectorized, llap
+          SHUFFLE [RS_35]
+            Map Join Operator [MAPJOIN_34] (rows=4 width=190)
+              Conds:SEL_33._col0=RS_31._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+            <-Map 3 [BROADCAST_EDGE] vectorized, llap
+              BROADCAST [RS_31]
+                PartitionCols:_col0
+                Select Operator [SEL_30] (rows=4 width=93)
+                  Output:["_col0","_col1"]
+                  Filter Operator [FIL_29] (rows=4 width=93)
+                    predicate:key is not null
+                    TableScan [TS_3] (rows=6 width=77)
+                      default@src_small,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+            <-Select Operator [SEL_33] (rows=4 width=97)
+                Output:["_col0","_col1","_col2"]
+                Filter Operator [FIL_32] (rows=4 width=97)
+                  predicate:key is not null
+                  TableScan [TS_0] (rows=6 width=81)
+                    default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value","id"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.key = b.key
+ORDER BY a.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_small
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.key = b.key
+ORDER BY a.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_small
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+101	val_101	1	101	val_101
+103	val_103	3	103	val_103
+104	NULL	4	104	NULL
+105	val_105	5	105	val_105
+PREHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.value = b.value
+ORDER BY a.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_small
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.value = b.value
+ORDER BY a.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_small
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2 vectorized, llap
+      File Output Operator [FS_37]
+        Select Operator [SEL_36] (rows=4 width=190)
+          Output:["_col0","_col1","_col2","_col3","_col4"]
+        <-Map 1 [SIMPLE_EDGE] vectorized, llap
+          SHUFFLE [RS_35]
+            Map Join Operator [MAPJOIN_34] (rows=4 width=190)
+              Conds:SEL_33._col1=RS_31._col1(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+            <-Map 3 [BROADCAST_EDGE] vectorized, llap
+              BROADCAST [RS_31]
+                PartitionCols:_col1
+                Select Operator [SEL_30] (rows=4 width=93)
+                  Output:["_col0","_col1"]
+                  Filter Operator [FIL_29] (rows=4 width=93)
+                    predicate:value is not null
+                    TableScan [TS_3] (rows=6 width=77)
+                      default@src_small,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+            <-Select Operator [SEL_33] (rows=4 width=97)
+                Output:["_col0","_col1","_col2"]
+                Filter Operator [FIL_32] (rows=4 width=97)
+                  predicate:value is not null
+                  TableScan [TS_0] (rows=6 width=81)
+                    default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value","id"]
+
+PREHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.value = b.value
+ORDER BY a.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_small
+PREHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT *
+FROM srcbucket_big a
+JOIN src_small b ON a.value = b.value
+ORDER BY a.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_small
+POSTHOOK: Input: default@srcbucket_big
+#### A masked pattern was here ####
+101	val_101	1	101	val_101
+NULL	val_102	2	NULL	val_102
+103	val_103	3	103	val_103
+105	val_105	5	105	val_105

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_8.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/iceberg_bucket_map_join_8.q.out
@@ -93,7 +93,7 @@ POSTHOOK: Input: default@srcbucket_big
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
+Map 1 <- Map 3 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
@@ -107,9 +107,9 @@ Stage-0
         <-Map 1 [SIMPLE_EDGE] vectorized, llap
           SHUFFLE [RS_35]
             Map Join Operator [MAPJOIN_34] (rows=4 width=190)
-              Conds:SEL_33._col0=RS_31._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
-            <-Map 3 [BROADCAST_EDGE] vectorized, llap
-              BROADCAST [RS_31]
+              BucketMapJoin:true,Conds:SEL_33._col0=RS_31._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4"]
+            <-Map 3 [CUSTOM_EDGE] vectorized, llap
+              MULTICAST [RS_31]
                 PartitionCols:_col0
                 Select Operator [SEL_30] (rows=4 width=93)
                   Output:["_col0","_col1"]
@@ -122,7 +122,7 @@ Stage-0
                 Filter Operator [FIL_32] (rows=4 width=97)
                   predicate:key is not null
                   TableScan [TS_0] (rows=6 width=81)
-                    default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value","id"]
+                    default@srcbucket_big,a,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:4,Grouping Partition Columns:["key"],Output:["key","value","id"]
 
 PREHOOK: query: SELECT *
 FROM srcbucket_big a

--- a/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_merge_mixed.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_merge_mixed.q.out
@@ -325,7 +325,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Map 5 (BROADCAST_EDGE)
+        Map 1 <- Map 5 (CUSTOM_EDGE)
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
         Reducer 3 <- Map 1 (SIMPLE_EDGE)
         Reducer 4 <- Map 1 (SIMPLE_EDGE)
@@ -556,12 +556,13 @@ STAGE PLANS:
                         key expressions: _col8 (type: int), _col7 (type: int)
                         null sort order: zz
                         sort order: ++
-                        Map-reduce partition columns: _col8 (type: int), _col7 (type: int)
+                        Map-reduce partition columns: _col7 (type: int)
                         Reduce Sink Vectorization:
-                            className: VectorReduceSinkMultiKeyOperator
+                            className: VectorReduceSinkObjectHashOperator
                             keyColumns: 3:int, 2:int
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                            partitionColumns: 2:int
                             valueColumns: 23:int, 24:bigint, 25:string, 26:bigint, 27:string, 28:int, 1:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2)
                         Statistics: Num rows: 2 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: int), _col12 (type: int), _col13 (type: int), _col14 (type: int), _col15 (type: int), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2)), _col23 (type: decimal(7,2)), _col24 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col27 (type: decimal(7,2))
@@ -884,7 +885,7 @@ POSTHOOK: Output: default@merge_tmp_table
 POSTHOOK: Output: default@store_sales
 POSTHOOK: Output: default@store_sales
 Vertex dependency in root stage
-Map 1 <- Map 5 (BROADCAST_EDGE)
+Map 1 <- Map 5 (CUSTOM_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
 Reducer 3 <- Map 1 (SIMPLE_EDGE)
 Reducer 4 <- Map 1 (SIMPLE_EDGE)
@@ -912,10 +913,10 @@ Stage-6
                         Select Operator [SEL_49] (rows=7 width=1029)
                           Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49"]
                           Map Join Operator [MAPJOIN_48] (rows=7 width=1029)
-                            Conds:SEL_47._col2, _col1=RS_46._col8, _col7(Left Outer),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51"]
-                          <-Map 5 [BROADCAST_EDGE] vectorized
-                            BROADCAST [RS_46]
-                              PartitionCols:_col8, _col7
+                            BucketMapJoin:true,Conds:SEL_47._col2, _col1=RS_46._col8, _col7(Left Outer),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51"]
+                          <-Map 5 [CUSTOM_EDGE] vectorized
+                            MULTICAST [RS_46]
+                              PartitionCols:_col7
                               Select Operator [SEL_45] (rows=2 width=1088)
                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27"]
                                 Filter Operator [FIL_44] (rows=2 width=700)
@@ -925,7 +926,7 @@ Stage-6
                           <-Select Operator [SEL_47] (rows=5 width=380)
                               Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23"]
                               TableScan [TS_0] (rows=5 width=372)
-                                default@ssv,s,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_time_sk","ss_item_sk2","ss_customer_sk2","ss_cdemo_sk","ss_hdemo_sk","ss_addr_sk","ss_store_sk","ss_promo_sk","ss_ticket_number","ss_quantity","ss_wholesale_cost","ss_list_price","ss_sales_price","ss_ext_discount_amt","ss_ext_sales_price","ss_ext_wholesale_cost","ss_ext_list_price","ss_ext_tax","ss_coupon_amt","ss_net_paid","ss_net_paid_inc_tax","ss_net_profit"]
+                                default@ssv,s,Tbl:COMPLETE,Col:COMPLETE,Grouping Num Buckets:3,Grouping Partition Columns:["ss_item_sk2"],Output:["ss_sold_time_sk","ss_item_sk2","ss_customer_sk2","ss_cdemo_sk","ss_hdemo_sk","ss_addr_sk","ss_store_sk","ss_promo_sk","ss_ticket_number","ss_quantity","ss_wholesale_cost","ss_list_price","ss_sales_price","ss_ext_discount_amt","ss_ext_sales_price","ss_ext_wholesale_cost","ss_ext_list_price","ss_ext_tax","ss_coupon_amt","ss_net_paid","ss_net_paid_inc_tax","ss_net_profit"]
               Reducer 3 vectorized
               File Output Operator [FS_66]
                 table:{"name:":"default.store_sales"}

--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -409,6 +409,14 @@ erasurecoding.only.query.files=\
   erasure_simple.q
 
 iceberg.llap.query.files=\
+  iceberg_bucket_map_join_1.q,\
+  iceberg_bucket_map_join_2.q,\
+  iceberg_bucket_map_join_3.q,\
+  iceberg_bucket_map_join_4.q,\
+  iceberg_bucket_map_join_5.q,\
+  iceberg_bucket_map_join_6.q,\
+  iceberg_bucket_map_join_7.q,\
+  iceberg_bucket_map_join_8.q,\
   iceberg_clustered.q,\
   iceberg_merge_delete_files.q,\
   iceberg_merge_files.q,\
@@ -435,6 +443,14 @@ iceberg.llap.query.compactor.files=\
   iceberg_optimize_table_unpartitioned.q
 
 iceberg.llap.only.query.files=\
+  iceberg_bucket_map_join_1.q,\
+  iceberg_bucket_map_join_2.q,\
+  iceberg_bucket_map_join_3.q,\
+  iceberg_bucket_map_join_4.q,\
+  iceberg_bucket_map_join_5.q,\
+  iceberg_bucket_map_join_6.q,\
+  iceberg_bucket_map_join_7.q,\
+  iceberg_bucket_map_join_8.q,\
   iceberg_clustered.q,\
   iceberg_merge_delete_files.q,\
   iceberg_merge_files.q,\

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ReduceSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ReduceSinkOperator.java
@@ -294,9 +294,11 @@ public class ReduceSinkOperator extends TerminalOperator<ReduceSinkDesc>
             conf.getOutputKeyColumnNames(), numDistributionKeys, rowInspector);
         valueObjectInspector = initEvaluatorsAndReturnStruct(valueEval,
             conf.getOutputValueColumnNames(), rowInspector);
-        partitionHashFunc = conf.getPartitionFunction(initEvaluators(partitionEval, rowInspector));
+        final ObjectInspector[] partitionObjectInspectors = initEvaluators(partitionEval, rowInspector);
+        partitionHashFunc = conf.getPartitionFunction(partitionObjectInspectors);
         if (bucketEval != null) {
-          bucketHashFunc = conf.getPartitionFunction(initEvaluators(bucketEval, rowInspector));
+          final ObjectInspector[] bucketObjectInspectors = initEvaluators(bucketEval, rowInspector);
+          bucketHashFunc = conf.getPartitionFunction(bucketObjectInspectors);
         }
         int numKeys = numDistinctExprs > 0 ? numDistinctExprs : 1;
         int keyLen = numDistinctExprs > 0 ? numDistributionKeys + 1 : numDistributionKeys;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ReduceSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ReduceSinkOperator.java
@@ -26,12 +26,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.function.BiFunction;
 
+import java.util.function.ToIntFunction;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
-import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.BucketCodec;
 import org.apache.hadoop.hive.ql.io.HiveKey;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -63,8 +62,6 @@ public class ReduceSinkOperator extends TerminalOperator<ReduceSinkDesc>
 
   private static final long serialVersionUID = 1L;
 
-  private transient ObjectInspector[] partitionObjectInspectors;
-  private transient ObjectInspector[] bucketObjectInspectors;
   private transient int buckColIdxInKey;
   /**
    * {@link org.apache.hadoop.hive.ql.optimizer.SortedDynPartitionOptimizer}
@@ -113,7 +110,8 @@ public class ReduceSinkOperator extends TerminalOperator<ReduceSinkDesc>
   protected transient List<List<Integer>> distinctColIndices;
   protected transient Random random;
 
-  protected transient BiFunction<Object[], ObjectInspector[], Integer> hashFunc;
+  protected transient ToIntFunction<Object[]> partitionHashFunc;
+  protected transient ToIntFunction<Object[]> bucketHashFunc;
 
   /**
    * This two dimensional array holds key data and a corresponding Union object
@@ -230,14 +228,6 @@ public class ReduceSinkOperator extends TerminalOperator<ReduceSinkDesc>
       useUniformHash = conf.getReducerTraits().contains(UNIFORM);
 
       firstRow = true;
-      // acidOp flag has to be checked to use JAVA hash which works like
-      // identity function for integers, necessary to read RecordIdentifier
-      // incase of ACID updates/deletes.
-      boolean acidOp = conf.getWriteType() == AcidUtils.Operation.UPDATE ||
-          conf.getWriteType() == AcidUtils.Operation.DELETE;
-      hashFunc = getConf().getBucketingVersion() == 2 && !acidOp ?
-          ObjectInspectorUtils::getBucketHashCode :
-          ObjectInspectorUtils::getBucketHashCodeOld;
     } catch (Exception e) {
       String msg = "Error initializing ReduceSinkOperator: " + e.getMessage();
       LOG.error(msg, e);
@@ -304,9 +294,9 @@ public class ReduceSinkOperator extends TerminalOperator<ReduceSinkDesc>
             conf.getOutputKeyColumnNames(), numDistributionKeys, rowInspector);
         valueObjectInspector = initEvaluatorsAndReturnStruct(valueEval,
             conf.getOutputValueColumnNames(), rowInspector);
-        partitionObjectInspectors = initEvaluators(partitionEval, rowInspector);
+        partitionHashFunc = conf.getPartitionFunction(initEvaluators(partitionEval, rowInspector));
         if (bucketEval != null) {
-          bucketObjectInspectors = initEvaluators(bucketEval, rowInspector);
+          bucketHashFunc = conf.getPartitionFunction(initEvaluators(bucketEval, rowInspector));
         }
         int numKeys = numDistinctExprs > 0 ? numDistinctExprs : 1;
         int keyLen = numDistinctExprs > 0 ? numDistributionKeys + 1 : numDistributionKeys;
@@ -391,8 +381,7 @@ public class ReduceSinkOperator extends TerminalOperator<ReduceSinkDesc>
     for (int i = 0; i < bucketEval.length; i++) {
       bucketFieldValues[i] = bucketEval[i].evaluate(row);
     }
-    return ObjectInspectorUtils.getBucketNumber(
-        hashFunc.apply(bucketFieldValues, bucketObjectInspectors), numBuckets);
+    return ObjectInspectorUtils.getBucketNumber(bucketHashFunc.applyAsInt(bucketFieldValues), numBuckets);
   }
 
   private void populateCachedDistributionKeys(Object row) throws HiveException {
@@ -447,7 +436,7 @@ public class ReduceSinkOperator extends TerminalOperator<ReduceSinkDesc>
       for(int i = 0; i < partitionEval.length; i++) {
         bucketFieldValues[i] = partitionEval[i].evaluate(row);
       }
-      keyHashCode = hashFunc.apply(bucketFieldValues, partitionObjectInspectors);
+      keyHashCode = partitionHashFunc.applyAsInt(bucketFieldValues);
     }
     int hashCode = buckNum < 0 ? keyHashCode : keyHashCode * 31 + buckNum;
     if (LOG.isTraceEnabled()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/CustomPartitionVertex.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/CustomPartitionVertex.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec.tez;
 
+import com.google.common.primitives.UnsignedBytes;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -25,18 +26,17 @@ import java.util.*;
 import java.util.Map.Entry;
 
 import com.google.common.collect.LinkedListMultimap;
+import org.apache.hadoop.hive.ql.io.HiveInputFormat.HiveInputSplit;
 import org.apache.hadoop.mapred.split.SplitLocationProvider;
 import org.apache.tez.runtime.api.events.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.plan.TezWork.VertexType;
 import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.serializer.SerializationFactory;
-import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.split.TezGroupedSplit;
@@ -75,23 +75,13 @@ import com.google.protobuf.ByteString;
  */
 public class CustomPartitionVertex extends VertexManagerPlugin {
 
-  public class PathComparatorForSplit implements Comparator<InputSplit> {
+  public static class ComparatorForSplit implements Comparator<InputSplit> {
 
     @Override
     public int compare(InputSplit inp1, InputSplit inp2) {
-      FileSplit fs1 = (FileSplit) inp1;
-      FileSplit fs2 = (FileSplit) inp2;
-
-      int retval = fs1.getPath().compareTo(fs2.getPath());
-      if (retval != 0) {
-        return retval;
-      }
-
-      if (fs1.getStart() != fs2.getStart()) {
-        return (int) (fs1.getStart() - fs2.getStart());
-      }
-
-      return 0;
+      HiveInputSplit fs1 = (HiveInputSplit) inp1;
+      HiveInputSplit fs2 = (HiveInputSplit) inp2;
+      return UnsignedBytes.lexicographicalComparator().compare(fs1.getBytesForIdentity(), fs2.getBytesForIdentity());
     }
   }
 
@@ -199,7 +189,7 @@ public class CustomPartitionVertex extends VertexManagerPlugin {
     }
 
     boolean dataInformationEventSeen = false;
-    Map<String, Set<FileSplit>> pathFileSplitsMap = new TreeMap<String, Set<FileSplit>>();
+    Map<Integer, Set<HiveInputSplit>> bucketFileSplitsMap = new TreeMap<>();
 
     for (Event event : events) {
       if (event instanceof InputConfigureVertexTasksEvent) {
@@ -221,28 +211,26 @@ public class CustomPartitionVertex extends VertexManagerPlugin {
       } else if (event instanceof InputDataInformationEvent) {
         dataInformationEventSeen = true;
         InputDataInformationEvent diEvent = (InputDataInformationEvent) event;
-        FileSplit fileSplit;
+        HiveInputSplit inputSplit;
         try {
-          fileSplit = getFileSplitFromEvent(diEvent);
+          inputSplit = getInputSplitFromEvent(diEvent);
         } catch (IOException e) {
           throw new RuntimeException("Failed to get file split for event: " + diEvent, e);
         }
-        Set<FileSplit> fsList =
-            pathFileSplitsMap.get(Utilities.getBucketFileNameFromPathSubString(fileSplit.getPath()
-                .getName()));
-        if (fsList == null) {
-          fsList = new TreeSet<FileSplit>(new PathComparatorForSplit());
-          pathFileSplitsMap.put(
-              Utilities.getBucketFileNameFromPathSubString(fileSplit.getPath().getName()), fsList);
+        final int bucketId = inputSplit.getBucketId().orElse(-1);
+        Set<HiveInputSplit> inputSplits = bucketFileSplitsMap.get(bucketId);
+        if (inputSplits == null) {
+          inputSplits = new TreeSet<>(new ComparatorForSplit());
+          bucketFileSplitsMap.put(bucketId, inputSplits);
         }
-        fsList.add(fileSplit);
+        inputSplits.add(inputSplit);
       }
     }
 
-    LOG.debug("Path file splits map for input name: {} is {}", inputName, pathFileSplitsMap);
+    LOG.debug("Bucket splits map for input name: {} is {}", inputName, bucketFileSplitsMap);
 
     Multimap<Integer, InputSplit> bucketToInitialSplitMap =
-        getBucketSplitMapForPath(inputName, pathFileSplitsMap);
+        getBucketSplitMapForBucket(inputName, bucketFileSplitsMap);
     Preconditions.checkState(
         bucketToInitialSplitMap.keySet().stream().allMatch(i -> 0 <= i && i < numBuckets));
 
@@ -512,8 +500,8 @@ public class CustomPartitionVertex extends VertexManagerPlugin {
     return UserPayload.create(ByteBuffer.wrap(serialized));
   }
 
-  private FileSplit getFileSplitFromEvent(InputDataInformationEvent event) throws IOException {
-    InputSplit inputSplit = null;
+  private HiveInputSplit getInputSplitFromEvent(InputDataInformationEvent event) throws IOException {
+    final InputSplit inputSplit;
     if (event.getDeserializedUserPayload() != null) {
       inputSplit = (InputSplit) event.getDeserializedUserPayload();
     } else {
@@ -522,19 +510,19 @@ public class CustomPartitionVertex extends VertexManagerPlugin {
       inputSplit = MRInputHelpers.createOldFormatSplitFromUserPayload(splitProto, serializationFactory);
     }
 
-    if (!(inputSplit instanceof FileSplit)) {
+    if (!(inputSplit instanceof HiveInputSplit)) {
       throw new UnsupportedOperationException(
-          "Cannot handle splits other than FileSplit for the moment. Current input split type: "
+          "Cannot handle splits other than HiveInputSplit for the moment. Current input split type: "
               + inputSplit.getClass().getSimpleName());
     }
-    return (FileSplit) inputSplit;
+    return (HiveInputSplit) inputSplit;
   }
 
   /*
    * This method generates the map of bucket to file splits.
    */
-  private Multimap<Integer, InputSplit> getBucketSplitMapForPath(String inputName,
-      Map<String, Set<FileSplit>> pathFileSplitsMap) {
+  private Multimap<Integer, InputSplit> getBucketSplitMapForBucket(String inputName,
+      Map<Integer, Set<HiveInputSplit>> bucketSplitsMap) {
 
     boolean isSMBJoin = numInputsAffectingRootInputSpecUpdate != 1;
     boolean isMainWork = mainWorkName.isEmpty() || inputName.compareTo(mainWorkName) == 0;
@@ -546,14 +534,13 @@ public class CustomPartitionVertex extends VertexManagerPlugin {
     Multimap<Integer, InputSplit> bucketToSplitMap = ArrayListMultimap.create();
 
     boolean fallback = false;
-    for (Map.Entry<String, Set<FileSplit>> entry : pathFileSplitsMap.entrySet()) {
+    for (Map.Entry<Integer, Set<HiveInputSplit>> entry : bucketSplitsMap.entrySet()) {
       // Extract the buckedID from pathFilesMap, this is more accurate method,
       // however. it may not work in certain cases where buckets are named
       // after files used while loading data. In such case, fallback to old
       // potential inaccurate method.
       // The accepted file names are such as 000000_0, 000001_0_copy_1.
-      String bucketIdStr = Utilities.getBucketFileNameFromPathSubString(entry.getKey());
-      int bucketId = Utilities.getBucketIdFromFile(bucketIdStr);
+      int bucketId = entry.getKey();
       if (bucketId < 0) {
         fallback = true;
         LOG.info("Fallback to using older sort based logic to assign buckets to splits.");
@@ -571,7 +558,7 @@ public class CustomPartitionVertex extends VertexManagerPlugin {
       // This is the old logic which assumes that the filenames are sorted in
       // alphanumeric order and mapped to appropriate bucket number.
       int curSplitIndex = 0;
-      for (Map.Entry<String, Set<FileSplit>> entry : pathFileSplitsMap.entrySet()) {
+      for (Map.Entry<Integer, Set<HiveInputSplit>> entry : bucketSplitsMap.entrySet()) {
         int bucketId = curSplitIndex % inputBucketSize;
         bucketToSplitMap.putAll(bucketId, entry.getValue());
         curSplitIndex++;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/CustomPartitionVertex.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/CustomPartitionVertex.java
@@ -79,7 +79,7 @@ public class CustomPartitionVertex extends VertexManagerPlugin {
 
     @Override
     public int compare(HiveInputSplit inp1, HiveInputSplit inp2) {
-      return UnsignedBytes.lexicographicalComparator().compare(inp1.getBytesForIdentity(), inp2.getBytesForIdentity());
+      return UnsignedBytes.lexicographicalComparator().compare(inp1.getBytesForEquality(), inp2.getBytesForEquality());
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
@@ -838,12 +838,7 @@ public class HiveInputFormat<K extends WritableComparable, V extends Writable>
           pushDownProjection = true;
           // push down filters and as of information
           pushFiltersAndAsOf(newjob, tableScan, this.mrwork);
-          final List<String> groupingPartitionColumns = tableScan.getConf().getGroupingPartitionColumns();
-          if (groupingPartitionColumns != null) {
-            newjob.setStrings(TableScanDesc.GROUPING_PARTITION_COLUMNS,
-                groupingPartitionColumns.toArray(new String[0]));
-            newjob.setInt(TableScanDesc.GROUPING_NUM_BUCKETS, tableScan.getConf().getGroupingNumBuckets());
-          }
+          addGroupingDetails(newjob, tableScan);
         }
       } else {
         if (LOG.isDebugEnabled()) {
@@ -1099,6 +1094,14 @@ public class HiveInputFormat<K extends WritableComparable, V extends Writable>
             ts.getConf().getAcidOperationalProperties());
         AcidUtils.setValidWriteIdList(job, ts.getConf());
       }
+    }
+  }
+
+  private void addGroupingDetails(JobConf conf, TableScanOperator tableScan) {
+    final List<String> groupingPartitionColumns = tableScan.getConf().getGroupingPartitionColumns();
+    if (groupingPartitionColumns != null) {
+      conf.setStrings(TableScanDesc.GROUPING_PARTITION_COLUMNS, groupingPartitionColumns.toArray(new String[0]));
+      conf.setInt(TableScanDesc.GROUPING_NUM_BUCKETS, tableScan.getConf().getGroupingNumBuckets());
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
@@ -59,7 +59,6 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.hive.serde2.SerDeUtils;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
@@ -175,11 +174,7 @@ public class HiveInputFormat<K extends WritableComparable, V extends Writable>
 
     public OptionalInt getBucketId() {
       if (inputSplit instanceof PartitionAwareSplit) {
-        final PartitionAwareSplit split = (PartitionAwareSplit) inputSplit;
-        final OptionalInt bucketHashCode = split.getBucketHashCode();
-        return bucketHashCode.isPresent()
-            ? OptionalInt.of(ObjectInspectorUtils.getBucketNumber(bucketHashCode.getAsInt(), split.getNumBuckets()))
-            : OptionalInt.empty();
+        return ((PartitionAwareSplit) inputSplit).getBucketId();
       }
 
       final int bucketId = Utilities.parseSplitBucket(inputSplit);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
@@ -276,7 +276,7 @@ public class HiveInputFormat<K extends WritableComparable, V extends Writable>
       }
     }
 
-    public byte[] getBytesForIdentity() {
+    public byte[] getBytesForEquality() {
       if (inputSplit instanceof HashableInputSplit) {
         return ((HashableInputSplit) inputSplit).getBytesForHash();
       } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/PartitionAwareSplit.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/PartitionAwareSplit.java
@@ -27,14 +27,8 @@ import org.apache.hadoop.hive.common.classification.InterfaceStability.Unstable;
 @Unstable
 public interface PartitionAwareSplit {
   /**
-   * Returns the bucket hash code. OptionalInt.empty() if this is not a bucketed split.
+   * Returns the bucket number of this split. OptionalInt.empty if this is not a bucketed split.
    */
   @Unstable
-  OptionalInt getBucketHashCode();
-
-  /**
-   * Returns the number of buckets.
-   */
-  @Unstable
-  int getNumBuckets();
+  OptionalInt getBucketId();
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/PartitionAwareSplit.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/PartitionAwareSplit.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.io;
+
+import java.util.OptionalInt;
+import org.apache.hadoop.hive.common.classification.InterfaceStability.Unstable;
+
+/**
+ * An InputSplit which supports Partition-Aware Table Scan.
+ */
+@Unstable
+public interface PartitionAwareSplit {
+  /**
+   * Returns the bucket hash code. OptionalInt.empty() if this is not a bucketed split.
+   */
+  @Unstable
+  OptionalInt getBucketHashCode();
+
+  /**
+   * Returns the number of buckets.
+   */
+  @Unstable
+  int getNumBuckets();
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hive.ql.parse.StorageFormat.StorageHandlerTypes;
 import org.apache.hadoop.hive.ql.parse.TransformSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.UpdateSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.plan.PartitionAwareOptimizationCtx;
 import org.apache.hadoop.hive.ql.plan.DynamicPartitionCtx;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.FileSinkDesc;
@@ -545,6 +546,29 @@ public interface HiveStorageHandler extends Configurable {
       throws SemanticException {
     Preconditions.checkState(alwaysUnpartitioned(), "Should only be called for table formats where partitioning " +
         "is not handled by Hive but the table format itself. See alwaysUnpartitioned() method.");
+    return null;
+  }
+
+  /**
+   * Checks whether the table supports Partition-Aware Optimization.
+   * @param table the table
+   * @return true if the table has partition definitions which potentially optimize query plans
+   * @throws SemanticException in case of any error.
+   */
+  default boolean supportsPartitionAwareOptimization(org.apache.hadoop.hive.ql.metadata.Table table)
+      throws SemanticException {
+    return false;
+  }
+
+  /**
+   * Creates a PartitionAwareOptimizationCtx that retains partition definitions applicable to query plan optimization.
+   * Hive can apply special optimization such as Bucket Map Join based on the storage layouts provided by this context.
+   * @param table the table
+   * @return the created PartitionAwareOptimizationCtx, null if this table doesn't support Partition-Aware Optimization
+   * @throws SemanticException in case of any error.
+   */
+  default PartitionAwareOptimizationCtx createPartitionAwareOptimizationContext(
+      org.apache.hadoop.hive.ql.metadata.Table table) throws SemanticException {
     return null;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 
@@ -56,6 +57,7 @@ import org.apache.hadoop.hive.ql.parse.GenTezUtils;
 import org.apache.hadoop.hive.ql.parse.OptimizeTezProcContext;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.plan.CustomBucketFunction;
 import org.apache.hadoop.hive.ql.plan.ColStatistics;
 import org.apache.hadoop.hive.ql.plan.CommonMergeJoinDesc;
 import org.apache.hadoop.hive.ql.plan.DummyStoreDesc;
@@ -211,8 +213,8 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     }
     // map join operator by default has no bucket cols and num of reduce sinks
     // reduced by 1
-    mapJoinOp.setOpTraits(new OpTraits(null, -1, null,
-        joinOp.getOpTraits().getNumReduceSinks()));
+    mapJoinOp.setOpTraits(new OpTraits(null, null, -1,
+        null, joinOp.getOpTraits().getNumReduceSinks()));
     preserveOperatorInfos(mapJoinOp, joinOp, context);
     // propagate this change till the next RS
     for (Operator<? extends OperatorDesc> childOp : mapJoinOp.getChildOperators()) {
@@ -545,8 +547,9 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
             joinOp.getSchema());
     context.parseContext.getContext().getPlanMapper().link(joinOp, mergeJoinOp);
     int numReduceSinks = joinOp.getOpTraits().getNumReduceSinks();
-    OpTraits opTraits = new OpTraits(joinOp.getOpTraits().getBucketColNames(), numBuckets,
-        joinOp.getOpTraits().getSortCols(), numReduceSinks);
+    OpTraits opTraits = new OpTraits(joinOp.getOpTraits().getBucketColNames(),
+        joinOp.getOpTraits().getCustomBucketFunctions(), numBuckets, joinOp.getOpTraits().getSortCols(),
+        numReduceSinks);
     mergeJoinOp.setOpTraits(opTraits);
     mergeJoinOp.getConf().setBucketingVersion(joinOp.getConf().getBucketingVersion());
     preserveOperatorInfos(mergeJoinOp, joinOp, context);
@@ -625,8 +628,9 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     if (currentOp instanceof ReduceSinkOperator) {
       return;
     }
-    currentOp.setOpTraits(new OpTraits(opTraits.getBucketColNames(),
-        opTraits.getNumBuckets(), opTraits.getSortCols(), opTraits.getNumReduceSinks()));
+    currentOp.setOpTraits(new OpTraits(opTraits.getBucketColNames(), opTraits.getCustomBucketFunctions(),
+        opTraits.getNumBuckets(), opTraits.getSortCols(),
+        opTraits.getNumReduceSinks()));
     for (Operator<? extends OperatorDesc> childOp : currentOp.getChildOperators()) {
       if ((childOp instanceof ReduceSinkOperator) || (childOp instanceof GroupByOperator)) {
         break;
@@ -657,6 +661,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     boolean updatePartitionCols = false;
     List<Integer> positions = new ArrayList<>();
 
+    final CustomBucketFunction bucketFunction;
     if (listBucketCols.get(0).size() != bigTablePartitionCols.size()) {
       updatePartitionCols = true;
       // Prepare updated partition columns for small table(s).
@@ -664,15 +669,33 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
 
       int bigTableExprPos = 0;
       Map<String, ExprNodeDesc> colExprMap = bigTableRS.getColumnExprMap();
+      final boolean[] retainedColumns = new boolean[listBucketCols.get(0).size()];
       for (ExprNodeDesc bigTableExpr : bigTablePartitionCols) {
         // It is guaranteed there is only 1 list within listBucketCols.
-        for (String colName : listBucketCols.get(0)) {
+        for (int i = 0; i < listBucketCols.get(0).size(); i++) {
+          final String colName = listBucketCols.get(0).get(i);
           if (colExprMap.get(colName).isSame(bigTableExpr)) {
             positions.add(bigTableExprPos);
+            retainedColumns[i] = true;
           }
         }
         bigTableExprPos = bigTableExprPos + 1;
       }
+
+      Preconditions.checkState(opTraits.getCustomBucketFunctions().size() == 1);
+      if (opTraits.getCustomBucketFunctions().get(0) == null) {
+        bucketFunction = null;
+      } else {
+        final Optional<CustomBucketFunction> selected =
+            opTraits.getCustomBucketFunctions().get(0).select(retainedColumns);
+        if (!selected.isPresent()) {
+          LOG.info("{} can't keep itself only with {}", opTraits.getCustomBucketFunctions().get(0), retainedColumns);
+          return false;
+        }
+        bucketFunction = selected.get();
+      }
+    } else {
+      bucketFunction = opTraits.getCustomBucketFunctions().get(0);
     }
 
     MapJoinOperator mapJoinOp = convertJoinMapJoin(joinOp, context, mapJoinConversion, true);
@@ -684,7 +707,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     joinDesc.setBucketMapJoin(true);
 
     // we can set the traits for this join operator
-    opTraits = new OpTraits(joinOp.getOpTraits().getBucketColNames(),
+    opTraits = new OpTraits(joinOp.getOpTraits().getBucketColNames(), joinOp.getOpTraits().getCustomBucketFunctions(),
         tezBucketJoinProcCtx.getNumBuckets(), null, joinOp.getOpTraits().getNumReduceSinks());
     mapJoinOp.setOpTraits(opTraits);
     preserveOperatorInfos(mapJoinOp, joinOp, context);
@@ -711,6 +734,23 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
           newPartitionCols.add(partitionCols.get(position));
         }
         rsOp.getConf().setPartitionCols(newPartitionCols);
+      }
+    }
+
+    if (bucketFunction != null) {
+      final Operator<?> bigTableOp = mapJoinOp.getParentOperators().get(bigTablePosition);
+      for (TableScanOperator tso : OperatorUtils.findOperatorsUpstream(bigTableOp, TableScanOperator.class)) {
+        tso.getConf().setGroupingPartitionColumns(bucketFunction.getSourceColumnNames());
+        tso.getConf().setGroupingNumBuckets(bucketFunction.getNumBuckets());
+      }
+
+      for (Operator<?> op : mapJoinOp.getParentOperators()) {
+        if (!(op instanceof ReduceSinkOperator)) {
+          continue;
+        }
+
+        ReduceSinkOperator rsOp = (ReduceSinkOperator) op;
+        rsOp.getConf().setCustomPartitionFunction(bucketFunction);
       }
     }
 
@@ -800,6 +840,11 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
         return false;
       }
       ReduceSinkOperator rsOp = (ReduceSinkOperator) parentOp;
+      if (rsOp.getOpTraits().hasCustomBucketFunction()) {
+        LOG.info("We don't support SMB with custom bucket functions yet");
+        return false;
+      }
+
       List<ExprNodeDesc> keyCols = rsOp.getConf().getKeyCols();
 
       // For SMB, the key column(s) in RS should be same as bucket column(s) and sort column(s)`
@@ -905,8 +950,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
    * can create a bucket map join eliminating the reduce sink.
    */
   private boolean checkConvertJoinBucketMapJoin(JoinOperator joinOp,
-      int bigTablePosition, TezBucketJoinProcCtx tezBucketJoinProcCtx)
-          throws SemanticException {
+      int bigTablePosition, TezBucketJoinProcCtx tezBucketJoinProcCtx) {
     // bail on mux-operator because mux operator masks the emit keys of the
     // constituent reduce sinks
     if (!(joinOp.getParentOperators().get(0) instanceof ReduceSinkOperator)) {
@@ -919,9 +963,10 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     List<List<String>> parentColNames = rs.getOpTraits().getBucketColNames();
     Operator<? extends OperatorDesc> parentOfParent = rs.getParentOperators().get(0);
     List<List<String>> grandParentColNames = parentOfParent.getOpTraits().getBucketColNames();
-    int numBuckets = parentOfParent.getOpTraits().getNumBuckets();
-    // all keys matched.
-    if (!checkColEquality(grandParentColNames, parentColNames, rs.getColumnExprMap(), true)) {
+    Preconditions.checkState(rs.getOpTraits().getCustomBucketFunctions() == null
+        || rs.getOpTraits().getCustomBucketFunctions().size() == 1);
+    final boolean hasCustomBucketFunction = rs.getOpTraits().hasCustomBucketFunction();
+    if (!checkColEquality(grandParentColNames, parentColNames, rs.getColumnExprMap(), !hasCustomBucketFunction)) {
       LOG.info("No info available to check for bucket map join. Cannot convert");
       return false;
     }
@@ -943,6 +988,10 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
      * this is the case when the big table is a sub-query and is probably already bucketed by the
      * join column in say a group by operation
      */
+    final CustomBucketFunction parentBucketFunction = rs.getOpTraits().getCustomBucketFunctions().get(0);
+    int numBuckets = parentBucketFunction != null
+        ? parentBucketFunction.getNumBuckets()
+        : parentOfParent.getOpTraits().getNumBuckets();
     if (numBuckets < 0) {
       numBuckets = rs.getConf().getNumReducers();
     }
@@ -1521,12 +1570,22 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     int estimatedBuckets = -1;
 
     for (Operator<? extends OperatorDesc>parentOp : joinOp.getParentOperators()) {
-      if (parentOp.getOpTraits().getNumBuckets() > 0) {
-        numBuckets = (numBuckets < parentOp.getOpTraits().getNumBuckets()) ?
-            parentOp.getOpTraits().getNumBuckets() : numBuckets;
+      final OpTraits parentOpTraits = parentOp.getOpTraits();
+      if (parentOpTraits.getNumBuckets() > 0) {
+        numBuckets = (numBuckets < parentOpTraits.getNumBuckets()) ?
+            parentOpTraits.getNumBuckets() : numBuckets;
       }
 
-      if (!useOpTraits && parentOp instanceof ReduceSinkOperator) {
+      if (!(parentOp instanceof ReduceSinkOperator)) {
+        continue;
+      }
+
+      if (parentOpTraits.hasCustomBucketFunction()) {
+        Preconditions.checkState(parentOpTraits.getCustomBucketFunctions().size() == 1);
+        numBuckets = Math.max(numBuckets, parentOpTraits.getCustomBucketFunctions().get(0).getNumBuckets());
+      }
+
+      if (!useOpTraits) {
         ReduceSinkOperator rs = (ReduceSinkOperator) parentOp;
         estimatedBuckets = (estimatedBuckets < rs.getConf().getNumReducers()) ?
             rs.getConf().getNumReducers() : estimatedBuckets;
@@ -1583,6 +1642,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
         // sortCols: This is an unsorted join - no sort cols
         OpTraits opTraits = new OpTraits(
             joinOp.getOpTraits().getBucketColNames(),
+            joinOp.getOpTraits().getCustomBucketFunctions(),
             numReducers,
             null,
             joinOp.getOpTraits().getNumReduceSinks());

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -718,7 +718,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     if (updatePartitionCols) {
       // use the positions to only pick the partitionCols which are required
       // on the small table side.
-      mapJoinOp.getParentOperators().stream().filter(op -> op instanceof ReduceSinkOperator).forEach(op -> {
+      mapJoinOp.getParentOperators().stream().filter(ReduceSinkOperator.class::isInstance).forEach(op -> {
         ReduceSinkOperator rsOp = (ReduceSinkOperator) op;
         List<ExprNodeDesc> newPartitionCols = new ArrayList<>();
         List<ExprNodeDesc> partitionCols = rsOp.getConf().getPartitionCols();
@@ -737,7 +737,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
       }
 
       final CustomBucketFunction finalBucketFunction = bucketFunction;
-      mapJoinOp.getParentOperators().stream().filter(op -> op instanceof ReduceSinkOperator).forEach(op -> {
+      mapJoinOp.getParentOperators().stream().filter(ReduceSinkOperator.class::isInstance).forEach(op -> {
         ReduceSinkOperator rsOp = (ReduceSinkOperator) op;
         rsOp.getConf().setCustomPartitionFunction(finalBucketFunction);
       });

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/metainfo/annotation/OpTraitsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/metainfo/annotation/OpTraitsRulesProcFactory.java
@@ -175,10 +175,7 @@ public class OpTraitsRulesProcFactory {
       } else {
         Preconditions.checkState(parentOpTraits.getBucketColNames().size() == 1);
         Preconditions.checkState(parentOpTraits.getCustomBucketFunctions().size() == 1);
-        final Map<String, String> inputToOutput = rs
-            .getColumnExprMap()
-            .entrySet()
-            .stream()
+        final Map<String, String> inputToOutput = rs.getColumnExprMap().entrySet().stream()
             .filter(entry -> entry.getValue() instanceof ExprNodeColumnDesc)
             .filter(entry -> rs.getConf().getKeyCols().stream().anyMatch(keyDesc -> keyDesc.isSame(entry.getValue())))
             .collect(Collectors.toMap(
@@ -191,8 +188,8 @@ public class OpTraitsRulesProcFactory {
         final List<String> rsBucketColNames = new ArrayList<>();
         for (int i = 0; i < parentBucketColNames.size(); i++) {
           final String rsColumnName = inputToOutput.get(parentBucketColNames.get(i));
-          retainedColumns[i] = rsColumnName != null;
           if (rsColumnName != null) {
+            retainedColumns[i] = true;
             rsBucketColNames.add(rsColumnName);
           }
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/CustomBucketFunction.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/CustomBucketFunction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.plan;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.hive.common.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+/**
+ * A bucketing logic based on flexible transformations, e.g. partition transforms of Apache Iceberg.
+ */
+@Unstable
+public interface CustomBucketFunction extends Serializable {
+  /**
+   * Creates a new CustomBucketFunction which accepts only the given columns.
+   *
+   * @param retainedColumns the flags of retained columns
+   * @return a new CustomBucketFunction accepting the retained columns
+   *         Optional.empty() if the subset can't generate a bucket id
+   */
+  @Unstable
+  Optional<CustomBucketFunction> select(boolean[] retainedColumns);
+
+  /**
+   * Initializes this bucket function with the given ObjectInspectors.
+   *
+   * @param bucketFieldInspectors the ObjectInspectors which decode the bucketFields
+   */
+  @Unstable
+  void initialize(ObjectInspector[] bucketFieldInspectors);
+
+  /**
+   * Returns the column names in the source table.
+   */
+  @Unstable
+  List<String> getSourceColumnNames();
+
+  /**
+   * Returns the number of buckets.
+   */
+  @Unstable
+  int getNumBuckets();
+
+  /**
+   * Produces a hash code from the given arguments.
+   *
+   * @param bucketFields the source fields
+   * @return the bucket hash code
+   */
+  @Unstable
+  int getBucketHashCode(Object[] bucketFields);
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/OpTraits.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/OpTraits.java
@@ -18,18 +18,28 @@
 
 package org.apache.hadoop.hive.ql.plan;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
+import java.util.Objects;
 
 public class OpTraits {
 
-  private List<List<String>> bucketColNames;
+  private final List<List<String>> bucketColNames;
+  private final List<CustomBucketFunction> customBucketFunctions;
   private List<List<String>> sortColNames;
   private int numBuckets;
   private int numReduceSinks;
 
-  public OpTraits(List<List<String>> bucketColNames, int numBuckets,
-      List<List<String>> sortColNames, int numReduceSinks) {
+  public OpTraits(List<List<String>> bucketColNames, List<CustomBucketFunction> customBucketFunctions, int numBuckets,
+      List<List<String>> sortColNames,
+      int numReduceSinks) {
+    if (bucketColNames == null) {
+      Preconditions.checkArgument(customBucketFunctions == null);
+    } else {
+      Preconditions.checkArgument(bucketColNames.size() == customBucketFunctions.size());
+    }
     this.bucketColNames = bucketColNames;
+    this.customBucketFunctions = customBucketFunctions;
     this.numBuckets = numBuckets;
     this.sortColNames = sortColNames;
     this.numReduceSinks = numReduceSinks;
@@ -41,10 +51,6 @@ public class OpTraits {
 
   public int getNumBuckets() {
     return numBuckets;
-  }
-
-  public void setBucketColNames(List<List<String>> bucketColNames) {
-    this.bucketColNames = bucketColNames;
   }
 
   public void setNumBuckets(int numBuckets) {
@@ -59,6 +65,13 @@ public class OpTraits {
     return sortColNames;
   }
 
+  public List<CustomBucketFunction> getCustomBucketFunctions() {
+    return customBucketFunctions;
+  }
+
+  public boolean hasCustomBucketFunction() {
+    return customBucketFunctions != null && customBucketFunctions.stream().anyMatch(Objects::nonNull);
+  }
 
   public void setNumReduceSinks(int numReduceSinks) {
     this.numReduceSinks = numReduceSinks;
@@ -70,7 +83,8 @@ public class OpTraits {
 
   @Override
   public String toString() {
-    return "{ bucket column names: " + bucketColNames + "; sort column names: "
-        + sortColNames + "; bucket count: " + numBuckets + "}";
+    return "{ bucket column names: " + bucketColNames + "; custom partition functions: " + customBucketFunctions
+        + "; sort column names: " + sortColNames + "; bucket count: " + numBuckets + "; num reduce sinks: "
+        + numReduceSinks + "}";
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PartitionAwareOptimizationCtx.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PartitionAwareOptimizationCtx.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.plan;
+
+import org.apache.hadoop.hive.common.classification.InterfaceStability.Unstable;
+
+/**
+ * A context to support Partition-Aware Optimization leveraging storage layouts.
+ */
+@Unstable
+public class PartitionAwareOptimizationCtx {
+  private final CustomBucketFunction bucketFunction;
+
+  /**
+   * Constructs a new PartitionAwareOptimizationCtx.
+   *
+   * @param bucketFunction the bucket function
+   */
+  @Unstable
+  public PartitionAwareOptimizationCtx(CustomBucketFunction bucketFunction) {
+    this.bucketFunction = bucketFunction;
+  }
+
+  /**
+   * Returns the bucket function for Partition-Aware Optimization.
+   */
+  @Unstable
+  public CustomBucketFunction getBucketFunction() {
+    return bucketFunction;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableScanDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableScanDesc.java
@@ -61,6 +61,9 @@ public class TableScanDesc extends AbstractOperatorDesc implements IStatsGatherD
    */
   private List<String> partColumns;
 
+  private List<String> groupingPartitionColumns;
+  private Integer groupingNumBuckets;
+
   /**
    * Used for split sampling (row count per split)
    * For example,
@@ -105,6 +108,12 @@ public class TableScanDesc extends AbstractOperatorDesc implements IStatsGatherD
 
   public static final String PARTITION_PRUNING_FILTER =
       "hive.io.pruning.filter";
+
+  public static final String GROUPING_PARTITION_COLUMNS =
+      "hive.io.grouping.partition.columns";
+
+  public static final String GROUPING_NUM_BUCKETS =
+      "hive.io.grouping.num.buckets";
 
   public static final String AS_OF_TIMESTAMP =
       "hive.io.as.of.timestamp";
@@ -348,6 +357,26 @@ public class TableScanDesc extends AbstractOperatorDesc implements IStatsGatherD
 
   public List<String> getPartColumns () {
     return partColumns;
+  }
+
+  public void setGroupingPartitionColumns(List<String> groupingPartitionColumns) {
+    this.groupingPartitionColumns = groupingPartitionColumns;
+  }
+
+  @Explain(displayName = "Grouping Partition Columns", explainLevels = { Level.USER, Level.EXTENDED })
+  @Signature
+  public List<String> getGroupingPartitionColumns() {
+    return groupingPartitionColumns;
+  }
+
+  public void setGroupingNumBuckets(int groupingNumBuckets) {
+    this.groupingNumBuckets = groupingNumBuckets;
+  }
+
+  @Explain(displayName = "Grouping Num Buckets", explainLevels = { Level.USER, Level.EXTENDED })
+  @Signature
+  public Integer getGroupingNumBuckets() {
+    return groupingNumBuckets;
   }
 
   public void setGatherStats(boolean gatherStats) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDF.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDF.java
@@ -100,6 +100,7 @@ public abstract class GenericUDF implements Closeable {
 
     @Override
     public void prepare(int version) throws HiveException {
+      // This implementation doesn't need to be prepared
     }
 
     @Override
@@ -116,6 +117,7 @@ public abstract class GenericUDF implements Closeable {
 
     @Override
     public void prepare(int version) throws HiveException {
+      // This implementation doesn't need to be prepared
     }
 
     @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDF.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDF.java
@@ -109,6 +109,26 @@ public abstract class GenericUDF implements Closeable {
   }
 
   /**
+   * A basic implementation of DeferredObject which allows to set or get a Java Object reference.
+   */
+  public static class SettableDeferredJavaObject implements DeferredObject {
+    private Object value;
+
+    @Override
+    public void prepare(int version) throws HiveException {
+    }
+
+    @Override
+    public Object get() throws HiveException {
+      return value;
+    }
+
+    public void set(Object value) {
+      this.value = value;
+    }
+  }
+
+  /**
    * The constructor.
    */
   public GenericUDF() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable Bucket Map Join using Bucket Transform of Apache Iceberg. This is a part of the Partition-Aware Optimization initiative.

- https://issues.apache.org/jira/browse/HIVE-28411
- https://issues.apache.org/jira/browse/HIVE-28410
- https://docs.google.com/document/d/1srEK3atO2T3Apa-FsF6bW__ECY-nFrev_1RZ8EN4UF8/edit#heading=h.jzie7kdemx93

### Why are the changes needed?

We know Bucket Map Join can significantly improve performance in some cases. This PR would unlock the capability to any Open Table Format.

### Does this PR introduce _any_ user-facing change?

Yes. Execution plans would change if Iceberg users had bucketed tables. They can disable the optimization with `hive.convert.join.bucket.mapjoin.tez=false`.

I expect non-Iceberg users not to see any changes.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

I added multiple tests. `iceberg_bucket_map_join_[1-6].q` are copied from original qtests of Hive native tables. `iceberg_bucket_map_join[7-8].q` are new test cases.

[The first commit](https://github.com/apache/hive/pull/5409/commits/211ce0fee7691117fcaaa8fd648e8a5013dfb1e9) added all test cases and `q.out` on the latest master branch. It would help you track how execution plans would change with this PR.

### Note

This PR doesn't introduce Bucket Map Join using non-bucketing partitions. Also, we don't support the case with partition evolutions yet as you can see it in `iceberg_bucket_map_join_4.q`.