### PR TITLE
HIVE-28538: Post JDK11-Fix locale-related discrepancies in test cases between local and Jenkins environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <test.excludes.additional/>
     <!-- Plugin and Plugin Dependency Versions -->
     <ant.contrib.version>1.0b3</ant.contrib.version>
-    <maven.test.jvm.args>-Xmx2048m -DJETTY_AVAILABLE_PROCESSORS=4</maven.test.jvm.args>
+    <maven.test.jvm.args>-Xmx2048m -DJETTY_AVAILABLE_PROCESSORS=4 -Duser.country=US</maven.test.jvm.args>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.build-helper.plugin.version>3.4.0</maven.build-helper.plugin.version>
     <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>


### PR DESCRIPTION


### What changes were proposed in this pull request?
Passing the locale in the pom.xml as <maven.test.jvm.args> to align both environments of local and jenkins


### Why are the changes needed?
Post jdk11: In JDK11, changes were made to the Java locale handling as documented in the following issues:

(https://bugs.openjdk.org/browse/JDK-8145136)
https://bugs.openjdk.org/browse/JDK-8211985

These changes result in different locale behaviors. This issue does not occur in Jenkins because the test cases are written according to the en_US locale. However, when run locally, the locale may differ (e.g., en_IN), causing discrepancies. For instance, en_IN would expect am/pm while the tests expect AM/PM, leading to failures.

The changes are needed to address test failures that occur locally but not in Jenkins. This discrepancy arises due to different locale settings between the two environments.

Various tests will start failing in local without alarming in the jenkins for example TestMiniLlapLocalCliDriver.udf_date_format.q as the locale in jenkins is en_US whereas varying from the user locale. ( for example en_IN ), the test will start failing 

There may be other test failures not yet captured due to different locales in local environments. Ensure all tests run with the en_US locale to identify and resolve any further issues.



### Does this PR introduce _any_ user-facing change?
NO

