### PR TITLE
HIVE-28541: Incorrectly treating materialized CTE as Table when privi…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
@@ -425,7 +425,9 @@ public class SimpleFetchOptimizer extends Transform {
       Utilities.addSchemaEvolutionToTableScanOperator(table, scanOp);
       TableDesc tableDesc = Utilities.getTableDesc(table);
       if (!table.isPartitioned()) {
-        inputs.add(new ReadEntity(table, parent, !table.isView() && parent == null));
+        if (!table.isMaterializedTable()) {
+          inputs.add(new ReadEntity(table, parent, !table.isView() && parent == null));
+        }
         FetchWork work = new FetchWork(table.getPath(), tableDesc);
         PlanUtils.configureInputJobPropertiesForStorageHandler(work.getTblDesc());
         work.setSplitSample(splitSample);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -148,6 +148,7 @@ import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.OperatorFactory;
 import org.apache.hadoop.hive.ql.exec.RowSchema;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
@@ -307,6 +308,7 @@ import org.apache.hadoop.hive.ql.parse.type.TypeCheckProcFactory;
 import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
+import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
 import org.apache.hadoop.hive.ql.plan.mapper.EmptyStatsSource;
 import org.apache.hadoop.hive.ql.plan.mapper.StatsSource;
@@ -1038,7 +1040,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
   }
 
   @Override
-  Table materializeCTE(String cteName, CTEClause cte) throws HiveException {
+  Table materializeCTE(String cteName, CTEClause cte, Set<ReadEntity> parentInputs) throws HiveException {
 
     ASTNode createTable = new ASTNode(new ClassicToken(HiveParser.TOK_CREATETABLE));
 
@@ -1065,6 +1067,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
       queryState.setCommandType(operation);
     }
 
+    for (ReadEntity input : analyzer.inputs) {
+      PlanUtils.addInput(parentInputs, input);
+    }
     Table table = analyzer.tableDesc.toTable(conf);
     Path location = table.getDataLocation();
     try {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -1154,6 +1154,9 @@ public final class PlanUtils {
       if (isValuesTempTable(part.getTable().getTableName())) {
         continue;
       }
+      if (part.getTable().isMaterializedTable()) {
+        continue;
+      }
 
       ReadEntity newInput = null;
       if (part.getTable().isPartitioned()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/HIVE-28541

 - check `isMaterializedTable()` before adding elements into `Collection<ReadEntity>`
 - add materialized CTE's real `ReadEntity` into parent's `inputs`

### Why are the changes needed?
it is a bug, which caused an exception when I used `hive.optimize.cte.materialize.threshold`

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
It is hard to test with simple units. I tested and deployed it in my production environment.

