### PR TITLE
HIVE-28543: Previous snapshotId is stored in backend database for iceberg tables

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -89,7 +89,6 @@ import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.PartitionsTable;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
@@ -1062,10 +1061,6 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     if (hmsTable != null) {
       try {
         Table tbl = IcebergTableUtil.getTable(conf, hmsTable);
-        Snapshot snapshot = tbl.currentSnapshot();
-        if (snapshot != null) {
-          hmsTable.getParameters().put("current-snapshot-id", String.valueOf(snapshot.snapshotId()));
-        }
         String formatVersion = String.valueOf(((BaseTable) tbl).operations().current().formatVersion());
         hmsTable.getParameters().put(TableProperties.FORMAT_VERSION, formatVersion);
         // Set the serde info


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HIVE-28543](https://issues.apache.org/jira/browse/HIVE-28543)


### Why are the changes needed?
In iceberg table, post inserting the data into iceberg table, the _current-snapshot-id_ in _desc formatted_ output is different from the value stored in backend db (for examlpe: mysql)


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO

### How was this patch tested?
On local setup
