### PR TITLE
HIVE-28487: Fix outdated MetastoreSchemaTool class reference in schemaTool.sh

### DIFF
--- a/standalone-metastore/metastore-server/src/main/scripts/ext/schemaTool.sh
+++ b/standalone-metastore/metastore-server/src/main/scripts/ext/schemaTool.sh
@@ -18,7 +18,7 @@ export SERVICE_LIST="${SERVICE_LIST}${THISSERVICE} "
 
 schemaTool() {
   METASTORE_OPTS=''
-  CLASS=org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool
+  CLASS=org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool
   if $cygwin; then
     METASTORE_LIB=`cygpath -w "$METASTORE_LIB"`
   fi


### PR DESCRIPTION

In a94c0306f48215d96be3b842525c4341772d26f9 `MetastoreSchemaTool` was moved from `org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool` to `org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool`, but it seems like `schemaTool.sh` was not updated.

This results in a `ClassNotFoundException: org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool`


### What changes were proposed in this pull request?

Update outdated class reference to actual one.

### Why are the changes needed?

Let `schemaTool.sh` work again :)

### Does this PR introduce _any_ user-facing change?
Yes, the shell script now works. See "How was this patch tested?" for the CLI output.

### Is the change a dependency upgrade?
No

### How was this patch tested?

Before (fails)

```bash
/stackable/apache-hive-metastore-4.0.0-bin $ bin/base --service schemaTool
Exception in thread "main" java.lang.ClassNotFoundException: org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:398)
        at org.apache.hadoop.util.RunJar.run(RunJar.java:321)
        at org.apache.hadoop.util.RunJar.main(RunJar.java:241)
```

After (works)

```bash
/stackable/apache-hive-metastore-4.0.0-bin $ bin/base --service schemaTool
# [...]
Failed to parse command line. 
org.apache.commons.cli.ParseException: HiveSchemaTool:Parsing failed. Reason: Missing required options: [-help print this message, -info Show config and schema details, -upgradeSchema Schema upgrade, -upgradeSchemaFrom Schema upgrade from a version, -initSchema Schema initialization, -dropAllDatabases Drop all Hive databases (with CASCADE). This will remove all managed data!, -initSchemaTo Schema initialization to a version, -initOrUpgradeSchema Initialize or upgrade schema to latest version, -validate Validate the database, -createCatalog Create a catalog, requires --catalogLocation parameter as well, -alterCatalog Alter a catalog, requires --catalogLocation and/or --catalogDescription parameter as well, -mergeCatalog Merge databases from a catalog into other, Argument is the source catalog name Requires --toCatalog to indicate the destination catalog, -moveDatabase Move a database between catalogs.  Argument is the database name. Requires --fromCatalog and --toCatalog parameters as well, -moveTable Move a table to a different database.  Argument is the table name. Requires --fromCatalog, --toCatalog, --fromDatabase, and --toDatabase  parameters as well., -createUser Create the Hive user, set hiveUser to the db admin user and the hive password to the db admin password with this, -createLogsTable Create table for Hive warehouse/compute logs], dbType
Underlying cause: org.apache.commons.cli.ParseException : HiveSchemaTool:Parsing failed. Reason: Missing required options: [-help print this message, -info Show config and schema details, -upgradeSchema Schema upgrade, -upgradeSchemaFrom Schema upgrade from a version, -initSchema Schema initialization, -dropAllDatabases Drop all Hive databases (with CASCADE). This will remove all managed data!, -initSchemaTo Schema initialization to a version, -initOrUpgradeSchema Initialize or upgrade schema to latest version, -validate Validate the database, -createCatalog Create a catalog, requires --catalogLocation parameter as well, -alterCatalog Alter a catalog, requires --catalogLocation and/or --catalogDescription parameter as well, -mergeCatalog Merge databases from a catalog into other, Argument is the source catalog name Requires --toCatalog to indicate the destination catalog, -moveDatabase Move a database between catalogs.  Argument is the database name. Requires --fromCatalog and --toCatalog parameters as well, -moveTable Move a table to a different database.  Argument is the table name. Requires --fromCatalog, --toCatalog, --fromDatabase, and --toDatabase  parameters as well., -createUser Create the Hive user, set hiveUser to the db admin user and the hive password to the db admin password with this, -createLogsTable Create table for Hive warehouse/compute logs], dbType
*** schemaTool failed ***
```

CC @miklosgergely and @ashutoshc, as you did the original refactoring