### PR TITLE
HIVE-28515: Iceberg: Concurrent queries fail during commit with ValidationException.

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestOptimisticRetry.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestOptimisticRetry.java
@@ -76,6 +76,7 @@ public class TestOptimisticRetry extends HiveIcebergStorageHandlerWithEngineBase
 
   @Test
   public void testConcurrentOverwriteAndUpdate() {
+    TestUtilPhaser.getInstance();
     testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
         PartitionSpec.unpartitioned(), fileFormat, HiveIcebergStorageHandlerTestUtils.OTHER_CUSTOMER_RECORDS_2,
         formatVersion);
@@ -93,6 +94,7 @@ public class TestOptimisticRetry extends HiveIcebergStorageHandlerWithEngineBase
       shell.executeStatement(sql[i]);
       shell.closeSession();
     });
+    TestUtilPhaser.destroyInstance();
   }
 
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteOnWriteConflictPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteOnWriteConflictPlugin.java
@@ -32,7 +32,6 @@ public class ReExecuteOnWriteConflictPlugin implements IReExecutionPlugin {
   private static final Logger LOG = LoggerFactory.getLogger(ReExecuteOnWriteConflictPlugin.class);
   private static boolean retryPossible;
 
-  private static final Pattern writeConflictErrorPattern = Pattern.compile("^Found.*conflicting.*files(.*)");
   private static final String validationException = "org.apache.iceberg.exceptions.ValidationException";
 
   private static final class LocalHook implements ExecuteWithHookContext {
@@ -44,8 +43,7 @@ public class ReExecuteOnWriteConflictPlugin implements IReExecutionPlugin {
         if (exception != null && exception.getMessage() != null) {
           Throwable cause = Throwables.getRootCause(exception);
 
-          if (cause.getClass().getName().equals(validationException) &&
-              cause.getMessage().matches(writeConflictErrorPattern.pattern())) {
+          if (cause.getClass().getName().equals(validationException)) {
             retryPossible = true;
             LOG.info("Retrying query due to write conflict.");
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Don't fail when the retry strategy is write_conflict in case of a commit failure, but rather retry

### Why are the changes needed?

To avoid query failures where multiple queries are running concurrently on the same table & writes on similar set of files

### Does this PR introduce _any_ user-facing change?

Yes, In case of concurrent queries with conflicting files, the query doesn't fail but rather retries. 

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT
