### PR TITLE
HIVE-28503: Wrong results(NULL) when string concat operation with || operator for ORC file format when vectorization enabled

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/StringGroupConcatColCol.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/StringGroupConcatColCol.java
@@ -320,7 +320,8 @@ public class StringGroupConcatColCol extends VectorExpression {
       /*
        * Do careful maintenance of the outputColVector.noNulls flag.
        */
-
+      // propagate not nulls flag.
+      outV.noNulls = true;
       // perform data operation
       if (inV1.isRepeating && inV2.isRepeating) {
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Set the output vector flag correctly about whether it has NULL or NOT NULL in case of all inputs values are NOT NULL.
StringGroupConcatColCol->evaluate() method:

if (inV1.noNulls && !inV2.noNulls) {    //if any one input has NULL, then output should be NULL. 
     outV.noNulls = false;                      // setting this flag false as all values in this are NULLs
 --- code --- 
}  else if (!inV1.noNulls && inV2.noNulls) {    //if any one input has NULL, then output should be NULL.
 // propagate nulls
   outV.noNulls = false;                  // setting this flag false as all values in this are NULLs
}  else if (!inV1.noNulls && !inV2.noNulls) {   // if two inputs are NULL, then output should be NULL.
   // propagate nulls
   outV.noNulls = false;           //setting this flag false as all values in this are NULLs
    --- code --- 
}  else  {                       // there are no nulls in either input vector
    outV.noNulls = true;    // this has to be set true, as there are no NULL values, this check is missed currently.
    // perform data operation
   --- code --- 
}

### Why are the changes needed?
While doing concat() operation, In StringGroupConcatColCol class, if input batch vector has mixed of NULL and NOT NULL values of inputs then we are not setting output vector batch flags related to NULL and NOT NULLS correctly . Each value in the vector has the flag whether it is NULL or NOT NULL. But  here we are not setting correctly the whole output vector flag (outV.noNulls). 


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Existing Q files. Cant add new tests as this was able to reproduce only in cluster with more input records. Tested in cluster and verified.
