### PR TITLE
HIVE-28483: Fix for casting invalid date give wrong result instead of…

### DIFF
--- a/common/src/test/org/apache/hive/common/util/TestDateParser.java
+++ b/common/src/test/org/apache/hive/common/util/TestDateParser.java
@@ -45,35 +45,27 @@ public class TestDateParser {
 
   @Test
   public void testValidCases() throws Exception {
-    checkValidCase("1945-12-31", Date.valueOf("1945-12-31"));
-    checkValidCase("1946-01-01", Date.valueOf("1946-01-01"));
-    checkValidCase("2001-11-12", Date.valueOf("2001-11-12"));
-    checkValidCase("0004-05-06", Date.valueOf("0004-05-06"));
-    checkValidCase("1678-09-10", Date.valueOf("1678-09-10"));
-    checkValidCase("9999-10-11", Date.valueOf("9999-10-11"));
+    checkValidCase("1945-12-31", Date.of(1945,12,31));
+    checkValidCase("1946-01-01", Date.of(1946,1,1));
+    checkValidCase("2001-11-12", Date.of(2001,11,12));
+    checkValidCase("0004-05-06", Date.of(4,5,6));
+    checkValidCase("1678-09-10", Date.of(1678,9,10));
+    checkValidCase("9999-10-11", Date.of(9999,10,11));
 
     // Timestamp strings should parse ok
-    checkValidCase("2001-11-12 01:02:03", Date.valueOf("2001-11-12"));
+    checkValidCase("2001-11-12 01:02:03", Date.of(2001,11,12));
 
     // Leading spaces
-    checkValidCase(" 1946-01-01", Date.valueOf("1946-01-01"));
-    checkValidCase(" 2001-11-12 01:02:03", Date.valueOf("2001-11-12"));
+    checkValidCase(" 1946-01-01", Date.of(1946,01,01));
+    checkValidCase(" 2001-11-12 01:02:03", Date.of(2001,11,12));
   }
 
   @Test
   public void testParseDateFromTimestampWithCommonTimeDelimiter() {
-    for (String d : new String[] { "T", " ", "-", ".", "_", "" }) {
+    for (String d : new String[] { "T", " ", "-", ".", "_" }) {
       String ts = "2023-08-03" + d + "01:02:03";
       assertEquals("Parsing " + ts, Date.of(2023, 8, 3), DateParser.parseDate(ts));
     }
-  }
-
-  @Test
-  public void testParseDateFromValidDateLiteralWithTrailingDigits() {
-    assertEquals(Date.of(2023, 8, 8), DateParser.parseDate("2023-08-0800"));
-    // The result may seem unexpected but for many "08-08-20" is a valid date so there is no reason to reject
-    // "08-08-2023" and return null unless in the future Hive becomes stricter in terms of parsing dates.
-    assertEquals(Date.of(8, 8, 20), DateParser.parseDate("08-08-2023"));
   }
 
   @Test
@@ -86,5 +78,8 @@ public class TestDateParser {
     checkInvalidCase("0000-00-00");
     checkInvalidCase("2001-13-12");
     checkInvalidCase("2001-11-31");
+    checkInvalidCase("19999-10-11");
+    checkInvalidCase("08-08-2023");
+    checkInvalidCase("2023-08-0800");
   }
 }


### PR DESCRIPTION
Fix for casting invalid date give wrong result instead of null

Change-Id: Iffee3e070fadbbfca83adb98561e95f216f7722e

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Casting invalid date may gave back strange date instead of null.


### Does this PR introduce _any_ user-facing change?
Yes, it gives back null if casting an invalid date, instead of a strange result.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Unit test.
