### PR TITLE
Feature/Improve performance when drop partition or drop table

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -3221,11 +3221,11 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         for (String partName : partNames) {
           String pathString = partitionLocations.get(partName);
           if (pathString != null) {
-            Path partPath = wh.getDnsPath(new Path(pathString));
             // Double check here. Maybe Warehouse.getDnsPath revealed relationship between the
             // path objects
             if (tableDnsPath == null ||
-                !FileUtils.isSubdirectory(tableDnsPath, partPath.toString())) {
+                !FileUtils.isSubdirectory(tableDnsPath, pathString)) {
+              Path partPath = wh.getDnsPath(new Path(pathString));
               if (!wh.isWritable(partPath.getParent())) {
                 throw new MetaException("Table metadata not deleted since the partition "
                     + partName + " has parent location " + partPath.getParent()

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -38,6 +38,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.lang.reflect.*;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.Sets;
@@ -66,6 +68,7 @@ import org.datanucleus.api.jdo.JDOPersistenceManager;
 import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
 import org.junit.Assert;
 import org.junit.Before;
+import org.mockito.Matchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -116,6 +119,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public abstract class TestHiveMetaStore {
   private static final Logger LOG = LoggerFactory.getLogger(TestHiveMetaStore.class);
@@ -3865,5 +3869,28 @@ public abstract class TestHiveMetaStore {
   public void testDropDataConnectorIfNotExistsTrue() throws Exception {
     // No such data connector, ignore NoSuchObjectException
     client.dropDataConnector("no_such_data_connector", true, false);
+  }
+
+  @Test
+  public void testIsDnsPathEqualsOriginalPath() throws MetaException {
+    Warehouse wh = mock(Warehouse.class);
+    String tableDnsPath = "hdfs://ns1/user/test_user/test_db/test_table";
+    String partitionDnsPath = tableDnsPath + "/dt=2024-09-13";
+    when(wh.getDnsPath(Matchers.any())).thenReturn(new Path(partitionDnsPath));
+    Path path = wh.getDnsPath(new Path(partitionDnsPath));
+    assertEquals(path.toString(), partitionDnsPath);
+  }
+
+  @Test
+  public void testIsSubdirectory() throws MetaException {
+    Warehouse wh = mock(Warehouse.class);
+    String tableDnsPath = "hdfs://ns1/user/test_user/test_db/test_table";
+    String partitionDnsPath = tableDnsPath + "/dt=2024-09-13";
+    when(wh.getDnsPath(Matchers.any())).thenReturn(new Path(partitionDnsPath));
+    Path path = wh.getDnsPath(new Path(partitionDnsPath));
+    boolean isSubDirectory = FileUtils.isSubdirectory(tableDnsPath, path.toString());
+    assertTrue(isSubDirectory);
+    isSubDirectory = FileUtils.isSubdirectory(tableDnsPath, partitionDnsPath);
+    assertTrue(isSubDirectory);
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Reduce getDnsPath times to improve performance


### Why are the changes needed?
When the number of partitions is large, such as 200,000, serial traversing and obtaining wh.getDnsPath will take a huge amount of time, and performance optimization can be done for this place


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
By ut
