### PR TITLE
HIVE-28492: Upgrade Janino version to 3.1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <re2j.version>1.2</re2j.version>
     <rs-api.version>2.0.1</rs-api.version>
     <json-path.version>2.9.0</json-path.version>
-    <janino.version>3.0.11</janino.version>
+    <janino.version>3.1.12</janino.version>
     <datasketches.version>1.2.0</datasketches.version>
     <spotbugs.version>4.0.3</spotbugs.version>
     <validation-api.version>1.1.0.Final</validation-api.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
The janino version is getting upgraded from 3.0.11 to 3.1.12


### Why are the changes needed?
The changes are needed as the current version of Janino has several CVEs 
Vulnerabilities from dependencies:
[CVE-2021-36373](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36373)
[CVE-2020-1945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1945)
[CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)

With the upgrade to 3.1.12, all the CVEs would be handled 

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes



