### PR TITLE
HIVE-21481: MERGE correctness issues with null safe equality

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
@@ -238,8 +238,6 @@ public enum ErrorMsg {
   TRUNCATE_FOR_NON_MANAGED_TABLE(10146, "Cannot truncate non-managed table {0}.", true),
   TRUNCATE_FOR_NON_NATIVE_TABLE(10147, "Cannot truncate non-native table {0}.", true),
   PARTSPEC_FOR_NON_PARTITIONED_TABLE(10148, "Partition spec for non partitioned table {0}.", true),
-  INVALID_TABLE_IN_ON_CLAUSE_OF_MERGE(10149, "No columns from target table ''{0}'' found in ON " +
-    "clause ''{1}'' of MERGE statement.", true),
 
   LOAD_INTO_STORED_AS_DIR(10195, "A stored-as-directories table cannot be used as target for LOAD"),
   ALTER_TBL_STOREDASDIR_NOT_SKEWED(10196, "This operation is only valid on skewed table."),

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_partitioned.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_partitioned.q
@@ -7,8 +7,8 @@ drop table if exists source;
 create external table target_ice(a int, b string, c int) partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg tblproperties ('format-version'='2', 'write.merge.mode'='copy-on-write');
 create table source(a int, b string, c int);
 
-insert into target_ice values (1, 'one', 50), (2, 'two', 51), (111, 'one', 55), (333, 'two', 56);
-insert into source values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54), (111, 'one', 55);
+insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56);
+insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56);
 
 -- merge
 explain

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_partitioned.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_partitioned.q
@@ -13,29 +13,29 @@ insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete',
 -- merge
 explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10;
-
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10;
-
-select * from target_ice;
-
-explain
-merge into target_ice as t using source src ON t.a = src.a
-when not matched then insert values (src.a, src.b, src.c);
-
-merge into target_ice as t using source src ON t.a = src.a
-when not matched and src.a <= 5 then insert values (src.a, src.b, src.c);
-
-select * from target_ice;
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 -- insert clause with a column list
+explain
 merge into target_ice as t using source src ON t.a = src.a
-when not matched then insert (a, c) values (src.a, src.c);
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'));
+
+merge into target_ice as t using source src ON t.a = src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 select * from target_ice;
 
+-- update all
+explain
+merge into target_ice as t using source src ON t.a = src.a
+when matched then update set b = 'Merged', c = t.c - 10;
 
+merge into target_ice as t using source src ON t.a = src.a
+when matched then update set b = 'Merged', c = t.c - 10;
 
+select * from target_ice;

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_partitioned_nullsafe.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_partitioned_nullsafe.q
@@ -1,0 +1,41 @@
+-- SORT_QUERY_RESULTS
+set hive.explain.user=false;
+
+drop table if exists target_ice;
+drop table if exists source;
+
+create external table target_ice(a int, b string, c int) partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg tblproperties ('format-version'='2', 'write.merge.mode'='copy-on-write');
+create table source(a int, b string, c int);
+
+insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56);
+insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56);
+
+-- merge
+explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
+
+-- insert clause with a column list
+explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'));
+
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
+
+select * from target_ice;
+
+-- update all
+explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10;
+
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10;
+
+select * from target_ice;

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
@@ -29,6 +29,7 @@ when matched then update set b = 'Merged', c = t.c + 10
 when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c);
 
 select * from target_ice;
+select * from source;
 
 -- update all 
 explain

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
@@ -29,7 +29,6 @@ when matched then update set b = 'Merged', c = t.c + 10
 when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c);
 
 select * from target_ice;
-select * from source;
 
 -- update all 
 explain

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
@@ -12,30 +12,30 @@ insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete',
 
 -- merge
 explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c);
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 -- insert clause with a column list
 explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
 when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'));
 
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c);
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 select * from target_ice;
 
--- update all 
+-- update all
 explain
-merge into target_ice as t using source src ON t.a = src.a
+merge into target_ice as t using source src ON t.a <=> src.a
 when matched then update set b = 'Merged', c = t.c - 10;
 
-merge into target_ice as t using source src ON t.a = src.a
+merge into target_ice as t using source src ON t.a <=> src.a
 when matched then update set b = 'Merged', c = t.c - 10;
 
 select * from target_ice;

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned.q
@@ -12,18 +12,18 @@ insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete',
 
 -- merge
 explain
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched and t.c > 50 THEN DELETE
 when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
 when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 -- insert clause with a column list
 explain
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched and t.c > 50 THEN DELETE
 when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'));
 
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched and t.c > 50 THEN DELETE
 when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
 when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
@@ -32,10 +32,10 @@ select * from target_ice;
 
 -- update all
 explain
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched then update set b = 'Merged', c = t.c - 10;
 
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched then update set b = 'Merged', c = t.c - 10;
 
 select * from target_ice;

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned_nullsafe.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_copy_on_write_unpartitioned_nullsafe.q
@@ -12,30 +12,30 @@ insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete',
 
 -- merge
 explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c);
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 -- insert clause with a column list
 explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
 when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'));
 
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c);
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 select * from target_ice;
 
 -- update all 
 explain
-merge into target_ice as t using source src ON t.a = src.a
+merge into target_ice as t using source src ON t.a <=> src.a
 when matched then update set b = 'Merged', c = t.c - 10;
 
-merge into target_ice as t using source src ON t.a = src.a
+merge into target_ice as t using source src ON t.a <=> src.a
 when matched then update set b = 'Merged', c = t.c - 10;
 
 select * from target_ice;

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_orc.q
@@ -10,14 +10,14 @@ insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete',
 -- merge
 explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 select * from target_ice;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_orc_nullsafe.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_orc_nullsafe.q
@@ -9,20 +9,20 @@ insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete',
 
 -- merge
 explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 select * from target_ice;
 
 create external table target_ice2(a int, `date` string, c int) stored by iceberg stored as orc;
 -- reserved keywords
 explain
-merge into target_ice2 as t using source src ON t.a = src.a
+merge into target_ice2 as t using source src ON t.a <=> src.a
 when not matched then insert (a, `date`) values (src.a, concat(src.b, '-merge'));

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_partitioned_orc.q
@@ -10,13 +10,13 @@ insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete',
 -- merge
 explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 select * from target_ice;

--- a/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_partitioned_orc_nullsafe.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/merge_iceberg_partitioned_orc_nullsafe.q
@@ -9,14 +9,14 @@ insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete',
 
 -- merge
 explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c);
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
 
 select * from target_ice;

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_merge_schema.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_merge_schema.q.out
@@ -216,14 +216,14 @@ STAGE PLANS:
                       Select Vectorization:
                           className: VectorSelectOperator
                           native: true
-                          projectedOutputColumnNums: [6, 7, 8, 9, 10, 11, 1, 2, 3, 4, 5]
-                          selectExpressions: ConstantVectorExpression(val 1090969) -> 11:bigint
+                          projectedOutputColumnNums: [6, 7, 8, 9, 10, 11, 1, 2, 3, 4, 5, 12]
+                          selectExpressions: ConstantVectorExpression(val 1090969) -> 11:bigint, ConstantVectorExpression(val 1) -> 12:boolean
                         Reduce Sink Vectorization:
                             className: VectorReduceSinkStringOperator
                             keyColumns: 4:string
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                            valueColumns: 6:int, 7:bigint, 8:string, 9:bigint, 10:string, 11:bigint, 1:string, 2:string, 3:int, 5:string
+                            valueColumns: 6:int, 7:bigint, 8:string, 9:bigint, 10:string, 11:bigint, 1:string, 2:string, 3:int, 5:string, 12:boolean
                     Filter Vectorization:
                         className: VectorFilterOperator
                         native: true
@@ -258,7 +258,7 @@ STAGE PLANS:
                     dataColumns: skey:bigint, hierarchy_number:string, hierarchy_name:string, language_id:int, hierarchy_display:string, orderby:string
                     neededVirtualColumns: #Masked#
                     partitionColumnCount: 0
-                    scratchColumnTypeNames: [bigint]
+                    scratchColumnTypeNames: [bigint, bigint]
         Reducer 2 
             MergeJoin Vectorization:
                 enabled: false
@@ -305,8 +305,36 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
+<<<<<<< HEAD
                 reduceColumnNullOrder: zzzz
                 reduceColumnSortOrder: ++++
+=======
+                reduceColumnNullOrder: zzzzz
+                reduceColumnSortOrder: +++++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 11
+                    dataColumns: KEY.reducesinkkey0:int, KEY.reducesinkkey1:bigint, KEY.reducesinkkey2:string, KEY.reducesinkkey3:bigint, KEY.reducesinkkey4:string, VALUE._col0:bigint, VALUE._col1:string, VALUE._col2:string, VALUE._col3:int, VALUE._col4:string, VALUE._col5:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+        Reducer 7 
+            Execution mode: vectorized
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
+                reduceColumnNullOrder: zzzzz
+                reduceColumnSortOrder: +++++
+>>>>>>> f7ae7daa2c (update q.out files)
                 allNative: false
                 usesVectorUDFAdaptor: true
                 vectorized: true

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_merge_schema.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_merge_schema.q.out
@@ -305,36 +305,8 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
-<<<<<<< HEAD
                 reduceColumnNullOrder: zzzz
                 reduceColumnSortOrder: ++++
-=======
-                reduceColumnNullOrder: zzzzz
-                reduceColumnSortOrder: +++++
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 11
-                    dataColumns: KEY.reducesinkkey0:int, KEY.reducesinkkey1:bigint, KEY.reducesinkkey2:string, KEY.reducesinkkey3:bigint, KEY.reducesinkkey4:string, VALUE._col0:bigint, VALUE._col1:string, VALUE._col2:string, VALUE._col3:int, VALUE._col4:string, VALUE._col5:string
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
-            Reduce Operator Tree:
-                Select Vectorization:
-                    className: VectorSelectOperator
-                    native: true
-                    projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-                  File Sink Vectorization:
-                      className: VectorFileSinkOperator
-                      native: false
-        Reducer 7 
-            Execution mode: vectorized
-            Reduce Vectorization:
-                enabled: true
-                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
-                reduceColumnNullOrder: zzzzz
-                reduceColumnSortOrder: +++++
->>>>>>> f7ae7daa2c (update q.out files)
                 allNative: false
                 usesVectorUDFAdaptor: true
                 vectorized: true

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned.q.out
@@ -72,35 +72,18 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 10 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 5 <- Union 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE), Union 4 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((a <= 100) or a is not null) (type: boolean)
+                  filterExpr: a is not null (type: boolean)
                   Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (a <= 100) (type: boolean)
-                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -120,32 +103,13 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Map 11 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
+                  filterExpr: (a is not null or a is null or (a <= 100)) (type: boolean)
                   Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
@@ -161,7 +125,7 @@ STAGE PLANS:
                         Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
                   Filter Operator
-                    predicate: (a <= 100) (type: boolean)
+                    predicate: (a is null or (a <= 100)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
@@ -174,161 +138,8 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
             Execution mode: vectorized
-        Reducer 10 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: ((_col5 <> _col8) or _col5 is null or _col8 is null) (type: boolean)
-                  Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 8 Data size: 3864 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 8 Data size: 3864 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                    null sort order: aa
-                    sort order: ++
-                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                    Statistics: Num rows: 7 Data size: 3384 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 4 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
-                File Output Operator
-                  compressed: false
-                  Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 7 Data size: 3384 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 5 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col1
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col1 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col1 (type: string)
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col1
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        output shape: _col1: string
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col1 ASC NULLS FIRST
-                        partition by: _col1
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                  null sort order: aa
-                  sort order: ++
-                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                  Statistics: Num rows: 7 Data size: 3384 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 8 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -345,7 +156,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col3 (type: string)
                   Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 9 
+        Reducer 3 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -383,10 +194,46 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: ++
                         Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                        Statistics: Num rows: 7 Data size: 3384 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 1938 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Union 3 
-            Vertex: Union 3
+        Reducer 5 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_SORTED
+                  Statistics: Num rows: 4 Data size: 1938 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Right Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 2 Data size: 792 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 2 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    null sort order: aa
+                    sort order: ++
+                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    Statistics: Num rows: 4 Data size: 1938 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Union 4 
+            Vertex: Union 4
 
   Stage: Stage-2
     Dependency Collection
@@ -462,6 +309,27 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: src
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string), _col2 (type: int)
+            Execution mode: vectorized
+        Map 4 
+            Map Operator Tree:
+                TableScan
                   alias: target_ice
                   Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -476,47 +344,27 @@ STAGE PLANS:
                       Statistics: Num rows: 3 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
             Execution mode: vectorized
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: string), c (type: int)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Full Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 12 Data size: 1952 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col5 is null (type: boolean)
-                  Statistics: Num rows: 9 Data size: 1464 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int), _col7 (type: string), _col8 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 9 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                      null sort order: aa
-                      sort order: ++
-                      Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                      Statistics: Num rows: 9 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 3 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    null sort order: aa
+                    sort order: ++
+                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    Statistics: Num rows: 3 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 3 
             Execution mode: vectorized
             Reduce Operator Tree:
@@ -526,7 +374,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 9 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -571,11 +419,10 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
+1	one	50
 2	Merged	61
-3	three	52
+2	two	51
 333	two	56
-4	four	53
-5	five	54
 PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
 when not matched then insert (a, c) values (src.a, src.c)
 PREHOOK: type: QUERY
@@ -597,9 +444,12 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
-111	NULL	55
+1	NULL	50
+1	NULL	50
+1	one	50
 2	Merged	61
-3	three	52
+2	NULL	51
+2	NULL	51
+2	two	51
 333	two	56
-4	four	53
-5	five	54
+NULL	NULL	NULL

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned.q.out
@@ -72,10 +72,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 10 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 10 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -103,13 +107,43 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
             Execution mode: vectorized
-        Map 7 
+        Map 11 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  filterExpr: (a is not null or a is null or (a <= 100)) (type: boolean)
                   Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
@@ -125,7 +159,7 @@ STAGE PLANS:
                         Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
                   Filter Operator
-                    predicate: (a is null or (a <= 100)) (type: boolean)
+                    predicate: (((a <= 100) or a is null) and a is not null) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
@@ -138,8 +172,161 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
             Execution mode: vectorized
+        Reducer 10 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 4 Data size: 1944 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    null sort order: aa
+                    sort order: ++
+                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    Statistics: Num rows: 5 Data size: 2418 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 4 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_SORTED
+                  Statistics: Num rows: 5 Data size: 2418 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col1 (type: int)
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: string)
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  null sort order: aa
+                  sort order: ++
+                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  Statistics: Num rows: 5 Data size: 2418 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -156,7 +343,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col3 (type: string)
                   Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 3 
+        Reducer 9 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -194,46 +381,10 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: ++
                         Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                        Statistics: Num rows: 4 Data size: 1938 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 2418 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
-                File Output Operator
-                  compressed: false
-                  Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 4 Data size: 1938 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 6 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Right Outer Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 2 Data size: 792 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 2 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                    null sort order: aa
-                    sort order: ++
-                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                    Statistics: Num rows: 4 Data size: 1938 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Union 4 
-            Vertex: Union 4
+        Union 3 
+            Vertex: Union 3
 
   Stage: Stage-2
     Dependency Collection
@@ -309,62 +460,61 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: src
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized
-        Map 4 
-            Map Operator Tree:
-                TableScan
                   alias: target_ice
                   Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                    Statistics: Num rows: 3 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 3 Data size: 1188 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col5 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 3 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
+                      Statistics: Num rows: 3 Data size: 1188 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+            Execution mode: vectorized
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Right Outer Join 0 to 1
+                     Full Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 3 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: int), _col1 (type: string), _col2 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 3 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                    null sort order: aa
-                    sort order: ++
-                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                    Statistics: Num rows: 3 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 9 Data size: 1952 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 6 Data size: 1464 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), _col8 (type: string), _col9 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 6 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      null sort order: aa
+                      sort order: ++
+                      Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      Statistics: Num rows: 6 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 3 
             Execution mode: vectorized
             Reduce Operator Tree:
@@ -374,7 +524,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 3 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -419,10 +569,11 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
-1	one	50
 2	Merged	61
-2	two	51
+3	three	52
 333	two	56
+4	four	53
+5	five	54
 PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
 when not matched then insert (a, c) values (src.a, src.c)
 PREHOOK: type: QUERY
@@ -444,12 +595,9 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
-1	NULL	50
-1	NULL	50
-1	one	50
+111	NULL	55
 2	Merged	61
-2	NULL	51
-2	NULL	51
-2	two	51
+3	three	52
 333	two	56
-NULL	NULL	NULL
+4	four	53
+5	five	54

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned.q.out
@@ -26,19 +26,19 @@ POSTHOOK: query: create table source(a int, b string, c int)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@source
-PREHOOK: query: insert into target_ice values (1, 'one', 50), (2, 'two', 51), (111, 'one', 55), (333, 'two', 56)
+PREHOOK: query: insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@target_ice
-POSTHOOK: query: insert into target_ice values (1, 'one', 50), (2, 'two', 51), (111, 'one', 55), (333, 'two', 56)
+POSTHOOK: query: insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@target_ice
-PREHOOK: query: insert into source values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54), (111, 'one', 55)
+PREHOOK: query: insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@source
-POSTHOOK: query: insert into source values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54), (111, 'one', 55)
+POSTHOOK: query: insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@source
@@ -72,14 +72,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 10 <- Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
         Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 10 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -87,91 +87,85 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: a (type: int)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: a (type: int), true (type: boolean)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: boolean)
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
         Map 11 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
                   Filter Operator
                     predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col4 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: (((a <= 100) or a is null) and a is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
                   Filter Operator
                     predicate: (a is not null and FILE__PATH is not null) (type: boolean)
                     Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
@@ -186,31 +180,61 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
+                  Filter Operator
+                    predicate: (a is not null and ((a <= 100) or a is null)) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
             Execution mode: vectorized
         Reducer 10 
+            Execution mode: vectorized
             Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (_col9 is null or (not _col9)) (type: boolean)
-                  Statistics: Num rows: 4 Data size: 1944 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        null sort order: aa
+                        sort order: ++
+                        Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        Statistics: Num rows: 7 Data size: 3411 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
@@ -220,17 +244,17 @@ STAGE PLANS:
                   0 _col0 (type: int)
                   1 _col5 (type: int)
                 outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 4 Data size: 1944 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
                     null sort order: aa
                     sort order: ++
                     Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                    Statistics: Num rows: 5 Data size: 2418 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 7 Data size: 3411 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 4 
             Execution mode: vectorized
@@ -241,7 +265,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 5 Data size: 2418 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7 Data size: 3411 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -251,36 +275,77 @@ STAGE PLANS:
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  null sort order: aa
+                  sort order: ++
+                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  Statistics: Num rows: 7 Data size: 3411 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col1
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0
                 Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col1 (type: string)
+                  key expressions: _col0 (type: string)
                   null sort order: a
                   sort order: +
-                  Map-reduce partition columns: _col1 (type: string)
+                  Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
+        Reducer 8 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col1
+                outputColumnNames: _col0
                 Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
                         input alias: ptf_0
-                        output shape: _col1: string
+                        output shape: _col0: string
                         type: WINDOWING
                       Windowing table definition
                         input alias: ptf_1
                         name: windowingtablefunction
-                        order by: _col1 ASC NULLS FIRST
-                        partition by: _col1
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
                         raw input shape:
                         window functions:
                             window function definition
@@ -294,7 +359,7 @@ STAGE PLANS:
                     predicate: (row_number_window_0 = 1) (type: boolean)
                     Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: string)
+                      expressions: _col0 (type: string)
                       outputColumnNames: _col0
                       Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
@@ -309,80 +374,23 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                  null sort order: aa
-                  sort order: ++
-                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                  Statistics: Num rows: 5 Data size: 2418 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 8 
+        Reducer 9 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col4 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col3 (type: string)
+                  key expressions: _col2 (type: string)
                   null sort order: a
                   sort order: +
-                  Map-reduce partition columns: _col3 (type: string)
-                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 9 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col3 ASC NULLS FIRST
-                        partition by: _col3
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                        null sort order: aa
-                        sort order: ++
-                        Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                        Statistics: Num rows: 5 Data size: 2418 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
         Union 3 
             Vertex: Union 3
 
@@ -426,8 +434,10 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
-2	Merged	61
-333	two	56
+2	not match	51
+3	Merged	65
+4	Merged	NULL
+NULL	match null	56
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when not matched then insert values (src.a, src.b, src.c)
@@ -461,34 +471,34 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 3 Data size: 1188 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col5 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 3 Data size: 1188 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
             Execution mode: vectorized
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: a (type: int), b (type: string), c (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized
         Reducer 2 
@@ -500,20 +510,20 @@ STAGE PLANS:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
-                Statistics: Num rows: 9 Data size: 1952 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 10 Data size: 4930 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: _col6 is null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 1464 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), _col8 (type: string), _col9 (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 6 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
                       null sort order: aa
                       sort order: ++
                       Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                      Statistics: Num rows: 6 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 3 
             Execution mode: vectorized
@@ -524,7 +534,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 6 Data size: 1452 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -569,11 +579,10 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
-2	Merged	61
-3	three	52
-333	two	56
-4	four	53
-5	five	54
+2	not match	51
+3	Merged	65
+4	Merged	NULL
+NULL	match null	56
 PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
 when not matched then insert (a, c) values (src.a, src.c)
 PREHOOK: type: QUERY
@@ -595,9 +604,9 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
-111	NULL	55
-2	Merged	61
-3	three	52
-333	two	56
-4	four	53
-5	five	54
+2	not match	51
+22	NULL	51
+3	Merged	65
+4	Merged	NULL
+NULL	NULL	56
+NULL	match null	56

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned.q.out
@@ -47,16 +47,833 @@ POSTHOOK: Lineage: source.b SCRIPT []
 POSTHOOK: Lineage: source.c SCRIPT []
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 10 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 12 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 13 <- Reducer 12 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 7 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 13 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+            Execution mode: vectorized
+        Map 14 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: int)
+            Execution mode: vectorized
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and ((c <= 50) or c is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col4 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+            Execution mode: vectorized
+        Reducer 10 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 11 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        null sort order: aa
+                        sort order: ++
+                        Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 12 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 13 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 10 Data size: 4930 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, ' New') (type: string), _col9 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      null sort order: aa
+                      sort order: ++
+                      Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 4 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_SORTED
+                  Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  null sort order: aa
+                  sort order: ++
+                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), concat(_col7, ' Merged') (type: string), (_col8 + 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    null sort order: aa
+                    sort order: ++
+                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a = src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a = src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 10 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 10 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
+            Execution mode: vectorized
+        Map 11 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 3 Data size: 303 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col4 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+            Execution mode: vectorized
+        Reducer 10 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 5 Data size: 2461 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col7 <= 50) or (not _col9) or (_col9 and (_col7 > 50)) is null) (type: boolean)
+                  Statistics: Num rows: 2 Data size: 986 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
+                Statistics: Num rows: 10 Data size: 4890 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      null sort order: aa
+                      sort order: ++
+                      Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 4 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_SORTED
+                  Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col1 (type: int)
+                outputColumnNames: _col1
+                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: string)
+                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1
+                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  null sort order: aa
+                  sort order: ++
+                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col4 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col3 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col3 (type: string)
+                  Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 481 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        null sort order: aa
+                        sort order: ++
+                        Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: select * from target_ice
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from target_ice
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	match Merged	60
+2	not match	51
+22	not match New	51
+4	not delete null Merged	NULL
+NULL	match null	56
+NULL	match null New	56
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a = src.a
+when matched then update set b = 'Merged', c = t.c - 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a = src.a
+when matched then update set b = 'Merged', c = t.c - 10
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -137,62 +954,59 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 606 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 6 Data size: 606 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 6 Data size: 2934 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 2934 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
                   Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col4 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                  Filter Operator
                     predicate: (a is not null and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: FILE__PATH (type: string), a (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
                   Filter Operator
-                    predicate: (a is not null and ((a <= 100) or a is null)) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col4 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
             Execution mode: vectorized
         Reducer 10 
@@ -201,7 +1015,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -220,7 +1034,7 @@ STAGE PLANS:
                               window function: GenericUDAFRowNumberEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (row_number_window_0 = 1) (type: boolean)
                     Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
@@ -233,7 +1047,7 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: ++
                         Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                        Statistics: Num rows: 7 Data size: 3411 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 2 
             Reduce Operator Tree:
@@ -241,20 +1055,20 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
+                  expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), 'Merged' (type: string), (_col6 - 10) (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 4 Data size: 1944 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 2430 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
                     null sort order: aa
                     sort order: ++
                     Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                    Statistics: Num rows: 7 Data size: 3411 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 4 
             Execution mode: vectorized
@@ -265,7 +1079,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 7 Data size: 3411 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -280,7 +1094,7 @@ STAGE PLANS:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 2958 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col9 is null or (not _col9)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
@@ -310,7 +1124,7 @@ STAGE PLANS:
                   null sort order: aa
                   sort order: ++
                   Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                  Statistics: Num rows: 7 Data size: 3411 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 7 
             Reduce Operator Tree:
@@ -321,20 +1135,20 @@ STAGE PLANS:
                   0 _col1 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: string)
                   null sort order: a
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 8 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -354,7 +1168,7 @@ STAGE PLANS:
                               window function: GenericUDAFRowNumberEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (row_number_window_0 = 1) (type: boolean)
                     Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
@@ -383,13 +1197,13 @@ STAGE PLANS:
                   0 _col4 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col2 (type: string)
                   null sort order: a
                   sort order: +
                   Map-reduce partition columns: _col2 (type: string)
-                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
         Union 3 
             Vertex: Union 3
@@ -412,15 +1226,13 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
+when matched then update set b = 'Merged', c = t.c - 10
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
+when matched then update set b = 'Merged', c = t.c - 10
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -433,180 +1245,9 @@ POSTHOOK: query: select * from target_ice
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	60
+1	Merged	50
 2	not match	51
-3	Merged	65
+22	Merged	41
 4	Merged	NULL
 NULL	match null	56
-PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when not matched then insert values (src.a, src.b, src.c)
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: default@target_ice
-POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when not matched then insert values (src.a, src.b, src.c)
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: default@target_ice
-STAGE DEPENDENCIES:
-  Stage-1 is a root stage
-  Stage-2 depends on stages: Stage-1
-  Stage-0 depends on stages: Stage-2
-  Stage-3 depends on stages: Stage-0
-
-STAGE PLANS:
-  Stage: Stage-1
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col5 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
-            Execution mode: vectorized
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: string), c (type: int)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized
-        Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Full Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
-                Statistics: Num rows: 10 Data size: 4930 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col6 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), _col8 (type: string), _col9 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                      null sort order: aa
-                      sort order: ++
-                      Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
-                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 3 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
-                File Output Operator
-                  compressed: false
-                  Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-
-  Stage: Stage-2
-    Dependency Collection
-
-  Stage: Stage-0
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-              name: default.target_ice
-
-  Stage: Stage-3
-    Stats Work
-      Basic Stats Work:
-
-PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when not matched and src.a <= 5 then insert values (src.a, src.b, src.c)
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: default@target_ice
-POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when not matched and src.a <= 5 then insert values (src.a, src.b, src.c)
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: default@target_ice
-PREHOOK: query: select * from target_ice
-PREHOOK: type: QUERY
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from target_ice
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	60
-2	not match	51
-3	Merged	65
-4	Merged	NULL
-NULL	match null	56
-PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when not matched then insert (a, c) values (src.a, src.c)
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: default@target_ice
-POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when not matched then insert (a, c) values (src.a, src.c)
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: default@target_ice
-PREHOOK: query: select * from target_ice
-PREHOOK: type: QUERY
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from target_ice
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	60
-2	not match	51
-22	NULL	51
-3	Merged	65
-4	Merged	NULL
-NULL	NULL	56
-NULL	match null	56
+NULL	match null New	56

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned_nullsafe.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_partitioned_nullsafe.q.out
@@ -1,0 +1,1217 @@
+PREHOOK: query: drop table if exists target_ice
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: drop table if exists target_ice
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: drop table if exists source
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: drop table if exists source
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: create external table target_ice(a int, b string, c int) partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg tblproperties ('format-version'='2', 'write.merge.mode'='copy-on-write')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: create external table target_ice(a int, b string, c int) partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg tblproperties ('format-version'='2', 'write.merge.mode'='copy-on-write')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: create table source(a int, b string, c int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source
+POSTHOOK: query: create table source(a int, b string, c int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source
+PREHOOK: query: insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source
+POSTHOOK: query: insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source
+POSTHOOK: Lineage: source.a SCRIPT []
+POSTHOOK: Lineage: source.b SCRIPT []
+POSTHOOK: Lineage: source.c SCRIPT []
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
+        Reducer 11 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 12 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 13 <- Reducer 12 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 7 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 10 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+            Execution mode: vectorized
+        Map 14 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: int)
+            Execution mode: vectorized
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Filter Operator
+                    predicate: (c is null or (c <= 50)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+            Execution mode: vectorized
+        Reducer 10 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 11 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), concat(_col7, ' Merged') (type: string), (_col8 + 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    null sort order: aa
+                    sort order: ++
+                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 12 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 13 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        null sort order: aa
+                        sort order: ++
+                        Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 10 Data size: 4930 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, ' New') (type: string), _col9 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      null sort order: aa
+                      sort order: ++
+                      Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 4 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_SORTED
+                  Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 6 Data size: 2958 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  null sort order: aa
+                  sort order: ++
+                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 10 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 5 <- Union 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
+            Execution mode: vectorized
+        Map 11 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 2401 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 5 Data size: 2401 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 936 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 5 Data size: 936 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+            Execution mode: vectorized
+        Reducer 10 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
+                Statistics: Num rows: 10 Data size: 4890 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      null sort order: aa
+                      sort order: ++
+                      Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                      Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 6 Data size: 2954 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col7 <= 50) or (not _col9) or (_col9 and (_col7 > 50)) is null) (type: boolean)
+                  Statistics: Num rows: 3 Data size: 1479 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 3 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  null sort order: aa
+                  sort order: ++
+                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 5 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_SORTED
+                  Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 7 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1439 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 3 Data size: 1463 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        null sort order: aa
+                        sort order: ++
+                        Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 4 
+            Vertex: Union 4
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: select * from target_ice
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from target_ice
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	match Merged	60
+2	not match	51
+22	not match New	51
+4	not delete null Merged	NULL
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 10 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 10 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+            Execution mode: vectorized
+        Map 11 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 4 Data size: 1956 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 4 Data size: 1956 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+            Execution mode: vectorized
+        Reducer 10 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 - 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 5 Data size: 2430 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    null sort order: aa
+                    sort order: ++
+                    Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                    Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 4 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: int), VALUE._col6 (type: string), VALUE._col7 (type: int), KEY.iceberg_bucket(_col5, 16) (type: int), KEY.iceberg_truncate(_col6, 3) (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, iceberg_bucket(_col5, 16), iceberg_truncate(_col6, 3)
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_SORTED
+                  Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col1 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: string)
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  null sort order: aa
+                  sort order: ++
+                  Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                  Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col4 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col3 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col3 (type: string)
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        null sort order: aa
+                        sort order: ++
+                        Map-reduce partition columns: iceberg_bucket(_col5, 16) (type: int), iceberg_truncate(_col6, 3) (type: string)
+                        Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: select * from target_ice
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from target_ice
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	Merged	50
+2	not match	51
+22	Merged	41
+4	Merged	NULL

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
@@ -74,35 +74,18 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 11 <- Map 10 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 7 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((a <= 100) or a is not null) (type: boolean)
+                  filterExpr: a is not null (type: boolean)
                   Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (a <= 100) (type: boolean)
-                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -122,14 +105,50 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  filterExpr: (a is null or (a <= 100)) (type: boolean)
+                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (a is null or (a <= 100)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+            Execution mode: vectorized
+        Map 7 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized
-        Map 10 
+        Map 9 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
@@ -145,71 +164,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col5 (type: int)
                       Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
-            Execution mode: vectorized
-        Map 12 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: string), c (type: int)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized
-        Map 13 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                  Filter Operator
-                    predicate: (a <= 100) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
@@ -225,158 +179,29 @@ STAGE PLANS:
                         Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
             Execution mode: vectorized
-        Reducer 11 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Full Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 14 Data size: 2440 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col5 is null (type: boolean)
-                  Statistics: Num rows: 10 Data size: 1952 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int), concat(_col7, '-merge new') (type: string), _col8 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 10 Data size: 3424 Basic stats: COMPLETE Column stats: COMPLETE
-                    File Output Operator
-                      compressed: false
-                      Statistics: Num rows: 17 Data size: 6808 Basic stats: COMPLETE Column stats: COMPLETE
-                      table:
-                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                          name: default.target_ice
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Inner Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
                   0 _col0 (type: int)
                   1 _col5 (type: int)
                 outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2 Data size: 792 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 17 Data size: 6808 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 10 Data size: 5410 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                         output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                         serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                         name: default.target_ice
         Reducer 4 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: ((_col5 <> _col8) or ((_col5 = _col8) or _col5 is null) is null) (type: boolean)
-                  Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 8 Data size: 3864 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 8 Data size: 3864 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 17 Data size: 6808 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 6 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col1
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col1 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col1 (type: string)
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col1
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        output shape: _col1: string
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col1 ASC NULLS FIRST
-                        partition by: _col1
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -393,7 +218,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col3 (type: string)
                   Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 9 
+        Reducer 5 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -428,12 +253,34 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 17 Data size: 6808 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 5410 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Right Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 6 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: int), concat(_col1, '-merge new') (type: string), _col2 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 6 Data size: 3472 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 10 Data size: 5410 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
         Union 3 
             Vertex: Union 3
 
@@ -481,16 +328,43 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
@@ -507,165 +381,43 @@ STAGE PLANS:
                       Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
                   Filter Operator
-                    predicate: FILE__PATH is not null (type: boolean)
+                    predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                  Filter Operator
-                    predicate: (a > 100) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 285 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 3 Data size: 1425 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col4 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 3 Data size: 1425 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: ((a > 100) and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string)
-                  Filter Operator
-                    predicate: (a > 100) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Full Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 14 Data size: 2420 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col5 is null (type: boolean)
-                  Statistics: Num rows: 10 Data size: 1936 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int), concat(_col7, '-merge new 2') (type: string), null (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 10 Data size: 3412 Basic stats: COMPLETE Column stats: COMPLETE
-                    File Output Operator
-                      compressed: false
-                      Statistics: Num rows: 13 Data size: 4861 Basic stats: COMPLETE Column stats: COMPLETE
-                      table:
-                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                          name: default.target_ice
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2788 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col2 (type: int), _col3 (type: bigint), _col4 (type: string), _col5 (type: bigint), _col6 (type: string), _col0 (type: int), concat(_col1, '-merge new 2') (type: string), null (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 6 Data size: 3456 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 8 Data size: 4422 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
         Reducer 4 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: ((((_col5 <> _col8) or (_col5 <= 100)) and _col5 is not null) or (((_col5 = _col8) and (_col5 > 100)) or _col5 is null) is null) (type: boolean)
-                  Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 8 Data size: 3864 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 8 Data size: 3864 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 13 Data size: 4861 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 6 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -674,21 +426,21 @@ STAGE PLANS:
                   0 _col0 (type: int)
                   1 _col4 (type: int)
                 outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 1 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col3 (type: string)
                   null sort order: a
                   sort order: +
                   Map-reduce partition columns: _col3 (type: string)
-                  Statistics: Num rows: 1 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
                 outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 1 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -707,84 +459,22 @@ STAGE PLANS:
                               window function: GenericUDAFRowNumberEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 1 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 13 Data size: 4861 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 8 Data size: 4422 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
-        Reducer 8 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col1
-                Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col1 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col1 (type: string)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col1
-                Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        output shape: _col1: string
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col1 ASC NULLS FIRST
-                        partition by: _col1
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
         Union 3 
             Vertex: Union 3
 
@@ -830,11 +520,25 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
+1	one-merge new	50
+111	one-merge new	55
 2	Merged	61
-3	three-merge new	52
-333	two	56
-4	four-merge new	53
-5	five-merge new	54
+2	two-merge new	51
+NULL	NULL	NULL
+PREHOOK: query: select * from source
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from source
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	one	50
+111	one	55
+2	two	51
+3	three	52
+4	four	53
+5	five	54
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched then update set b = 'Merged', c = t.c - 10
@@ -860,34 +564,27 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
@@ -902,33 +599,8 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: int)
                         Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 6 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 6 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
             Execution mode: vectorized
-        Map 10 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -953,18 +625,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
@@ -974,41 +634,21 @@ STAGE PLANS:
                 keys:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 12 Data size: 5824 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: ((_col5 <> _col8) or _col5 is null or _col8 is null) (type: boolean)
-                  Statistics: Num rows: 12 Data size: 5824 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 12 Data size: 5796 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 12 Data size: 5796 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 3 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 15 Data size: 7263 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 5 
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 12 Data size: 4752 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), 'Merged' (type: string), (_col6 - 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 12 Data size: 5832 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 15 Data size: 7281 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 4 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -1025,7 +665,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string)
                   Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -1060,98 +700,14 @@ STAGE PLANS:
                       Statistics: Num rows: 3 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 15 Data size: 7263 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 15 Data size: 7281 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
-        Reducer 7 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), 'Merged' (type: string), (_col6 - 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 6 Data size: 2916 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 15 Data size: 7263 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
-        Reducer 8 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col1 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0
-                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col0
-                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        output shape: _col0: string
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col0 ASC NULLS FIRST
-                        partition by: _col0
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-        Union 4 
-            Vertex: Union 4
+        Union 3 
+            Vertex: Union 3
 
   Stage: Stage-2
     Dependency Collection
@@ -1190,9 +746,9 @@ POSTHOOK: query: select * from target_ice
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	Merged	40
 1	Merged	50
+111	Merged	45
+2	Merged	41
 2	Merged	51
-3	Merged	42
-333	two	56
-4	Merged	43
-5	Merged	44
+NULL	Merged	NULL

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
@@ -839,20 +839,6 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 333	two	56
 4	four-merge new	53
 5	five-merge new	54
-PREHOOK: query: select * from source
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from source
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	one	50
-111	one	55
-2	two	51
-3	three	52
-4	four	53
-5	five	54
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched then update set b = 'Merged', c = t.c - 10

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
@@ -74,10 +74,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 11 <- Map 10 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -99,6 +103,31 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
@@ -106,14 +135,61 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Map 6 
+        Map 10 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  filterExpr: (a is null or (a <= 100)) (type: boolean)
-                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+            Execution mode: vectorized
+        Map 12 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: int)
+            Execution mode: vectorized
+        Map 13 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (a is null or (a <= 100)) (type: boolean)
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Filter Operator
+                    predicate: (((a <= 100) or a is null) and a is not null) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
@@ -126,44 +202,20 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
-            Execution mode: vectorized
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
-                        key expressions: _col0 (type: int)
+                        key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                    Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col5 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
@@ -179,29 +231,158 @@ STAGE PLANS:
                         Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
             Execution mode: vectorized
+        Reducer 11 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 12 Data size: 2440 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 8 Data size: 1952 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new') (type: string), _col9 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 8 Data size: 3056 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 13 Data size: 5474 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.target_ice
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Right Outer Join 0 to 1
+                     Inner Join 0 to 1
                 keys:
                   0 _col0 (type: int)
                   1 _col5 (type: int)
                 outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 2 Data size: 792 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 2 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 10 Data size: 5410 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 13 Data size: 5474 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                         output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                         serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                         name: default.target_ice
         Reducer 4 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 4 Data size: 1944 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 13 Data size: 5474 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col1 (type: int)
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: string)
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -218,7 +399,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col3 (type: string)
                   Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
+        Reducer 9 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -253,34 +434,12 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 10 Data size: 5410 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 13 Data size: 5474 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
-        Reducer 8 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Right Outer Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 6 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: int), concat(_col1, '-merge new') (type: string), _col2 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 6 Data size: 3472 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 10 Data size: 5410 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
         Union 3 
             Vertex: Union 3
 
@@ -328,58 +487,45 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: src
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), b (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 6 
-            Map Operator Tree:
-                TableScan
                   alias: target_ice
                   Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                    Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col5 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
+                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
@@ -394,30 +540,136 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: int)
                         Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+            Execution mode: vectorized
+        Map 10 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Right Outer Join 0 to 1
+                     Full Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2788 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col2 (type: int), _col3 (type: bigint), _col4 (type: string), _col5 (type: bigint), _col6 (type: string), _col0 (type: int), concat(_col1, '-merge new 2') (type: string), null (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 6 Data size: 3456 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 8 Data size: 4422 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
+                Statistics: Num rows: 12 Data size: 2420 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 8 Data size: 1936 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 8 Data size: 3044 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 13 Data size: 5459 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.target_ice
         Reducer 4 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col5 <= 100) or (not _col9) or (_col9 and (_col5 > 100)) is null) (type: boolean)
+                  Statistics: Num rows: 6 Data size: 2914 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 13 Data size: 5459 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 6 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -434,7 +686,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col3 (type: string)
                   Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
+        Reducer 7 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -469,12 +721,74 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 8 Data size: 4422 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 13 Data size: 5459 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col1 (type: int)
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: string)
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
         Union 3 
             Vertex: Union 3
 
@@ -520,11 +834,11 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
-1	one-merge new	50
-111	one-merge new	55
 2	Merged	61
-2	two-merge new	51
-NULL	NULL	NULL
+3	three-merge new	52
+333	two	56
+4	four-merge new	53
+5	five-merge new	54
 PREHOOK: query: select * from source
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
@@ -564,27 +878,34 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col5 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+                  Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
@@ -599,8 +920,33 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: int)
                         Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 6 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 6 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
             Execution mode: vectorized
-        Map 6 
+        Map 10 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -609,6 +955,17 @@ STAGE PLANS:
                   Filter Operator
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
                     Select Operator
                       expressions: a (type: int)
                       outputColumnNames: _col0
@@ -619,6 +976,20 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
@@ -634,21 +1005,41 @@ STAGE PLANS:
                 keys:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 12 Data size: 4752 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), 'Merged' (type: string), (_col6 - 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 12 Data size: 5832 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 15 Data size: 7281 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
-        Reducer 4 
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 12 Data size: 5824 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 6 Data size: 2914 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 3 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 12 Data size: 5814 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 5 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -665,7 +1056,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string)
                   Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-        Reducer 5 
+        Reducer 6 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -700,14 +1091,98 @@ STAGE PLANS:
                       Statistics: Num rows: 3 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 15 Data size: 7281 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 12 Data size: 5814 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
-        Union 3 
-            Vertex: Union 3
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), 'Merged' (type: string), (_col6 - 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 6 Data size: 2916 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 12 Data size: 5814 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 4 
+            Vertex: Union 4
 
   Stage: Stage-2
     Dependency Collection
@@ -746,9 +1221,9 @@ POSTHOOK: query: select * from target_ice
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	40
 1	Merged	50
-111	Merged	45
-2	Merged	41
 2	Merged	51
-NULL	Merged	NULL
+3	Merged	42
+333	two	56
+4	Merged	43
+5	Merged	44

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
@@ -46,7 +46,7 @@ POSTHOOK: Lineage: source.a SCRIPT []
 POSTHOOK: Lineage: source.b SCRIPT []
 POSTHOOK: Lineage: source.c SCRIPT []
 PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched and t.c > 50 THEN DELETE
 when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
 when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
@@ -55,7 +55,7 @@ PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched and t.c > 50 THEN DELETE
 when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
 when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
@@ -74,14 +74,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 10 <- Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 11 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 12 <- Reducer 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 12 <- Reducer 11 (SIMPLE_EDGE)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 6 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 12 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -105,40 +105,52 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
+                  filterExpr: a is not null (type: boolean)
                   Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), true (type: boolean)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: boolean)
-                  Select Operator
-                    expressions: a (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
         Map 4 
             Map Operator Tree:
@@ -176,19 +188,8 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
                   Filter Operator
-                    predicate: (c is null or (c <= 50)) (type: boolean)
+                    predicate: (a is not null and ((c <= 50) or c is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
@@ -201,66 +202,42 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col4 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col4 (type: int)
-                      Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col4 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
             Execution mode: vectorized
         Reducer 10 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), concat(_col7, ' Merged') (type: string), (_col8 + 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
-        Reducer 11 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col4 (type: int)
-                  1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col2 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col2 (type: string)
-                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-        Reducer 12 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -279,22 +256,84 @@ STAGE PLANS:
                               window function: GenericUDAFRowNumberEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
+        Reducer 11 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 12 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
@@ -303,7 +342,6 @@ STAGE PLANS:
                 keys:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
-                nullSafes: [true]
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
                 Statistics: Num rows: 10 Data size: 4930 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
@@ -315,7 +353,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -329,9 +367,8 @@ STAGE PLANS:
                 keys:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
-                nullSafes: [true]
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 6 Data size: 2958 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col9 is null or (not _col9)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
@@ -358,7 +395,7 @@ STAGE PLANS:
                 Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -370,63 +407,39 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col1 (type: int)
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), concat(_col7, ' Merged') (type: string), (_col8 + 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 5 Data size: 2627 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
                   1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col0
-                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col0 (type: string)
+                  key expressions: _col2 (type: string)
                   null sort order: a
                   sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col0
-                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        output shape: _col0: string
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col0 ASC NULLS FIRST
-                        partition by: _col0
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
         Union 3 
             Vertex: Union 3
 
@@ -448,7 +461,7 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched and t.c > 50 THEN DELETE
 when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
 PREHOOK: type: QUERY
@@ -456,379 +469,9 @@ PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a <=> src.a
+merge into target_ice as t using source src ON t.a = src.a
 when matched and t.c > 50 THEN DELETE
 when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: default@target_ice
-STAGE DEPENDENCIES:
-  Stage-1 is a root stage
-  Stage-2 depends on stages: Stage-1
-  Stage-0 depends on stages: Stage-2
-  Stage-3 depends on stages: Stage-0
-
-STAGE PLANS:
-  Stage: Stage-1
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
-        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 4 (CONTAINS)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), true (type: boolean)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: boolean)
-                  Select Operator
-                    expressions: a (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string)
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 5 Data size: 2401 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col4 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col4 (type: int)
-                      Statistics: Num rows: 5 Data size: 2401 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 5 Data size: 936 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 5 Data size: 936 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col5 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
-            Execution mode: vectorized
-        Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 6 Data size: 2954 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: ((_col7 <= 50) or (not _col9) or (_col9 and (_col7 > 50)) is null) (type: boolean)
-                  Statistics: Num rows: 3 Data size: 1479 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 3 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 5 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col4 (type: int)
-                  1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col2 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col2 (type: string)
-                  Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-        Reducer 6 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col2 ASC NULLS FIRST
-                        partition by: _col2
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 1439 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 3 Data size: 1463 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
-        Reducer 7 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col1 (type: int)
-                  1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col0
-                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col0
-                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        output shape: _col0: string
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col0 ASC NULLS FIRST
-                        partition by: _col0
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Full Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
-                Statistics: Num rows: 10 Data size: 4890 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col6 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
-                    File Output Operator
-                      compressed: false
-                      Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
-                      table:
-                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                          name: default.target_ice
-        Union 4 
-            Vertex: Union 4
-
-  Stage: Stage-2
-    Dependency Collection
-
-  Stage: Stage-0
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-              name: default.target_ice
-
-  Stage: Stage-3
-    Stats Work
-      Basic Stats Work:
-
-PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
-when matched and t.c > 50 THEN DELETE
-when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: default@target_ice
-POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
-when matched and t.c > 50 THEN DELETE
-when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: default@target_ice
-PREHOOK: query: select * from target_ice
-PREHOOK: type: QUERY
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from target_ice
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	match Merged	60
-2	not match	51
-22	not match New	51
-4	not delete null Merged	NULL
-PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a <=> src.a
-when matched then update set b = 'Merged', c = t.c - 10
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: default@target_ice
-POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a <=> src.a
-when matched then update set b = 'Merged', c = t.c - 10
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -857,117 +500,133 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
-                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: a (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), true (type: boolean)
+                    expressions: a (type: int), b (type: string)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: boolean)
+                      Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
             Execution mode: vectorized
         Map 10 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col4 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col4 (type: int)
-                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1956 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1956 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
                   Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col5 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+                      Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 3 Data size: 303 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col4 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Inner Join 0 to 1
+                     Full Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 - 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 5 Data size: 2430 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
+                Statistics: Num rows: 10 Data size: 4890 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.target_ice
         Reducer 4 
             Reduce Operator Tree:
               Merge Join Operator
@@ -976,22 +635,21 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
-                nullSafes: [true]
                 outputColumnNames: _col1
-                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col1 (type: string)
                   null sort order: a
                   sort order: +
                   Map-reduce partition columns: _col1 (type: string)
-                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 5 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col1
-                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -1011,26 +669,26 @@ STAGE PLANS:
                               window function: GenericUDAFRowNumberEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col1 (type: string)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: _col0 (type: string)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0
-                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 6 
             Reduce Operator Tree:
               Merge Join Operator
@@ -1043,7 +701,7 @@ STAGE PLANS:
                 Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -1057,15 +715,14 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col4 (type: int)
-                nullSafes: [true]
                 outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col3 (type: string)
                   null sort order: a
                   sort order: +
                   Map-reduce partition columns: _col3 (type: string)
-                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Reducer 8 
             Execution mode: vectorized
@@ -1073,7 +730,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
                 outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -1092,17 +749,17 @@ STAGE PLANS:
                               window function: GenericUDAFRowNumberEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 481 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -1116,22 +773,21 @@ STAGE PLANS:
                 keys:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
-                nullSafes: [true]
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 2461 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col9 is null or (not _col9)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: ((_col7 <= 50) or (not _col9) or (_col9 and (_col7 > 50)) is null) (type: boolean)
+                  Statistics: Num rows: 2 Data size: 986 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col2 (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Union 3 
             Vertex: Union 3
@@ -1153,13 +809,391 @@ STAGE PLANS:
     Stats Work
       Basic Stats Work:
 
-PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: select * from target_ice
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from target_ice
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	match Merged	60
+2	not match	51
+22	not match New	51
+4	not delete null Merged	NULL
+NULL	match null	56
+NULL	match null New	56
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a = src.a
 when matched then update set b = 'Merged', c = t.c - 10
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@target_ice
-POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a = src.a
+when matched then update set b = 'Merged', c = t.c - 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 10 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 6 Data size: 606 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 606 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 6 Data size: 2934 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 6 Data size: 2934 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col4 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+            Execution mode: vectorized
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), 'Merged' (type: string), (_col6 - 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 5 Data size: 2430 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 4 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 6 Data size: 2958 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
+when matched then update set b = 'Merged', c = t.c - 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
 when matched then update set b = 'Merged', c = t.c - 10
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
@@ -1177,3 +1211,5 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 2	not match	51
 22	Merged	41
 4	Merged	NULL
+NULL	match null	56
+NULL	match null New	56

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
@@ -46,19 +46,19 @@ POSTHOOK: Lineage: source.a SCRIPT []
 POSTHOOK: Lineage: source.b SCRIPT []
 POSTHOOK: Lineage: source.c SCRIPT []
 PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c)
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c)
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -74,14 +74,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 10 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 11 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 12 <- Reducer 11 (SIMPLE_EDGE)
+        Reducer 12 <- Reducer 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 6 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 12 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 9 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -105,52 +105,40 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: a is not null (type: boolean)
                   Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), true (type: boolean)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: boolean)
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
         Map 4 
             Map Operator Tree:
@@ -188,56 +176,91 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                  Filter Operator
-                    predicate: (a is not null and ((a <= 100) or a is null)) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col4 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: FILE__PATH (type: string), a (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
+                  Filter Operator
+                    predicate: (c is null or (c <= 50)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
             Execution mode: vectorized
         Reducer 10 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), concat(_col7, ' Merged') (type: string), (_col8 + 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 11 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 12 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -256,84 +279,22 @@ STAGE PLANS:
                               window function: GenericUDAFRowNumberEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 8 Data size: 3991 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
-        Reducer 11 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col1 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 12 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col0
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        output shape: _col0: string
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col0 ASC NULLS FIRST
-                        partition by: _col0
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
@@ -342,18 +303,19 @@ STAGE PLANS:
                 keys:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
+                nullSafes: [true]
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
                 Statistics: Num rows: 10 Data size: 4930 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: _col6 is null (type: boolean)
                   Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new') (type: string), _col9 (type: int)
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, ' New') (type: string), _col9 (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                     Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 8 Data size: 3991 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -367,8 +329,9 @@ STAGE PLANS:
                 keys:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
+                nullSafes: [true]
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 2958 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col9 is null or (not _col9)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
@@ -395,660 +358,13 @@ STAGE PLANS:
                 Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 8 Data size: 3991 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                       serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                       name: default.target_ice
         Reducer 8 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 4 Data size: 1944 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 8 Data size: 3991 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
-        Reducer 9 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col4 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col2 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col2 (type: string)
-                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-        Union 3 
-            Vertex: Union 3
-
-  Stage: Stage-2
-    Dependency Collection
-
-  Stage: Stage-0
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-              name: default.target_ice
-
-  Stage: Stage-3
-    Stats Work
-      Basic Stats Work:
-
-PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: default@target_ice
-POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: default@target_ice
-STAGE DEPENDENCIES:
-  Stage-1 is a root stage
-  Stage-2 depends on stages: Stage-1
-  Stage-0 depends on stages: Stage-2
-  Stage-3 depends on stages: Stage-0
-
-STAGE PLANS:
-  Stage: Stage-1
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string)
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), true (type: boolean)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: boolean)
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col5 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 3 Data size: 303 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col4 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Full Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
-                Statistics: Num rows: 10 Data size: 4890 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col6 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
-                    File Output Operator
-                      compressed: false
-                      Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
-                      table:
-                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                          name: default.target_ice
-        Reducer 4 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col1
-                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col1 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col1 (type: string)
-                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col1
-                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        output shape: _col1: string
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col1 ASC NULLS FIRST
-                        partition by: _col1
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 7 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col4 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col3 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col3 (type: string)
-                  Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 8 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col3 ASC NULLS FIRST
-                        partition by: _col3
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 481 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
-        Reducer 9 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 5 Data size: 2461 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: ((_col5 <= 100) or (not _col9) or (_col9 and (_col5 > 100)) is null) (type: boolean)
-                  Statistics: Num rows: 5 Data size: 2461 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Union 3 
-            Vertex: Union 3
-
-  Stage: Stage-2
-    Dependency Collection
-
-  Stage: Stage-0
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-              name: default.target_ice
-
-  Stage: Stage-3
-    Stats Work
-      Basic Stats Work:
-
-PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c)
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: default@target_ice
-POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, concat(src.b, '-merge new'), src.c)
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: default@target_ice
-PREHOOK: query: select * from target_ice
-PREHOOK: type: QUERY
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from target_ice
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	60
-2	not match	51
-22	not match-merge new	51
-3	Merged	65
-4	Merged	NULL
-NULL	match null	56
-NULL	match null-merge new	56
-PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched then update set b = 'Merged', c = t.c - 10
-PREHOOK: type: QUERY
-PREHOOK: Input: default@source
-PREHOOK: Input: default@target_ice
-PREHOOK: Output: default@target_ice
-POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched then update set b = 'Merged', c = t.c - 10
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@source
-POSTHOOK: Input: default@target_ice
-POSTHOOK: Output: default@target_ice
-STAGE DEPENDENCIES:
-  Stage-1 is a root stage
-  Stage-2 depends on stages: Stage-1
-  Stage-0 depends on stages: Stage-2
-  Stage-3 depends on stages: Stage-0
-
-STAGE PLANS:
-  Stage: Stage-1
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), true (type: boolean)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: boolean)
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  Statistics: Num rows: 7 Data size: 707 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 7 Data size: 707 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 7 Data size: 3423 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 7 Data size: 3423 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                  Filter Operator
-                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 6 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 6 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 606 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col4 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
-            Execution mode: vectorized
-        Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), 'Merged' (type: string), (_col6 - 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 6 Data size: 2916 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 10 Data size: 4872 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
-        Reducer 4 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 7 Data size: 3451 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (_col9 is null or (not _col9)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 10 Data size: 4872 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 6 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -1056,6 +372,7 @@ STAGE PLANS:
                 keys:
                   0 _col1 (type: int)
                   1 _col0 (type: int)
+                nullSafes: [true]
                 outputColumnNames: _col0
                 Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
@@ -1064,7 +381,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 9 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -1110,64 +427,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col4 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col2 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col2 (type: string)
-                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-        Reducer 9 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col2 ASC NULLS FIRST
-                        partition by: _col2
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 10 Data size: 4872 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
         Union 3 
             Vertex: Union 3
 
@@ -1188,13 +447,719 @@ STAGE PLANS:
     Stats Work
       Basic Stats Work:
 
-PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 4 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
+            Execution mode: vectorized
+        Map 10 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 2401 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 5 Data size: 2401 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 936 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 5 Data size: 936 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+            Execution mode: vectorized
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 6 Data size: 2954 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col7 <= 50) or (not _col9) or (_col9 and (_col7 > 50)) is null) (type: boolean)
+                  Statistics: Num rows: 3 Data size: 1479 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 3 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 6 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1439 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 3 Data size: 1463 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
+                Statistics: Num rows: 10 Data size: 4890 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.target_ice
+        Union 4 
+            Vertex: Union 4
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: select * from target_ice
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from target_ice
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	match Merged	60
+2	not match	51
+22	not match New	51
+4	not delete null Merged	NULL
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
 when matched then update set b = 'Merged', c = t.c - 10
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@target_ice
-POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+            Execution mode: vectorized
+        Map 10 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 4 Data size: 1956 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 4 Data size: 1956 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+            Execution mode: vectorized
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 - 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 5 Data size: 2430 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 4 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col1 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: string)
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 5 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col4 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col3 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col3 (type: string)
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
 when matched then update set b = 'Merged', c = t.c - 10
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
@@ -1211,7 +1176,4 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	50
 2	not match	51
 22	Merged	41
-3	Merged	55
 4	Merged	NULL
-NULL	match null	56
-NULL	match null-merge new	56

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
@@ -26,19 +26,19 @@ POSTHOOK: query: create table source(a int, b string, c int)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@source
-PREHOOK: query: insert into target_ice values (1, 'one', 50), (2, 'two', 51), (111, 'one', 55), (333, 'two', 56)
+PREHOOK: query: insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@target_ice
-POSTHOOK: query: insert into target_ice values (1, 'one', 50), (2, 'two', 51), (111, 'one', 55), (333, 'two', 56)
+POSTHOOK: query: insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@target_ice
-PREHOOK: query: insert into source values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54), (111, 'one', 55)
+PREHOOK: query: insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@source
-POSTHOOK: query: insert into source values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54), (111, 'one', 55)
+POSTHOOK: query: insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@source
@@ -74,134 +74,148 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 11 <- Map 10 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 10 <- Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 11 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 12 <- Reducer 11 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 12 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: src
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), true (type: boolean)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: boolean)
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
                   alias: target_ice
-                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col5 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
             Execution mode: vectorized
-        Map 12 
+        Map 13 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: a (type: int), b (type: string), c (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized
-        Map 13 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
-                  Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
                   Filter Operator
-                    predicate: (((a <= 100) or a is null) and a is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (a is not null and ((a <= 100) or a is null)) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col4 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
                   Filter Operator
                     predicate: (a is not null and FILE__PATH is not null) (type: boolean)
                     Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
@@ -216,144 +230,82 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col4 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
             Execution mode: vectorized
+        Reducer 10 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 8 Data size: 3991 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
         Reducer 11 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Full Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
-                Statistics: Num rows: 12 Data size: 2440 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col6 is null (type: boolean)
-                  Statistics: Num rows: 8 Data size: 1952 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new') (type: string), _col9 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 8 Data size: 3056 Basic stats: COMPLETE Column stats: COMPLETE
-                    File Output Operator
-                      compressed: false
-                      Statistics: Num rows: 13 Data size: 5474 Basic stats: COMPLETE Column stats: COMPLETE
-                      table:
-                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                          name: default.target_ice
-        Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 13 Data size: 5474 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.target_ice
-        Reducer 4 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
+                  0 _col1 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (_col9 is null or (not _col9)) (type: boolean)
-                  Statistics: Num rows: 4 Data size: 1944 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 13 Data size: 5474 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 6 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col1
+                outputColumnNames: _col0
                 Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col1 (type: string)
+                  key expressions: _col0 (type: string)
                   null sort order: a
                   sort order: +
-                  Map-reduce partition columns: _col1 (type: string)
+                  Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 12 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col1
+                outputColumnNames: _col0
                 Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
                         input alias: ptf_0
-                        output shape: _col1: string
+                        output shape: _col0: string
                         type: WINDOWING
                       Windowing table definition
                         input alias: ptf_1
                         name: windowingtablefunction
-                        order by: _col1 ASC NULLS FIRST
-                        partition by: _col1
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
                         raw input shape:
                         window functions:
                             window function definition
@@ -367,7 +319,7 @@ STAGE PLANS:
                     predicate: (row_number_window_0 = 1) (type: boolean)
                     Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: string)
+                      expressions: _col0 (type: string)
                       outputColumnNames: _col0
                       Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
@@ -382,6 +334,73 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 10 Data size: 4930 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new') (type: string), _col9 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 8 Data size: 3991 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.target_ice
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 8 Data size: 3991 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
         Reducer 8 
             Reduce Operator Tree:
               Merge Join Operator
@@ -389,57 +408,38 @@ STAGE PLANS:
                      Inner Join 0 to 1
                 keys:
                   0 _col0 (type: int)
-                  1 _col4 (type: int)
+                  1 _col5 (type: int)
                 outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 + 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 4 Data size: 1944 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 8 Data size: 3991 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col3 (type: string)
+                  key expressions: _col2 (type: string)
                   null sort order: a
                   sort order: +
-                  Map-reduce partition columns: _col3 (type: string)
-                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 9 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col3 ASC NULLS FIRST
-                        partition by: _col3
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 13 Data size: 5474 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
         Union 3 
             Vertex: Union 3
 
@@ -489,118 +489,118 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: target_ice
-                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col5 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
-                  Filter Operator
-                    predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col4 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                  Filter Operator
-                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: FILE__PATH (type: string), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
                   alias: src
-                  Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: a (type: int), b (type: string)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 6 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string)
                   Filter Operator
                     predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: a (type: int)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: a (type: int), true (type: boolean)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: boolean)
+            Execution mode: vectorized
+        Map 10 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 3 Data size: 303 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col4 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: (a is not null and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
@@ -611,17 +611,17 @@ STAGE PLANS:
                   0 _col5 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
-                Statistics: Num rows: 12 Data size: 2420 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 10 Data size: 4890 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: _col6 is null (type: boolean)
-                  Statistics: Num rows: 8 Data size: 1936 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 8 Data size: 3044 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 13 Data size: 5459 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -631,125 +631,25 @@ STAGE PLANS:
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: ((_col5 <= 100) or (not _col9) or (_col9 and (_col5 > 100)) is null) (type: boolean)
-                  Statistics: Num rows: 6 Data size: 2914 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 3 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 13 Data size: 5459 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 6 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col4 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col3 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col3 (type: string)
-                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 7 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col3 ASC NULLS FIRST
-                        partition by: _col3
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 13 Data size: 5459 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
-        Reducer 8 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
                      Inner Join 0 to 1
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
                 outputColumnNames: _col1
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col1 (type: string)
                   null sort order: a
                   sort order: +
                   Map-reduce partition columns: _col1 (type: string)
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
+                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 5 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col1
-                Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -769,26 +669,126 @@ STAGE PLANS:
                               window function: GenericUDAFRowNumberEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col1 (type: string)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: _col0 (type: string)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0
-                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col4 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col3 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col3 (type: string)
+                  Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 481 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 3 Data size: 1558 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 5 Data size: 2461 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col5 <= 100) or (not _col9) or (_col9 and (_col5 > 100)) is null) (type: boolean)
+                  Statistics: Num rows: 5 Data size: 2461 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
         Union 3 
             Vertex: Union 3
 
@@ -834,11 +834,12 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	60
-2	Merged	61
-3	three-merge new	52
-333	two	56
-4	four-merge new	53
-5	five-merge new	54
+2	not match	51
+22	not match-merge new	51
+3	Merged	65
+4	Merged	NULL
+NULL	match null	56
+NULL	match null-merge new	56
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
 when matched then update set b = 'Merged', c = t.c - 10
@@ -864,59 +865,85 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
         Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: src
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 10 
+            Map Operator Tree:
+                TableScan
                   alias: target_ice
-                  Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7 Data size: 707 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: FILE__PATH is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 7 Data size: 707 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 7 Data size: 3423 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 7 Data size: 3423 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col4 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col4 (type: int)
-                        Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                      Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
                   Filter Operator
                     predicate: (a is not null and FILE__PATH is not null) (type: boolean)
                     Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -931,159 +958,33 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 6 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 6 Data size: 606 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: a (type: int), true (type: boolean)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
-                        key expressions: _col0 (type: int)
+                        key expressions: _col4 (type: int)
                         null sort order: z
                         sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: boolean)
+                        Map-reduce partition columns: _col4 (type: int)
+                        Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
                     Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
-                        key expressions: _col0 (type: int)
+                        key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 6 Data size: 2376 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
             Execution mode: vectorized
         Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col5 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
-                Statistics: Num rows: 12 Data size: 5824 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (_col9 is null or (not _col9)) (type: boolean)
-                  Statistics: Num rows: 6 Data size: 2914 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col2 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: string)
-                      Statistics: Num rows: 6 Data size: 2898 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 3 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col2 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 3 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 12 Data size: 5814 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 5 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col4 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col2 (type: string)
-                  null sort order: a
-                  sort order: +
-                  Map-reduce partition columns: _col2 (type: string)
-                  Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-        Reducer 6 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col2 ASC NULLS FIRST
-                        partition by: _col2
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 6 Data size: 2850 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 1425 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 3 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 12 Data size: 5814 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
-        Reducer 7 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -1099,13 +1000,55 @@ STAGE PLANS:
                   Statistics: Num rows: 6 Data size: 2916 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 12 Data size: 5814 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 10 Data size: 4872 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                         output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                         serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                         name: default.target_ice
-        Reducer 8 
+        Reducer 4 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 7 Data size: 3451 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 10 Data size: 4872 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 6 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -1121,7 +1064,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
+        Reducer 7 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -1167,8 +1110,66 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
-        Union 4 
-            Vertex: Union 4
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 10 Data size: 4872 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Union 3 
+            Vertex: Union 3
 
   Stage: Stage-2
     Dependency Collection
@@ -1208,8 +1209,9 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	Merged	50
-2	Merged	51
-3	Merged	42
-333	two	56
-4	Merged	43
-5	Merged	44
+2	not match	51
+22	Merged	41
+3	Merged	55
+4	Merged	NULL
+NULL	match null	56
+NULL	match null-merge new	56

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned_nullsafe.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned_nullsafe.q.out
@@ -1,0 +1,1179 @@
+PREHOOK: query: drop table if exists target_ice
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: drop table if exists target_ice
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: drop table if exists source
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: drop table if exists source
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: create external table target_ice(a int, b string, c int) stored by iceberg tblproperties ('format-version'='2', 'write.merge.mode'='copy-on-write')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: create external table target_ice(a int, b string, c int) stored by iceberg tblproperties ('format-version'='2', 'write.merge.mode'='copy-on-write')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: create table source(a int, b string, c int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source
+POSTHOOK: query: create table source(a int, b string, c int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source
+PREHOOK: query: insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: insert into target_ice values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source
+POSTHOOK: query: insert into source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source
+POSTHOOK: Lineage: source.a SCRIPT []
+POSTHOOK: Lineage: source.b SCRIPT []
+POSTHOOK: Lineage: source.c SCRIPT []
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 10 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 11 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 12 <- Reducer 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 13 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+            Execution mode: vectorized
+        Map 13 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: int)
+            Execution mode: vectorized
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 2445 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 5 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Filter Operator
+                    predicate: (c is null or (c <= 50)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+            Execution mode: vectorized
+        Reducer 10 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), concat(_col7, ' Merged') (type: string), (_col8 + 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 11 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 12 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 2886 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1443 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 10 Data size: 4930 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, ' New') (type: string), _col9 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.target_ice
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 6 Data size: 2958 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 6 Data size: 3116 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 8 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when not matched then insert (a, b) values (src.a, concat(src.b, '-merge new 2'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 4 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
+            Execution mode: vectorized
+        Map 10 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 2401 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 5 Data size: 2401 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 5 Data size: 501 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 5 Data size: 2441 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 936 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 5 Data size: 936 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 1976 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: boolean)
+            Execution mode: vectorized
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 6 Data size: 2954 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col7 <= 50) or (not _col9) or (_col9 and (_col7 > 50)) is null) (type: boolean)
+                  Statistics: Num rows: 3 Data size: 1479 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 3 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 5 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col4 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: string)
+                  Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+        Reducer 6 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: int), VALUE._col4 (type: string), VALUE._col5 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 2882 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1439 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), -1L (type: bigint), _col3 (type: string), _col4 (type: int), _col5 (type: string), _col6 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 3 Data size: 1463 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 6 Data size: 1104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Full Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6, _col7, _col8
+                Statistics: Num rows: 10 Data size: 4890 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col7 (type: int), concat(_col8, '-merge new 2') (type: string), null (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 7 Data size: 3510 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.target_ice
+        Union 4 
+            Vertex: Union 4
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: select * from target_ice
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from target_ice
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	match Merged	60
+2	not match	51
+22	not match New	51
+4	not delete null Merged	NULL
+PREHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: explain
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
+            Execution mode: vectorized
+        Map 10 
+            Map Operator Tree:
+                TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col4 (type: int)
+                      Statistics: Num rows: 4 Data size: 1924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
+                  Filter Operator
+                    predicate: FILE__PATH is not null (type: boolean)
+                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 4 Data size: 1956 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: int)
+                        Statistics: Num rows: 4 Data size: 1956 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                    Select Operator
+                      expressions: FILE__PATH (type: string), a (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 4 Data size: 1584 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+            Execution mode: vectorized
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col5 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 1980 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), _col4 (type: bigint), _col5 (type: string), _col6 (type: int), 'Merged' (type: string), (_col7 - 10) (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 5 Data size: 2430 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.target_ice
+        Reducer 4 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col1 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: string)
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 5 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 7 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col4 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col3 (type: string)
+                  null sort order: a
+                  sort order: +
+                  Map-reduce partition columns: _col3 (type: string)
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Reducer 8 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 5 Data size: 2405 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 962 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 8 Data size: 3897 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Reducer 9 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col9
+                Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col9 is null or (not _col9)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 493 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.target_ice
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: default@target_ice
+POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched then update set b = 'Merged', c = t.c - 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: default@target_ice
+PREHOOK: query: select * from target_ice
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from target_ice
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	Merged	50
+2	not match	51
+22	Merged	41
+4	Merged	NULL

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
@@ -35,9 +35,9 @@ POSTHOOK: Lineage: source.b SCRIPT []
 POSTHOOK: Lineage: source.c SCRIPT []
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -46,9 +46,9 @@ PREHOOK: Output: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -125,22 +125,7 @@ STAGE PLANS:
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
                   Statistics: Num rows: 5 Data size: 2990 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col0 and (_col6 > 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
-                  Filter Operator
-                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
+                    predicate: (_col0 and (_col4 > 50)) (type: boolean)
                     Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
@@ -155,15 +140,30 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col4 <= 50) or (_col4 > 50) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col6 (type: int), 'Merged' (type: string), (_col4 + 10) (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+                  Filter Operator
+                    predicate: (_col0 and ((_col4 <= 50) or (_col4 > 50) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col6 (type: int), concat(_col5, ' Merged') (type: string), (_col4 + 10) (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -173,12 +173,12 @@ STAGE PLANS:
                     predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col9 (type: int), _col8 (type: string), _col11 (type: int)
+                      expressions: _col9 (type: int), concat(_col8, ' New') (type: string), _col11 (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -262,9 +262,9 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -272,9 +272,9 @@ PREHOOK: Output: default@merge_tmp_table
 PREHOOK: Output: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -290,13 +290,12 @@ POSTHOOK: query: select * from target_ice
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	60
+1	match Merged	60
 2	not match	51
-22	not match	51
-3	Merged	65
-4	Merged	NULL
+22	not match New	51
+4	not delete null Merged	NULL
 NULL	match null	56
-NULL	match null	56
+NULL	match null New	56
 PREHOOK: query: create external table target_ice2(a int, `date` string, c int) stored by iceberg stored as orc
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
@@ -145,25 +145,15 @@ STAGE PLANS:
                     Select Operator
                       expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-<<<<<<< HEAD
-                      Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
-=======
-                      Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
-                        null sort order: zzzzz
-                        sort order: +++++
-                        Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col5 (type: int), _col6 (type: string), _col7 (type: int)
->>>>>>> f7ae7daa2c (update q.out files)
                   Filter Operator
                     predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
                     Statistics: Num rows: 3 Data size: 1270 Basic stats: COMPLETE Column stats: COMPLETE
@@ -198,27 +188,12 @@ STAGE PLANS:
                     predicate: (_col6 = _col9) (type: boolean)
                     Statistics: Num rows: 5 Data size: 1953 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
-                      outputColumnNames: _col2, _col5, _col6, _col7
-                      Statistics: Num rows: 5 Data size: 1929 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                      expressions: _col2 (type: string), _col3 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
-                      outputColumnNames: _col2, _col3, _col5, _col6, _col7
-                      Statistics: Num rows: 5 Data size: 1941 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
-                      Group By Operator
-                        aggregations: count()
-                        keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)
-=======
-                      expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
-                      outputColumnNames: _col1, _col2, _col3, _col10, _col12
+                      expressions: _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
+                      outputColumnNames: _col2, _col3, _col10, _col12
                       Statistics: Num rows: 5 Data size: 1953 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string)
->>>>>>> 874d07004f (update q.out)
+                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
@@ -233,39 +208,6 @@ STAGE PLANS:
         Reducer 3 
             Execution mode: vectorized
             Reduce Operator Tree:
-<<<<<<< HEAD
-=======
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 4 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 5 
-            Execution mode: vectorized
-            Reduce Operator Tree:
->>>>>>> f7ae7daa2c (update q.out files)
               Group By Operator
                 aggregations: count(VALUE._col0)
                 keys: KEY._col0 (type: int), KEY._col1 (type: bigint), KEY._col2 (type: string), KEY._col3 (type: bigint)

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
@@ -99,16 +99,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                      Statistics: Num rows: 4 Data size: 1948 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                        Statistics: Num rows: 4 Data size: 1948 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: boolean)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
@@ -118,15 +118,15 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                Statistics: Num rows: 10 Data size: 3375 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                Statistics: Num rows: 10 Data size: 3395 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                  Statistics: Num rows: 10 Data size: 3375 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                  Statistics: Num rows: 10 Data size: 3395 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 > 100)) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 1833 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and (_col10 > 100)) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 1845 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
@@ -140,11 +140,12 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 <= 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 579 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1262 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+<<<<<<< HEAD
                       Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
@@ -154,24 +155,33 @@ STAGE PLANS:
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
+=======
+                      Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
+                        null sort order: zzzzz
+                        sort order: +++++
+                        Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col5 (type: int), _col6 (type: string), _col7 (type: int)
+>>>>>>> f7ae7daa2c (update q.out files)
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 <= 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 579 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1262 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col10 (type: int), 'Merged' (type: string), (_col8 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 290 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 3 Data size: 290 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: _col10 is null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 2025 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col11 is null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 2037 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2
@@ -186,11 +196,17 @@ STAGE PLANS:
                             name: default.target_ice
                   Filter Operator
                     predicate: (_col10 = _col1) (type: boolean)
-                    Statistics: Num rows: 5 Data size: 1929 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1941 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
+<<<<<<< HEAD
                       expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
                       outputColumnNames: _col2, _col5, _col6, _col7
                       Statistics: Num rows: 5 Data size: 1929 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                      expressions: _col2 (type: string), _col3 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
+                      outputColumnNames: _col2, _col3, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 1941 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                       Group By Operator
                         aggregations: count()
                         keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)
@@ -208,6 +224,39 @@ STAGE PLANS:
         Reducer 3 
             Execution mode: vectorized
             Reduce Operator Tree:
+<<<<<<< HEAD
+=======
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 4 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 5 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+>>>>>>> f7ae7daa2c (update q.out files)
               Group By Operator
                 aggregations: count(VALUE._col0)
                 keys: KEY._col0 (type: int), KEY._col1 (type: bigint), KEY._col2 (type: string), KEY._col3 (type: bigint)
@@ -343,8 +392,8 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
@@ -352,6 +401,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: boolean)
             Execution mode: vectorized
         Map 4 
             Map Operator Tree:
@@ -378,13 +428,13 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2
+                outputColumnNames: _col1, _col2, _col3
                 Statistics: Num rows: 6 Data size: 607 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
-                  predicate: _col0 is null (type: boolean)
+                  predicate: _col1 is null (type: boolean)
                   Statistics: Num rows: 3 Data size: 303 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
-                    expressions: _col1 (type: int), concat(_col2, '-merge') (type: string), null (type: int)
+                    expressions: _col2 (type: int), concat(_col3, '-merge') (type: string), null (type: int)
                     outputColumnNames: _col0, _col1, _col2
                     Statistics: Num rows: 3 Data size: 303 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
@@ -121,14 +121,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
                 Statistics: Num rows: 10 Data size: 3395 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                  Statistics: Num rows: 10 Data size: 3395 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col11 (type: boolean), _col7 (type: string), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean), _col1 (type: string), _col0 (type: int), _col5 (type: string), _col2 (type: int), _col6 (type: bigint)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+                  Statistics: Num rows: 10 Data size: 3415 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col11 and (_col10 > 100)) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 1845 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and (_col6 > 100)) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 1857 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                       Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -140,10 +140,10 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 1262 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1270 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
 <<<<<<< HEAD
                       Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
@@ -165,10 +165,10 @@ STAGE PLANS:
                         value expressions: _col5 (type: int), _col6 (type: string), _col7 (type: int)
 >>>>>>> f7ae7daa2c (update q.out files)
                   Filter Operator
-                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 1262 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1270 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col10 (type: int), 'Merged' (type: string), (_col8 + 10) (type: int)
+                      expressions: _col6 (type: int), 'Merged' (type: string), (_col4 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 3 Data size: 290 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -180,10 +180,10 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: _col11 is null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 2037 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col7 is null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 2049 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: int)
+                      expressions: _col9 (type: int), _col8 (type: string), _col11 (type: int)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -195,9 +195,10 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: (_col10 = _col1) (type: boolean)
-                    Statistics: Num rows: 5 Data size: 1941 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col6 = _col9) (type: boolean)
+                    Statistics: Num rows: 5 Data size: 1953 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
+<<<<<<< HEAD
 <<<<<<< HEAD
                       expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
                       outputColumnNames: _col2, _col5, _col6, _col7
@@ -210,6 +211,14 @@ STAGE PLANS:
                       Group By Operator
                         aggregations: count()
                         keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)
+=======
+                      expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
+                      outputColumnNames: _col1, _col2, _col3, _col10, _col12
+                      Statistics: Num rows: 5 Data size: 1953 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string)
+>>>>>>> 874d07004f (update q.out)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc_nullsafe.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc_nullsafe.q.out
@@ -34,10 +34,10 @@ POSTHOOK: Lineage: source.a SCRIPT []
 POSTHOOK: Lineage: source.b SCRIPT []
 POSTHOOK: Lineage: source.c SCRIPT []
 PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -45,10 +45,10 @@ PREHOOK: Output: default@merge_tmp_table
 PREHOOK: Output: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -75,6 +75,23 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                    Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: boolean)
+            Execution mode: vectorized
+        Map 4 
+            Map Operator Tree:
+                TableScan
                   alias: src
                   Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -89,43 +106,38 @@ STAGE PLANS:
                       Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int), true (type: boolean)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                      Statistics: Num rows: 4 Data size: 1972 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1972 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: boolean)
-            Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                Statistics: Num rows: 5 Data size: 2970 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 3564 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col11 (type: boolean), _col7 (type: string), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean), _col1 (type: string), _col0 (type: int), _col5 (type: string), _col2 (type: int), _col6 (type: bigint)
+                  expressions: _col8 (type: boolean), _col4 (type: string), _col1 (type: bigint), _col0 (type: int), _col7 (type: int), _col6 (type: string), _col5 (type: int), _col8 (type: boolean), _col10 (type: string), _col9 (type: int), _col2 (type: string), _col11 (type: int), _col3 (type: bigint)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
-                  Statistics: Num rows: 5 Data size: 2990 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 3588 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col0 and (_col6 > 100)) (type: boolean)
+                    predicate: (_col0 and (_col4 > 50)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1794 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+                  Filter Operator
+                    predicate: (_col0 and ((_col4 <= 50) or (_col4 > 50) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
@@ -140,30 +152,15 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col4 <= 50) or (_col4 > 50) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
-                  Filter Operator
-                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col6 (type: int), 'Merged' (type: string), (_col4 + 10) (type: int)
+                      expressions: _col6 (type: int), concat(_col5, ' Merged') (type: string), (_col4 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -173,37 +170,37 @@ STAGE PLANS:
                     predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col9 (type: int), _col8 (type: string), _col11 (type: int)
+                      expressions: _col9 (type: int), concat(_col8, ' New') (type: string), _col11 (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: (_col6 = _col9) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col6 IS NOT DISTINCT FROM _col9) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1794 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
                       outputColumnNames: _col2, _col3, _col10, _col12
-                      Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 1794 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                        Statistics: Num rows: 2 Data size: 424 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint)
                           null sort order: zzzz
                           sort order: ++++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint)
-                          Statistics: Num rows: 2 Data size: 424 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col4 (type: bigint)
         Reducer 3 
             Execution mode: vectorized
@@ -213,7 +210,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: int), KEY._col1 (type: bigint), KEY._col2 (type: string), KEY._col3 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 2 Data size: 424 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col4 > 1L) (type: boolean)
                   Statistics: Num rows: 1 Data size: 212 Basic stats: COMPLETE Column stats: COMPLETE
@@ -261,20 +258,20 @@ STAGE PLANS:
     Stats Work
       Basic Stats Work:
 
-PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@merge_tmp_table
 PREHOOK: Output: default@target_ice
 PREHOOK: Output: default@target_ice
-POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -290,13 +287,10 @@ POSTHOOK: query: select * from target_ice
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	60
+1	match Merged	60
 2	not match	51
-22	not match	51
-3	Merged	65
-4	Merged	NULL
-NULL	match null	56
-NULL	match null	56
+22	not match New	51
+4	not delete null Merged	NULL
 PREHOOK: query: create external table target_ice2(a int, `date` string, c int) stored by iceberg stored as orc
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -306,14 +300,14 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@target_ice2
 PREHOOK: query: explain
-merge into target_ice2 as t using source src ON t.a = src.a
+merge into target_ice2 as t using source src ON t.a <=> src.a
 when not matched then insert (a, `date`) values (src.a, concat(src.b, '-merge'))
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice2
 PREHOOK: Output: default@target_ice2
 POSTHOOK: query: explain
-merge into target_ice2 as t using source src ON t.a = src.a
+merge into target_ice2 as t using source src ON t.a <=> src.a
 when not matched then insert (a, `date`) values (src.a, concat(src.b, '-merge'))
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
@@ -338,22 +332,18 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: target_ice2
-                  filterExpr: a is not null (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
+                  Select Operator
+                    expressions: a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: a (type: int), true (type: boolean)
-                      outputColumnNames: _col0, _col1
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: boolean)
+                      value expressions: _col1 (type: boolean)
             Execution mode: vectorized
         Map 4 
             Map Operator Tree:
@@ -380,6 +370,7 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
+                nullSafes: [true]
                 outputColumnNames: _col1, _col2, _col3
                 Statistics: Num rows: 5 Data size: 533 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
@@ -35,9 +35,9 @@ POSTHOOK: Lineage: source.b SCRIPT []
 POSTHOOK: Lineage: source.c SCRIPT []
 PREHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -46,9 +46,9 @@ PREHOOK: Output: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
 merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -127,22 +127,7 @@ STAGE PLANS:
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
                   Statistics: Num rows: 5 Data size: 2990 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col0 and (_col6 > 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
-                  Filter Operator
-                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
+                    predicate: (_col0 and (_col4 > 50)) (type: boolean)
                     Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
@@ -157,32 +142,47 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col4 <= 50) or (_col4 > 50) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col6 (type: int), 'Merged' (type: string), (_col4 + 10) (type: int)
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 1 Data size: 489 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+                  Filter Operator
+                    predicate: (_col0 and ((_col4 <= 50) or (_col4 > 50) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col6 (type: int), concat(_col5, ' Merged') (type: string), (_col4 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
                         null sort order: aa
                         sort order: ++
                         Map-reduce partition columns: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
-                        Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                   Filter Operator
                     predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col9 (type: int), _col8 (type: string), _col11 (type: int)
+                      expressions: _col9 (type: int), concat(_col8, ' New') (type: string), _col11 (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
                         null sort order: aa
                         sort order: ++
                         Map-reduce partition columns: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
-                        Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                   Filter Operator
                     predicate: (_col6 = _col9) (type: boolean)
@@ -214,7 +214,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -229,7 +229,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -292,9 +292,9 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -302,9 +302,9 @@ PREHOOK: Output: default@merge_tmp_table
 PREHOOK: Output: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -320,10 +320,9 @@ POSTHOOK: query: select * from target_ice
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	60
+1	match Merged	60
 2	not match	51
-22	not match	51
-3	Merged	65
-4	Merged	NULL
+22	not match New	51
+4	not delete null Merged	NULL
 NULL	match null	56
-NULL	match null	56
+NULL	match null New	56

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
@@ -123,14 +123,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
                 Statistics: Num rows: 10 Data size: 3395 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                  Statistics: Num rows: 10 Data size: 3395 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col11 (type: boolean), _col7 (type: string), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean), _col1 (type: string), _col0 (type: int), _col5 (type: string), _col2 (type: int), _col6 (type: bigint)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+                  Statistics: Num rows: 10 Data size: 3415 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col11 and (_col10 > 100)) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 1845 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and (_col6 > 100)) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 1857 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                       Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -142,10 +142,10 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 1262 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1270 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
 <<<<<<< HEAD
                       Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
@@ -167,10 +167,10 @@ STAGE PLANS:
                         value expressions: _col5 (type: int), _col6 (type: string), _col7 (type: int)
 >>>>>>> f7ae7daa2c (update q.out files)
                   Filter Operator
-                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 1262 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1270 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col10 (type: int), 'Merged' (type: string), (_col8 + 10) (type: int)
+                      expressions: _col6 (type: int), 'Merged' (type: string), (_col4 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 3 Data size: 290 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -181,10 +181,10 @@ STAGE PLANS:
                         Statistics: Num rows: 3 Data size: 290 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                   Filter Operator
-                    predicate: _col11 is null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 2037 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col7 is null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 2049 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: int)
+                      expressions: _col9 (type: int), _col8 (type: string), _col11 (type: int)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -195,9 +195,10 @@ STAGE PLANS:
                         Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                   Filter Operator
-                    predicate: (_col10 = _col1) (type: boolean)
-                    Statistics: Num rows: 5 Data size: 1941 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col6 = _col9) (type: boolean)
+                    Statistics: Num rows: 5 Data size: 1953 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
+<<<<<<< HEAD
 <<<<<<< HEAD
                       expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
                       outputColumnNames: _col2, _col5, _col6, _col7
@@ -210,6 +211,14 @@ STAGE PLANS:
                       Group By Operator
                         aggregations: count()
                         keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)
+=======
+                      expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
+                      outputColumnNames: _col1, _col2, _col3, _col10, _col12
+                      Statistics: Num rows: 5 Data size: 1953 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string)
+>>>>>>> 874d07004f (update q.out)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
@@ -147,25 +147,15 @@ STAGE PLANS:
                     Select Operator
                       expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-<<<<<<< HEAD
-                      Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
                         table:
                             input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
-=======
-                      Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
-                        null sort order: zzzzz
-                        sort order: +++++
-                        Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col5 (type: int), _col6 (type: string), _col7 (type: int)
->>>>>>> f7ae7daa2c (update q.out files)
                   Filter Operator
                     predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
                     Statistics: Num rows: 3 Data size: 1270 Basic stats: COMPLETE Column stats: COMPLETE
@@ -198,27 +188,12 @@ STAGE PLANS:
                     predicate: (_col6 = _col9) (type: boolean)
                     Statistics: Num rows: 5 Data size: 1953 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
-                      outputColumnNames: _col2, _col5, _col6, _col7
-                      Statistics: Num rows: 5 Data size: 1929 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                      expressions: _col2 (type: string), _col3 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
-                      outputColumnNames: _col2, _col3, _col5, _col6, _col7
-                      Statistics: Num rows: 5 Data size: 1941 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
-                      Group By Operator
-                        aggregations: count()
-                        keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)
-=======
-                      expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
-                      outputColumnNames: _col1, _col2, _col3, _col10, _col12
+                      expressions: _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
+                      outputColumnNames: _col2, _col3, _col10, _col12
                       Statistics: Num rows: 5 Data size: 1953 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string)
->>>>>>> 874d07004f (update q.out)
+                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
@@ -234,39 +209,6 @@ STAGE PLANS:
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
-<<<<<<< HEAD
-=======
-                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 4 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.target_ice
-        Reducer 5 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
->>>>>>> f7ae7daa2c (update q.out files)
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int), KEY.iceberg_bucket(_col0, 16) (type: int), KEY.iceberg_truncate(_col1, 3) (type: string)
                 outputColumnNames: _col0, _col1, _col2, iceberg_bucket(_col0, 16), iceberg_truncate(_col1, 3)
                 File Output Operator

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
@@ -101,16 +101,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                      Statistics: Num rows: 4 Data size: 1948 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1932 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                        Statistics: Num rows: 4 Data size: 1948 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: boolean)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
@@ -120,15 +120,15 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                Statistics: Num rows: 10 Data size: 3375 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                Statistics: Num rows: 10 Data size: 3395 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                  Statistics: Num rows: 10 Data size: 3375 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                  Statistics: Num rows: 10 Data size: 3395 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 > 100)) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 1833 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and (_col10 > 100)) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 1845 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
@@ -142,11 +142,12 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 <= 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 579 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1262 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+<<<<<<< HEAD
                       Statistics: Num rows: 1 Data size: 483 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
@@ -156,23 +157,32 @@ STAGE PLANS:
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
+=======
+                      Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
+                        null sort order: zzzzz
+                        sort order: +++++
+                        Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col5 (type: int), _col6 (type: string), _col7 (type: int)
+>>>>>>> f7ae7daa2c (update q.out files)
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 <= 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 579 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1262 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col10 (type: int), 'Merged' (type: string), (_col8 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 290 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
                         null sort order: aa
                         sort order: ++
                         Map-reduce partition columns: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
-                        Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 3 Data size: 290 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                   Filter Operator
-                    predicate: _col10 is null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 2025 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col11 is null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 2037 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2
@@ -186,11 +196,17 @@ STAGE PLANS:
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                   Filter Operator
                     predicate: (_col10 = _col1) (type: boolean)
-                    Statistics: Num rows: 5 Data size: 1929 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1941 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
+<<<<<<< HEAD
                       expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
                       outputColumnNames: _col2, _col5, _col6, _col7
                       Statistics: Num rows: 5 Data size: 1929 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                      expressions: _col2 (type: string), _col3 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
+                      outputColumnNames: _col2, _col3, _col5, _col6, _col7
+                      Statistics: Num rows: 5 Data size: 1941 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                       Group By Operator
                         aggregations: count()
                         keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)
@@ -209,12 +225,45 @@ STAGE PLANS:
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
+<<<<<<< HEAD
+=======
+                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 4 Data size: 1449 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 4 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 3 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.target_ice
+        Reducer 5 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+>>>>>>> f7ae7daa2c (update q.out files)
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int), KEY.iceberg_bucket(_col0, 16) (type: int), KEY.iceberg_truncate(_col1, 3) (type: string)
                 outputColumnNames: _col0, _col1, _col2, iceberg_bucket(_col0, 16), iceberg_truncate(_col1, 3)
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 290 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc_nullsafe.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc_nullsafe.q.out
@@ -34,10 +34,10 @@ POSTHOOK: Lineage: source.a SCRIPT []
 POSTHOOK: Lineage: source.b SCRIPT []
 POSTHOOK: Lineage: source.c SCRIPT []
 PREHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
@@ -45,10 +45,10 @@ PREHOOK: Output: default@merge_tmp_table
 PREHOOK: Output: default@target_ice
 PREHOOK: Output: default@target_ice
 POSTHOOK: query: explain
-merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -77,6 +77,23 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: target_ice
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                    Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 5 Data size: 2465 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: boolean)
+            Execution mode: vectorized
+        Map 6 
+            Map Operator Tree:
+                TableScan
                   alias: src
                   Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -91,43 +108,38 @@ STAGE PLANS:
                       Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 4 Data size: 404 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int), true (type: boolean)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                      Statistics: Num rows: 4 Data size: 1972 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 4 Data size: 1972 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: boolean)
-            Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col5 (type: int)
+                  0 _col5 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                Statistics: Num rows: 5 Data size: 2970 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 3564 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col11 (type: boolean), _col7 (type: string), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean), _col1 (type: string), _col0 (type: int), _col5 (type: string), _col2 (type: int), _col6 (type: bigint)
+                  expressions: _col8 (type: boolean), _col4 (type: string), _col1 (type: bigint), _col0 (type: int), _col7 (type: int), _col6 (type: string), _col5 (type: int), _col8 (type: boolean), _col10 (type: string), _col9 (type: int), _col2 (type: string), _col11 (type: int), _col3 (type: bigint)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
-                  Statistics: Num rows: 5 Data size: 2990 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 3588 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col0 and (_col6 > 100)) (type: boolean)
+                    predicate: (_col0 and (_col4 > 50)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1794 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+                  Filter Operator
+                    predicate: (_col0 and ((_col4 <= 50) or (_col4 > 50) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
@@ -142,68 +154,53 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.target_ice
                   Filter Operator
-                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col4 <= 50) or (_col4 > 50) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 2 Data size: 978 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
-                  Filter Operator
-                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col6 (type: int), 'Merged' (type: string), (_col4 + 10) (type: int)
+                      expressions: _col6 (type: int), concat(_col5, ' Merged') (type: string), (_col4 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
                         null sort order: aa
                         sort order: ++
                         Map-reduce partition columns: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
-                        Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                   Filter Operator
                     predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 598 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col9 (type: int), _col8 (type: string), _col11 (type: int)
+                      expressions: _col9 (type: int), concat(_col8, ' New') (type: string), _col11 (type: int)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
                         null sort order: aa
                         sort order: ++
                         Map-reduce partition columns: iceberg_bucket(_col0, 16) (type: int), iceberg_truncate(_col1, 3) (type: string)
-                        Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                   Filter Operator
-                    predicate: (_col6 = _col9) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col6 IS NOT DISTINCT FROM _col9) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 1794 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
                       outputColumnNames: _col2, _col3, _col10, _col12
-                      Statistics: Num rows: 2 Data size: 1196 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 1794 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                        Statistics: Num rows: 2 Data size: 424 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint)
                           null sort order: zzzz
                           sort order: ++++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint)
-                          Statistics: Num rows: 2 Data size: 424 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col4 (type: bigint)
         Reducer 3 
             Execution mode: vectorized
@@ -214,7 +211,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -229,7 +226,7 @@ STAGE PLANS:
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
-                  Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -243,7 +240,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: int), KEY._col1 (type: bigint), KEY._col2 (type: string), KEY._col3 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 2 Data size: 424 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col4 > 1L) (type: boolean)
                   Statistics: Num rows: 1 Data size: 212 Basic stats: COMPLETE Column stats: COMPLETE
@@ -291,20 +288,20 @@ STAGE PLANS:
     Stats Work
       Basic Stats Work:
 
-PREHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+PREHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@source
 PREHOOK: Input: default@target_ice
 PREHOOK: Output: default@merge_tmp_table
 PREHOOK: Output: default@target_ice
 PREHOOK: Output: default@target_ice
-POSTHOOK: query: merge into target_ice as t using source src ON t.a = src.a
-when matched and t.a > 100 THEN DELETE
-when matched then update set b = 'Merged', c = t.c + 10
-when not matched then insert values (src.a, src.b, src.c)
+POSTHOOK: query: merge into target_ice as t using source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source
 POSTHOOK: Input: default@target_ice
@@ -320,10 +317,7 @@ POSTHOOK: query: select * from target_ice
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target_ice
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-1	Merged	60
+1	match Merged	60
 2	not match	51
-22	not match	51
-3	Merged	65
-4	Merged	NULL
-NULL	match null	56
-NULL	match null	56
+22	not match New	51
+4	not delete null Merged	NULL

--- a/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_merge_mixed.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_merge_mixed.q.out
@@ -366,29 +366,35 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.mapjoin.optimized.hashtable IS true, hive.vectorized.execution.mapjoin.native.enabled IS true, hive.execution.engine tez IN [tez] IS true, One MapJoin Condition IS true, No nullsafe IS true, Small table vectorizes IS true, Outer Join has keys IS true, Optimized Table and Supports Key Types IS true
                           outerSmallTableKeyMapping: 2 -> 41, 3 -> 42
-                          projectedOutput: 1:int, 2:int, 3:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2), 34:int, 35:bigint, 36:string, 37:bigint, 38:string, 39:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 53:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
-                          smallTableValueMapping: 34:int, 35:bigint, 36:string, 37:bigint, 38:string, 39:int, 40:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 53:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
+                          projectedOutput: 1:int, 2:int, 3:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2), 34:int, 35:bigint, 36:string, 37:bigint, 38:string, 39:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 53:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2), 62:boolean
+                          smallTableValueMapping: 34:int, 35:bigint, 36:string, 37:bigint, 38:string, 39:int, 40:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 53:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2), 62:boolean
                           hashTableImplementationType: OPTIMIZED
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32, _col33, _col34, _col35, _col36, _col37, _col38, _col39, _col40, _col41, _col42, _col43, _col44, _col45, _col46, _col47, _col48, _col49, _col50, _col51
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32, _col33, _col34, _col35, _col36, _col37, _col38, _col39, _col40, _col41, _col42, _col43, _col44, _col45, _col46, _col47, _col48, _col49, _col50, _col51, _col52
                       input vertices:
+<<<<<<< HEAD
                         1 Map 5
                       Statistics: Num rows: 7 Data size: 7208 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                        1 Map 6
+                      Statistics: Num rows: 7 Data size: 7220 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                       Select Operator
-                        expressions: _col40 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col33 (type: int), _col39 (type: int), _col24 (type: int), _col21 (type: decimal(7,2)), _col26 (type: string), _col7 (type: int), _col3 (type: int), _col10 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col38 (type: int), _col28 (type: string), _col6 (type: int), _col50 (type: decimal(7,2)), _col11 (type: decimal(7,2)), _col34 (type: int), _col17 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col45 (type: decimal(7,2)), _col47 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col8 (type: int), _col35 (type: int), _col31 (type: int), _col41 (type: decimal(7,2)), _col36 (type: int), _col4 (type: int), _col48 (type: decimal(7,2)), _col5 (type: int), _col13 (type: decimal(7,2)), _col12 (type: decimal(7,2)), _col44 (type: decimal(7,2)), _col43 (type: decimal(7,2)), _col1 (type: int), _col16 (type: decimal(7,2)), _col29 (type: int), _col2 (type: int), _col15 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col25 (type: bigint), _col9 (type: int), _col30 (type: int), _col42 (type: decimal(7,2)), _col0 (type: int), _col27 (type: bigint), _col51 (type: decimal(7,2)), _col32 (type: int), _col37 (type: int), _col46 (type: decimal(7,2))
-                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32, _col33, _col34, _col35, _col36, _col37, _col38, _col39, _col40, _col41, _col42, _col43, _col44, _col45, _col46, _col47, _col48, _col49
+                        expressions: _col40 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col33 (type: int), _col39 (type: int), _col24 (type: int), _col21 (type: decimal(7,2)), _col26 (type: string), _col7 (type: int), _col3 (type: int), _col10 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col38 (type: int), _col28 (type: string), _col6 (type: int), _col50 (type: decimal(7,2)), _col11 (type: decimal(7,2)), _col34 (type: int), _col17 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col45 (type: decimal(7,2)), _col47 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col8 (type: int), _col35 (type: int), _col31 (type: int), _col41 (type: decimal(7,2)), _col36 (type: int), _col4 (type: int), _col48 (type: decimal(7,2)), _col5 (type: int), _col52 (type: boolean), _col13 (type: decimal(7,2)), _col12 (type: decimal(7,2)), _col44 (type: decimal(7,2)), _col43 (type: decimal(7,2)), _col1 (type: int), _col16 (type: decimal(7,2)), _col29 (type: int), _col2 (type: int), _col15 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col25 (type: bigint), _col9 (type: int), _col30 (type: int), _col42 (type: decimal(7,2)), _col0 (type: int), _col27 (type: bigint), _col51 (type: decimal(7,2)), _col32 (type: int), _col37 (type: int), _col46 (type: decimal(7,2))
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32, _col33, _col34, _col35, _col36, _col37, _col38, _col39, _col40, _col41, _col42, _col43, _col44, _col45, _col46, _col47, _col48, _col49, _col50
                         Select Vectorization:
                             className: VectorSelectOperator
                             native: true
-                            projectedOutputColumnNums: [50, 20, 43, 49, 34, 22, 36, 8, 4, 11, 59, 48, 38, 7, 60, 12, 44, 18, 15, 55, 57, 21, 9, 45, 41, 51, 46, 5, 58, 6, 14, 13, 54, 53, 2, 17, 39, 3, 16, 19, 35, 10, 40, 52, 1, 37, 61, 42, 47, 56]
-                        Statistics: Num rows: 7 Data size: 7208 Basic stats: COMPLETE Column stats: COMPLETE
+                            projectedOutputColumnNums: [50, 20, 43, 49, 34, 22, 36, 8, 4, 11, 59, 48, 38, 7, 60, 12, 44, 18, 15, 55, 57, 21, 9, 45, 41, 51, 46, 5, 58, 6, 62, 14, 13, 54, 53, 2, 17, 39, 3, 16, 19, 35, 10, 40, 52, 1, 37, 61, 42, 47, 56]
+                        Statistics: Num rows: 7 Data size: 7220 Basic stats: COMPLETE Column stats: COMPLETE
                         Filter Operator
                           Filter Vectorization:
                               className: VectorFilterOperator
                               native: true
-                              predicateExpression: FilterExprAndExpr(children: FilterLongColEqualLongColumn(col 41:int, col 2:int), FilterLongColEqualLongColumn(col 42:int, col 3:int), FilterLongColEqualLongScalar(col 39:int, val 2451181), FilterLongColumnBetween(col 31:bigint, left 1000, right 2000)(children: LongColMultiplyLongScalar(col 30:bigint, val 1000)(children: FuncFloorDoubleToLong(col 28:double)(children: LongColDivideLongScalar(col 2:int, val 1000) -> 28:double) -> 30:bigint) -> 31:bigint), FilterDecimalColLessDecimalScalar(col 14:decimal(7,2), val 0), SelectColumnIsNull(col 53:decimal(7,2)))
-                          predicate: ((_col24 = _col34) and (_col47 = _col37) and (_col36 = 2451181) and (floor((_col34 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col30 < 0) and _col33 is null) (type: boolean)
-                          Statistics: Num rows: 1 Data size: 3160 Basic stats: COMPLETE Column stats: COMPLETE
+                              predicateExpression: FilterExprAndExpr(children: SelectColumnIsTrue(col 62:boolean), SelectColumnIsNull(col 53:decimal(7,2)))
+                          predicate: (_col30 and _col34 is null) (type: boolean)
+                          Statistics: Num rows: 3 Data size: 5072 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
+<<<<<<< HEAD
                             expressions: _col4 (type: int), _col40 (type: bigint), _col6 (type: string), _col45 (type: bigint), _col12 (type: string), 2451181 (type: int), _col42 (type: int), _col24 (type: int), _col47 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col48 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col43 (type: decimal(7,2)), null (type: decimal(7,2)), _col32 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col46 (type: decimal(7,2))
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
                             Select Vectorization:
@@ -408,22 +414,49 @@ STAGE PLANS:
                                   output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                                   serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                                   name: default.store_sales
+=======
+                            expressions: _col4 (type: int), _col41 (type: bigint), _col6 (type: string), _col46 (type: bigint), _col12 (type: string), _col37 (type: int), _col43 (type: int), _col24 (type: int), _col48 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col49 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col44 (type: decimal(7,2)), _col33 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col50 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col47 (type: decimal(7,2))
+                            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
+                            Select Vectorization:
+                                className: VectorSelectOperator
+                                native: true
+                                projectedOutputColumnNums: [34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 54, 55, 56, 57, 58, 59, 60, 61]
+                            Statistics: Num rows: 3 Data size: 2064 Basic stats: COMPLETE Column stats: COMPLETE
+                            Reduce Output Operator
+                              key expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
+                              null sort order: zzzzz
+                              sort order: +++++
+                              Reduce Sink Vectorization:
+                                  className: VectorReduceSinkObjectHashOperator
+                                  keyColumns: 34:int, 35:bigint, 36:string, 37:bigint, 38:string
+                                  native: true
+                                  nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                                  valueColumns: 39:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
+                              Statistics: Num rows: 3 Data size: 2064 Basic stats: COMPLETE Column stats: COMPLETE
+                              value expressions: _col5 (type: int), _col6 (type: int), _col7 (type: int), _col8 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: int), _col12 (type: int), _col13 (type: int), _col14 (type: int), _col15 (type: int), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2)), _col23 (type: decimal(7,2)), _col24 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col27 (type: decimal(7,2))
+>>>>>>> f7ae7daa2c (update q.out files)
                         Filter Operator
                           Filter Vectorization:
                               className: VectorFilterOperator
                               native: true
-                              predicateExpression: FilterExprAndExpr(children: FilterLongColEqualLongColumn(col 41:int, col 2:int), FilterLongColEqualLongColumn(col 42:int, col 3:int), FilterLongColEqualLongScalar(col 39:int, val 2451181), FilterLongColumnBetween(col 31:bigint, left 1000, right 2000)(children: LongColMultiplyLongScalar(col 30:bigint, val 1000)(children: FuncFloorDoubleToLong(col 28:double)(children: LongColDivideLongScalar(col 2:int, val 1000) -> 28:double) -> 30:bigint) -> 31:bigint), FilterDecimalColLessDecimalScalar(col 14:decimal(7,2), val 0), SelectColumnIsNull(col 53:decimal(7,2)))
-                          predicate: ((_col24 = _col34) and (_col47 = _col37) and (_col36 = 2451181) and (floor((_col34 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col30 < 0) and _col33 is null) (type: boolean)
-                          Statistics: Num rows: 1 Data size: 3160 Basic stats: COMPLETE Column stats: COMPLETE
+                              predicateExpression: FilterExprAndExpr(children: SelectColumnIsTrue(col 62:boolean), SelectColumnIsNull(col 53:decimal(7,2)))
+                          predicate: (_col30 and _col34 is null) (type: boolean)
+                          Statistics: Num rows: 3 Data size: 5072 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
-                            expressions: 2451181 (type: int), _col42 (type: int), _col24 (type: int), _col47 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col48 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col43 (type: decimal(7,2)), 0 (type: decimal(7,2)), _col32 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col46 (type: decimal(7,2))
+                            expressions: _col37 (type: int), _col43 (type: int), _col24 (type: int), _col48 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col49 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col44 (type: decimal(7,2)), 0 (type: decimal(7,2)), _col33 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col50 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col47 (type: decimal(7,2))
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22
                             Select Vectorization:
                                 className: VectorSelectOperator
                                 native: true
+<<<<<<< HEAD
                                 projectedOutputColumnNums: [31, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 63, 54, 55, 56, 57, 58, 59, 60, 61]
                                 selectExpressions: ConstantVectorExpression(val 2451181) -> 31:int, ConstantVectorExpression(val 0) -> 63:decimal(7,2)
                             Statistics: Num rows: 1 Data size: 1388 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                                projectedOutputColumnNums: [39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 63, 54, 55, 56, 57, 58, 59, 60, 61]
+                                selectExpressions: ConstantVectorExpression(val 0) -> 63:decimal(7,2)
+                            Statistics: Num rows: 3 Data size: 1624 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                             Reduce Output Operator
                               key expressions: _col3 (type: int), iceberg_bucket(_col2, 3) (type: int)
                               null sort order: aa
@@ -431,29 +464,44 @@ STAGE PLANS:
                               Map-reduce partition columns: _col3 (type: int), iceberg_bucket(_col2, 3) (type: int)
                               Reduce Sink Vectorization:
                                   className: VectorReduceSinkMultiKeyOperator
+<<<<<<< HEAD
                                   keyColumns: 42:int, 65:int
                                   keyExpressions: VectorUDFAdaptor(iceberg_bucket(_col2, 3)) -> 65:int
                                   native: true
                                   nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                                   valueColumns: 31:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 63:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
                               Statistics: Num rows: 1 Data size: 1388 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                                  keyColumns: 42:int, 31:int
+                                  keyExpressions: VectorUDFAdaptor(iceberg_bucket(_col2, 3)) -> 31:int
+                                  native: true
+                                  nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                                  valueColumns: 39:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 63:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
+                              Statistics: Num rows: 3 Data size: 1624 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                               value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int), _col4 (type: int), _col5 (type: int), _col6 (type: int), _col7 (type: int), _col8 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: decimal(7,2)), _col12 (type: decimal(7,2)), _col13 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2))
                         Filter Operator
                           Filter Vectorization:
                               className: VectorFilterOperator
                               native: true
-                              predicateExpression: FilterExprAndExpr(children: SelectColumnIsNull(col 41:int), SelectColumnIsNull(col 42:int), SelectColumnIsNull(col 39:int))
-                          predicate: (_col24 is null and _col47 is null and _col36 is null) (type: boolean)
-                          Statistics: Num rows: 3 Data size: 5064 Basic stats: COMPLETE Column stats: COMPLETE
+                              predicateExpression: SelectColumnIsNull(col 62:boolean)
+                          predicate: _col30 is null (type: boolean)
+                          Statistics: Num rows: 5 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
-                            expressions: 2451181 (type: int), _col44 (type: int), _col34 (type: int), _col37 (type: int), _col8 (type: int), _col27 (type: int), _col29 (type: int), _col13 (type: int), _col7 (type: int), _col22 (type: int), _col41 (type: int), _col9 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col31 (type: decimal(7,2)), _col30 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col38 (type: decimal(7,2)), _col35 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col39 (type: decimal(7,2)), _col1 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col5 (type: decimal(7,2))
+                            expressions: 2451181 (type: int), _col45 (type: int), _col35 (type: int), _col38 (type: int), _col8 (type: int), _col27 (type: int), _col29 (type: int), _col13 (type: int), _col7 (type: int), _col22 (type: int), _col42 (type: int), _col9 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col32 (type: decimal(7,2)), _col31 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col39 (type: decimal(7,2)), _col36 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col40 (type: decimal(7,2)), _col1 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col5 (type: decimal(7,2))
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22
                             Select Vectorization:
                                 className: VectorSelectOperator
                                 native: true
+<<<<<<< HEAD
                                 projectedOutputColumnNums: [64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
                                 selectExpressions: ConstantVectorExpression(val 2451181) -> 64:int
                             Statistics: Num rows: 3 Data size: 2900 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                                projectedOutputColumnNums: [30, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+                                selectExpressions: ConstantVectorExpression(val 2451181) -> 30:int
+                            Statistics: Num rows: 5 Data size: 3148 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                             Reduce Output Operator
                               key expressions: _col3 (type: int), iceberg_bucket(_col2, 3) (type: int)
                               null sort order: aa
@@ -465,17 +513,23 @@ STAGE PLANS:
                                   keyExpressions: VectorUDFAdaptor(iceberg_bucket(_col2, 3)) -> 66:int
                                   native: true
                                   nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+<<<<<<< HEAD
                                   valueColumns: 64:int, 1:int, 2:int, 3:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2)
                               Statistics: Num rows: 3 Data size: 2900 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                                  valueColumns: 30:int, 1:int, 2:int, 3:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2)
+                              Statistics: Num rows: 5 Data size: 3148 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                               value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int), _col4 (type: int), _col5 (type: int), _col6 (type: int), _col7 (type: int), _col8 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: decimal(7,2)), _col12 (type: decimal(7,2)), _col13 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2))
                         Filter Operator
                           Filter Vectorization:
                               className: VectorFilterOperator
                               native: true
                               predicateExpression: FilterExprAndExpr(children: FilterLongColEqualLongColumn(col 41:int, col 2:int), FilterLongColEqualLongColumn(col 42:int, col 3:int), FilterLongColEqualLongScalar(col 39:int, val 2451181), FilterLongColumnBetween(col 31:bigint, left 1000, right 2000)(children: LongColMultiplyLongScalar(col 30:bigint, val 1000)(children: FuncFloorDoubleToLong(col 28:double)(children: LongColDivideLongScalar(col 2:int, val 1000) -> 28:double) -> 30:bigint) -> 31:bigint), FilterDecimalColLessDecimalScalar(col 14:decimal(7,2), val 0))
-                          predicate: ((_col24 = _col34) and (_col47 = _col37) and (_col36 = 2451181) and (floor((_col34 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col30 < 0)) (type: boolean)
-                          Statistics: Num rows: 1 Data size: 3160 Basic stats: COMPLETE Column stats: COMPLETE
+                          predicate: ((_col24 = _col35) and (_col48 = _col38) and (_col37 = 2451181) and (floor((_col35 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col31 < 0)) (type: boolean)
+                          Statistics: Num rows: 1 Data size: 3164 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
+<<<<<<< HEAD
                             expressions: _col4 (type: int), _col6 (type: string), _col40 (type: bigint), _col45 (type: bigint)
                             outputColumnNames: _col4, _col6, _col40, _col45
                             Select Vectorization:
@@ -483,6 +537,15 @@ STAGE PLANS:
                                 native: true
                                 projectedOutputColumnNums: [34, 36, 35, 37]
                             Statistics: Num rows: 1 Data size: 3160 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                            expressions: _col4 (type: int), _col6 (type: string), _col12 (type: string), _col41 (type: bigint), _col46 (type: bigint)
+                            outputColumnNames: _col4, _col6, _col12, _col41, _col46
+                            Select Vectorization:
+                                className: VectorSelectOperator
+                                native: true
+                                projectedOutputColumnNums: [34, 36, 38, 35, 37]
+                            Statistics: Num rows: 1 Data size: 3164 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                             Group By Operator
                               aggregations: count()
                               Group By Vectorization:
@@ -493,7 +556,11 @@ STAGE PLANS:
                                   native: false
                                   vectorProcessingMode: HASH
                                   projectedOutputColumnNums: [0]
+<<<<<<< HEAD
                               keys: _col4 (type: int), _col40 (type: bigint), _col6 (type: string), _col45 (type: bigint)
+=======
+                              keys: _col4 (type: int), _col41 (type: bigint), _col6 (type: string), _col46 (type: bigint), _col12 (type: string)
+>>>>>>> f7ae7daa2c (update q.out files)
                               minReductionHashAggr: 0.4
                               mode: hash
                               outputColumnNames: _col0, _col1, _col2, _col3, _col4
@@ -526,8 +593,13 @@ STAGE PLANS:
                     includeColumns: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
                     dataColumns: ss_sold_date_sk:int, ss_sold_time_sk:int, ss_item_sk2:int, ss_customer_sk2:int, ss_cdemo_sk:int, ss_hdemo_sk:int, ss_addr_sk:int, ss_store_sk:int, ss_promo_sk:int, ss_ticket_number:int, ss_quantity:int, ss_wholesale_cost:decimal(7,2), ss_list_price:decimal(7,2), ss_sales_price:decimal(7,2), ss_ext_discount_amt:decimal(7,2), ss_ext_sales_price:decimal(7,2), ss_ext_wholesale_cost:decimal(7,2), ss_ext_list_price:decimal(7,2), ss_ext_tax:decimal(7,2), ss_coupon_amt:decimal(7,2), ss_net_paid:decimal(7,2), ss_net_paid_inc_tax:decimal(7,2), ss_net_profit:decimal(7,2)
                     partitionColumnCount: 0
+<<<<<<< HEAD
                     scratchColumnTypeNames: [double, double, bigint, bigint, bigint, bigint, bigint, bigint, string, bigint, string, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), bigint, bigint, bigint]
         Map 5 
+=======
+                    scratchColumnTypeNames: [double, double, bigint, bigint, bigint, bigint, bigint, bigint, string, bigint, string, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), bigint, decimal(7,2), bigint]
+        Map 6 
+>>>>>>> f7ae7daa2c (update q.out files)
             Map Operator Tree:
                 TableScan
                   alias: store_sales
@@ -544,14 +616,14 @@ STAGE PLANS:
                     predicate: ((ss_sold_date_sk = 2451181) and ss_item_sk is not null and ss_customer_sk is not null) (type: boolean)
                     Statistics: Num rows: 2 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), 2451181 (type: int), ss_sold_time_sk (type: int), ss_item_sk (type: int), ss_customer_sk (type: int), ss_cdemo_sk (type: int), ss_hdemo_sk (type: int), ss_addr_sk (type: int), ss_store_sk (type: int), ss_promo_sk (type: int), ss_ticket_number (type: int), ss_quantity (type: int), ss_wholesale_cost (type: decimal(7,2)), ss_list_price (type: decimal(7,2)), ss_sales_price (type: decimal(7,2)), ss_ext_discount_amt (type: decimal(7,2)), ss_ext_sales_price (type: decimal(7,2)), ss_ext_wholesale_cost (type: decimal(7,2)), ss_ext_list_price (type: decimal(7,2)), ss_ext_tax (type: decimal(7,2)), ss_coupon_amt (type: decimal(7,2)), ss_net_paid (type: decimal(7,2)), ss_net_paid_inc_tax (type: decimal(7,2)), ss_net_profit (type: decimal(7,2))
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), 2451181 (type: int), ss_sold_time_sk (type: int), ss_item_sk (type: int), ss_customer_sk (type: int), ss_cdemo_sk (type: int), ss_hdemo_sk (type: int), ss_addr_sk (type: int), ss_store_sk (type: int), ss_promo_sk (type: int), ss_ticket_number (type: int), ss_quantity (type: int), ss_wholesale_cost (type: decimal(7,2)), ss_list_price (type: decimal(7,2)), ss_sales_price (type: decimal(7,2)), ss_ext_discount_amt (type: decimal(7,2)), ss_ext_sales_price (type: decimal(7,2)), ss_ext_wholesale_cost (type: decimal(7,2)), ss_ext_list_price (type: decimal(7,2)), ss_ext_tax (type: decimal(7,2)), ss_coupon_amt (type: decimal(7,2)), ss_net_paid (type: decimal(7,2)), ss_net_paid_inc_tax (type: decimal(7,2)), ss_net_profit (type: decimal(7,2)), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27, _col28
                       Select Vectorization:
                           className: VectorSelectOperator
                           native: true
-                          projectedOutputColumnNums: [23, 24, 25, 26, 27, 28, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-                          selectExpressions: ConstantVectorExpression(val 2451181) -> 28:int
-                      Statistics: Num rows: 2 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
+                          projectedOutputColumnNums: [23, 24, 25, 26, 27, 28, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 29]
+                          selectExpressions: ConstantVectorExpression(val 2451181) -> 28:int, ConstantVectorExpression(val 1) -> 29:boolean
+                      Statistics: Num rows: 2 Data size: 2184 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col8 (type: int), _col7 (type: int)
                         null sort order: zz
@@ -562,9 +634,9 @@ STAGE PLANS:
                             keyColumns: 3:int, 2:int
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                            valueColumns: 23:int, 24:bigint, 25:string, 26:bigint, 27:string, 28:int, 1:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2)
-                        Statistics: Num rows: 2 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: int), _col12 (type: int), _col13 (type: int), _col14 (type: int), _col15 (type: int), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2)), _col23 (type: decimal(7,2)), _col24 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col27 (type: decimal(7,2))
+                            valueColumns: 23:int, 24:bigint, 25:string, 26:bigint, 27:string, 28:int, 1:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2), 29:boolean
+                        Statistics: Num rows: 2 Data size: 2184 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: int), _col12 (type: int), _col13 (type: int), _col14 (type: int), _col15 (type: int), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2)), _col23 (type: decimal(7,2)), _col24 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col27 (type: decimal(7,2)), _col28 (type: boolean)
             Execution mode: vectorized
             Map Vectorization:
                 enabled: true
@@ -581,7 +653,7 @@ STAGE PLANS:
                     dataColumns: ss_sold_date_sk:int, ss_sold_time_sk:int, ss_item_sk:int, ss_customer_sk:int, ss_cdemo_sk:int, ss_hdemo_sk:int, ss_addr_sk:int, ss_store_sk:int, ss_promo_sk:int, ss_ticket_number:int, ss_quantity:int, ss_wholesale_cost:decimal(7,2), ss_list_price:decimal(7,2), ss_sales_price:decimal(7,2), ss_ext_discount_amt:decimal(7,2), ss_ext_sales_price:decimal(7,2), ss_ext_wholesale_cost:decimal(7,2), ss_ext_list_price:decimal(7,2), ss_ext_tax:decimal(7,2), ss_coupon_amt:decimal(7,2), ss_net_paid:decimal(7,2), ss_net_paid_inc_tax:decimal(7,2), ss_net_profit:decimal(7,2)
                     neededVirtualColumns: #Masked#
                     partitionColumnCount: 0
-                    scratchColumnTypeNames: [bigint]
+                    scratchColumnTypeNames: [bigint, bigint]
         Reducer 2 
             Execution mode: vectorized
             Reduce Vectorization:
@@ -593,6 +665,7 @@ STAGE PLANS:
                 usesVectorUDFAdaptor: false
                 vectorized: true
                 rowBatchContext:
+<<<<<<< HEAD
                     dataColumnCount: 25
                     dataColumns: KEY._col3:int, KEY.iceberg_bucket(_col2, 3):int, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:int, VALUE._col4:int, VALUE._col5:int, VALUE._col6:int, VALUE._col7:int, VALUE._col8:int, VALUE._col9:int, VALUE._col10:int, VALUE._col11:decimal(7,2)/DECIMAL_64, VALUE._col12:decimal(7,2)/DECIMAL_64, VALUE._col13:decimal(7,2)/DECIMAL_64, VALUE._col14:decimal(7,2)/DECIMAL_64, VALUE._col15:decimal(7,2)/DECIMAL_64, VALUE._col16:decimal(7,2)/DECIMAL_64, VALUE._col17:decimal(7,2)/DECIMAL_64, VALUE._col18:decimal(7,2)/DECIMAL_64, VALUE._col19:decimal(7,2)/DECIMAL_64, VALUE._col20:decimal(7,2)/DECIMAL_64, VALUE._col21:decimal(7,2)/DECIMAL_64, VALUE._col22:decimal(7,2)/DECIMAL_64
                     partitionColumnCount: 0
@@ -605,13 +678,33 @@ STAGE PLANS:
                     className: VectorSelectOperator
                     native: true
                     projectedOutputColumnNums: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 0, 1]
+=======
+                    dataColumnCount: 27
+                    dataColumns: KEY.reducesinkkey0:int, KEY.reducesinkkey1:bigint, KEY.reducesinkkey2:string, KEY.reducesinkkey3:bigint, KEY.reducesinkkey4:string, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:int, VALUE._col4:int, VALUE._col5:int, VALUE._col6:int, VALUE._col7:int, VALUE._col8:int, VALUE._col9:int, VALUE._col10:int, VALUE._col11:decimal(7,2)/DECIMAL_64, VALUE._col12:decimal(7,2)/DECIMAL_64, VALUE._col13:decimal(7,2)/DECIMAL_64, VALUE._col15:decimal(7,2)/DECIMAL_64, VALUE._col16:decimal(7,2)/DECIMAL_64, VALUE._col17:decimal(7,2)/DECIMAL_64, VALUE._col18:decimal(7,2)/DECIMAL_64, VALUE._col19:decimal(7,2)/DECIMAL_64, VALUE._col20:decimal(7,2)/DECIMAL_64, VALUE._col21:decimal(7,2)/DECIMAL_64, VALUE._col22:decimal(7,2)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [decimal(7,2)]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: int), VALUE._col3 (type: int), VALUE._col4 (type: int), VALUE._col5 (type: int), VALUE._col6 (type: int), VALUE._col7 (type: int), VALUE._col8 (type: int), VALUE._col9 (type: int), VALUE._col10 (type: int), VALUE._col11 (type: decimal(7,2)), VALUE._col12 (type: decimal(7,2)), VALUE._col13 (type: decimal(7,2)), null (type: decimal(7,2)), VALUE._col15 (type: decimal(7,2)), VALUE._col16 (type: decimal(7,2)), VALUE._col17 (type: decimal(7,2)), VALUE._col18 (type: decimal(7,2)), VALUE._col19 (type: decimal(7,2)), VALUE._col20 (type: decimal(7,2)), VALUE._col21 (type: decimal(7,2)), VALUE._col22 (type: decimal(7,2))
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 27, 19, 20, 21, 22, 23, 24, 25, 26]
+                    selectExpressions: ConstantVectorExpression(val null) -> 27:decimal(7,2)
+                Statistics: Num rows: 3 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
                   File Sink Vectorization:
                       className: VectorFileSinkOperator
                       native: false
+<<<<<<< HEAD
                   Statistics: Num rows: 1 Data size: 1388 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                  Statistics: Num rows: 3 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -646,7 +739,11 @@ STAGE PLANS:
                   File Sink Vectorization:
                       className: VectorFileSinkOperator
                       native: false
+<<<<<<< HEAD
                   Statistics: Num rows: 3 Data size: 2900 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                  Statistics: Num rows: 3 Data size: 1624 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -657,8 +754,48 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
+<<<<<<< HEAD
                 reduceColumnNullOrder: zzzz
                 reduceColumnSortOrder: ++++
+=======
+                reduceColumnNullOrder: aa
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 25
+                    dataColumns: KEY._col3:int, KEY.iceberg_bucket(_col2, 3):int, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:int, VALUE._col4:int, VALUE._col5:int, VALUE._col6:int, VALUE._col7:int, VALUE._col8:int, VALUE._col9:int, VALUE._col10:int, VALUE._col11:decimal(7,2)/DECIMAL_64, VALUE._col12:decimal(7,2)/DECIMAL_64, VALUE._col13:decimal(7,2)/DECIMAL_64, VALUE._col14:decimal(7,2)/DECIMAL_64, VALUE._col15:decimal(7,2)/DECIMAL_64, VALUE._col16:decimal(7,2)/DECIMAL_64, VALUE._col17:decimal(7,2)/DECIMAL_64, VALUE._col18:decimal(7,2)/DECIMAL_64, VALUE._col19:decimal(7,2)/DECIMAL_64, VALUE._col20:decimal(7,2)/DECIMAL_64, VALUE._col21:decimal(7,2)/DECIMAL_64, VALUE._col22:decimal(7,2)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: int), VALUE._col3 (type: int), VALUE._col4 (type: int), VALUE._col5 (type: int), VALUE._col6 (type: int), VALUE._col7 (type: int), VALUE._col8 (type: int), VALUE._col9 (type: int), VALUE._col10 (type: int), VALUE._col11 (type: decimal(7,2)), VALUE._col12 (type: decimal(7,2)), VALUE._col13 (type: decimal(7,2)), VALUE._col14 (type: decimal(7,2)), VALUE._col15 (type: decimal(7,2)), VALUE._col16 (type: decimal(7,2)), VALUE._col17 (type: decimal(7,2)), VALUE._col18 (type: decimal(7,2)), VALUE._col19 (type: decimal(7,2)), VALUE._col20 (type: decimal(7,2)), VALUE._col21 (type: decimal(7,2)), VALUE._col22 (type: decimal(7,2)), KEY._col3 (type: int), KEY.iceberg_bucket(_col2, 3) (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col3, iceberg_bucket(_col2, 3)
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 0, 1]
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_SORTED
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 5 Data size: 3148 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.store_sales
+        Reducer 5 
+            Execution mode: vectorized
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
+                reduceColumnNullOrder: zzzzz
+                reduceColumnSortOrder: +++++
+>>>>>>> f7ae7daa2c (update q.out files)
                 allNative: false
                 usesVectorUDFAdaptor: true
                 vectorized: true
@@ -900,6 +1037,7 @@ Stage-6
               Reducer 2 vectorized
               File Output Operator [FS_64]
                 table:{"name:":"default.store_sales"}
+<<<<<<< HEAD
                 Select Operator [SEL_63]
                   Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col3","iceberg_bucket(_col2, 3)"]
                 <-Map 1 [SIMPLE_EDGE] vectorized
@@ -919,6 +1057,26 @@ Stage-6
                               Select Operator [SEL_45] (rows=2 width=1088)
                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27"]
                                 Filter Operator [FIL_44] (rows=2 width=700)
+=======
+                Select Operator [SEL_65] (rows=3 width=725)
+                  Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27"]
+                <-Map 1 [SIMPLE_EDGE] vectorized
+                  SHUFFLE [RS_60]
+                    Select Operator [SEL_56] (rows=3 width=688)
+                      Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27"]
+                      Filter Operator [FIL_52] (rows=3 width=1690)
+                        predicate:(_col30 and _col34 is null)
+                        Select Operator [SEL_51] (rows=7 width=1031)
+                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50"]
+                          Map Join Operator [MAPJOIN_50] (rows=7 width=1031)
+                            Conds:SEL_49._col2, _col1=RS_48._col8, _col7(Left Outer),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51","_col52"]
+                          <-Map 6 [BROADCAST_EDGE] vectorized
+                            BROADCAST [RS_48]
+                              PartitionCols:_col8, _col7
+                              Select Operator [SEL_47] (rows=2 width=1092)
+                                Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28"]
+                                Filter Operator [FIL_46] (rows=2 width=700)
+>>>>>>> f7ae7daa2c (update q.out files)
                                   predicate:((ss_sold_date_sk = 2451181) and ss_item_sk is not null and ss_customer_sk is not null)
                                   TableScan [TS_2] (rows=2 width=55###)
                                     default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_sold_time_sk","ss_item_sk","ss_customer_sk","ss_cdemo_sk","ss_hdemo_sk","ss_addr_sk","ss_store_sk","ss_promo_sk","ss_ticket_number","ss_quantity","ss_wholesale_cost","ss_list_price","ss_sales_price","ss_ext_discount_amt","ss_ext_sales_price","ss_ext_wholesale_cost","ss_ext_list_price","ss_ext_tax","ss_coupon_amt","ss_net_paid","ss_net_paid_inc_tax","ss_net_profit"]
@@ -934,6 +1092,7 @@ Stage-6
                 <-Map 1 [SIMPLE_EDGE] vectorized
                   SHUFFLE [RS_60]
                     PartitionCols:_col3, iceberg_bucket(_col2, 3)
+<<<<<<< HEAD
                     Select Operator [SEL_56] (rows=3 width=966)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
                       Filter Operator [FIL_52] (rows=3 width=1688)
@@ -941,6 +1100,28 @@ Stage-6
                          Please refer to the previous Select Operator [SEL_49]
               Reducer 4 vectorized
               File Output Operator [FS_70]
+=======
+                    Select Operator [SEL_57] (rows=3 width=541)
+                      Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
+                      Filter Operator [FIL_53] (rows=3 width=1690)
+                        predicate:(_col30 and _col34 is null)
+                         Please refer to the previous Select Operator [SEL_51]
+              Reducer 4 vectorized
+              File Output Operator [FS_70]
+                table:{"name:":"default.store_sales"}
+                Select Operator [SEL_69]
+                  Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col3","iceberg_bucket(_col2, 3)"]
+                <-Map 1 [SIMPLE_EDGE] vectorized
+                  SHUFFLE [RS_62]
+                    PartitionCols:_col3, iceberg_bucket(_col2, 3)
+                    Select Operator [SEL_58] (rows=5 width=629)
+                      Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
+                      Filter Operator [FIL_54] (rows=5 width=1062)
+                        predicate:_col30 is null
+                         Please refer to the previous Select Operator [SEL_51]
+              Reducer 5 vectorized
+              File Output Operator [FS_74]
+>>>>>>> f7ae7daa2c (update q.out files)
                 table:{"name:":"default.merge_tmp_table"}
                 Select Operator [SEL_69] (rows=1 width=4)
                   Output:["_col0"]
@@ -949,6 +1130,7 @@ Stage-6
                     Group By Operator [GBY_67] (rows=1 width=212)
                       Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2, KEY._col3
                     <-Map 1 [SIMPLE_EDGE] vectorized
+<<<<<<< HEAD
                       SHUFFLE [RS_62]
                         PartitionCols:_col0, _col1, _col2, _col3
                         Group By Operator [GBY_61] (rows=1 width=212)
@@ -958,6 +1140,17 @@ Stage-6
                             Filter Operator [FIL_53] (rows=1 width=3160)
                               predicate:((_col24 = _col34) and (_col47 = _col37) and (_col36 = 2451181) and (floor((_col34 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col30 < 0))
                                Please refer to the previous Select Operator [SEL_49]
+=======
+                      SHUFFLE [RS_64]
+                        PartitionCols:_col0, _col1, _col2, _col3, _col4
+                        Group By Operator [GBY_63] (rows=1 width=396)
+                          Output:["_col0","_col1","_col2","_col3","_col4","_col5"],aggregations:["count()"],keys:_col4, _col41, _col6, _col46, _col12
+                          Select Operator [SEL_59] (rows=1 width=3164)
+                            Output:["_col4","_col6","_col12","_col41","_col46"]
+                            Filter Operator [FIL_55] (rows=1 width=3164)
+                              predicate:((_col24 = _col35) and (_col48 = _col38) and (_col37 = 2451181) and (floor((_col35 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col31 < 0))
+                               Please refer to the previous Select Operator [SEL_51]
+>>>>>>> f7ae7daa2c (update q.out files)
 Stage-7
   Stats Work{}
     Stage-3

--- a/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_merge_mixed.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_merge_mixed.q.out
@@ -371,13 +371,8 @@ STAGE PLANS:
                           hashTableImplementationType: OPTIMIZED
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32, _col33, _col34, _col35, _col36, _col37, _col38, _col39, _col40, _col41, _col42, _col43, _col44, _col45, _col46, _col47, _col48, _col49, _col50, _col51, _col52
                       input vertices:
-<<<<<<< HEAD
                         1 Map 5
-                      Statistics: Num rows: 7 Data size: 7208 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                        1 Map 6
                       Statistics: Num rows: 7 Data size: 7220 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
                       Select Operator
                         expressions: _col40 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col33 (type: int), _col39 (type: int), _col24 (type: int), _col21 (type: decimal(7,2)), _col26 (type: string), _col7 (type: int), _col3 (type: int), _col10 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col52 (type: boolean), _col38 (type: int), _col28 (type: string), _col6 (type: int), _col50 (type: decimal(7,2)), _col11 (type: decimal(7,2)), _col34 (type: int), _col17 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col45 (type: decimal(7,2)), _col47 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col8 (type: int), _col35 (type: int), _col31 (type: int), _col41 (type: decimal(7,2)), _col36 (type: int), _col4 (type: int), _col48 (type: decimal(7,2)), _col5 (type: int), _col13 (type: decimal(7,2)), _col52 (type: boolean), _col12 (type: decimal(7,2)), _col44 (type: decimal(7,2)), _col43 (type: decimal(7,2)), _col1 (type: int), _col16 (type: decimal(7,2)), _col29 (type: int), _col2 (type: int), _col15 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col25 (type: bigint), _col9 (type: int), _col30 (type: int), _col42 (type: decimal(7,2)), _col0 (type: int), _col27 (type: bigint), _col51 (type: decimal(7,2)), _col32 (type: int), _col37 (type: int), _col46 (type: decimal(7,2))
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32, _col33, _col34, _col35, _col36, _col37, _col38, _col39, _col40, _col41, _col42, _col43, _col44, _col45, _col46, _col47, _col48, _col49, _col50, _col51
@@ -394,51 +389,25 @@ STAGE PLANS:
                           predicate: (_col11 and _col35 is null) (type: boolean)
                           Statistics: Num rows: 3 Data size: 5080 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
-<<<<<<< HEAD
-<<<<<<< HEAD
-                            expressions: _col4 (type: int), _col40 (type: bigint), _col6 (type: string), _col45 (type: bigint), _col12 (type: string), 2451181 (type: int), _col42 (type: int), _col24 (type: int), _col47 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col48 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col43 (type: decimal(7,2)), null (type: decimal(7,2)), _col32 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col46 (type: decimal(7,2))
+                            expressions: _col4 (type: int), _col42 (type: bigint), _col6 (type: string), _col47 (type: bigint), _col13 (type: string), _col38 (type: int), _col44 (type: int), _col25 (type: int), _col49 (type: int), _col2 (type: int), _col17 (type: int), _col24 (type: int), _col27 (type: int), _col50 (type: int), _col12 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col45 (type: decimal(7,2)), null (type: decimal(7,2)), _col34 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col51 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col29 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col48 (type: decimal(7,2))
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
                             Select Vectorization:
                                 className: VectorSelectOperator
                                 native: true
-                                projectedOutputColumnNums: [34, 35, 36, 37, 38, 30, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 62, 54, 55, 56, 57, 58, 59, 60, 61]
-                                selectExpressions: ConstantVectorExpression(val 2451181) -> 30:int, ConstantVectorExpression(val null) -> 62:decimal(7,2)
-                            Statistics: Num rows: 1 Data size: 1776 Basic stats: COMPLETE Column stats: COMPLETE
+                                projectedOutputColumnNums: [34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 63, 54, 55, 56, 57, 58, 59, 60, 61]
+                                selectExpressions: ConstantVectorExpression(val null) -> 63:decimal(7,2)
+                            Statistics: Num rows: 3 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
                             File Output Operator
                               compressed: false
                               File Sink Vectorization:
                                   className: VectorFileSinkOperator
                                   native: false
-                              Statistics: Num rows: 1 Data size: 1776 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 3 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
                               table:
                                   input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                                   output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                                   serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                                   name: default.store_sales
-=======
-                            expressions: _col4 (type: int), _col41 (type: bigint), _col6 (type: string), _col46 (type: bigint), _col12 (type: string), _col37 (type: int), _col43 (type: int), _col24 (type: int), _col48 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col49 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col44 (type: decimal(7,2)), _col33 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col50 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col47 (type: decimal(7,2))
-=======
-                            expressions: _col4 (type: int), _col42 (type: bigint), _col6 (type: string), _col47 (type: bigint), _col13 (type: string), _col38 (type: int), _col44 (type: int), _col25 (type: int), _col49 (type: int), _col2 (type: int), _col17 (type: int), _col24 (type: int), _col27 (type: int), _col50 (type: int), _col12 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col45 (type: decimal(7,2)), _col34 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col51 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col29 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col48 (type: decimal(7,2))
->>>>>>> 874d07004f (update q.out)
-                            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
-                            Select Vectorization:
-                                className: VectorSelectOperator
-                                native: true
-                                projectedOutputColumnNums: [34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 54, 55, 56, 57, 58, 59, 60, 61]
-                            Statistics: Num rows: 3 Data size: 2064 Basic stats: COMPLETE Column stats: COMPLETE
-                            Reduce Output Operator
-                              key expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
-                              null sort order: zzzzz
-                              sort order: +++++
-                              Reduce Sink Vectorization:
-                                  className: VectorReduceSinkObjectHashOperator
-                                  keyColumns: 34:int, 35:bigint, 36:string, 37:bigint, 38:string
-                                  native: true
-                                  nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                                  valueColumns: 39:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
-                              Statistics: Num rows: 3 Data size: 2064 Basic stats: COMPLETE Column stats: COMPLETE
-                              value expressions: _col5 (type: int), _col6 (type: int), _col7 (type: int), _col8 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: int), _col12 (type: int), _col13 (type: int), _col14 (type: int), _col15 (type: int), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2)), _col23 (type: decimal(7,2)), _col24 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col27 (type: decimal(7,2))
->>>>>>> f7ae7daa2c (update q.out files)
                         Filter Operator
                           Filter Vectorization:
                               className: VectorFilterOperator
@@ -452,15 +421,9 @@ STAGE PLANS:
                             Select Vectorization:
                                 className: VectorSelectOperator
                                 native: true
-<<<<<<< HEAD
-                                projectedOutputColumnNums: [31, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 63, 54, 55, 56, 57, 58, 59, 60, 61]
-                                selectExpressions: ConstantVectorExpression(val 2451181) -> 31:int, ConstantVectorExpression(val 0) -> 63:decimal(7,2)
-                            Statistics: Num rows: 1 Data size: 1388 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                                projectedOutputColumnNums: [39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 63, 54, 55, 56, 57, 58, 59, 60, 61]
-                                selectExpressions: ConstantVectorExpression(val 0) -> 63:decimal(7,2)
+                                projectedOutputColumnNums: [39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 64, 54, 55, 56, 57, 58, 59, 60, 61]
+                                selectExpressions: ConstantVectorExpression(val 0) -> 64:decimal(7,2)
                             Statistics: Num rows: 3 Data size: 1624 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
                             Reduce Output Operator
                               key expressions: _col3 (type: int), iceberg_bucket(_col2, 3) (type: int)
                               null sort order: aa
@@ -468,21 +431,12 @@ STAGE PLANS:
                               Map-reduce partition columns: _col3 (type: int), iceberg_bucket(_col2, 3) (type: int)
                               Reduce Sink Vectorization:
                                   className: VectorReduceSinkMultiKeyOperator
-<<<<<<< HEAD
-                                  keyColumns: 42:int, 65:int
-                                  keyExpressions: VectorUDFAdaptor(iceberg_bucket(_col2, 3)) -> 65:int
-                                  native: true
-                                  nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                                  valueColumns: 31:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 63:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
-                              Statistics: Num rows: 1 Data size: 1388 Basic stats: COMPLETE Column stats: COMPLETE
-=======
                                   keyColumns: 42:int, 31:int
                                   keyExpressions: VectorUDFAdaptor(iceberg_bucket(_col2, 3)) -> 31:int
                                   native: true
                                   nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                                  valueColumns: 39:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 63:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
+                                  valueColumns: 39:int, 40:int, 41:int, 42:int, 43:int, 44:int, 45:int, 46:int, 47:int, 48:int, 49:int, 50:decimal(7,2), 51:decimal(7,2), 52:decimal(7,2), 64:decimal(7,2), 54:decimal(7,2), 55:decimal(7,2), 56:decimal(7,2), 57:decimal(7,2), 58:decimal(7,2), 59:decimal(7,2), 60:decimal(7,2), 61:decimal(7,2)
                               Statistics: Num rows: 3 Data size: 1624 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
                               value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int), _col4 (type: int), _col5 (type: int), _col6 (type: int), _col7 (type: int), _col8 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: decimal(7,2)), _col12 (type: decimal(7,2)), _col13 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2))
                         Filter Operator
                           Filter Vectorization:
@@ -497,15 +451,9 @@ STAGE PLANS:
                             Select Vectorization:
                                 className: VectorSelectOperator
                                 native: true
-<<<<<<< HEAD
-                                projectedOutputColumnNums: [64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-                                selectExpressions: ConstantVectorExpression(val 2451181) -> 64:int
-                            Statistics: Num rows: 3 Data size: 2900 Basic stats: COMPLETE Column stats: COMPLETE
-=======
                                 projectedOutputColumnNums: [30, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
                                 selectExpressions: ConstantVectorExpression(val 2451181) -> 30:int
                             Statistics: Num rows: 5 Data size: 3148 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
                             Reduce Output Operator
                               key expressions: _col3 (type: int), iceberg_bucket(_col2, 3) (type: int)
                               null sort order: aa
@@ -513,17 +461,12 @@ STAGE PLANS:
                               Map-reduce partition columns: _col3 (type: int), iceberg_bucket(_col2, 3) (type: int)
                               Reduce Sink Vectorization:
                                   className: VectorReduceSinkMultiKeyOperator
-                                  keyColumns: 3:int, 66:int
-                                  keyExpressions: VectorUDFAdaptor(iceberg_bucket(_col2, 3)) -> 66:int
+                                  keyColumns: 3:int, 65:int
+                                  keyExpressions: VectorUDFAdaptor(iceberg_bucket(_col2, 3)) -> 65:int
                                   native: true
                                   nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-<<<<<<< HEAD
-                                  valueColumns: 64:int, 1:int, 2:int, 3:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2)
-                              Statistics: Num rows: 3 Data size: 2900 Basic stats: COMPLETE Column stats: COMPLETE
-=======
                                   valueColumns: 30:int, 1:int, 2:int, 3:int, 4:int, 5:int, 6:int, 7:int, 8:int, 9:int, 10:int, 11:decimal(7,2), 12:decimal(7,2), 13:decimal(7,2), 14:decimal(7,2), 15:decimal(7,2), 16:decimal(7,2), 17:decimal(7,2), 18:decimal(7,2), 19:decimal(7,2), 20:decimal(7,2), 21:decimal(7,2), 22:decimal(7,2)
                               Statistics: Num rows: 5 Data size: 3148 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
                               value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int), _col4 (type: int), _col5 (type: int), _col6 (type: int), _col7 (type: int), _col8 (type: int), _col9 (type: int), _col10 (type: int), _col11 (type: decimal(7,2)), _col12 (type: decimal(7,2)), _col13 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col16 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col22 (type: decimal(7,2))
                         Filter Operator
                           Filter Vectorization:
@@ -533,32 +476,13 @@ STAGE PLANS:
                           predicate: ((_col25 = _col36) and (_col49 = _col39) and (_col38 = 2451181) and (floor((_col36 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col31 < 0)) (type: boolean)
                           Statistics: Num rows: 1 Data size: 3168 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
-<<<<<<< HEAD
-<<<<<<< HEAD
-                            expressions: _col4 (type: int), _col6 (type: string), _col40 (type: bigint), _col45 (type: bigint)
-                            outputColumnNames: _col4, _col6, _col40, _col45
+                            expressions: _col4 (type: int), _col6 (type: string), _col42 (type: bigint), _col47 (type: bigint)
+                            outputColumnNames: _col4, _col6, _col42, _col47
                             Select Vectorization:
                                 className: VectorSelectOperator
                                 native: true
                                 projectedOutputColumnNums: [34, 36, 35, 37]
-                            Statistics: Num rows: 1 Data size: 3160 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                            expressions: _col4 (type: int), _col6 (type: string), _col12 (type: string), _col41 (type: bigint), _col46 (type: bigint)
-                            outputColumnNames: _col4, _col6, _col12, _col41, _col46
-=======
-                            expressions: _col4 (type: int), _col6 (type: string), _col13 (type: string), _col42 (type: bigint), _col47 (type: bigint)
-                            outputColumnNames: _col4, _col6, _col13, _col42, _col47
->>>>>>> 874d07004f (update q.out)
-                            Select Vectorization:
-                                className: VectorSelectOperator
-                                native: true
-                                projectedOutputColumnNums: [34, 36, 38, 35, 37]
-<<<<<<< HEAD
-                            Statistics: Num rows: 1 Data size: 3164 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
-=======
                             Statistics: Num rows: 1 Data size: 3168 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> 874d07004f (update q.out)
                             Group By Operator
                               aggregations: count()
                               Group By Vectorization:
@@ -569,15 +493,7 @@ STAGE PLANS:
                                   native: false
                                   vectorProcessingMode: HASH
                                   projectedOutputColumnNums: [0]
-<<<<<<< HEAD
-<<<<<<< HEAD
-                              keys: _col4 (type: int), _col40 (type: bigint), _col6 (type: string), _col45 (type: bigint)
-=======
-                              keys: _col4 (type: int), _col41 (type: bigint), _col6 (type: string), _col46 (type: bigint), _col12 (type: string)
->>>>>>> f7ae7daa2c (update q.out files)
-=======
-                              keys: _col4 (type: int), _col42 (type: bigint), _col6 (type: string), _col47 (type: bigint), _col13 (type: string)
->>>>>>> 874d07004f (update q.out)
+                              keys: _col4 (type: int), _col42 (type: bigint), _col6 (type: string), _col47 (type: bigint)
                               minReductionHashAggr: 0.4
                               mode: hash
                               outputColumnNames: _col0, _col1, _col2, _col3, _col4
@@ -610,13 +526,8 @@ STAGE PLANS:
                     includeColumns: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
                     dataColumns: ss_sold_date_sk:int, ss_sold_time_sk:int, ss_item_sk2:int, ss_customer_sk2:int, ss_cdemo_sk:int, ss_hdemo_sk:int, ss_addr_sk:int, ss_store_sk:int, ss_promo_sk:int, ss_ticket_number:int, ss_quantity:int, ss_wholesale_cost:decimal(7,2), ss_list_price:decimal(7,2), ss_sales_price:decimal(7,2), ss_ext_discount_amt:decimal(7,2), ss_ext_sales_price:decimal(7,2), ss_ext_wholesale_cost:decimal(7,2), ss_ext_list_price:decimal(7,2), ss_ext_tax:decimal(7,2), ss_coupon_amt:decimal(7,2), ss_net_paid:decimal(7,2), ss_net_paid_inc_tax:decimal(7,2), ss_net_profit:decimal(7,2)
                     partitionColumnCount: 0
-<<<<<<< HEAD
-                    scratchColumnTypeNames: [double, double, bigint, bigint, bigint, bigint, bigint, bigint, string, bigint, string, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), bigint, bigint, bigint]
+                    scratchColumnTypeNames: [double, double, bigint, bigint, bigint, bigint, bigint, bigint, string, bigint, string, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), bigint, decimal(7,2), decimal(7,2), bigint]
         Map 5 
-=======
-                    scratchColumnTypeNames: [double, double, bigint, bigint, bigint, bigint, bigint, bigint, string, bigint, string, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), decimal(7,2), bigint, decimal(7,2), bigint]
-        Map 6 
->>>>>>> f7ae7daa2c (update q.out files)
             Map Operator Tree:
                 TableScan
                   alias: store_sales
@@ -682,7 +593,6 @@ STAGE PLANS:
                 usesVectorUDFAdaptor: false
                 vectorized: true
                 rowBatchContext:
-<<<<<<< HEAD
                     dataColumnCount: 25
                     dataColumns: KEY._col3:int, KEY.iceberg_bucket(_col2, 3):int, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:int, VALUE._col4:int, VALUE._col5:int, VALUE._col6:int, VALUE._col7:int, VALUE._col8:int, VALUE._col9:int, VALUE._col10:int, VALUE._col11:decimal(7,2)/DECIMAL_64, VALUE._col12:decimal(7,2)/DECIMAL_64, VALUE._col13:decimal(7,2)/DECIMAL_64, VALUE._col14:decimal(7,2)/DECIMAL_64, VALUE._col15:decimal(7,2)/DECIMAL_64, VALUE._col16:decimal(7,2)/DECIMAL_64, VALUE._col17:decimal(7,2)/DECIMAL_64, VALUE._col18:decimal(7,2)/DECIMAL_64, VALUE._col19:decimal(7,2)/DECIMAL_64, VALUE._col20:decimal(7,2)/DECIMAL_64, VALUE._col21:decimal(7,2)/DECIMAL_64, VALUE._col22:decimal(7,2)/DECIMAL_64
                     partitionColumnCount: 0
@@ -695,33 +605,13 @@ STAGE PLANS:
                     className: VectorSelectOperator
                     native: true
                     projectedOutputColumnNums: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 0, 1]
-=======
-                    dataColumnCount: 27
-                    dataColumns: KEY.reducesinkkey0:int, KEY.reducesinkkey1:bigint, KEY.reducesinkkey2:string, KEY.reducesinkkey3:bigint, KEY.reducesinkkey4:string, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:int, VALUE._col4:int, VALUE._col5:int, VALUE._col6:int, VALUE._col7:int, VALUE._col8:int, VALUE._col9:int, VALUE._col10:int, VALUE._col11:decimal(7,2)/DECIMAL_64, VALUE._col12:decimal(7,2)/DECIMAL_64, VALUE._col13:decimal(7,2)/DECIMAL_64, VALUE._col15:decimal(7,2)/DECIMAL_64, VALUE._col16:decimal(7,2)/DECIMAL_64, VALUE._col17:decimal(7,2)/DECIMAL_64, VALUE._col18:decimal(7,2)/DECIMAL_64, VALUE._col19:decimal(7,2)/DECIMAL_64, VALUE._col20:decimal(7,2)/DECIMAL_64, VALUE._col21:decimal(7,2)/DECIMAL_64, VALUE._col22:decimal(7,2)/DECIMAL_64
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: [decimal(7,2)]
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), KEY.reducesinkkey4 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: int), VALUE._col3 (type: int), VALUE._col4 (type: int), VALUE._col5 (type: int), VALUE._col6 (type: int), VALUE._col7 (type: int), VALUE._col8 (type: int), VALUE._col9 (type: int), VALUE._col10 (type: int), VALUE._col11 (type: decimal(7,2)), VALUE._col12 (type: decimal(7,2)), VALUE._col13 (type: decimal(7,2)), null (type: decimal(7,2)), VALUE._col15 (type: decimal(7,2)), VALUE._col16 (type: decimal(7,2)), VALUE._col17 (type: decimal(7,2)), VALUE._col18 (type: decimal(7,2)), VALUE._col19 (type: decimal(7,2)), VALUE._col20 (type: decimal(7,2)), VALUE._col21 (type: decimal(7,2)), VALUE._col22 (type: decimal(7,2))
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
-                Select Vectorization:
-                    className: VectorSelectOperator
-                    native: true
-                    projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 27, 19, 20, 21, 22, 23, 24, 25, 26]
-                    selectExpressions: ConstantVectorExpression(val null) -> 27:decimal(7,2)
-                Statistics: Num rows: 3 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
                 File Output Operator
                   compressed: false
                   Dp Sort State: PARTITION_SORTED
                   File Sink Vectorization:
                       className: VectorFileSinkOperator
                       native: false
-<<<<<<< HEAD
-                  Statistics: Num rows: 1 Data size: 1388 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                  Statistics: Num rows: 3 Data size: 2176 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
+                  Statistics: Num rows: 3 Data size: 1624 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -756,11 +646,7 @@ STAGE PLANS:
                   File Sink Vectorization:
                       className: VectorFileSinkOperator
                       native: false
-<<<<<<< HEAD
-                  Statistics: Num rows: 3 Data size: 2900 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                  Statistics: Num rows: 3 Data size: 1624 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
+                  Statistics: Num rows: 5 Data size: 3148 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -771,48 +657,8 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
-<<<<<<< HEAD
                 reduceColumnNullOrder: zzzz
                 reduceColumnSortOrder: ++++
-=======
-                reduceColumnNullOrder: aa
-                reduceColumnSortOrder: ++
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 25
-                    dataColumns: KEY._col3:int, KEY.iceberg_bucket(_col2, 3):int, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:int, VALUE._col4:int, VALUE._col5:int, VALUE._col6:int, VALUE._col7:int, VALUE._col8:int, VALUE._col9:int, VALUE._col10:int, VALUE._col11:decimal(7,2)/DECIMAL_64, VALUE._col12:decimal(7,2)/DECIMAL_64, VALUE._col13:decimal(7,2)/DECIMAL_64, VALUE._col14:decimal(7,2)/DECIMAL_64, VALUE._col15:decimal(7,2)/DECIMAL_64, VALUE._col16:decimal(7,2)/DECIMAL_64, VALUE._col17:decimal(7,2)/DECIMAL_64, VALUE._col18:decimal(7,2)/DECIMAL_64, VALUE._col19:decimal(7,2)/DECIMAL_64, VALUE._col20:decimal(7,2)/DECIMAL_64, VALUE._col21:decimal(7,2)/DECIMAL_64, VALUE._col22:decimal(7,2)/DECIMAL_64
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: int), VALUE._col3 (type: int), VALUE._col4 (type: int), VALUE._col5 (type: int), VALUE._col6 (type: int), VALUE._col7 (type: int), VALUE._col8 (type: int), VALUE._col9 (type: int), VALUE._col10 (type: int), VALUE._col11 (type: decimal(7,2)), VALUE._col12 (type: decimal(7,2)), VALUE._col13 (type: decimal(7,2)), VALUE._col14 (type: decimal(7,2)), VALUE._col15 (type: decimal(7,2)), VALUE._col16 (type: decimal(7,2)), VALUE._col17 (type: decimal(7,2)), VALUE._col18 (type: decimal(7,2)), VALUE._col19 (type: decimal(7,2)), VALUE._col20 (type: decimal(7,2)), VALUE._col21 (type: decimal(7,2)), VALUE._col22 (type: decimal(7,2)), KEY._col3 (type: int), KEY.iceberg_bucket(_col2, 3) (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col3, iceberg_bucket(_col2, 3)
-                Select Vectorization:
-                    className: VectorSelectOperator
-                    native: true
-                    projectedOutputColumnNums: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 0, 1]
-                File Output Operator
-                  compressed: false
-                  Dp Sort State: PARTITION_SORTED
-                  File Sink Vectorization:
-                      className: VectorFileSinkOperator
-                      native: false
-                  Statistics: Num rows: 5 Data size: 3148 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                      name: default.store_sales
-        Reducer 5 
-            Execution mode: vectorized
-            Reduce Vectorization:
-                enabled: true
-                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
-                reduceColumnNullOrder: zzzzz
-                reduceColumnSortOrder: +++++
->>>>>>> f7ae7daa2c (update q.out files)
                 allNative: false
                 usesVectorUDFAdaptor: true
                 vectorized: true
@@ -1054,46 +900,25 @@ Stage-6
               Reducer 2 vectorized
               File Output Operator [FS_64]
                 table:{"name:":"default.store_sales"}
-<<<<<<< HEAD
                 Select Operator [SEL_63]
                   Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col3","iceberg_bucket(_col2, 3)"]
                 <-Map 1 [SIMPLE_EDGE] vectorized
                   SHUFFLE [RS_59]
                     PartitionCols:_col3, iceberg_bucket(_col2, 3)
-                    Select Operator [SEL_55] (rows=1 width=1388)
+                    Select Operator [SEL_55] (rows=3 width=541)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
-                      Filter Operator [FIL_51] (rows=1 width=3160)
-                        predicate:((_col24 = _col34) and (_col47 = _col37) and (_col36 = 2451181) and (floor((_col34 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col30 < 0) and _col33 is null)
-                        Select Operator [SEL_49] (rows=7 width=1029)
-                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49"]
-                          Map Join Operator [MAPJOIN_48] (rows=7 width=1029)
-                            Conds:SEL_47._col2, _col1=RS_46._col8, _col7(Left Outer),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51"]
+                      Filter Operator [FIL_51] (rows=3 width=1693)
+                        predicate:(_col11 and _col35 is null)
+                        Select Operator [SEL_49] (rows=7 width=1033)
+                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51"]
+                          Map Join Operator [MAPJOIN_48] (rows=7 width=1031)
+                            Conds:SEL_47._col2, _col1=RS_46._col8, _col7(Left Outer),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51","_col52"]
                           <-Map 5 [BROADCAST_EDGE] vectorized
                             BROADCAST [RS_46]
                               PartitionCols:_col8, _col7
-                              Select Operator [SEL_45] (rows=2 width=1088)
-                                Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27"]
-                                Filter Operator [FIL_44] (rows=2 width=700)
-=======
-                Select Operator [SEL_65] (rows=3 width=725)
-                  Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27"]
-                <-Map 1 [SIMPLE_EDGE] vectorized
-                  SHUFFLE [RS_60]
-                    Select Operator [SEL_56] (rows=3 width=688)
-                      Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27"]
-                      Filter Operator [FIL_52] (rows=3 width=1693)
-                        predicate:(_col11 and _col35 is null)
-                        Select Operator [SEL_51] (rows=7 width=1033)
-                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51"]
-                          Map Join Operator [MAPJOIN_50] (rows=7 width=1031)
-                            Conds:SEL_49._col2, _col1=RS_48._col8, _col7(Left Outer),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51","_col52"]
-                          <-Map 6 [BROADCAST_EDGE] vectorized
-                            BROADCAST [RS_48]
-                              PartitionCols:_col8, _col7
-                              Select Operator [SEL_47] (rows=2 width=1092)
+                              Select Operator [SEL_45] (rows=2 width=1092)
                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28"]
-                                Filter Operator [FIL_46] (rows=2 width=700)
->>>>>>> f7ae7daa2c (update q.out files)
+                                Filter Operator [FIL_44] (rows=2 width=700)
                                   predicate:((ss_sold_date_sk = 2451181) and ss_item_sk is not null and ss_customer_sk is not null)
                                   TableScan [TS_2] (rows=2 width=55###)
                                     default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_sold_time_sk","ss_item_sk","ss_customer_sk","ss_cdemo_sk","ss_hdemo_sk","ss_addr_sk","ss_store_sk","ss_promo_sk","ss_ticket_number","ss_quantity","ss_wholesale_cost","ss_list_price","ss_sales_price","ss_ext_discount_amt","ss_ext_sales_price","ss_ext_wholesale_cost","ss_ext_list_price","ss_ext_tax","ss_coupon_amt","ss_net_paid","ss_net_paid_inc_tax","ss_net_profit"]
@@ -1109,36 +934,13 @@ Stage-6
                 <-Map 1 [SIMPLE_EDGE] vectorized
                   SHUFFLE [RS_60]
                     PartitionCols:_col3, iceberg_bucket(_col2, 3)
-<<<<<<< HEAD
-                    Select Operator [SEL_56] (rows=3 width=966)
+                    Select Operator [SEL_56] (rows=5 width=629)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
-                      Filter Operator [FIL_52] (rows=3 width=1688)
-                        predicate:(_col24 is null and _col47 is null and _col36 is null)
+                      Filter Operator [FIL_52] (rows=5 width=1064)
+                        predicate:_col32 is null
                          Please refer to the previous Select Operator [SEL_49]
               Reducer 4 vectorized
               File Output Operator [FS_70]
-=======
-                    Select Operator [SEL_57] (rows=3 width=541)
-                      Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
-                      Filter Operator [FIL_53] (rows=3 width=1693)
-                        predicate:(_col11 and _col35 is null)
-                         Please refer to the previous Select Operator [SEL_51]
-              Reducer 4 vectorized
-              File Output Operator [FS_70]
-                table:{"name:":"default.store_sales"}
-                Select Operator [SEL_69]
-                  Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col3","iceberg_bucket(_col2, 3)"]
-                <-Map 1 [SIMPLE_EDGE] vectorized
-                  SHUFFLE [RS_62]
-                    PartitionCols:_col3, iceberg_bucket(_col2, 3)
-                    Select Operator [SEL_58] (rows=5 width=629)
-                      Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
-                      Filter Operator [FIL_54] (rows=5 width=1064)
-                        predicate:_col32 is null
-                         Please refer to the previous Select Operator [SEL_51]
-              Reducer 5 vectorized
-              File Output Operator [FS_74]
->>>>>>> f7ae7daa2c (update q.out files)
                 table:{"name:":"default.merge_tmp_table"}
                 Select Operator [SEL_69] (rows=1 width=4)
                   Output:["_col0"]
@@ -1147,27 +949,15 @@ Stage-6
                     Group By Operator [GBY_67] (rows=1 width=212)
                       Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2, KEY._col3
                     <-Map 1 [SIMPLE_EDGE] vectorized
-<<<<<<< HEAD
                       SHUFFLE [RS_62]
                         PartitionCols:_col0, _col1, _col2, _col3
                         Group By Operator [GBY_61] (rows=1 width=212)
-                          Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["count()"],keys:_col4, _col40, _col6, _col45
-                          Select Operator [SEL_57] (rows=1 width=3160)
-                            Output:["_col4","_col6","_col40","_col45"]
-                            Filter Operator [FIL_53] (rows=1 width=3160)
-                              predicate:((_col24 = _col34) and (_col47 = _col37) and (_col36 = 2451181) and (floor((_col34 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col30 < 0))
-                               Please refer to the previous Select Operator [SEL_49]
-=======
-                      SHUFFLE [RS_64]
-                        PartitionCols:_col0, _col1, _col2, _col3, _col4
-                        Group By Operator [GBY_63] (rows=1 width=396)
-                          Output:["_col0","_col1","_col2","_col3","_col4","_col5"],aggregations:["count()"],keys:_col4, _col42, _col6, _col47, _col13
-                          Select Operator [SEL_59] (rows=1 width=3168)
-                            Output:["_col4","_col6","_col13","_col42","_col47"]
-                            Filter Operator [FIL_55] (rows=1 width=3168)
+                          Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["count()"],keys:_col4, _col42, _col6, _col47
+                          Select Operator [SEL_57] (rows=1 width=3168)
+                            Output:["_col4","_col6","_col42","_col47"]
+                            Filter Operator [FIL_53] (rows=1 width=3168)
                               predicate:((_col25 = _col36) and (_col49 = _col39) and (_col38 = 2451181) and (floor((_col36 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col31 < 0))
-                               Please refer to the previous Select Operator [SEL_51]
->>>>>>> f7ae7daa2c (update q.out files)
+                               Please refer to the previous Select Operator [SEL_49]
 Stage-7
   Stats Work{}
     Stage-3

--- a/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_merge_mixed.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_merge_mixed.q.out
@@ -379,21 +379,22 @@ STAGE PLANS:
                       Statistics: Num rows: 7 Data size: 7220 Basic stats: COMPLETE Column stats: COMPLETE
 >>>>>>> f7ae7daa2c (update q.out files)
                       Select Operator
-                        expressions: _col40 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col33 (type: int), _col39 (type: int), _col24 (type: int), _col21 (type: decimal(7,2)), _col26 (type: string), _col7 (type: int), _col3 (type: int), _col10 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col38 (type: int), _col28 (type: string), _col6 (type: int), _col50 (type: decimal(7,2)), _col11 (type: decimal(7,2)), _col34 (type: int), _col17 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col45 (type: decimal(7,2)), _col47 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col8 (type: int), _col35 (type: int), _col31 (type: int), _col41 (type: decimal(7,2)), _col36 (type: int), _col4 (type: int), _col48 (type: decimal(7,2)), _col5 (type: int), _col52 (type: boolean), _col13 (type: decimal(7,2)), _col12 (type: decimal(7,2)), _col44 (type: decimal(7,2)), _col43 (type: decimal(7,2)), _col1 (type: int), _col16 (type: decimal(7,2)), _col29 (type: int), _col2 (type: int), _col15 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col25 (type: bigint), _col9 (type: int), _col30 (type: int), _col42 (type: decimal(7,2)), _col0 (type: int), _col27 (type: bigint), _col51 (type: decimal(7,2)), _col32 (type: int), _col37 (type: int), _col46 (type: decimal(7,2))
-                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32, _col33, _col34, _col35, _col36, _col37, _col38, _col39, _col40, _col41, _col42, _col43, _col44, _col45, _col46, _col47, _col48, _col49, _col50
+                        expressions: _col40 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col33 (type: int), _col39 (type: int), _col24 (type: int), _col21 (type: decimal(7,2)), _col26 (type: string), _col7 (type: int), _col3 (type: int), _col10 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col52 (type: boolean), _col38 (type: int), _col28 (type: string), _col6 (type: int), _col50 (type: decimal(7,2)), _col11 (type: decimal(7,2)), _col34 (type: int), _col17 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col45 (type: decimal(7,2)), _col47 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col8 (type: int), _col35 (type: int), _col31 (type: int), _col41 (type: decimal(7,2)), _col36 (type: int), _col4 (type: int), _col48 (type: decimal(7,2)), _col5 (type: int), _col13 (type: decimal(7,2)), _col52 (type: boolean), _col12 (type: decimal(7,2)), _col44 (type: decimal(7,2)), _col43 (type: decimal(7,2)), _col1 (type: int), _col16 (type: decimal(7,2)), _col29 (type: int), _col2 (type: int), _col15 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col25 (type: bigint), _col9 (type: int), _col30 (type: int), _col42 (type: decimal(7,2)), _col0 (type: int), _col27 (type: bigint), _col51 (type: decimal(7,2)), _col32 (type: int), _col37 (type: int), _col46 (type: decimal(7,2))
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32, _col33, _col34, _col35, _col36, _col37, _col38, _col39, _col40, _col41, _col42, _col43, _col44, _col45, _col46, _col47, _col48, _col49, _col50, _col51
                         Select Vectorization:
                             className: VectorSelectOperator
                             native: true
-                            projectedOutputColumnNums: [50, 20, 43, 49, 34, 22, 36, 8, 4, 11, 59, 48, 38, 7, 60, 12, 44, 18, 15, 55, 57, 21, 9, 45, 41, 51, 46, 5, 58, 6, 62, 14, 13, 54, 53, 2, 17, 39, 3, 16, 19, 35, 10, 40, 52, 1, 37, 61, 42, 47, 56]
-                        Statistics: Num rows: 7 Data size: 7220 Basic stats: COMPLETE Column stats: COMPLETE
+                            projectedOutputColumnNums: [50, 20, 43, 49, 34, 22, 36, 8, 4, 11, 59, 62, 48, 38, 7, 60, 12, 44, 18, 15, 55, 57, 21, 9, 45, 41, 51, 46, 5, 58, 6, 14, 62, 13, 54, 53, 2, 17, 39, 3, 16, 19, 35, 10, 40, 52, 1, 37, 61, 42, 47, 56]
+                        Statistics: Num rows: 7 Data size: 7232 Basic stats: COMPLETE Column stats: COMPLETE
                         Filter Operator
                           Filter Vectorization:
                               className: VectorFilterOperator
                               native: true
                               predicateExpression: FilterExprAndExpr(children: SelectColumnIsTrue(col 62:boolean), SelectColumnIsNull(col 53:decimal(7,2)))
-                          predicate: (_col30 and _col34 is null) (type: boolean)
-                          Statistics: Num rows: 3 Data size: 5072 Basic stats: COMPLETE Column stats: COMPLETE
+                          predicate: (_col11 and _col35 is null) (type: boolean)
+                          Statistics: Num rows: 3 Data size: 5080 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
+<<<<<<< HEAD
 <<<<<<< HEAD
                             expressions: _col4 (type: int), _col40 (type: bigint), _col6 (type: string), _col45 (type: bigint), _col12 (type: string), 2451181 (type: int), _col42 (type: int), _col24 (type: int), _col47 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col48 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col43 (type: decimal(7,2)), null (type: decimal(7,2)), _col32 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col49 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col46 (type: decimal(7,2))
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
@@ -416,6 +417,9 @@ STAGE PLANS:
                                   name: default.store_sales
 =======
                             expressions: _col4 (type: int), _col41 (type: bigint), _col6 (type: string), _col46 (type: bigint), _col12 (type: string), _col37 (type: int), _col43 (type: int), _col24 (type: int), _col48 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col49 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col44 (type: decimal(7,2)), _col33 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col50 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col47 (type: decimal(7,2))
+=======
+                            expressions: _col4 (type: int), _col42 (type: bigint), _col6 (type: string), _col47 (type: bigint), _col13 (type: string), _col38 (type: int), _col44 (type: int), _col25 (type: int), _col49 (type: int), _col2 (type: int), _col17 (type: int), _col24 (type: int), _col27 (type: int), _col50 (type: int), _col12 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col45 (type: decimal(7,2)), _col34 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col51 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col29 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col48 (type: decimal(7,2))
+>>>>>>> 874d07004f (update q.out)
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27
                             Select Vectorization:
                                 className: VectorSelectOperator
@@ -440,10 +444,10 @@ STAGE PLANS:
                               className: VectorFilterOperator
                               native: true
                               predicateExpression: FilterExprAndExpr(children: SelectColumnIsTrue(col 62:boolean), SelectColumnIsNull(col 53:decimal(7,2)))
-                          predicate: (_col30 and _col34 is null) (type: boolean)
-                          Statistics: Num rows: 3 Data size: 5072 Basic stats: COMPLETE Column stats: COMPLETE
+                          predicate: (_col11 and _col35 is null) (type: boolean)
+                          Statistics: Num rows: 3 Data size: 5080 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
-                            expressions: _col37 (type: int), _col43 (type: int), _col24 (type: int), _col48 (type: int), _col2 (type: int), _col16 (type: int), _col23 (type: int), _col26 (type: int), _col49 (type: int), _col11 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col25 (type: decimal(7,2)), _col44 (type: decimal(7,2)), 0 (type: decimal(7,2)), _col33 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col50 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col28 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col14 (type: decimal(7,2)), _col47 (type: decimal(7,2))
+                            expressions: _col38 (type: int), _col44 (type: int), _col25 (type: int), _col49 (type: int), _col2 (type: int), _col17 (type: int), _col24 (type: int), _col27 (type: int), _col50 (type: int), _col12 (type: int), _col3 (type: int), _col0 (type: decimal(7,2)), _col26 (type: decimal(7,2)), _col45 (type: decimal(7,2)), 0 (type: decimal(7,2)), _col34 (type: decimal(7,2)), _col20 (type: decimal(7,2)), _col51 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col29 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col48 (type: decimal(7,2))
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22
                             Select Vectorization:
                                 className: VectorSelectOperator
@@ -485,10 +489,10 @@ STAGE PLANS:
                               className: VectorFilterOperator
                               native: true
                               predicateExpression: SelectColumnIsNull(col 62:boolean)
-                          predicate: _col30 is null (type: boolean)
-                          Statistics: Num rows: 5 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
+                          predicate: _col32 is null (type: boolean)
+                          Statistics: Num rows: 5 Data size: 5320 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
-                            expressions: 2451181 (type: int), _col45 (type: int), _col35 (type: int), _col38 (type: int), _col8 (type: int), _col27 (type: int), _col29 (type: int), _col13 (type: int), _col7 (type: int), _col22 (type: int), _col42 (type: int), _col9 (type: decimal(7,2)), _col15 (type: decimal(7,2)), _col32 (type: decimal(7,2)), _col31 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col39 (type: decimal(7,2)), _col36 (type: decimal(7,2)), _col17 (type: decimal(7,2)), _col40 (type: decimal(7,2)), _col1 (type: decimal(7,2)), _col21 (type: decimal(7,2)), _col5 (type: decimal(7,2))
+                            expressions: 2451181 (type: int), _col46 (type: int), _col36 (type: int), _col39 (type: int), _col8 (type: int), _col28 (type: int), _col30 (type: int), _col14 (type: int), _col7 (type: int), _col23 (type: int), _col43 (type: int), _col9 (type: decimal(7,2)), _col16 (type: decimal(7,2)), _col33 (type: decimal(7,2)), _col31 (type: decimal(7,2)), _col19 (type: decimal(7,2)), _col40 (type: decimal(7,2)), _col37 (type: decimal(7,2)), _col18 (type: decimal(7,2)), _col41 (type: decimal(7,2)), _col1 (type: decimal(7,2)), _col22 (type: decimal(7,2)), _col5 (type: decimal(7,2))
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22
                             Select Vectorization:
                                 className: VectorSelectOperator
@@ -526,9 +530,10 @@ STAGE PLANS:
                               className: VectorFilterOperator
                               native: true
                               predicateExpression: FilterExprAndExpr(children: FilterLongColEqualLongColumn(col 41:int, col 2:int), FilterLongColEqualLongColumn(col 42:int, col 3:int), FilterLongColEqualLongScalar(col 39:int, val 2451181), FilterLongColumnBetween(col 31:bigint, left 1000, right 2000)(children: LongColMultiplyLongScalar(col 30:bigint, val 1000)(children: FuncFloorDoubleToLong(col 28:double)(children: LongColDivideLongScalar(col 2:int, val 1000) -> 28:double) -> 30:bigint) -> 31:bigint), FilterDecimalColLessDecimalScalar(col 14:decimal(7,2), val 0))
-                          predicate: ((_col24 = _col35) and (_col48 = _col38) and (_col37 = 2451181) and (floor((_col35 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col31 < 0)) (type: boolean)
-                          Statistics: Num rows: 1 Data size: 3164 Basic stats: COMPLETE Column stats: COMPLETE
+                          predicate: ((_col25 = _col36) and (_col49 = _col39) and (_col38 = 2451181) and (floor((_col36 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col31 < 0)) (type: boolean)
+                          Statistics: Num rows: 1 Data size: 3168 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
+<<<<<<< HEAD
 <<<<<<< HEAD
                             expressions: _col4 (type: int), _col6 (type: string), _col40 (type: bigint), _col45 (type: bigint)
                             outputColumnNames: _col4, _col6, _col40, _col45
@@ -540,12 +545,20 @@ STAGE PLANS:
 =======
                             expressions: _col4 (type: int), _col6 (type: string), _col12 (type: string), _col41 (type: bigint), _col46 (type: bigint)
                             outputColumnNames: _col4, _col6, _col12, _col41, _col46
+=======
+                            expressions: _col4 (type: int), _col6 (type: string), _col13 (type: string), _col42 (type: bigint), _col47 (type: bigint)
+                            outputColumnNames: _col4, _col6, _col13, _col42, _col47
+>>>>>>> 874d07004f (update q.out)
                             Select Vectorization:
                                 className: VectorSelectOperator
                                 native: true
                                 projectedOutputColumnNums: [34, 36, 38, 35, 37]
+<<<<<<< HEAD
                             Statistics: Num rows: 1 Data size: 3164 Basic stats: COMPLETE Column stats: COMPLETE
 >>>>>>> f7ae7daa2c (update q.out files)
+=======
+                            Statistics: Num rows: 1 Data size: 3168 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> 874d07004f (update q.out)
                             Group By Operator
                               aggregations: count()
                               Group By Vectorization:
@@ -557,10 +570,14 @@ STAGE PLANS:
                                   vectorProcessingMode: HASH
                                   projectedOutputColumnNums: [0]
 <<<<<<< HEAD
+<<<<<<< HEAD
                               keys: _col4 (type: int), _col40 (type: bigint), _col6 (type: string), _col45 (type: bigint)
 =======
                               keys: _col4 (type: int), _col41 (type: bigint), _col6 (type: string), _col46 (type: bigint), _col12 (type: string)
 >>>>>>> f7ae7daa2c (update q.out files)
+=======
+                              keys: _col4 (type: int), _col42 (type: bigint), _col6 (type: string), _col47 (type: bigint), _col13 (type: string)
+>>>>>>> 874d07004f (update q.out)
                               minReductionHashAggr: 0.4
                               mode: hash
                               outputColumnNames: _col0, _col1, _col2, _col3, _col4
@@ -1064,10 +1081,10 @@ Stage-6
                   SHUFFLE [RS_60]
                     Select Operator [SEL_56] (rows=3 width=688)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27"]
-                      Filter Operator [FIL_52] (rows=3 width=1690)
-                        predicate:(_col30 and _col34 is null)
-                        Select Operator [SEL_51] (rows=7 width=1031)
-                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50"]
+                      Filter Operator [FIL_52] (rows=3 width=1693)
+                        predicate:(_col11 and _col35 is null)
+                        Select Operator [SEL_51] (rows=7 width=1033)
+                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22","_col23","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51"]
                           Map Join Operator [MAPJOIN_50] (rows=7 width=1031)
                             Conds:SEL_49._col2, _col1=RS_48._col8, _col7(Left Outer),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col24","_col25","_col26","_col27","_col28","_col29","_col30","_col31","_col32","_col33","_col34","_col35","_col36","_col37","_col38","_col39","_col40","_col41","_col42","_col43","_col44","_col45","_col46","_col47","_col48","_col49","_col50","_col51","_col52"]
                           <-Map 6 [BROADCAST_EDGE] vectorized
@@ -1103,8 +1120,8 @@ Stage-6
 =======
                     Select Operator [SEL_57] (rows=3 width=541)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
-                      Filter Operator [FIL_53] (rows=3 width=1690)
-                        predicate:(_col30 and _col34 is null)
+                      Filter Operator [FIL_53] (rows=3 width=1693)
+                        predicate:(_col11 and _col35 is null)
                          Please refer to the previous Select Operator [SEL_51]
               Reducer 4 vectorized
               File Output Operator [FS_70]
@@ -1116,8 +1133,8 @@ Stage-6
                     PartitionCols:_col3, iceberg_bucket(_col2, 3)
                     Select Operator [SEL_58] (rows=5 width=629)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
-                      Filter Operator [FIL_54] (rows=5 width=1062)
-                        predicate:_col30 is null
+                      Filter Operator [FIL_54] (rows=5 width=1064)
+                        predicate:_col32 is null
                          Please refer to the previous Select Operator [SEL_51]
               Reducer 5 vectorized
               File Output Operator [FS_74]
@@ -1144,11 +1161,11 @@ Stage-6
                       SHUFFLE [RS_64]
                         PartitionCols:_col0, _col1, _col2, _col3, _col4
                         Group By Operator [GBY_63] (rows=1 width=396)
-                          Output:["_col0","_col1","_col2","_col3","_col4","_col5"],aggregations:["count()"],keys:_col4, _col41, _col6, _col46, _col12
-                          Select Operator [SEL_59] (rows=1 width=3164)
-                            Output:["_col4","_col6","_col12","_col41","_col46"]
-                            Filter Operator [FIL_55] (rows=1 width=3164)
-                              predicate:((_col24 = _col35) and (_col48 = _col38) and (_col37 = 2451181) and (floor((_col35 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col31 < 0))
+                          Output:["_col0","_col1","_col2","_col3","_col4","_col5"],aggregations:["count()"],keys:_col4, _col42, _col6, _col47, _col13
+                          Select Operator [SEL_59] (rows=1 width=3168)
+                            Output:["_col4","_col6","_col13","_col42","_col47"]
+                            Filter Operator [FIL_55] (rows=1 width=3168)
+                              predicate:((_col25 = _col36) and (_col49 = _col39) and (_col38 = 2451181) and (floor((_col36 / 1000)) * 1000) BETWEEN 1000 AND 2000 and (_col31 < 0))
                                Please refer to the previous Select Operator [SEL_51]
 >>>>>>> f7ae7daa2c (update q.out files)
 Stage-7

--- a/iceberg/iceberg-handler/src/test/results/positive/write_iceberg_branch.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/write_iceberg_branch.q.out
@@ -478,14 +478,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
                 Statistics: Num rows: 3 Data size: 1755 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                  Statistics: Num rows: 3 Data size: 1755 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col11 (type: boolean), _col7 (type: string), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean), _col1 (type: string), _col0 (type: int), _col5 (type: string), _col2 (type: int), _col6 (type: bigint)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+                  Statistics: Num rows: 3 Data size: 1767 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col11 and (_col10 > 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and (_col6 > 100)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 589 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                       Statistics: Num rows: 1 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -497,10 +497,10 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.ice01
                   Filter Operator
-                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 589 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
+                      expressions: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string), _col6 (type: int), _col5 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                       Statistics: Num rows: 1 Data size: 485 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -512,10 +512,10 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.ice01
                   Filter Operator
-                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and ((_col6 <= 100) or (_col6 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 589 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col10 (type: int), 'Merged' (type: string), (_col8 + 10) (type: int)
+                      expressions: _col6 (type: int), 'Merged' (type: string), (_col4 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -527,10 +527,10 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.ice01
                   Filter Operator
-                    predicate: _col11 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col7 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 589 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: int)
+                      expressions: _col9 (type: int), _col8 (type: string), _col11 (type: int)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
@@ -542,9 +542,10 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.ice01
                   Filter Operator
-                    predicate: (_col10 = _col1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col6 = _col9) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 589 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
+<<<<<<< HEAD
 <<<<<<< HEAD
                       expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
                       outputColumnNames: _col2, _col5, _col6, _col7
@@ -557,6 +558,14 @@ STAGE PLANS:
                       Group By Operator
                         aggregations: count()
                         keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)
+=======
+                      expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
+                      outputColumnNames: _col1, _col2, _col3, _col10, _col12
+                      Statistics: Num rows: 1 Data size: 589 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string)
+>>>>>>> 874d07004f (update q.out)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4

--- a/iceberg/iceberg-handler/src/test/results/positive/write_iceberg_branch.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/write_iceberg_branch.q.out
@@ -456,16 +456,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 3 Data size: 291 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 3 Data size: 1455 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int), b (type: string), c (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                      Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col5 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col5 (type: int)
-                        Statistics: Num rows: 3 Data size: 1455 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int)
+                        Statistics: Num rows: 3 Data size: 1467 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: boolean)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
@@ -475,15 +475,15 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col5 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                Statistics: Num rows: 3 Data size: 1743 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                Statistics: Num rows: 3 Data size: 1755 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                  Statistics: Num rows: 3 Data size: 1743 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col7 (type: string), _col2 (type: int), _col6 (type: bigint), _col4 (type: bigint), _col3 (type: int), _col10 (type: int), _col9 (type: string), _col8 (type: int), _col11 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                  Statistics: Num rows: 3 Data size: 1755 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 > 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 581 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and (_col10 > 100)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
@@ -497,8 +497,8 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.ice01
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 <= 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 581 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint), _col3 (type: string), _col10 (type: int), _col9 (type: string), _col8 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
@@ -512,8 +512,8 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.ice01
                   Filter Operator
-                    predicate: ((_col10 = _col1) and (_col10 <= 100)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 581 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col11 and ((_col10 <= 100) or (_col10 > 100) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col10 (type: int), 'Merged' (type: string), (_col8 + 10) (type: int)
                       outputColumnNames: _col0, _col1, _col2
@@ -527,8 +527,8 @@ STAGE PLANS:
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.ice01
                   Filter Operator
-                    predicate: _col10 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 581 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col11 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col4 (type: int)
                       outputColumnNames: _col0, _col1, _col2
@@ -543,11 +543,17 @@ STAGE PLANS:
                             name: default.ice01
                   Filter Operator
                     predicate: (_col10 = _col1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 581 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
+<<<<<<< HEAD
                       expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
                       outputColumnNames: _col2, _col5, _col6, _col7
                       Statistics: Num rows: 1 Data size: 581 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                      expressions: _col2 (type: string), _col3 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
+                      outputColumnNames: _col2, _col3, _col5, _col6, _col7
+                      Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> f7ae7daa2c (update q.out files)
                       Group By Operator
                         aggregations: count()
                         keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)

--- a/iceberg/iceberg-handler/src/test/results/positive/write_iceberg_branch.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/write_iceberg_branch.q.out
@@ -545,27 +545,12 @@ STAGE PLANS:
                     predicate: (_col6 = _col9) (type: boolean)
                     Statistics: Num rows: 1 Data size: 589 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      expressions: _col2 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
-                      outputColumnNames: _col2, _col5, _col6, _col7
-                      Statistics: Num rows: 1 Data size: 581 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                      expressions: _col2 (type: string), _col3 (type: string), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: int)
-                      outputColumnNames: _col2, _col3, _col5, _col6, _col7
-                      Statistics: Num rows: 1 Data size: 585 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> f7ae7daa2c (update q.out files)
-                      Group By Operator
-                        aggregations: count()
-                        keys: _col7 (type: int), _col6 (type: bigint), _col2 (type: string), _col5 (type: bigint)
-=======
-                      expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
-                      outputColumnNames: _col1, _col2, _col3, _col10, _col12
+                      expressions: _col2 (type: bigint), _col3 (type: int), _col10 (type: string), _col12 (type: bigint)
+                      outputColumnNames: _col2, _col3, _col10, _col12
                       Statistics: Num rows: 1 Data size: 589 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint), _col1 (type: string)
->>>>>>> 874d07004f (update q.out)
+                        keys: _col3 (type: int), _col2 (type: bigint), _col10 (type: string), _col12 (type: bigint)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/MergeSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/MergeSemanticAnalyzer.java
@@ -31,11 +31,9 @@ import org.apache.hadoop.hive.ql.parse.rewrite.RewriterFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A subclass of the {@link org.apache.hadoop.hive.ql.parse.SemanticAnalyzer} that just handles

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/MergeSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/MergeSemanticAnalyzer.java
@@ -163,9 +163,7 @@ public class MergeSemanticAnalyzer extends RewriteSemanticAnalyzer<MergeStatemen
           conf, onClauseAsText);
         oca.analyze();
         
-        mergeStatementBuilder.addWhenClause(
-            handleInsert(whenClause, oca.getPredicate(), targetTable))
-          .onClausePredicate(oca.getPredicate());
+        mergeStatementBuilder.addWhenClause(handleInsert(whenClause, oca.getPredicate(), targetTable));
         break;
       case HiveParser.TOK_UPDATE:
         numWhenMatchedUpdateClauses++;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java
@@ -206,8 +206,7 @@ public class CopyOnWriteMergeRewriter extends MergeRewriter {
       sqlGenerator.append("\nFROM " + mergeStatement.getSourceName());
 
       addWhereClauseOfUpdate(
-          onClauseAsString, updateClause.getExtraPredicate(), updateClause.getDeleteExtraPredicate(), sqlGenerator,
-          columnRefsFunc);
+          updateClause.getExtraPredicate(), updateClause.getDeleteExtraPredicate(), sqlGenerator, columnRefsFunc);
       sqlGenerator.append(" AND sourceRecordExists\n");
     }
     
@@ -217,11 +216,10 @@ public class CopyOnWriteMergeRewriter extends MergeRewriter {
     }
 
     @Override
-    protected void handleWhenMatchedDelete(String onClauseAsString, String extraPredicate, String updateExtraPredicate,
+    protected void handleWhenMatchedDelete(String extraPredicate, String updateExtraPredicate,
                                          String hintStr, MultiInsertSqlGenerator sqlGenerator) {
       String targetAlias = mergeStatement.getTargetAlias();
       String sourceName = mergeStatement.getSourceName();
-      String onClausePredicate = mergeStatement.getOnClausePredicate();
 
       UnaryOperator<String> columnRefsFunc = value -> replaceColumnRefsWithTargetPrefix(targetAlias, value);
       List<String> deleteValues = sqlGenerator.getDeleteValues(Context.Operation.DELETE);
@@ -252,8 +250,6 @@ public class CopyOnWriteMergeRewriter extends MergeRewriter {
         //we have WHEN MATCHED AND <boolean expr> THEN DELETE
         whereClause.append(" AND ").append(extraPredicate);
       }
-      String whereClauseStr = columnRefsFunc.apply(whereClause.toString());
-
       sqlGenerator.append("\n").indent();
       sqlGenerator.append("( NOT(%s) OR (%s) IS NULL )".replace("%s", columnRefsFunc.apply(
           whereClause.toString())));

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java
@@ -53,7 +53,7 @@ import static org.apache.hadoop.hive.ql.parse.rewrite.sql.SqlGeneratorFactory.TA
  * Example:
  * <pre>
  * merge into target_ice as t using source src ON t.a = src.a
- * when matched and t.c > 50 THEN DELETE
+ * when matched and t.c &gt; 50 THEN DELETE
  * when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
  * when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
  * </pre>
@@ -75,7 +75,7 @@ import static org.apache.hadoop.hive.ql.parse.rewrite.sql.SqlGeneratorFactory.TA
  * INSERT INTO `default`.`target_ice`
  * -- update clause (insert part)
  * SELECT `t__PARTITION__SPEC__ID`,`t__PARTITION__HASH`,`t__FILE__PATH`,`t__ROW__POSITION`,`t__PARTITION__PROJECTION`,`t__a`,`concat`(`t__b`, ' Merged') AS `t__b`,`t__c`   10 AS `t__c`
- * FROM `src`  WHERE t__targetRecordExists AND (NOT(`t__c` > 50) OR (`t__c` > 50) IS NULL) AND sourceRecordExists
+ * FROM `src`  WHERE t__targetRecordExists AND (NOT(`t__c` &gt; 50) OR (`t__c` &gt; 50) IS NULL) AND sourceRecordExists
  * union all
  * -- insert clause
  * SELECT `t__PARTITION__SPEC__ID`,`t__PARTITION__HASH`,`t__FILE__PATH`,`t__ROW__POSITION`,`t__PARTITION__PROJECTION`,`src`.`a`,concat(`src`.`b`, ' New'),`src`.`c`

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteMergeRewriter.java
@@ -188,7 +188,6 @@ public class CopyOnWriteMergeRewriter extends MergeRewriter {
     public void appendWhenMatchedUpdateClause(MergeStatement.UpdateClause updateClause) {
       Table targetTable = mergeStatement.getTargetTable();
       String targetAlias = mergeStatement.getTargetAlias();
-      String onClauseAsString = mergeStatement.getOnClauseAsText();
 
       UnaryOperator<String> columnRefsFunc = value -> replaceColumnRefsWithTargetPrefix(targetAlias, value);
       sqlGenerator.append("    -- update clause (insert part)\n").append("SELECT ");

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
@@ -107,7 +107,7 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
     sqlGenerator.append("(SELECT ");
     sqlGenerator.appendAcidSelectColumns(Operation.MERGE);
     sqlGenerator.appendAllColsOfTargetTable();
-    sqlGenerator.append(" FROM ").appendTargetTableName().append(") ");
+    sqlGenerator.append(", true AS targetRecordExists FROM ").appendTargetTableName().append(") ");
     sqlGenerator.appendSubQueryAlias();
     sqlGenerator.append('\n');
     sqlGenerator.indent().append(hasWhenNotMatchedClause ? "RIGHT OUTER JOIN" : "INNER JOIN").append("\n");
@@ -193,7 +193,7 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
       }
 
       sqlGenerator.append(String.join(", ", insertClause.getValuesClause()));
-      sqlGenerator.append("\n   WHERE ").append(insertClause.getPredicate());
+      sqlGenerator.append("\n   WHERE targetRecordExists IS NULL ");
 
       if (insertClause.getExtraPredicate() != null) {
         //we have WHEN NOT MATCHED AND <boolean expr> THEN INSERT
@@ -252,7 +252,7 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
     
     protected void addWhereClauseOfUpdate(String onClauseAsString, String extraPredicate, String deleteExtraPredicate,
                                           MultiInsertSqlGenerator sqlGenerator, UnaryOperator<String> columnRefsFunc) {
-      StringBuilder whereClause = new StringBuilder(onClauseAsString);
+      StringBuilder whereClause = new StringBuilder("targetRecordExists");
       if (extraPredicate != null) {
         //we have WHEN MATCHED AND <boolean expr> THEN DELETE
         whereClause.append(" AND ").append(extraPredicate);
@@ -275,7 +275,7 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
                                          String hintStr, MultiInsertSqlGenerator sqlGenerator) {
       sqlGenerator.appendDeleteBranch(hintStr);
 
-      sqlGenerator.indent().append("WHERE ").append(onClauseAsString);
+      sqlGenerator.indent().append("WHERE targetRecordExists ");
       if (extraPredicate != null) {
         //we have WHEN MATCHED AND <boolean expr> THEN DELETE
         sqlGenerator.append(" AND ").append(extraPredicate);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
@@ -207,7 +207,6 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
     public void appendWhenMatchedUpdateClause(MergeStatement.UpdateClause updateClause) {
       Table targetTable = mergeStatement.getTargetTable();
       String targetAlias = mergeStatement.getTargetAlias();
-      String onClauseAsString = mergeStatement.getOnClauseAsText();
 
       sqlGenerator.append("    -- update clause").append("\n");
       List<String> valuesAndAcidSortKeys = new ArrayList<>(
@@ -217,8 +216,7 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
       sqlGenerator.appendInsertBranch(hintStr, valuesAndAcidSortKeys);
       hintStr = null;
 
-      addWhereClauseOfUpdate(
-          onClauseAsString, updateClause.getExtraPredicate(), updateClause.getDeleteExtraPredicate(), sqlGenerator);
+      addWhereClauseOfUpdate(updateClause.getExtraPredicate(), updateClause.getDeleteExtraPredicate(), sqlGenerator);
 
       sqlGenerator.appendSortKeys();
     }
@@ -245,12 +243,12 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
       return newValue;
     }
 
-    protected void addWhereClauseOfUpdate(String onClauseAsString, String extraPredicate, String deleteExtraPredicate,
+    protected void addWhereClauseOfUpdate(String extraPredicate, String deleteExtraPredicate,
                                           MultiInsertSqlGenerator sqlGenerator) {
-      addWhereClauseOfUpdate(onClauseAsString, extraPredicate, deleteExtraPredicate, sqlGenerator, UnaryOperator.identity());
+      addWhereClauseOfUpdate(extraPredicate, deleteExtraPredicate, sqlGenerator, UnaryOperator.identity());
     }
     
-    protected void addWhereClauseOfUpdate(String onClauseAsString, String extraPredicate, String deleteExtraPredicate,
+    protected void addWhereClauseOfUpdate(String extraPredicate, String deleteExtraPredicate,
                                           MultiInsertSqlGenerator sqlGenerator, UnaryOperator<String> columnRefsFunc) {
       StringBuilder whereClause = new StringBuilder(mergeStatement.getTargetAlias());
       whereClause.append(".targetRecordExists");
@@ -268,12 +266,12 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
 
     @Override
     public void appendWhenMatchedDeleteClause(MergeStatement.DeleteClause deleteClause) {
-      handleWhenMatchedDelete(mergeStatement.getOnClauseAsText(),
+      handleWhenMatchedDelete(
           deleteClause.getExtraPredicate(), deleteClause.getUpdateExtraPredicate(), hintStr, sqlGenerator);
       hintStr = null;
     }
 
-    protected void handleWhenMatchedDelete(String onClauseAsString, String extraPredicate, String updateExtraPredicate,
+    protected void handleWhenMatchedDelete(String extraPredicate, String updateExtraPredicate,
                                          String hintStr, MultiInsertSqlGenerator sqlGenerator) {
       sqlGenerator.appendDeleteBranch(hintStr);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
@@ -63,7 +63,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  * Example:
  * <pre>
  * MERGE INTO target as t using source s ON t.a = s.a
- * WHEN MATCHED AND s.a > 8 THEN DELETE
+ * WHEN MATCHED AND s.a &gt; 8 THEN DELETE
  * WHEN MATCHED THEN UPDATE SET b = 7
  * WHEN NOT MATCHED THEN INSERT VALUES(s.a, s.b);
  * </pre>
@@ -75,12 +75,12 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  * -- delete
  * INSERT INTO `default`.`target_table`
  * SELECT `t`.ROW__ID
- * WHERE `t`.targetRecordExists  AND `s`.`a` > 8
+ * WHERE `t`.targetRecordExists  AND `s`.`a` &gt; 8
  * SORT BY `t`.ROW__ID
  * -- update
  * INSERT INTO `default`.`target_table`
  * SELECT `t`.ROW__ID,`t`.`a`,7
- * WHERE `t`.targetRecordExists AND (NOT(`s`.`a` > 8) OR (`s`.`a` > 8) IS NULL)
+ * WHERE `t`.targetRecordExists AND (NOT(`s`.`a` &gt; 8) OR (`s`.`a` &gt; 8) IS NULL)
  * SORT BY `t`.ROW__ID
  * -- insert
  * INSERT INTO `default`.`target_table`
@@ -89,7 +89,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  * -- cardinality check
  * INSERT INTO merge_tmp_table
  * SELECT cardinality_violation(`t`.ROW__ID)
- * WHERE `t`.`a` = `s`.`a` GROUP BY `t`.ROW__ID HAVING count(*) > 1
+ * WHERE `t`.`a` = `s`.`a` GROUP BY `t`.ROW__ID HAVING count(*) &gt; 1
  * </pre>
  */
 public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.DestClausePrefixSetter {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
@@ -258,7 +258,7 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
         whereClause.append(" AND ").append(extraPredicate);
       }
       if (deleteExtraPredicate != null) {
-        whereClause.append(" AND NOT(").append(deleteExtraPredicate).append(")");
+        whereClause.append(" AND (NOT(").append(deleteExtraPredicate).append(") OR (").append(deleteExtraPredicate).append(") IS NULL)");
       }
       sqlGenerator.indent().append("WHERE ");
       sqlGenerator.append(columnRefsFunc.apply(whereClause.toString()));
@@ -281,7 +281,7 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
         sqlGenerator.append(" AND ").append(extraPredicate);
       }
       if (updateExtraPredicate != null) {
-        sqlGenerator.append(" AND NOT(").append(updateExtraPredicate).append(")");
+        sqlGenerator.append(" AND (NOT(").append(updateExtraPredicate).append(") OR (").append(updateExtraPredicate).append(") IS NULL)");
       }
       sqlGenerator.append("\n").indent();
       sqlGenerator.appendSortKeys();

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeRewriter.java
@@ -252,13 +252,15 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
     
     protected void addWhereClauseOfUpdate(String onClauseAsString, String extraPredicate, String deleteExtraPredicate,
                                           MultiInsertSqlGenerator sqlGenerator, UnaryOperator<String> columnRefsFunc) {
-      StringBuilder whereClause = new StringBuilder("targetRecordExists");
+      StringBuilder whereClause = new StringBuilder(mergeStatement.getTargetAlias());
+      whereClause.append(".targetRecordExists");
       if (extraPredicate != null) {
         //we have WHEN MATCHED AND <boolean expr> THEN DELETE
         whereClause.append(" AND ").append(extraPredicate);
       }
       if (deleteExtraPredicate != null) {
-        whereClause.append(" AND (NOT(").append(deleteExtraPredicate).append(") OR (").append(deleteExtraPredicate).append(") IS NULL)");
+        whereClause.append(" AND (NOT(").append(deleteExtraPredicate).append(") OR (")
+            .append(deleteExtraPredicate).append(") IS NULL)");
       }
       sqlGenerator.indent().append("WHERE ");
       sqlGenerator.append(columnRefsFunc.apply(whereClause.toString()));
@@ -275,13 +277,14 @@ public class MergeRewriter implements Rewriter<MergeStatement>, MergeStatement.D
                                          String hintStr, MultiInsertSqlGenerator sqlGenerator) {
       sqlGenerator.appendDeleteBranch(hintStr);
 
-      sqlGenerator.indent().append("WHERE targetRecordExists ");
+      sqlGenerator.indent().append("WHERE ").append(mergeStatement.getTargetAlias()).append(".targetRecordExists ");
       if (extraPredicate != null) {
         //we have WHEN MATCHED AND <boolean expr> THEN DELETE
         sqlGenerator.append(" AND ").append(extraPredicate);
       }
       if (updateExtraPredicate != null) {
-        sqlGenerator.append(" AND (NOT(").append(updateExtraPredicate).append(") OR (").append(updateExtraPredicate).append(") IS NULL)");
+        sqlGenerator.append(" AND (NOT(").append(updateExtraPredicate).append(") OR (")
+            .append(updateExtraPredicate).append(") IS NULL)");
       }
       sqlGenerator.append("\n").indent();
       sqlGenerator.appendSortKeys();

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeStatement.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeStatement.java
@@ -182,12 +182,10 @@ public class MergeStatement {
   public static class InsertClause extends WhenClause {
     private final List<String> columnList;
     private final List<String> valuesClause;
-    private final String predicate;
 
 
-    public InsertClause(List<String> columnList, List<String> valuesClause, String predicate, String extraPredicate) {
+    public InsertClause(List<String> columnList, List<String> valuesClause, String extraPredicate) {
       super(extraPredicate);
-      this.predicate = predicate;
       this.columnList = columnList;
       this.valuesClause = valuesClause;
     }
@@ -198,10 +196,6 @@ public class MergeStatement {
 
     public List<String> getValuesClause() {
       return valuesClause;
-    }
-
-    public String getPredicate() {
-      return predicate;
     }
 
     @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeStatement.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/MergeStatement.java
@@ -42,7 +42,6 @@ public class MergeStatement {
     private final String targetAlias;
     private String sourceName;
     private String sourceAlias;
-    private String onClausePredicate;
     private String onClauseAsText;
     private String hintStr;
     private final List<WhenClause> whenClauses;
@@ -62,10 +61,6 @@ public class MergeStatement {
       this.sourceAlias = sourceAlias;
       return this;
     }
-    public MergeStatementBuilder onClausePredicate(String onClausePredicate) {
-      this.onClausePredicate = onClausePredicate;
-      return this;
-    }
     public MergeStatementBuilder onClauseAsText(String onClauseAsText) {
       this.onClauseAsText = onClauseAsText;
       return this;
@@ -82,8 +77,7 @@ public class MergeStatement {
 
     public MergeStatement build() {
       return new MergeStatement(targetTable, targetName, targetAlias, sourceName, sourceAlias,
-          onClausePredicate, onClauseAsText, hintStr,
-          Collections.unmodifiableList(whenClauses));
+          onClauseAsText, hintStr, Collections.unmodifiableList(whenClauses));
     }
   }
 
@@ -92,19 +86,17 @@ public class MergeStatement {
   private final String targetAlias;
   private final String sourceName;
   private final String sourceAlias;
-  private final String onClausePredicate;
   private final String onClauseAsText;
   private final String hintStr;
   private final List<WhenClause> whenClauses;
 
   private MergeStatement(Table targetTable, String targetName, String targetAlias, String sourceName, String sourceAlias,
-                         String onClausePredicate, String onClauseAsText, String hintStr, List<WhenClause> whenClauses) {
+                         String onClauseAsText, String hintStr, List<WhenClause> whenClauses) {
     this.targetTable = targetTable;
     this.targetName = targetName;
     this.targetAlias = targetAlias;
     this.sourceName = sourceName;
     this.sourceAlias = sourceAlias;
-    this.onClausePredicate = onClausePredicate;
     this.onClauseAsText = onClauseAsText;
     this.hintStr = hintStr;
     this.whenClauses = whenClauses;
@@ -130,10 +122,6 @@ public class MergeStatement {
     return sourceAlias;
   }
 
-  public String getOnClausePredicate() {
-    return onClausePredicate;
-  }
-  
   public String getOnClauseAsText() {
     return onClauseAsText;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/SplitMergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/SplitMergeRewriter.java
@@ -29,6 +29,36 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 
+/**
+ * This version of {@link MergeRewriter} rewrites the update branch of the merge statement
+ * to two insert branches of multi-insert statement.
+ * <br>
+ * <ul>
+ *   <li>A branch for deleting old values which should be updated.</li>
+ *   <li>And another branch for inserting new updated values.</li>
+ * </ul>
+ * <br>
+ * <pre>
+ * MERGE INTO target as t using source s ON t.a = s.a
+ * WHEN MATCHED AND s.a > 8 THEN DELETE
+ * WHEN MATCHED THEN UPDATE SET b = 7
+ * WHEN NOT MATCHED THEN INSERT VALUES(s.a, s.b);
+ * </pre>
+ * is rewritten to
+ * <pre>
+ * ...
+ * -- update (insert part)
+ * INSERT INTO `default`.`target_table`
+ *   SELECT `t`.`a`,7
+ *   WHERE `t`.targetRecordExists AND (NOT(`s`.`a` > 8) OR (`s`.`a` > 8) IS NULL)
+ * -- update (delete part)
+ * INSERT INTO `default`.`target_table`
+ *   SELECT `t`.ROW__ID
+ *   WHERE `t`.targetRecordExists  AND (NOT(`s`.`a` > 8) OR (`s`.`a` > 8) IS NULL)
+ *   SORT BY `t`.ROW__ID
+ * ...
+ * </pre>
+ */
 public class SplitMergeRewriter extends MergeRewriter {
 
   public SplitMergeRewriter(Hive db, HiveConf conf, SqlGeneratorFactory sqlGeneratorFactory) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/SplitMergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/SplitMergeRewriter.java
@@ -52,7 +52,6 @@ public class SplitMergeRewriter extends MergeRewriter {
     public void appendWhenMatchedUpdateClause(MergeStatement.UpdateClause updateClause) {
       Table targetTable = mergeStatement.getTargetTable();
       String targetAlias = mergeStatement.getTargetAlias();
-      String onClauseAsString = mergeStatement.getOnClauseAsText();
 
       sqlGenerator.append("    -- update clause (insert part)\n");
       List<String> values = new ArrayList<>(targetTable.getCols().size() + targetTable.getPartCols().size());
@@ -60,13 +59,12 @@ public class SplitMergeRewriter extends MergeRewriter {
       sqlGenerator.appendInsertBranch(hintStr, values);
       hintStr = null;
 
-      addWhereClauseOfUpdate(
-          onClauseAsString, updateClause.getExtraPredicate(), updateClause.getDeleteExtraPredicate(), sqlGenerator);
+      addWhereClauseOfUpdate(updateClause.getExtraPredicate(), updateClause.getDeleteExtraPredicate(), sqlGenerator);
 
       sqlGenerator.append("\n");
 
       sqlGenerator.append("    -- update clause (delete part)\n");
-      handleWhenMatchedDelete(onClauseAsString,
+      handleWhenMatchedDelete(
           updateClause.getExtraPredicate(), updateClause.getDeleteExtraPredicate(), hintStr, sqlGenerator);
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/SplitMergeRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/SplitMergeRewriter.java
@@ -40,7 +40,7 @@ import static java.util.Arrays.asList;
  * <br>
  * <pre>
  * MERGE INTO target as t using source s ON t.a = s.a
- * WHEN MATCHED AND s.a > 8 THEN DELETE
+ * WHEN MATCHED AND s.a &gt; 8 THEN DELETE
  * WHEN MATCHED THEN UPDATE SET b = 7
  * WHEN NOT MATCHED THEN INSERT VALUES(s.a, s.b);
  * </pre>
@@ -50,11 +50,11 @@ import static java.util.Arrays.asList;
  * -- update (insert part)
  * INSERT INTO `default`.`target_table`
  *   SELECT `t`.`a`,7
- *   WHERE `t`.targetRecordExists AND (NOT(`s`.`a` > 8) OR (`s`.`a` > 8) IS NULL)
+ *   WHERE `t`.targetRecordExists AND (NOT(`s`.`a` &gt; 8) OR (`s`.`a` &gt; 8) IS NULL)
  * -- update (delete part)
  * INSERT INTO `default`.`target_table`
  *   SELECT `t`.ROW__ID
- *   WHERE `t`.targetRecordExists  AND (NOT(`s`.`a` > 8) OR (`s`.`a` > 8) IS NULL)
+ *   WHERE `t`.targetRecordExists  AND (NOT(`s`.`a` &gt; 8) OR (`s`.`a` &gt; 8) IS NULL)
  *   SORT BY `t`.ROW__ID
  * ...
  * </pre>

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -1376,7 +1376,7 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
             "       from " + Table.NONACIDORCTBL + " src) sub on sub.a = target.a\n" +
             "when not matched then insert values (sub.a,sub.b)");
     Assert.assertTrue("Error didn't match: " + e, e.getMessage().contains(
-        "No columns from target table 'trgt' found in ON clause '`sub`.`a` = `target`.`a`' of MERGE statement."));
+        "Invalid table alias or column reference 'target'"));
   }
 
   /**

--- a/ql/src/test/queries/clientpositive/sqlmerge_nullsafe.q
+++ b/ql/src/test/queries/clientpositive/sqlmerge_nullsafe.q
@@ -1,0 +1,23 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+create table t_target(a int, b string, c int)stored as orc TBLPROPERTIES ('transactional'='true');
+create table t_source(a int, b string, c int);
+
+
+insert into t_target values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56);
+insert into t_source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56);
+
+
+explain
+merge into t_target as t using t_source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
+
+merge into t_target as t using t_source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c);
+
+select * from t_target;

--- a/ql/src/test/results/clientpositive/llap/acid_direct_update_delete_with_merge.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_direct_update_delete_with_merge.q.out
@@ -130,14 +130,14 @@ PREHOOK: Input: default@transactions
 PREHOOK: Input: default@transactions@tran_date=20170410
 PREHOOK: Input: default@transactions@tran_date=20170413
 PREHOOK: Input: default@transactions@tran_date=20170415
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: SELECT * FROM transactions
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@transactions
 POSTHOOK: Input: default@transactions@tran_date=20170410
 POSTHOOK: Input: default@transactions@tran_date=20170413
 POSTHOOK: Input: default@transactions@tran_date=20170415
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 1	value_01	creation	20170410
 10	value_10	creation	20170413
 11	value_11	merge_insert	20170415

--- a/ql/src/test/results/clientpositive/llap/acid_direct_update_delete_with_merge.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_direct_update_delete_with_merge.q.out
@@ -130,14 +130,14 @@ PREHOOK: Input: default@transactions
 PREHOOK: Input: default@transactions@tran_date=20170410
 PREHOOK: Input: default@transactions@tran_date=20170413
 PREHOOK: Input: default@transactions@tran_date=20170415
-#### A masked pattern was here ####
+PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: SELECT * FROM transactions
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@transactions
 POSTHOOK: Input: default@transactions@tran_date=20170410
 POSTHOOK: Input: default@transactions@tran_date=20170413
 POSTHOOK: Input: default@transactions@tran_date=20170415
-#### A masked pattern was here ####
+POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	value_01	creation	20170410
 10	value_10	creation	20170413
 11	value_11	merge_insert	20170415

--- a/ql/src/test/results/clientpositive/llap/acid_no_buckets.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_no_buckets.q.out
@@ -1896,13 +1896,14 @@ STAGE PLANS:
                       Select Vectorization:
                           className: VectorSelectOperator
                           native: true
-                          projectedOutputColumnNums: [4, 2, 3, 0, 1]
+                          projectedOutputColumnNums: [4, 2, 3, 0, 1, 6]
+                          selectExpressions: ConstantVectorExpression(val 1) -> 6:boolean
                         Reduce Sink Vectorization:
                             className: VectorReduceSinkMultiKeyOperator
                             keyColumns: 2:string, 3:string, 0:string, 1:string
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                            valueColumns: 4:struct<writeid:bigint,bucketid:int,rowid:bigint>
+                            valueColumns: 4:struct<writeid:bigint,bucketid:int,rowid:bigint>, 6:boolean
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
             Map Vectorization:
@@ -1921,7 +1922,7 @@ STAGE PLANS:
                     neededVirtualColumns: [ROWID]
                     partitionColumnCount: 2
                     partitionColumns: ds:string, hr:string
-                    scratchColumnTypeNames: []
+                    scratchColumnTypeNames: [bigint]
         Map 6 
             Map Operator Tree:
                   TableScan Vectorization:
@@ -2800,13 +2801,14 @@ STAGE PLANS:
                       Select Vectorization:
                           className: VectorSelectOperator
                           native: true
-                          projectedOutputColumnNums: [4, 2, 3, 0, 1]
+                          projectedOutputColumnNums: [4, 2, 3, 0, 1, 6]
+                          selectExpressions: ConstantVectorExpression(val 1) -> 6:boolean
                         Reduce Sink Vectorization:
                             className: VectorReduceSinkMultiKeyOperator
                             keyColumns: 2:string, 3:string, 0:string, 1:string
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                            valueColumns: 4:struct<writeid:bigint,bucketid:int,rowid:bigint>
+                            valueColumns: 4:struct<writeid:bigint,bucketid:int,rowid:bigint>, 6:boolean
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
             Map Vectorization:
@@ -2825,7 +2827,7 @@ STAGE PLANS:
                     neededVirtualColumns: [ROWID]
                     partitionColumnCount: 2
                     partitionColumns: ds:string, hr:string
-                    scratchColumnTypeNames: []
+                    scratchColumnTypeNames: [bigint]
         Map 8 
             Map Operator Tree:
                   TableScan Vectorization:

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -2519,6 +2519,28 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: tmerge
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 7 
+            Map Operator Tree:
+                TableScan
                   alias: s
                   Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
@@ -2534,102 +2556,80 @@ STAGE PLANS:
                       value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: tmerge
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 5)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col5 (type: int), _col2 (type: string)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint((_col1 is not null and ((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false)) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -2637,10 +2637,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2653,10 +2653,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2669,10 +2669,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2685,10 +2685,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2788,6 +2788,28 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: tmerge
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 8 
+            Map Operator Tree:
+                TableScan
                   alias: s
                   Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
@@ -2803,123 +2825,101 @@ STAGE PLANS:
                       value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: tmerge
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 5)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col5 (type: int), _col2 (type: string)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint((_col1 is not null and ((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false)) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
                     predicate: (_col5 = _col1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col3
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
                         keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -2927,10 +2927,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2943,10 +2943,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2959,10 +2959,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2975,10 +2975,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2993,17 +2993,17 @@ STAGE PLANS:
                 keys: KEY._col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
                   predicate: (_col1 > 1L) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: cardinality_violation(_col0) (type: int)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -3131,8 +3131,8 @@ STAGE PLANS:
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int)
-                      outputColumnNames: _col0, _col1
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
@@ -3140,7 +3140,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
@@ -3152,14 +3152,14 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  expressions: _col1 (type: string), _col0 (type: int), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int), _col5 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                   Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col4 = _col1) and (_col1 < 5)) (type: boolean)
+                    predicate: (_col5 and (_col1 < 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -3172,7 +3172,7 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col4 is null (type: boolean)
+                    predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col3 (type: string)

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -2568,14 +2568,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
                 Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  expressions: _col3 (type: boolean), _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                   Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 5)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -2585,10 +2585,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3) and ((_col2 >= 5) or (_col2 < 5) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -2598,10 +2598,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3) and ((_col2 >= 5) or (_col2 < 5) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), _col2 (type: string)
+                      expressions: _col6 (type: int), _col3 (type: string)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -2615,10 +2615,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col6 is null (type: boolean)
+                    predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
+                      expressions: _col2 (type: int), _col1 (type: string), _col5 (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -2837,14 +2837,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
                 Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  expressions: _col3 (type: boolean), _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                   Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 5)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -2854,10 +2854,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3) and ((_col2 >= 5) or (_col2 < 5) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -2867,10 +2867,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3) and ((_col2 >= 5) or (_col2 < 5) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), _col2 (type: string)
+                      expressions: _col6 (type: int), _col3 (type: string)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -2884,10 +2884,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col6 is null (type: boolean)
+                    predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
+                      expressions: _col2 (type: int), _col1 (type: string), _col5 (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -2901,15 +2901,15 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
-                    predicate: (_col5 = _col1) (type: boolean)
+                    predicate: (_col6 = _col2) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col3
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col4
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -3155,14 +3155,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int), _col5 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  expressions: _col5 (type: boolean), _col1 (type: string), _col0 (type: int), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int), _col5 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
                   Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col5 and (_col1 < 5)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -3172,10 +3172,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
+                    predicate: _col6 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col3 (type: string)
+                      expressions: _col2 (type: int), _col1 (type: string), _col4 (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -3189,15 +3189,15 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
-                    predicate: (_col4 = _col1) (type: boolean)
+                    predicate: (_col5 = _col2) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col2
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_3.q.out
@@ -53,17 +53,39 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 9 <- Reducer 8 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+        Map 1 <- Reducer 9 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 7 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 8 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: acidtbl
+                  filterExpr: (a is not null and a BETWEEN DynamicValue(RS_6_s_a_min) AND DynamicValue(RS_6_s_a_max) and in_bloom_filter(a, DynamicValue(RS_6_s_a_bloom_filter))) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (a is not null and a BETWEEN DynamicValue(RS_6_s_a_min) AND DynamicValue(RS_6_s_a_max) and in_bloom_filter(a, DynamicValue(RS_6_s_a_bloom_filter))) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 8 
             Map Operator Tree:
                 TableScan
                   alias: s
@@ -96,116 +118,94 @@ STAGE PLANS:
                           value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: binary)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: acidtbl
-                  filterExpr: (a is not null and a BETWEEN DynamicValue(RS_5_s_a_min) AND DynamicValue(RS_5_s_a_max) and in_bloom_filter(a, DynamicValue(RS_5_s_a_bloom_filter))) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (a is not null and a BETWEEN DynamicValue(RS_5_s_a_min) AND DynamicValue(RS_5_s_a_max) and in_bloom_filter(a, DynamicValue(RS_5_s_a_bloom_filter))) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col3 (type: int), _col0 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col2 (type: boolean), _col3 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 > 8)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col3 and (_col4 > 8)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col2 (type: int)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col2 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: _col3 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: int), _col1 (type: int)
+                      expressions: _col4 (type: int), _col1 (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col2 = _col3) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col2 = _col4) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
                         keys: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -213,10 +213,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -229,10 +229,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -245,10 +245,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -261,10 +261,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -279,23 +279,23 @@ STAGE PLANS:
                 keys: KEY._col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
                   predicate: (_col1 > 1L) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: cardinality_violation(_col0) (type: int)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                           name: default.merge_tmp_table
-        Reducer 8 
+        Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -426,8 +426,8 @@ STAGE PLANS:
                     predicate: (a is not null and a BETWEEN DynamicValue(RS_6_s_a_min) AND DynamicValue(RS_6_s_a_max) and in_bloom_filter(a, DynamicValue(RS_6_s_a_bloom_filter))) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
@@ -435,6 +435,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -479,13 +480,13 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2
+                outputColumnNames: _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
-                  predicate: _col0 is null (type: boolean)
+                  predicate: _col1 is null (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
-                    expressions: _col1 (type: int), _col2 (type: int)
+                    expressions: _col2 (type: int), _col3 (type: int)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
@@ -670,8 +671,8 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                      outputColumnNames: _col0, _col1
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
@@ -679,7 +680,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 9 
@@ -713,14 +714,14 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col3 (type: int), _col0 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3
+                  expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col3 (type: int), _col4 (type: boolean), _col0 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
                   Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 > 8)) (type: boolean)
+                    predicate: (_col3 and (_col4 > 8)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -733,7 +734,7 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
+                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -746,7 +747,7 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
+                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col2 (type: int)
@@ -759,10 +760,10 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col2 is null (type: boolean)
+                    predicate: _col3 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: int), _col1 (type: int)
+                      expressions: _col4 (type: int), _col1 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -773,7 +774,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col2 = _col3) (type: boolean)
+                    predicate: (_col2 = _col4) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)

--- a/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_3.q.out
@@ -130,14 +130,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col2 (type: boolean), _col3 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  expressions: _col2 (type: boolean), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col3 (type: int), _col2 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and (_col4 > 8)) (type: boolean)
+                    predicate: (_col0 and (_col4 > 8)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -147,10 +147,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    predicate: (_col0 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -160,10 +160,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    predicate: (_col0 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: int)
+                      expressions: _col3 (type: int)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -173,10 +173,10 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col3 is null (type: boolean)
+                    predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col4 (type: int), _col1 (type: int)
+                      expressions: _col4 (type: int), _col2 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -187,15 +187,15 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col2 = _col4) (type: boolean)
+                    predicate: (_col3 = _col4) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -717,14 +717,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col3 (type: int), _col4 (type: boolean), _col0 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  expressions: _col4 (type: boolean), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col3 (type: int), _col0 (type: int), _col4 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                   Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and (_col4 > 8)) (type: boolean)
+                    predicate: (_col0 and (_col4 > 8)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -734,10 +734,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    predicate: (_col0 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -747,10 +747,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    predicate: (_col0 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: int)
+                      expressions: _col3 (type: int)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -760,10 +760,10 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col3 is null (type: boolean)
+                    predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col4 (type: int), _col1 (type: int)
+                      expressions: _col4 (type: int), _col2 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -774,15 +774,15 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col2 = _col4) (type: boolean)
+                    predicate: (_col3 = _col4) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col1
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
+++ b/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
@@ -4567,6 +4567,24 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: masking_test_n4
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 7 
+            Map Operator Tree:
+                TableScan
                   alias: s
                   Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
@@ -4582,98 +4600,80 @@ STAGE PLANS:
                       value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_n4
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col1 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col1 (type: int)
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 5)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col5 (type: int), _col2 (type: string)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -4681,10 +4681,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -4697,10 +4697,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -4713,10 +4713,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -4729,10 +4729,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -4853,6 +4853,24 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: masking_test_n4
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 8 
+            Map Operator Tree:
+                TableScan
                   alias: s
                   Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
@@ -4868,119 +4886,101 @@ STAGE PLANS:
                       value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_n4
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col1 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col1 (type: int)
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 5)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col5 (type: int), _col2 (type: string)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
                     predicate: (_col5 = _col1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col3
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
                         keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -4988,10 +4988,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -5004,10 +5004,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -5020,10 +5020,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -5036,10 +5036,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -5054,17 +5054,17 @@ STAGE PLANS:
                 keys: KEY._col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
                   predicate: (_col1 > 1L) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: cardinality_violation(_col0) (type: int)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -5211,8 +5211,8 @@ STAGE PLANS:
                   alias: masking_test_n4
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
-                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int)
-                    outputColumnNames: _col0, _col1
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col1 (type: int)
@@ -5220,7 +5220,7 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col1 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
@@ -5232,14 +5232,14 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  expressions: _col1 (type: string), _col0 (type: int), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int), _col5 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                   Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col4 = _col1) and (_col1 < 5)) (type: boolean)
+                    predicate: (_col5 and (_col1 < 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -5252,7 +5252,7 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col4 is null (type: boolean)
+                    predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col3 (type: string)
@@ -5438,6 +5438,24 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: masking_test_n4
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 7 
+            Map Operator Tree:
+                TableScan
                   alias: s
                   Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
@@ -5453,106 +5471,88 @@ STAGE PLANS:
                       value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_n4
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col1 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col1 (type: int)
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col5 (type: string), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col6 and (_col1 < 3)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col5 (type: int), _col2 (type: string)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
                     predicate: (_col5 = _col1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col3
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
                         keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -5560,10 +5560,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -5576,10 +5576,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -5592,10 +5592,10 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -5610,17 +5610,17 @@ STAGE PLANS:
                 keys: KEY._col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
                   predicate: (_col1 > 1L) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: cardinality_violation(_col0) (type: int)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -5724,6 +5724,24 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: masking_test_n4
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 5 
+            Map Operator Tree:
+                TableScan
                   alias: s
                   filterExpr: key is not null (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
@@ -5742,24 +5760,6 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_n4
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col1 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col1 (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -5767,44 +5767,48 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: ((_col2 = _col0) and (_col0 < 5)) (type: boolean)
+                Select Operator
+                  expressions: _col2 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int)
+                  outputColumnNames: _col0, _col1, _col2
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
+                  Filter Operator
+                    predicate: (_col0 < 5) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: (_col2 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col1
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Group By Operator
-                      aggregations: count()
-                      keys: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0, _col1
+                    Select Operator
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
-                        Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: bigint)
+                  Filter Operator
+                    predicate: (_col2 = _col0) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col1
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      Group By Operator
+                        aggregations: count()
+                        keys: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        minReductionHashAggr: 0.99
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                          value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
+++ b/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
@@ -4612,14 +4612,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
                 Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  expressions: _col3 (type: boolean), _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                   Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 5)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -4629,10 +4629,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3) and ((_col2 >= 5) or (_col2 < 5) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -4642,10 +4642,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3) and ((_col2 >= 5) or (_col2 < 5) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), _col2 (type: string)
+                      expressions: _col6 (type: int), _col3 (type: string)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -4659,10 +4659,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col6 is null (type: boolean)
+                    predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
+                      expressions: _col2 (type: int), _col1 (type: string), _col5 (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -4898,14 +4898,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
                 Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  expressions: _col3 (type: boolean), _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                   Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 5)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -4915,10 +4915,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3) and ((_col2 >= 5) or (_col2 < 5) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -4928,10 +4928,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3) and ((_col1 >= 5) or (_col1 < 5) is null)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3) and ((_col2 >= 5) or (_col2 < 5) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), _col2 (type: string)
+                      expressions: _col6 (type: int), _col3 (type: string)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -4945,10 +4945,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col6 is null (type: boolean)
+                    predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
+                      expressions: _col2 (type: int), _col1 (type: string), _col5 (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -4962,15 +4962,15 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
-                    predicate: (_col5 = _col1) (type: boolean)
+                    predicate: (_col6 = _col2) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col3
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col4
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -5235,14 +5235,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int), _col5 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  expressions: _col5 (type: boolean), _col1 (type: string), _col0 (type: int), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col4 (type: int), _col5 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
                   Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col5 and (_col1 < 5)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -5252,10 +5252,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
+                    predicate: _col6 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col3 (type: string)
+                      expressions: _col2 (type: int), _col1 (type: string), _col4 (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -5269,15 +5269,15 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
-                    predicate: (_col4 = _col1) (type: boolean)
+                    predicate: (_col5 = _col2) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col2
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -5483,14 +5483,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
                 Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  expressions: _col3 (type: boolean), _col5 (type: string), _col4 (type: int), _col2 (type: string), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col6 (type: string), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
                   Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -5500,10 +5500,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col6 and (_col1 < 3)) (type: boolean)
+                    predicate: (_col0 and (_col2 < 3)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), _col2 (type: string)
+                      expressions: _col6 (type: int), _col3 (type: string)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -5517,10 +5517,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col6 is null (type: boolean)
+                    predicate: _col7 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
+                      expressions: _col2 (type: int), _col1 (type: string), _col5 (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
@@ -5534,15 +5534,15 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
-                    predicate: (_col5 = _col1) (type: boolean)
+                    predicate: (_col6 = _col2) (type: boolean)
                     Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col3
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col4
                       Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -5773,13 +5773,13 @@ STAGE PLANS:
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
                   expressions: _col2 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int)
-                  outputColumnNames: _col0, _col1, _col2
+                  outputColumnNames: _col1, _col2, _col3
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col0 < 5) (type: boolean)
+                    predicate: (_col1 < 5) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -5789,15 +5789,15 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col2 = _col0) (type: boolean)
+                    predicate: (_col3 = _col1) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col1
+                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col2
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
@@ -2827,15 +2827,16 @@ STAGE PLANS:
                   alias: acidtable
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: key (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: key (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -2864,13 +2865,13 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1
+                outputColumnNames: _col1, _col2
                 Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col0 is null (type: boolean)
+                  predicate: _col1 is null (type: boolean)
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col1 (type: int)
+                    expressions: _col2 (type: int)
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                     Filter Operator
@@ -3069,16 +3070,16 @@ STAGE PLANS:
                   alias: acidtable
                   Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 1 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), key (type: int), value (type: string), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col1 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col1 (type: int)
-                      Statistics: Num rows: 1 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string)
+                      Statistics: Num rows: 1 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
@@ -3090,15 +3091,15 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 2 Data size: 432 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 2 Data size: 440 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col4 (type: string), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 2 Data size: 432 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col1 (type: string), _col0 (type: int), _col4 (type: string), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int), _col5 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 2 Data size: 440 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((_col4 = _col1) and (_col1 < 3)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col5 and (_col1 < 3)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
@@ -3110,8 +3111,8 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((_col4 = _col1) and (_col1 > 3) and (_col1 >= 3)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col5 and (_col1 > 3) and ((_col1 >= 3) or (_col1 < 3) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
@@ -3123,8 +3124,8 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((_col4 = _col1) and (_col1 > 3) and (_col1 >= 3)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col5 and (_col1 > 3) and ((_col1 >= 3) or (_col1 < 3) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col4 (type: int), _col2 (type: string)
                       outputColumnNames: _col0, _col2
@@ -3140,8 +3141,8 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col4 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col1 (type: int), _col0 (type: string)
                       outputColumnNames: _col0, _col1
@@ -3158,11 +3159,11 @@ STAGE PLANS:
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
                     predicate: (_col4 = _col1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col3
-                      Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -3433,8 +3434,8 @@ STAGE PLANS:
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: key (type: int)
-                      outputColumnNames: _col0
+                      expressions: key (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
@@ -3442,6 +3443,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -3470,10 +3472,10 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0
+                outputColumnNames: _col1
                 Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
-                  predicate: _col0 is null (type: boolean)
+                  predicate: _col1 is null (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
@@ -3094,14 +3094,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 2 Data size: 440 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col4 (type: string), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int), _col5 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 2 Data size: 440 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col5 (type: boolean), _col1 (type: string), _col0 (type: int), _col4 (type: string), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int), _col5 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col5 and (_col1 < 3)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and (_col2 < 3)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 269 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -3111,10 +3111,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col5 and (_col1 > 3) and ((_col1 >= 3) or (_col1 < 3) is null)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and (_col2 > 3) and ((_col2 >= 3) or (_col2 < 3) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 269 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -3124,10 +3124,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col5 and (_col1 > 3) and ((_col1 >= 3) or (_col1 < 3) is null)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col0 and (_col2 > 3) and ((_col2 >= 3) or (_col2 < 3) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 269 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), _col2 (type: string)
+                      expressions: _col5 (type: int), _col3 (type: string)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
                       Filter Operator
@@ -3141,10 +3141,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 269 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string)
+                      expressions: _col2 (type: int), _col1 (type: string)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 91 Basic stats: COMPLETE Column stats: COMPLETE
                       Filter Operator
@@ -3158,15 +3158,15 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 91 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
-                    predicate: (_col4 = _col1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col5 = _col2) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 269 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col3
-                      Statistics: Num rows: 1 Data size: 265 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col4
+                      Statistics: Num rows: 1 Data size: 269 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/runtime_stats_merge.q.out
+++ b/ql/src/test/results/clientpositive/llap/runtime_stats_merge.q.out
@@ -121,54 +121,52 @@ Stage-4
           Dependency Collection{}
             Stage-2
               Reducer 2 vectorized, llap
-              File Output Operator [FS_54]
+              File Output Operator [FS_52]
                 table:{"name:":"default.lineitem2"}
-                Select Operator [SEL_53] (runtime: rows=1 width=76)
+                Select Operator [SEL_51] (runtime: rows=1 width=76)
                   Output:["_col0"]
                 <-Map 1 [SIMPLE_EDGE] llap
-                  SHUFFLE [RS_14]
+                  SHUFFLE [RS_13]
                     PartitionCols:UDFToInteger(_col0)
-                    Select Operator [SEL_11] (runtime: rows=1 width=76)
+                    Select Operator [SEL_10] (runtime: rows=1 width=76)
                       Output:["_col0"]
-                      Filter Operator [FIL_10] (runtime: rows=1 width=84)
-                        predicate:(_col1 = _col2)
-                        Select Operator [SEL_9] (runtime: rows=1 width=84)
-                          Output:["_col0","_col1","_col2"]
-                          Map Join Operator [MAPJOIN_39] (runtime: rows=1 width=84)
-                            Conds:SEL_2._col1=RS_43._col0(Inner),Output:["_col0","_col1","_col2"]
-                          <-Map 4 [BROADCAST_EDGE] vectorized, llap
-                            BROADCAST [RS_43]
-                              PartitionCols:_col0
-                              Select Operator [SEL_42] (runtime: rows=1 width=4)
-                                Output:["_col0"]
-                                Filter Operator [FIL_41] (runtime: rows=1 width=4)
-                                  predicate:l_orderkey is not null
-                                  TableScan [TS_3] (runtime: rows=1 width=4)
-                                    default@lineitem_stage,lineitem_stage, ACID table,Tbl:COMPLETE,Col:COMPLETE,Output:["l_orderkey"]
-                          <-Select Operator [SEL_2] (runtime: rows=3 width=80)
-                              Output:["_col0","_col1"]
-                              Filter Operator [FIL_27] (runtime: rows=3 width=4)
+                      Select Operator [SEL_9] (runtime: rows=1 width=84)
+                        Output:["_col0","_col1","_col3"]
+                        Map Join Operator [MAPJOIN_38] (runtime: rows=1 width=84)
+                          Conds:SEL_2._col1=RS_42._col0(Inner),Output:["_col0","_col1","_col2"]
+                        <-Map 4 [BROADCAST_EDGE] vectorized, llap
+                          BROADCAST [RS_42]
+                            PartitionCols:_col0
+                            Select Operator [SEL_41] (runtime: rows=1 width=4)
+                              Output:["_col0"]
+                              Filter Operator [FIL_40] (runtime: rows=1 width=4)
                                 predicate:l_orderkey is not null
-                                TableScan [TS_0] (runtime: rows=3 width=4)
-                                  default@lineitem2,lineitem2, ACID table,Tbl:COMPLETE,Col:COMPLETE,Output:["l_orderkey"]
+                                TableScan [TS_3] (runtime: rows=1 width=4)
+                                  default@lineitem_stage,lineitem_stage, ACID table,Tbl:COMPLETE,Col:COMPLETE,Output:["l_orderkey"]
+                        <-Select Operator [SEL_2] (runtime: rows=3 width=80)
+                            Output:["_col0","_col1"]
+                            Filter Operator [FIL_26] (runtime: rows=3 width=4)
+                              predicate:l_orderkey is not null
+                              TableScan [TS_0] (runtime: rows=3 width=4)
+                                default@lineitem2,lineitem2, ACID table,Tbl:COMPLETE,Col:COMPLETE,Output:["l_orderkey"]
               Reducer 3 llap
-              File Output Operator [FS_24]
+              File Output Operator [FS_23]
                 table:{"name:":"default.merge_tmp_table"}
-                Select Operator [SEL_23] (runtime: rows=0 width=-1)
+                Select Operator [SEL_22] (runtime: rows=0 width=-1)
                   Output:["_col0"]
-                  Filter Operator [FIL_22] (runtime: rows=0 width=-1)
+                  Filter Operator [FIL_21] (runtime: rows=0 width=-1)
                     predicate:(_col1 > 1L)
-                    Group By Operator [GBY_21] (runtime: rows=1 width=84)
+                    Group By Operator [GBY_20] (runtime: rows=1 width=84)
                       Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
                     <-Map 1 [SIMPLE_EDGE] llap
-                      SHUFFLE [RS_20]
+                      SHUFFLE [RS_19]
                         PartitionCols:_col0
-                        Group By Operator [GBY_19] (runtime: rows=1 width=84)
+                        Group By Operator [GBY_18] (runtime: rows=1 width=84)
                           Output:["_col0","_col1"],aggregations:["count()"],keys:_col0
-                          Select Operator [SEL_18] (runtime: rows=1 width=84)
+                          Select Operator [SEL_17] (runtime: rows=1 width=84)
                             Output:["_col0"]
-                            Filter Operator [FIL_17] (runtime: rows=1 width=84)
-                              predicate:(_col1 = _col2)
+                            Filter Operator [FIL_16] (runtime: rows=1 width=84)
+                              predicate:(_col1 = _col3)
                                Please refer to the previous Select Operator [SEL_9]
 Stage-5
   Stats Work{}

--- a/ql/src/test/results/clientpositive/llap/runtime_stats_merge.q.out
+++ b/ql/src/test/results/clientpositive/llap/runtime_stats_merge.q.out
@@ -131,7 +131,7 @@ Stage-4
                     Select Operator [SEL_10] (runtime: rows=1 width=76)
                       Output:["_col0"]
                       Select Operator [SEL_9] (runtime: rows=1 width=84)
-                        Output:["_col0","_col1","_col3"]
+                        Output:["_col0","_col2","_col3"]
                         Map Join Operator [MAPJOIN_38] (runtime: rows=1 width=84)
                           Conds:SEL_2._col1=RS_42._col0(Inner),Output:["_col0","_col1","_col2"]
                         <-Map 4 [BROADCAST_EDGE] vectorized, llap
@@ -166,7 +166,7 @@ Stage-4
                           Select Operator [SEL_17] (runtime: rows=1 width=84)
                             Output:["_col0"]
                             Filter Operator [FIL_16] (runtime: rows=1 width=84)
-                              predicate:(_col1 = _col3)
+                              predicate:(_col2 = _col3)
                                Please refer to the previous Select Operator [SEL_9]
 Stage-5
   Stats Work{}

--- a/ql/src/test/results/clientpositive/llap/semijoin_hint.q.out
+++ b/ql/src/test/results/clientpositive/llap/semijoin_hint.q.out
@@ -3344,14 +3344,14 @@ POSTHOOK: Output: default@merge_tmp_table
 STAGE DEPENDENCIES:
   Stage-5 is a root stage
   Stage-6 depends on stages: Stage-5
-  Stage-0 depends on stages: Stage-6
-  Stage-7 depends on stages: Stage-0
-  Stage-1 depends on stages: Stage-6
-  Stage-8 depends on stages: Stage-1
-  Stage-2 depends on stages: Stage-6
-  Stage-9 depends on stages: Stage-2
   Stage-4 depends on stages: Stage-6
-  Stage-10 depends on stages: Stage-4
+  Stage-7 depends on stages: Stage-4
+  Stage-0 depends on stages: Stage-6
+  Stage-8 depends on stages: Stage-0
+  Stage-1 depends on stages: Stage-6
+  Stage-9 depends on stages: Stage-1
+  Stage-2 depends on stages: Stage-6
+  Stage-10 depends on stages: Stage-2
   Stage-3 depends on stages: Stage-6
   Stage-11 depends on stages: Stage-3
 
@@ -3380,8 +3380,8 @@ STAGE PLANS:
                     predicate: (a BETWEEN DynamicValue(RS_4_s_a_min) AND DynamicValue(RS_4_s_a_max) and in_bloom_filter(a, DynamicValue(RS_4_s_a_bloom_filter))) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                      outputColumnNames: _col0, _col1
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col3
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
@@ -3389,7 +3389,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 8 
@@ -3430,49 +3430,10 @@ STAGE PLANS:
                 keys:
                   0 _col1 (type: int)
                   1 a (type: int)
-                outputColumnNames: _col0, _col1, _col3, _col4
+                outputColumnNames: _col0, _col1, _col3, _col4, _col5
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
-                  predicate: ((_col3 > 8) and (_col1 = _col3)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: ((_col3 <= 8) and (_col1 = _col3)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: ((_col3 <= 8) and (_col1 = _col3)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: _col1 (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: (_col1 = _col3) (type: boolean)
+                  predicate: (_col1 = _col4) (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -3493,10 +3454,49 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: bigint)
                 Filter Operator
-                  predicate: _col1 is null (type: boolean)
+                  predicate: ((_col4 > 8) and _col3) (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
-                    expressions: _col3 (type: int), _col4 (type: int)
+                    expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                Filter Operator
+                  predicate: (((_col4 <= 8) or (_col4 > 8) is null) and _col3) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                Filter Operator
+                  predicate: (((_col4 <= 8) or (_col4 > 8) is null) and _col3) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: _col1 (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                Filter Operator
+                  predicate: _col3 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: _col4 (type: int), _col5 (type: int)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
@@ -3507,54 +3507,6 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col1 (type: int)
         Reducer 3 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.acidtbl
-                  Write Type: DELETE
-        Reducer 4 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.acidtbl
-                  Write Type: DELETE
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.acidtbl
-                  Write Type: INSERT
-        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
@@ -3578,6 +3530,54 @@ STAGE PLANS:
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                           name: default.merge_tmp_table
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.acidtbl
+                  Write Type: DELETE
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.acidtbl
+                  Write Type: DELETE
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.acidtbl
+                  Write Type: INSERT
         Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -3611,22 +3611,21 @@ STAGE PLANS:
   Stage: Stage-6
     Dependency Collection
 
-  Stage: Stage-0
+  Stage: Stage-4
     Move Operator
       tables:
           replace: false
           table:
-              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-              name: default.acidtbl
-          Write Type: DELETE
+              input format: org.apache.hadoop.mapred.TextInputFormat
+              output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+              name: default.merge_tmp_table
 
   Stage: Stage-7
     Stats Work
       Basic Stats Work:
 
-  Stage: Stage-1
+  Stage: Stage-0
     Move Operator
       tables:
           replace: false
@@ -3641,6 +3640,21 @@ STAGE PLANS:
     Stats Work
       Basic Stats Work:
 
+  Stage: Stage-1
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.acidtbl
+          Write Type: DELETE
+
+  Stage: Stage-9
+    Stats Work
+      Basic Stats Work:
+
   Stage: Stage-2
     Move Operator
       tables:
@@ -3651,20 +3665,6 @@ STAGE PLANS:
               serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
               name: default.acidtbl
           Write Type: INSERT
-
-  Stage: Stage-9
-    Stats Work
-      Basic Stats Work:
-
-  Stage: Stage-4
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.hadoop.mapred.TextInputFormat
-              output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-              name: default.merge_tmp_table
 
   Stage: Stage-10
     Stats Work
@@ -3708,14 +3708,14 @@ POSTHOOK: Output: default@merge_tmp_table
 STAGE DEPENDENCIES:
   Stage-5 is a root stage
   Stage-6 depends on stages: Stage-5
-  Stage-0 depends on stages: Stage-6
-  Stage-7 depends on stages: Stage-0
-  Stage-1 depends on stages: Stage-6
-  Stage-8 depends on stages: Stage-1
-  Stage-2 depends on stages: Stage-6
-  Stage-9 depends on stages: Stage-2
   Stage-4 depends on stages: Stage-6
-  Stage-10 depends on stages: Stage-4
+  Stage-7 depends on stages: Stage-4
+  Stage-0 depends on stages: Stage-6
+  Stage-8 depends on stages: Stage-0
+  Stage-1 depends on stages: Stage-6
+  Stage-9 depends on stages: Stage-1
+  Stage-2 depends on stages: Stage-6
+  Stage-10 depends on stages: Stage-2
   Stage-3 depends on stages: Stage-6
   Stage-11 depends on stages: Stage-3
 
@@ -3738,8 +3738,8 @@ STAGE PLANS:
                   alias: acidtbl
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
-                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                    outputColumnNames: _col0, _col1
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col3
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col1 (type: int)
@@ -3747,7 +3747,7 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col1 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 8 
@@ -3773,49 +3773,10 @@ STAGE PLANS:
                 keys:
                   0 _col1 (type: int)
                   1 a (type: int)
-                outputColumnNames: _col0, _col1, _col3, _col4
+                outputColumnNames: _col0, _col1, _col3, _col4, _col5
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
-                  predicate: ((_col3 > 8) and (_col1 = _col3)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: ((_col3 <= 8) and (_col1 = _col3)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: ((_col3 <= 8) and (_col1 = _col3)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: _col1 (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: (_col1 = _col3) (type: boolean)
+                  predicate: (_col1 = _col4) (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -3836,10 +3797,49 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: bigint)
                 Filter Operator
-                  predicate: _col1 is null (type: boolean)
+                  predicate: ((_col4 > 8) and _col3) (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
-                    expressions: _col3 (type: int), _col4 (type: int)
+                    expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                Filter Operator
+                  predicate: (((_col4 <= 8) or (_col4 > 8) is null) and _col3) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                Filter Operator
+                  predicate: (((_col4 <= 8) or (_col4 > 8) is null) and _col3) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: _col1 (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                Filter Operator
+                  predicate: _col3 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: _col4 (type: int), _col5 (type: int)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
@@ -3850,54 +3850,6 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col1 (type: int)
         Reducer 3 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.acidtbl
-                  Write Type: DELETE
-        Reducer 4 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.acidtbl
-                  Write Type: DELETE
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.acidtbl
-                  Write Type: INSERT
-        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
@@ -3921,6 +3873,54 @@ STAGE PLANS:
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                           name: default.merge_tmp_table
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.acidtbl
+                  Write Type: DELETE
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.acidtbl
+                  Write Type: DELETE
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.acidtbl
+                  Write Type: INSERT
         Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -3941,22 +3941,21 @@ STAGE PLANS:
   Stage: Stage-6
     Dependency Collection
 
-  Stage: Stage-0
+  Stage: Stage-4
     Move Operator
       tables:
           replace: false
           table:
-              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-              name: default.acidtbl
-          Write Type: DELETE
+              input format: org.apache.hadoop.mapred.TextInputFormat
+              output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+              name: default.merge_tmp_table
 
   Stage: Stage-7
     Stats Work
       Basic Stats Work:
 
-  Stage: Stage-1
+  Stage: Stage-0
     Move Operator
       tables:
           replace: false
@@ -3971,6 +3970,21 @@ STAGE PLANS:
     Stats Work
       Basic Stats Work:
 
+  Stage: Stage-1
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.acidtbl
+          Write Type: DELETE
+
+  Stage: Stage-9
+    Stats Work
+      Basic Stats Work:
+
   Stage: Stage-2
     Move Operator
       tables:
@@ -3981,20 +3995,6 @@ STAGE PLANS:
               serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
               name: default.acidtbl
           Write Type: INSERT
-
-  Stage: Stage-9
-    Stats Work
-      Basic Stats Work:
-
-  Stage: Stage-4
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.hadoop.mapred.TextInputFormat
-              output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-              name: default.merge_tmp_table
 
   Stage: Stage-10
     Stats Work

--- a/ql/src/test/results/clientpositive/llap/sort_acid.q.out
+++ b/ql/src/test/results/clientpositive/llap/sort_acid.q.out
@@ -292,11 +292,11 @@ POSTHOOK: Output: default@acidtlb
 POSTHOOK: Output: default@acidtlb
 POSTHOOK: Output: default@merge_tmp_table
 CBO PLAN:
-HiveProject(col0=[$2], col1=[$0], col2=[$1], col3=[$3])
+HiveProject(col0=[$2], col1=[$0], col2=[$1], col3=[$3], col4=[$4])
   HiveJoin(condition=[=($3, $0)], joinType=[left], algorithm=[none], cost=[not available])
     HiveProject(c=[$0], d=[$1])
       HiveTableScan(table=[[default, othertlb]], table:alias=[s])
-    HiveProject(row__id=[$5], a=[$0])
+    HiveProject(row__id=[$5], a=[$0], targetrecordexists=[true])
       HiveFilter(condition=[IS NOT NULL($0)])
         HiveTableScan(table=[[default, acidtlb]], table:alias=[acidtlb])
 

--- a/ql/src/test/results/clientpositive/llap/sort_acid.q.out
+++ b/ql/src/test/results/clientpositive/llap/sort_acid.q.out
@@ -292,7 +292,7 @@ POSTHOOK: Output: default@acidtlb
 POSTHOOK: Output: default@acidtlb
 POSTHOOK: Output: default@merge_tmp_table
 CBO PLAN:
-HiveProject(col0=[$2], col1=[$0], col2=[$1], col3=[$3], col4=[$4])
+HiveProject(col0=[$4], col1=[$2], col2=[$0], col3=[$1], col4=[$3], col5=[$4])
   HiveJoin(condition=[=($3, $0)], joinType=[left], algorithm=[none], cost=[not available])
     HiveProject(c=[$0], d=[$1])
       HiveTableScan(table=[[default, othertlb]], table:alias=[s])

--- a/ql/src/test/results/clientpositive/llap/sqlmerge.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge.q.out
@@ -64,6 +64,28 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: acidtbl_n0
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 8 
+            Map Operator Tree:
+                TableScan
                   alias: s
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
@@ -79,116 +101,94 @@ STAGE PLANS:
                       value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: acidtbl_n0
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col3 (type: int), _col0 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col2 (type: boolean), _col3 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 > 8)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col3 and (_col4 > 8)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col2 (type: int)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col2 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: _col3 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: int), _col1 (type: int)
+                      expressions: _col4 (type: int), _col1 (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col2 = _col3) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col2 = _col4) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
                         keys: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -196,10 +196,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -212,10 +212,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -228,10 +228,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -244,10 +244,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -262,17 +262,17 @@ STAGE PLANS:
                 keys: KEY._col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
                   predicate: (_col1 > 1L) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: cardinality_violation(_col0) (type: int)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -394,8 +394,8 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: a (type: int)
-                      outputColumnNames: _col0
+                      expressions: a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
@@ -403,6 +403,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -432,13 +433,13 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2
+                outputColumnNames: _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
-                  predicate: _col0 is null (type: boolean)
+                  predicate: _col1 is null (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
-                    expressions: _col1 (type: int), _col2 (type: int)
+                    expressions: _col2 (type: int), _col3 (type: int)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
@@ -570,6 +571,28 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: acidtbl_n0
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 7 
+            Map Operator Tree:
+                TableScan
                   alias: s
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
@@ -585,104 +608,82 @@ STAGE PLANS:
                       value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: acidtbl_n0
-                  filterExpr: a is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col3 (type: int), _col0 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col2 (type: boolean), _col3 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 > 8)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col3 and (_col4 > 8)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col2 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: _col3 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col3 (type: int), _col1 (type: int)
+                      expressions: _col4 (type: int), _col1 (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col2 = _col3) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    predicate: (_col2 = _col4) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
                         keys: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -690,10 +691,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -706,10 +707,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -722,10 +723,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 7 (type: int)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -740,17 +741,17 @@ STAGE PLANS:
                 keys: KEY._col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Filter Operator
                   predicate: (_col1 > 1L) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: cardinality_violation(_col0) (type: int)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.TextInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat

--- a/ql/src/test/results/clientpositive/llap/sqlmerge.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge.q.out
@@ -113,14 +113,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col2 (type: boolean), _col3 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  expressions: _col2 (type: boolean), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col3 (type: int), _col2 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and (_col4 > 8)) (type: boolean)
+                    predicate: (_col0 and (_col4 > 8)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -130,10 +130,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    predicate: (_col0 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -143,10 +143,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    predicate: (_col0 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: int)
+                      expressions: _col3 (type: int)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -156,10 +156,10 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col3 is null (type: boolean)
+                    predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col4 (type: int), _col1 (type: int)
+                      expressions: _col4 (type: int), _col2 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -170,15 +170,15 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col2 = _col4) (type: boolean)
+                    predicate: (_col3 = _col4) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -620,14 +620,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col2 (type: boolean), _col3 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  expressions: _col2 (type: boolean), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col1 (type: int), _col3 (type: int), _col2 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (_col3 and (_col4 > 8)) (type: boolean)
+                    predicate: (_col0 and (_col4 > 8)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -637,10 +637,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: _col3 is null (type: boolean)
+                    predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col4 (type: int), _col1 (type: int)
+                      expressions: _col4 (type: int), _col2 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -651,10 +651,10 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col3 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
+                    predicate: (_col0 and ((_col4 <= 8) or (_col4 > 8) is null)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int)
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
@@ -665,15 +665,15 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col2 = _col4) (type: boolean)
+                    predicate: (_col3 = _col4) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0
+                      expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col1
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       Group By Operator
                         aggregations: count()
-                        keys: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/sqlmerge_nullsafe.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge_nullsafe.q.out
@@ -1,0 +1,389 @@
+PREHOOK: query: create table t_target(a int, b string, c int)stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_target
+POSTHOOK: query: create table t_target(a int, b string, c int)stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_target
+PREHOOK: query: create table t_source(a int, b string, c int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_source
+POSTHOOK: query: create table t_source(a int, b string, c int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_source
+PREHOOK: query: insert into t_target values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t_target
+POSTHOOK: query: insert into t_target values (1, 'match', 50), (2, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t_target
+POSTHOOK: Lineage: t_target.a SCRIPT []
+POSTHOOK: Lineage: t_target.b SCRIPT []
+POSTHOOK: Lineage: t_target.c SCRIPT []
+PREHOOK: query: insert into t_source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t_source
+POSTHOOK: query: insert into t_source values (1, 'match', 50), (22, 'not match', 51), (3, 'delete', 55), (4, 'not delete null', null), (null, 'match null', 56)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t_source
+POSTHOOK: Lineage: t_source.a SCRIPT []
+POSTHOOK: Lineage: t_source.b SCRIPT []
+POSTHOOK: Lineage: t_source.c SCRIPT []
+PREHOOK: query: explain
+merge into t_target as t using t_source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t_source
+PREHOOK: Input: default@t_target
+PREHOOK: Output: default@merge_tmp_table
+PREHOOK: Output: default@t_target
+PREHOOK: Output: default@t_target
+POSTHOOK: query: explain
+merge into t_target as t using t_source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t_source
+POSTHOOK: Input: default@t_target
+POSTHOOK: Output: default@merge_tmp_table
+POSTHOOK: Output: default@t_target
+POSTHOOK: Output: default@t_target
+STAGE DEPENDENCIES:
+  Stage-5 is a root stage
+  Stage-6 depends on stages: Stage-5
+  Stage-0 depends on stages: Stage-6
+  Stage-7 depends on stages: Stage-0
+  Stage-1 depends on stages: Stage-6
+  Stage-8 depends on stages: Stage-1
+  Stage-2 depends on stages: Stage-6
+  Stage-9 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-6
+  Stage-10 depends on stages: Stage-3
+  Stage-4 depends on stages: Stage-6
+  Stage-11 depends on stages: Stage-4
+
+STAGE PLANS:
+  Stage: Stage-5
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t_target
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), b (type: string), c (type: int), true (type: boolean)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                    Statistics: Num rows: 5 Data size: 905 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 5 Data size: 905 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: int), _col4 (type: boolean)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 5 Data size: 505 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Right Outer Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 6 Data size: 1692 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col4 (type: boolean), _col6 (type: string), _col5 (type: int), _col7 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int), _col2 (type: string), _col1 (type: int), _col4 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                  Statistics: Num rows: 6 Data size: 1716 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (_col0 and (_col5 > 50)) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 858 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 228 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                        Statistics: Num rows: 3 Data size: 228 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (_col0 and ((_col5 <= 50) or (_col5 > 50) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 286 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (_col0 and ((_col5 <= 50) or (_col5 > 50) is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 286 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col7 (type: int), concat(_col6, ' Merged') (type: string), (_col5 + 10) (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                            serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                            name: default.t_target
+                        Write Type: INSERT
+                  Filter Operator
+                    predicate: _col8 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 286 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col2 (type: int), concat(_col1, ' New') (type: string), _col3 (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                            serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                            name: default.t_target
+                        Write Type: INSERT
+                  Filter Operator
+                    predicate: (_col7 IS NOT DISTINCT FROM _col2) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 858 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col4
+                      Statistics: Num rows: 3 Data size: 858 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: _col4 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 3 Data size: 252 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          Statistics: Num rows: 3 Data size: 252 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 228 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 3 Data size: 228 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.t_target
+                  Write Type: DELETE
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.t_target
+                  Write Type: DELETE
+        Reducer 5 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 3 Data size: 252 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col1 > 1L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: cardinality_violation(_col0) (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.TextInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          name: default.merge_tmp_table
+
+  Stage: Stage-6
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.t_target
+          Write Type: DELETE
+
+  Stage: Stage-7
+    Stats Work
+      Basic Stats Work:
+
+  Stage: Stage-1
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.t_target
+          Write Type: DELETE
+
+  Stage: Stage-8
+    Stats Work
+      Basic Stats Work:
+
+  Stage: Stage-2
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.t_target
+          Write Type: INSERT
+
+  Stage: Stage-9
+    Stats Work
+      Basic Stats Work:
+
+  Stage: Stage-3
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.t_target
+          Write Type: INSERT
+
+  Stage: Stage-10
+    Stats Work
+      Basic Stats Work:
+
+  Stage: Stage-4
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.mapred.TextInputFormat
+              output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+              name: default.merge_tmp_table
+
+  Stage: Stage-11
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: merge into t_target as t using t_source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t_source
+PREHOOK: Input: default@t_target
+PREHOOK: Output: default@merge_tmp_table
+PREHOOK: Output: default@t_target
+PREHOOK: Output: default@t_target
+POSTHOOK: query: merge into t_target as t using t_source src ON t.a <=> src.a
+when matched and t.c > 50 THEN DELETE
+when matched then update set b = concat(t.b, ' Merged'), c = t.c + 10
+when not matched then insert values (src.a, concat(src.b, ' New'), src.c)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t_source
+POSTHOOK: Input: default@t_target
+POSTHOOK: Output: default@merge_tmp_table
+POSTHOOK: Output: default@t_target
+POSTHOOK: Output: default@t_target
+POSTHOOK: Lineage: merge_tmp_table.val EXPRESSION [(t_target)t_target.FieldSchema(name:ROW__ID, type:struct<writeId:bigint,bucketId:int,rowId:bigint>, comment:), ]
+POSTHOOK: Lineage: t_target.a SIMPLE [(t_source)src.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: t_target.a SIMPLE [(t_source)src.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: t_target.b EXPRESSION [(t_source)src.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: t_target.b EXPRESSION [(t_source)src.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: t_target.c SIMPLE [(t_source)src.FieldSchema(name:c, type:int, comment:null), ]
+POSTHOOK: Lineage: t_target.c SIMPLE [(t_source)src.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: select * from t_target
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t_target
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t_target
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t_target
+#### A masked pattern was here ####
+2	not match	51
+1	match Merged	60
+4	not delete null Merged	NULL
+22	not match New	51

--- a/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
@@ -174,16 +174,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 1 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
@@ -195,11 +195,11 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 2 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col0
@@ -211,8 +211,8 @@ STAGE PLANS:
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col3 (type: int)
                     outputColumnNames: _col0
@@ -224,8 +224,8 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col3 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: int)
                     outputColumnNames: _col0, _col1
@@ -239,11 +239,11 @@ STAGE PLANS:
                       value expressions: _col1 (type: int)
                 Filter Operator
                   predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col2
-                    Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -711,16 +711,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 4 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), c (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 4 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 4 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int)
+                        Statistics: Num rows: 4 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col3 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 7 
@@ -750,42 +750,42 @@ STAGE PLANS:
                 keys:
                   0 _col1 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 4 Data size: 284 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 4 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col3 (type: int), _col4 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 4 Data size: 284 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 4 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col4 (type: int), _col3 (type: int)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: int)
                   Filter Operator
-                    predicate: _col4 is null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: int), _col1 (type: int)
                       outputColumnNames: _col0, _col1
@@ -799,11 +799,11 @@ STAGE PLANS:
                         value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col2
-                      Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -824,10 +824,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -840,10 +840,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), 99 (type: int), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -1030,16 +1030,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 5 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), c (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 5 Data size: 440 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 5 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int)
+                        Statistics: Num rows: 5 Data size: 440 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col3 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 7 
@@ -1069,42 +1069,42 @@ STAGE PLANS:
                 keys:
                   0 _col1 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 4 Data size: 284 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 4 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col3 (type: int), _col4 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 4 Data size: 284 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 4 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col4 (type: int), _col3 (type: int)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: int)
                   Filter Operator
-                    predicate: _col4 is null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: int), _col1 (type: int)
                       outputColumnNames: _col0, _col1
@@ -1118,11 +1118,11 @@ STAGE PLANS:
                         value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col2
-                      Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -1143,10 +1143,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -1159,10 +1159,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), 98 (type: int), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -1349,16 +1349,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 6 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), c (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 6 Data size: 528 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 6 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int)
+                        Statistics: Num rows: 6 Data size: 528 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col3 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 7 
@@ -1388,42 +1388,42 @@ STAGE PLANS:
                 keys:
                   0 _col1 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 5 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 5 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col3 (type: int), _col4 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 5 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 5 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col4 (type: int), _col3 (type: int)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: int)
                   Filter Operator
-                    predicate: _col4 is null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: int), _col1 (type: int)
                       outputColumnNames: _col0, _col1
@@ -1437,11 +1437,11 @@ STAGE PLANS:
                         value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col2
-                      Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -1462,10 +1462,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -1478,10 +1478,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), 97 (type: int), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -1668,16 +1668,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 7 Data size: 56 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), c (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 7 Data size: 588 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), c (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 7 Data size: 616 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 7 Data size: 588 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int)
+                        Statistics: Num rows: 7 Data size: 616 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col3 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 7 
@@ -1707,42 +1707,42 @@ STAGE PLANS:
                 keys:
                   0 _col1 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 5 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 5 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col3 (type: int), _col4 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 5 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 5 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col4 (type: int), _col3 (type: int)
                       outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: int)
                   Filter Operator
-                    predicate: _col4 is null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: int), _col1 (type: int)
                       outputColumnNames: _col0, _col1
@@ -1756,11 +1756,11 @@ STAGE PLANS:
                         value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col2
-                      Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -1781,10 +1781,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -1797,10 +1797,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), 96 (type: int), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2054,16 +2054,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 2 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        Statistics: Num rows: 2 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
@@ -2075,11 +2075,11 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 2 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col0
@@ -2091,8 +2091,8 @@ STAGE PLANS:
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col3 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col1 (type: int)
                     outputColumnNames: _col0
@@ -2105,11 +2105,11 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col2
-                    Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
@@ -2365,16 +2365,16 @@ STAGE PLANS:
                     predicate: a is not null (type: boolean)
                     Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), a (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 2 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        Statistics: Num rows: 2 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
@@ -2386,11 +2386,11 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 2 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col0
@@ -2402,8 +2402,8 @@ STAGE PLANS:
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col3 (type: int)
                     outputColumnNames: _col0
@@ -2415,8 +2415,8 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col3 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col1 (type: int)
                     outputColumnNames: _col0
@@ -2429,11 +2429,11 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col2
-                    Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)

--- a/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
@@ -197,67 +197,71 @@ STAGE PLANS:
                   1 _col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                Select Operator
+                  expressions: _col4 (type: boolean), _col0 (type: int), _col1 (type: int), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int), _col4 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col3 (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col1 (type: int)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: int)
-                Filter Operator
-                  predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col2
-                    Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
-                        Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col4 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: a
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int), _col2 (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: a
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
+                  Filter Operator
+                    predicate: (_col4 = _col1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
+                      Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: bigint)
+                        Reduce Output Operator
+                          key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -753,14 +757,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 4 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 4 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col3 (type: boolean), _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 4 Data size: 308 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: _col5 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -770,10 +774,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: _col5 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), _col3 (type: int)
+                      expressions: _col5 (type: int), _col4 (type: int)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -784,10 +788,10 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col0 (type: int), _col1 (type: int)
+                      expressions: _col1 (type: int), _col2 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -798,15 +802,15 @@ STAGE PLANS:
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col5 = _col1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col2
-                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
+                      Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -1072,14 +1076,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 4 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 4 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col3 (type: boolean), _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 4 Data size: 308 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: _col5 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1089,10 +1093,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: _col5 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), _col3 (type: int)
+                      expressions: _col5 (type: int), _col4 (type: int)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1103,10 +1107,10 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col0 (type: int), _col1 (type: int)
+                      expressions: _col1 (type: int), _col2 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1117,15 +1121,15 @@ STAGE PLANS:
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col5 = _col1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col2
-                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
+                      Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -1391,14 +1395,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 5 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 5 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col3 (type: boolean), _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 5 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: _col5 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1408,10 +1412,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: _col5 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), _col3 (type: int)
+                      expressions: _col5 (type: int), _col4 (type: int)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1422,10 +1426,10 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col0 (type: int), _col1 (type: int)
+                      expressions: _col1 (type: int), _col2 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1436,15 +1440,15 @@ STAGE PLANS:
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col5 = _col1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col2
-                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
+                      Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -1710,14 +1714,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                 Statistics: Num rows: 5 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 5 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: _col3 (type: boolean), _col4 (type: int), _col5 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: int), _col1 (type: int), _col3 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                  Statistics: Num rows: 5 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: _col5 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1727,10 +1731,10 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: _col5 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), _col3 (type: int)
+                      expressions: _col5 (type: int), _col4 (type: int)
                       outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1741,10 +1745,10 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: int)
                   Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: _col6 is null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col0 (type: int), _col1 (type: int)
+                      expressions: _col1 (type: int), _col2 (type: int)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
@@ -1755,15 +1759,15 @@ STAGE PLANS:
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
                   Filter Operator
-                    predicate: (_col4 = _col0) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (_col5 = _col1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col2
-                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
+                      Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1
@@ -2029,24 +2033,6 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: u
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: int)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 6 
-            Map Operator Tree:
-                TableScan
                   alias: t3
                   filterExpr: a is not null (type: boolean)
                   Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2066,64 +2052,86 @@ STAGE PLANS:
                         value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: u
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                Select Operator
+                  expressions: _col2 (type: boolean), _col3 (type: int), _col4 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col2 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col1 (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col2
-                    Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
-                        Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col2 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: a
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (_col4 = _col1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
+                      Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: bigint)
+                        Reduce Output Operator
+                          key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -2340,24 +2348,6 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: u
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: int)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 7 
-            Map Operator Tree:
-                TableScan
                   alias: t4
                   filterExpr: a is not null (type: boolean)
                   Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2377,77 +2367,99 @@ STAGE PLANS:
                         value expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+        Map 7 
+            Map Operator Tree:
+                TableScan
+                  alias: u
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Left Outer Join 0 to 1
+                     Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col1 (type: int)
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                Select Operator
+                  expressions: _col2 (type: boolean), _col3 (type: int), _col4 (type: int), _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col1 (type: int), _col2 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col3 (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col1 (type: int)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (_col3 = _col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col2
-                    Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
-                        Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col4 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: a
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col2 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: a
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (_col4 = _col1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col3
+                      Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: bigint)
+                        Reduce Output Operator
+                          key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                          Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Merge statements in Hive are rewritten to multi-insert statements (Merge on Read) or insert select statements where the select clause has union all branches. In the case of both approaches the target and the source tables must be joined to find records that need to be inserted/updated/deleted. This is performed by outer join in most cases. Then the joined records are pushed to the insert/select branches (MOR) or union branches (COW). Each operation (I/U/D) has its branch with a where clause to filter the records only relevant to the branch. In the current implementation, this filter predicate is inherited from the join condition: a record should be inserted or updated depending on whether the target tables' join keys have null values or not in the joined record. This logic can not handle the case when both the source and target table join key columns are null and we want to update these records.
Instead of this logic, I propose to use flags to indicate whether a source and a target table record exist in the joined record:
```
FROM SELECT (SELECT *, true AS targetRecordExists FROM target) t RIGHT OUTER JOIN source src ON t.a <=> src.a
-- insert new records
INSERT INTO target
   SELECT ... WHERE targetRecordExists IS NULL
-- update records matching join criteria
INSERT INTO target
   SELECT ... WHERE targetRecordExists
```

### Why are the changes needed?
See jira https://issues.apache.org/jira/browse/HIVE-21481

### Does this PR introduce _any_ user-facing change?
Yes, 
* execution plan of merge statements.
* result set of queries executed after merge statements merging into tables having null values on merge join columns

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=sqlmerge_nullsafe.q -pl itests/qtest -Pitests
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestIcebergCliDriver -Dqfile=merge_iceberg_copy_on_write_partitioned.q,merge_iceberg_copy_on_write_partitioned_nullsafe.q,merge_iceberg_copy_on_write_unpartitioned.q,merge_iceberg_copy_on_write_unpartitioned_nullsafe.q,merge_iceberg_orc.q,merge_iceberg_orc_nullsafe.q,merge_iceberg_partitioned_orc.q,merge_iceberg_partitioned_orc_nullsafe.q -pl itests/qtest-iceberg -Pitests,iceberg
```