### PR TITLE
HIVE-28534: Improve HMS Client Exception Handling for Hive-3

### DIFF
--- a/upgrade-acid/pom.xml
+++ b/upgrade-acid/pom.xml
@@ -80,6 +80,13 @@
             <artifactId>hive-exec</artifactId>
             <version>2.3.3</version>
             <scope>provided</scope>
+            <exclusions>
+                <!-- This causes build failure -->
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
**MOTIVATION**
When the HMS client fails to connect to the server due to a `TTransportException`, there is no issue with error reporting.

However, when the failure is caused by an `IOException`, the exception object, which is used for reporting purposes, remains null. As a result, it does not properly capture the root cause, and end-users encounter an unrelated NPE, masking the actual issue.
```
Exception in thread "main" java.lang.AssertionError: Unable to connect to HMS!
	at TestHMS.main(TestHMS.java:20)
Caused by: java.lang.NullPointerException
	at org.apache.hadoop.util.StringUtils.stringifyException(StringUtils.java:90)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.open(HiveMetaStoreClient.java:613)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.<init>(HiveMetaStoreClient.java:233)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.<init>(HiveMetaStoreClient.java:145)
	at TestHMS.main(TestHMS.java:13)
```

**SOLUTION**
I have added an `IOException` object to capture the corresponding exception during connection attempts. If the `IOException` is not null, it will now be output, providing clearer information about the failure.

**CHECKS**
After applying the patch, instead of an NPE, I now receive a proper error message:
```
Exception in thread "main" java.lang.AssertionError: Unable to connect to HMS!
	at TestHMS.main(TestHMS.java:20)
Caused by: MetaException(message:Could not connect to meta store using any of the URIs provided. Most recent failure: 
javax.security.auth.login.LoginException: Unable to obtain MapR credentials)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.open(HiveMetaStoreClient.java:618)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.<init>(HiveMetaStoreClient.java:233)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.<init>(HiveMetaStoreClient.java:145)
	at TestHMS.main(TestHMS.java:13)
```