### PR TITLE
HIVE-28514: Iceberg: Fix checkstyle file to adapt new checkstyle version

### DIFF
--- a/iceberg/checkstyle/checkstyle.xml
+++ b/iceberg/checkstyle/checkstyle.xml
@@ -448,7 +448,7 @@
           <property name="max" value="12"/>
         </module>
         <module name="JavadocMethod"> <!-- Java Style Guide: Where Javadoc is used -->
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>

--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -88,8 +88,8 @@ public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException>
 
   @Override
   protected boolean isConnectionException(Exception e) {
-    return super.isConnectionException(e) || (e != null && e instanceof MetaException &&
-        e.getMessage().contains("Got exception: org.apache.thrift.transport.TTransportException"));
+    return super.isConnectionException(e) || e != null && e instanceof MetaException &&
+        e.getMessage().contains("Got exception: org.apache.thrift.transport.TTransportException");
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -1019,8 +1019,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
 
   private boolean isOrcOnlyFiles(org.apache.hadoop.hive.metastore.api.Table hmsTable) {
     return !"FALSE".equalsIgnoreCase(hmsTable.getParameters().get(ORC_FILES_ONLY)) &&
-        ((hmsTable.getSd().getInputFormat() != null &&
-            hmsTable.getSd().getInputFormat().toUpperCase().contains(org.apache.iceberg.FileFormat.ORC.name())) ||
+        (hmsTable.getSd().getInputFormat() != null &&
+            hmsTable.getSd().getInputFormat().toUpperCase().contains(org.apache.iceberg.FileFormat.ORC.name()) ||
             org.apache.iceberg.FileFormat.ORC.name()
                 .equalsIgnoreCase(hmsTable.getSd().getSerdeInfo().getParameters().get("write.format.default")) ||
             org.apache.iceberg.FileFormat.ORC.name()

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -542,15 +542,15 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
         puffinWriter.finish();
 
         statisticsFile =
-          new GenericStatisticsFile(
-            snapshotId,
-            statsPath,
-            puffinWriter.fileSize(),
-            puffinWriter.footerSize(),
-            puffinWriter.writtenBlobsMetadata().stream()
-              .map(GenericBlobMetadata::from)
-              .collect(ImmutableList.toImmutableList())
-          );
+            new GenericStatisticsFile(
+                snapshotId,
+                statsPath,
+                puffinWriter.fileSize(),
+                puffinWriter.footerSize(),
+                puffinWriter.writtenBlobsMetadata().stream()
+                    .map(GenericBlobMetadata::from)
+                    .collect(ImmutableList.toImmutableList())
+            );
       } catch (IOException e) {
         LOG.warn("Unable to write stats to puffin file {}", e.getMessage());
         return false;
@@ -1543,7 +1543,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * for example in Parquet (in Parquet files Time type is an int64 with 'time' logical annotation).
    * @param tableProps iceberg table properties
    * @param tableSchema iceberg table schema
-   * @return
+   * @return true if having time type column
    */
   private static boolean hasOrcTimeInSchema(Properties tableProps, Schema tableSchema) {
     if (!FileFormat.ORC.name().equalsIgnoreCase(tableProps.getProperty(TableProperties.DEFAULT_FILE_FORMAT))) {
@@ -1558,7 +1558,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * check {@link VectorizedParquetRecordReader#checkListColumnSupport} for details on nested types under lists
    * @param tableProps iceberg table properties
    * @param tableSchema iceberg table schema
-   * @return
+   * @return true if having nested types
    */
   private static boolean hasParquetNestedTypeWithinListOrMap(Properties tableProps, Schema tableSchema) {
     if (!FileFormat.PARQUET.name().equalsIgnoreCase(tableProps.getProperty(TableProperties.DEFAULT_FILE_FORMAT))) {
@@ -1740,16 +1740,16 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   /**
    * Check the operation type of all snapshots which are newer than the specified. The specified snapshot is excluded.
-   * @deprecated
-   * <br>Use {@link HiveStorageHandler#getSnapshotContexts(
-   * org.apache.hadoop.hive.ql.metadata.Table hmsTable, SnapshotContext since)}
-   * and check {@link SnapshotContext.WriteOperationType#APPEND}.equals({@link SnapshotContext#getOperation()}).
-   *
    * @param hmsTable table metadata stored in Hive Metastore
    * @param since the snapshot preceding the oldest snapshot which should be checked.
    *              The value null means all should be checked.
    * @return null if table is empty, true if all snapshots are {@link SnapshotContext.WriteOperationType#APPEND}s,
    * false otherwise.
+   *
+   * @deprecated
+   * <br>Use {@link HiveStorageHandler#getSnapshotContexts(
+   * org.apache.hadoop.hive.ql.metadata.Table hmsTable, SnapshotContext since)}
+   * and check {@link SnapshotContext.WriteOperationType#APPEND}.equals({@link SnapshotContext#getOperation()}).
    */
   @Deprecated
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
@@ -408,9 +408,9 @@ public class IcebergTableUtil {
         CloseableIterable.filter(fileScanTasks, t -> {
           DataFile file = t.asFileScanTask().file();
           return !table.spec().isPartitioned() ||
-              (partitionPath == null && file.specId() != table.spec().specId()) ||
-              (partitionPath != null &&
-                  table.specs().get(file.specId()).partitionToPath(file.partition()).equals(partitionPath));
+              partitionPath == null && file.specId() != table.spec().specId() ||
+              partitionPath != null &&
+                  table.specs().get(file.specId()).partitionToPath(file.partition()).equals(partitionPath);
         });
     return Lists.newArrayList(CloseableIterable.transform(filteredFileScanTasks, t -> t.file()));
   }
@@ -431,9 +431,9 @@ public class IcebergTableUtil {
         CloseableIterable.filter(deletesScanTasks, t -> {
           DeleteFile file = ((PositionDeletesScanTask) t).file();
           return !table.spec().isPartitioned() ||
-              (partitionPath == null && file.specId() != table.spec().specId()) ||
-              (partitionPath != null &&
-                  table.specs().get(file.specId()).partitionToPath(file.partition()).equals(partitionPath));
+              partitionPath == null && file.specId() != table.spec().specId() ||
+              partitionPath != null &&
+                  table.specs().get(file.specId()).partitionToPath(file.partition()).equals(partitionPath);
         });
     return Lists.newArrayList(CloseableIterable.transform(filteredDeletesScanTasks,
         t -> ((PositionDeletesScanTask) t).file()));

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java
@@ -118,7 +118,7 @@ public class TestHiveIcebergSelects extends HiveIcebergStorageHandlerWithEngineB
   public void testJoinTablesSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
-      if ((type == Types.TimestampType.withZone()) && isVectorized && fileFormat == FileFormat.ORC) {
+      if (type == Types.TimestampType.withZone() && isVectorized && fileFormat == FileFormat.ORC) {
         // ORC/TIMESTAMP_INSTANT is not supported vectorized types for Hive
         continue;
       }
@@ -145,7 +145,7 @@ public class TestHiveIcebergSelects extends HiveIcebergStorageHandlerWithEngineB
   public void testSelectDistinctFromTable() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
-      if ((type == Types.TimestampType.withZone()) &&
+      if (type == Types.TimestampType.withZone() &&
           isVectorized && fileFormat == FileFormat.ORC) {
         // ORC/TIMESTAMP_INSTANT is not supported vectorized types for Hive
         continue;

--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -30,7 +30,7 @@
     <iceberg.mockito-core.version>3.4.4</iceberg.mockito-core.version>
     <iceberg.avro.version>1.11.3</iceberg.avro.version>
     <iceberg.kryo.version>5.5.0</iceberg.kryo.version>
-    <iceberg.checkstyle.plugin.version>3.1.2</iceberg.checkstyle.plugin.version>
+    <iceberg.checkstyle.plugin.version>3.5.0</iceberg.checkstyle.plugin.version>
     <spotless.maven.plugin.version>2.5.0</spotless.maven.plugin.version>
     <google.errorprone.javac.version>9+181-r4173-1</google.errorprone.javac.version>
     <google.errorprone.version>2.5.1</google.errorprone.version>

--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -277,7 +277,8 @@
           <configLocation>${basedir}/${path.to.iceberg.root}/checkstyle/checkstyle.xml</configLocation>
           <suppressionsLocation>${basedir}/${path.to.iceberg.root}/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
-          <encoding>UTF-8</encoding>
+          <inputEncoding>UTF-8</inputEncoding>
+          <outputEncoding>UTF-8</outputEncoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
         </configuration>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Upgrading maven maven-checkstyle-plugin to latest 3.5.0 and change checkstyle file & some class to adapt the higher version checkstyle rules.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See details HIVE-28514 & HIVE-28499.

BTW, the new CheckStyle version has some extra check rules. I have fixed them in this change.
```
[ERROR] hive/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveClientPool.java:91:46: Unnecessary parentheses around expression. [UnnecessaryParentheses]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java:1546: At-clause should have a non-empty description. [NonEmptyAtclauseDescription]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java:1561: At-clause should have a non-empty description. [NonEmptyAtclauseDescription]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java:1748: Block tags have to appear in the order '[@param, @return, @throws, @deprecated]'. [AtclauseOrder]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java:1749: Block tags have to appear in the order '[@param, @return, @throws, @deprecated]'. [AtclauseOrder]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java:1751: Block tags have to appear in the order '[@param, @return, @throws, @deprecated]'. [AtclauseOrder]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java:411:15: Unnecessary parentheses around expression. [UnnecessaryParentheses]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java:412:15: Unnecessary parentheses around expression. [UnnecessaryParentheses]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java:434:15: Unnecessary parentheses around expression. [UnnecessaryParentheses]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java:435:15: Unnecessary parentheses around expression. [UnnecessaryParentheses]
[ERROR] hive/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java:1022:10: Unnecessary parentheses around expression. [UnnecessaryParentheses]
[ERROR] hive/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java:121:11: Unnecessary parentheses around expression. [UnnecessaryParentheses]
[ERROR] hive/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java:148:11: Unnecessary parentheses around expression. [UnnecessaryParentheses]
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
mvn build Hive Iceberg handler.