### PR TITLE
HIVE-28540: Special characters in user DN escaped when querying LDAP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,7 @@
     <jansi.version>2.4.0</jansi.version>
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
     <spring.version>5.3.21</spring.version>
+    <spring.ldap.version>2.4.1</spring.ldap.version>
     <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
   <repositories>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -232,6 +232,11 @@
       <artifactId>spring-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.ldap</groupId>
+      <artifactId>spring-ldap-core</artifactId>
+      <version>${spring.ldap.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.jamon</groupId>
       <artifactId>jamon-runtime</artifactId>
     </dependency>

--- a/service/src/java/org/apache/hive/service/auth/ldap/LdapSearch.java
+++ b/service/src/java/org/apache/hive/service/auth/ldap/LdapSearch.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
@@ -29,6 +30,7 @@ import javax.naming.directory.SearchResult;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ldap.support.LdapEncoder;
 
 /**
  * Implements search for LDAP.
@@ -180,7 +182,8 @@ public final class LdapSearch implements DirSearch {
    */
   @Override
   public List<String> executeUserAndGroupFilterQuery(String user, String userDn, String groupSearchFilter, String groupBaseDn) throws NamingException {
-    Query query = queries.findDnByUserAndGroupSearch(user, userDn, groupSearchFilter);
+    String userDnTransformed = Matcher.quoteReplacement(LdapEncoder.filterEncode(userDn));
+    Query query = queries.findDnByUserAndGroupSearch(user, userDnTransformed, groupSearchFilter);
     return execute(Collections.singletonList(groupBaseDn), query).getAllLdapNames();
   }
 

--- a/service/src/test/org/apache/hive/service/auth/ldap/TestLdapSearch.java
+++ b/service/src/test/org/apache/hive/service/auth/ldap/TestLdapSearch.java
@@ -290,4 +290,56 @@ public class TestLdapSearch {
     assertTrue(search.isUserMemberOfGroup("CN=User1,OU=org1,DC=foo,DC=bar", "grp1"));
     assertFalse(search.isUserMemberOfGroup("CN=User2,OU=org1,DC=foo,DC=bar", "grp2"));
   }
+  @Test
+  public void testExecuteUserAndGroupFilterQueryWithSpecialCharacter() throws NamingException {
+    final String groupSearchFilter = "member=CN={0},OU=org1,DC=foo,DC=bar";
+    final String groupBaseDn = "dc=example,dc=com";
+    NamingEnumeration<SearchResult> validResult1 = LdapTestUtils.mockNamingEnumeration("Test User 1");
+    NamingEnumeration<SearchResult> validResult2 = LdapTestUtils.mockNamingEnumeration("Test User 2");
+    NamingEnumeration<SearchResult> validResult3 = LdapTestUtils.mockNamingEnumeration("Test User 3");
+    NamingEnumeration<SearchResult> validResult4 = LdapTestUtils.mockNamingEnumeration("Test User 4");
+    NamingEnumeration<SearchResult> validResult5 = LdapTestUtils.mockNamingEnumeration("Test User 5");
+
+    when(ctx.search(anyString(), contains("member=CN=Test \\5c User,OU=org1,DC=foo,DC=bar,OU=org1,DC=foo,DC=bar"),
+        any(SearchControls.class))).thenReturn(validResult1);
+    when(ctx.search(anyString(), contains("member=CN=Test \\2a User,OU=org1,DC=foo,DC=bar,OU=org1,DC=foo,DC=bar"),
+        any(SearchControls.class))).thenReturn(validResult2);
+    when(ctx.search(anyString(), contains("member=CN=Test \\28 User,OU=org1,DC=foo,DC=bar,OU=org1,DC=foo,DC=bar"),
+        any(SearchControls.class))).thenReturn(validResult3);
+    when(ctx.search(anyString(), contains("member=CN=Test \\29 User,OU=org1,DC=foo,DC=bar,OU=org1,DC=foo,DC=bar"),
+        any(SearchControls.class))).thenReturn(validResult4);
+    when(ctx.search(anyString(), contains("member=CN=Test \\00 User,OU=org1,DC=foo,DC=bar,OU=org1,DC=foo,DC=bar"),
+        any(SearchControls.class))).thenReturn(validResult5);
+    search = new LdapSearch(conf, ctx);
+
+    // contains \
+    List<String> result = search.executeUserAndGroupFilterQuery("Test , User", "Test \\ User,OU=org1,DC=foo,DC=bar",
+        groupSearchFilter, groupBaseDn);
+    assertEquals(1, result.size());
+    assertEquals("Test User 1", result.get(0));
+
+    //contains *
+    result = search.executeUserAndGroupFilterQuery("Test , User", "Test * User,OU=org1,DC=foo,DC=bar",
+        groupSearchFilter, groupBaseDn);
+    assertEquals(1, result.size());
+    assertEquals("Test User 2", result.get(0));
+
+    //contains (
+    result = search.executeUserAndGroupFilterQuery("Test , User", "Test ( User,OU=org1,DC=foo,DC=bar",
+        groupSearchFilter, groupBaseDn);
+    assertEquals(1, result.size());
+    assertEquals("Test User 3", result.get(0));
+
+    //contains )
+    result = search.executeUserAndGroupFilterQuery("Test , User", "Test ) User,OU=org1,DC=foo,DC=bar",
+        groupSearchFilter, groupBaseDn);
+    assertEquals(1, result.size());
+    assertEquals("Test User 4", result.get(0));
+
+    //contains   
+    result = search.executeUserAndGroupFilterQuery("Test , User", "Test \000 User,OU=org1,DC=foo,DC=bar",
+        groupSearchFilter, groupBaseDn);
+    assertEquals(1, result.size());
+    assertEquals("Test User 5", result.get(0));
+  }
 }

--- a/standalone-metastore/metastore-common/pom.xml
+++ b/standalone-metastore/metastore-common/pom.xml
@@ -311,6 +311,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.ldap</groupId>
+      <artifactId>spring-ldap-core</artifactId>
+      <version>${spring.ldap.version}</version>
+    </dependency>
     <!-- test scope dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ldap/LdapSearch.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ldap/LdapSearch.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
@@ -30,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ldap.support.LdapEncoder;
 
 /**
  * Implements search for LDAP.
@@ -181,7 +183,8 @@ public final class LdapSearch implements DirSearch {
    */
   @Override
   public List<String> executeUserAndGroupFilterQuery(String user, String userDn, String groupSearchFilter, String groupBaseDn) throws NamingException {
-    Query query = queries.findDnByUserAndGroupSearch(user, userDn, groupSearchFilter);
+    String userDnTransformed = Matcher.quoteReplacement(LdapEncoder.filterEncode(userDn));
+    Query query = queries.findDnByUserAndGroupSearch(user, userDnTransformed, groupSearchFilter);
     return execute(Collections.singletonList(groupBaseDn), query).getAllLdapNames();
   }
 

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -114,6 +114,7 @@
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
     <spring.version>5.3.21</spring.version>
+    <spring.ldap.version>2.4.1</spring.ldap.version>
     <!-- Thrift properties -->
     <thrift.home>you-must-set-this-to-run-thrift</thrift.home>
     <thrift.gen.dir>${basedir}/src/gen/thrift</thrift.gen.dir>


### PR DESCRIPTION
Change-Id: If2db478039cdfe87022b2f3b10ecf5de09dfcbe0

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When user name has a comma in it, and it is not escaped properly by Hive when querying LDAP, the query failes.
For example if the given user DN is "user , name", the correct escaped LDAP query should contain: "user r\5c, name".


### Why are the changes needed?
If connected to LDAP it requires that.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Unit tests.