### PR TITLE
HIVE-28526 may produce null pointer when struct type value is null

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeConstantDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeConstantDesc.java
@@ -181,7 +181,7 @@ public class ExprNodeConstantDesc extends ExprNodeDesc implements Serializable {
       List<?> items = (List<?>) getWritableObjectInspector().getWritableConstantValue();
       List<TypeInfo> structTypes = ((StructTypeInfo) typeInfo).getAllStructFieldTypeInfos();
       for (int i = 0; i < structTypes.size(); i++) {
-        final Object o = (i < items.size()) ? items.get(i) : null;
+        final Object o = (items != null && i < items.size()) ? items.get(i) : null;
         sb.append(getFormatted(structTypes.get(i), o)).append(",");
       }
       sb.setCharAt(sb.length() - 1, ')');

--- a/ql/src/test/queries/clientpositive/struct_null_select.q
+++ b/ql/src/test/queries/clientpositive/struct_null_select.q
@@ -1,0 +1,10 @@
+create table test_struct
+(
+    f1 string,
+    demo_struct struct<f1:string,f2:string,f3:string>,
+    datestr string
+);
+
+insert into test_struct(f1, datestr) select 'test_f1','datestr_1';
+
+drop table test_struct;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
null pointer check


### Why are the changes needed?
 it is a bug.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
sql test, add ql/src/test/queries/clientpositive/struct_null_select.q
create table test_struct
(
    f1 string,
    demo_struct struct\<f1:string,f2:string,f3:string\>,
    datestr string
);
insert into test_struct(f1, datestr) select 'test_f1','datestr_1';