### PR TITLE
HIVE-28517: Roaringbit version should be in sync with iceberg dependency required version

### DIFF
--- a/iceberg/iceberg-handler/pom.xml
+++ b/iceberg/iceberg-handler/pom.xml
@@ -119,11 +119,6 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.roaringbitmap</groupId>
-      <artifactId>RoaringBitmap</artifactId>
-      <version>0.9.22</version>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -25,6 +25,7 @@
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
     <path.to.iceberg.root>.</path.to.iceberg.root>
+    <!-- Upgrade roaringbit version in parent pom.xml whenever upgrading iceberg version -->
     <iceberg.version>1.5.2</iceberg.version>
     <kryo-shaded.version>4.0.3</kryo-shaded.version>
     <iceberg.mockito-core.version>3.4.4</iceberg.mockito-core.version>

--- a/itests/qtest-iceberg/pom.xml
+++ b/itests/qtest-iceberg/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>org.roaringbitmap</groupId>
       <artifactId>RoaringBitmap</artifactId>
-      <version>0.9.22</version>
+      <version>${roaringbit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
     <plexus.version>1.5.6</plexus.version>
     <protobuf.version>3.24.4</protobuf.version>
     <rat.version>0.16.1</rat.version>
+    <roaringbit.version>1.0.1</roaringbit.version>
     <stax.version>1.0.1</stax.version>
     <slf4j.version>1.7.30</slf4j.version>
     <ST4.version>4.0.4</ST4.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -869,7 +869,7 @@
     <dependency>
       <groupId>org.roaringbitmap</groupId>
       <artifactId>RoaringBitmap</artifactId>
-      <version>0.9.22</version>
+      <version>${roaringbit.version}</version>
     </dependency>
   </dependencies>
   <profiles>
@@ -1105,7 +1105,6 @@
                   <include>org.apache.calcite.avatica:avatica</include>
                   <include>com.esri.geometry:esri-geometry-api</include>
                   <include>org.roaringbitmap:RoaringBitmap</include>
-                  <include>org.roaringbitmap:shims</include>
                   <include>com.github.luben:zstd-jni</include>
                 </includes>
               </artifactSet>


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HIVE-28517](https://issues.apache.org/jira/browse/HIVE-28517)


### Why are the changes needed?
Difference in roaringbit version in classpath can cause problem in runtime. In iceberg 1.5.2 (currently used), it has dependency on roaringbit 1.0.1 and in hive, we are packaging 0.9.22 version.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes
[dependency_tree.txt](https://github.com/user-attachments/files/16958281/dependency_tree.txt)


### How was this patch tested?
Will see CI outcome
