### PR TITLE
HIVE-28548: Subdivide memory size allocated to parallel operators

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/GroupByOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/GroupByOperator.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.type.TimestampTZ;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.llap.LlapDaemonInfo;
+import org.apache.hadoop.hive.llap.LlapUtil;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.parse.OpParseContext;
@@ -389,14 +390,14 @@ public class GroupByOperator extends Operator<GroupByDesc> implements IConfigure
     isLlap = LlapDaemonInfo.INSTANCE.isLlap();
     numExecutors = isLlap ? LlapDaemonInfo.INSTANCE.getNumExecutors() : 1;
     firstRow = true;
+    memoryMXBean = ManagementFactory.getMemoryMXBean();
+    maxMemory = isTez ? getConf().getMaxMemoryAvailable() : memoryMXBean.getHeapMemoryUsage().getMax();
     // estimate the number of hash table entries based on the size of each
     // entry. Since the size of a entry
     // is not known, estimate that based on the number of entries
     if (hashAggr) {
       computeMaxEntriesHashAggr();
     }
-    memoryMXBean = ManagementFactory.getMemoryMXBean();
-    maxMemory = isTez ? getConf().getMaxMemoryAvailable() : memoryMXBean.getHeapMemoryUsage().getMax();
     memoryThreshold = this.getConf().getMemoryThreshold();
     LOG.info("isTez: {} isLlap: {} numExecutors: {} maxMemory: {}", isTez, isLlap, numExecutors, maxMemory);
   }
@@ -411,13 +412,12 @@ public class GroupByOperator extends Operator<GroupByDesc> implements IConfigure
    *         aggregation only
    **/
   private void computeMaxEntriesHashAggr() throws HiveException {
-    float memoryPercentage = this.getConf().getGroupByMemoryUsage();
-    if (isTez) {
-      maxHashTblMemory = (long) (memoryPercentage * getConf().getMaxMemoryAvailable());
-    } else {
-      maxHashTblMemory = (long) (memoryPercentage * Runtime.getRuntime().maxMemory());
+    final float memoryPercentage = this.getConf().getGroupByMemoryUsage();
+    maxHashTblMemory = (long) (memoryPercentage * maxMemory);
+    if (LOG.isInfoEnabled()) {
+      LOG.info("Max hash table memory: {} ({} * {})", LlapUtil.humanReadableByteCount(maxHashTblMemory),
+          LlapUtil.humanReadableByteCount(maxMemory), memoryPercentage);
     }
-    LOG.info("Max hash table memory: {} bytes", maxHashTblMemory);
     estimateRowSize();
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -385,17 +385,22 @@ public class OperatorUtils {
   }
 
   public static void setMemoryAvailable(final List<Operator<? extends OperatorDesc>> operators,
-    final long memoryAvailableToTask) {
-    if (operators == null) {
+    final long memoryAvailable) {
+    if (operators == null || operators.isEmpty()) {
       return;
     }
 
+    final long memoryAvailablePerOperator = memoryAvailable / operators.size();
+    Preconditions.checkArgument(memoryAvailablePerOperator > 0);
+    if (operators.size() > 1) {
+      LOG.info("Assigning {} bytes to {} operators", memoryAvailablePerOperator, operators.size());
+    }
     for (Operator<? extends OperatorDesc> op : operators) {
       if (op.getConf() != null) {
-        op.getConf().setMaxMemoryAvailable(memoryAvailableToTask);
+        op.getConf().setMaxMemoryAvailable(memoryAvailablePerOperator);
       }
       if (op.getChildOperators() != null && !op.getChildOperators().isEmpty()) {
-        setMemoryAvailable(op.getChildOperators(), memoryAvailableToTask);
+        setMemoryAvailable(op.getChildOperators(), memoryAvailablePerOperator);
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorGroupByOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorGroupByOperator.java
@@ -450,7 +450,7 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
                 + "minReductionHashAggr:{} ", maxHtEntries, groupingSets.length,
             numRowsCompareHashAggr, minReductionHashAggr);
       }
-      computeMemoryLimits();
+      computeMemoryLimits(HiveConf.getVar(hconf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE).equals("tez"));
       LOG.debug("using hash aggregation processing mode");
 
       if (keyWrappersBatch.getVectorHashKeyWrappers()[0] instanceof VectorHashKeyWrapperGeneral) {
@@ -616,7 +616,7 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
     /**
      * Computes the memory limits for hash table flush (spill).
      */
-    private void computeMemoryLimits() {
+    private void computeMemoryLimits(boolean isTez) {
       JavaDataModel model = JavaDataModel.get();
 
       fixedHashEntrySize =
@@ -625,7 +625,7 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
           aggregationBatchInfo.getAggregatorsFixedSize();
 
       MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
-      maxMemory = isLlap ? getConf().getMaxMemoryAvailable() : memoryMXBean.getHeapMemoryUsage().getMax();
+      maxMemory = isTez ? getConf().getMaxMemoryAvailable() : memoryMXBean.getHeapMemoryUsage().getMax();
       memoryThreshold = conf.getMemoryThreshold();
       // Tests may leave this unitialized, so better set it to 1
       if (memoryThreshold == 0.0f) {
@@ -634,15 +634,16 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
 
       maxHashTblMemory = (int)(maxMemory * memoryThreshold);
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("GBY memory limits - isLlap: {} maxMemory: {} ({} * {}) fixSize:{} (key:{} agg:{})",
-          isLlap,
-          LlapUtil.humanReadableByteCount(maxHashTblMemory),
-          LlapUtil.humanReadableByteCount(maxMemory),
-          memoryThreshold,
-          fixedHashEntrySize,
-          keyWrappersBatch.getKeysFixedSize(),
-          aggregationBatchInfo.getAggregatorsFixedSize());
+      if (LOG.isInfoEnabled()) {
+        LOG.info("GBY memory limits - isTez: {} isLlap: {} maxHashTblMemory: {} ({} * {}) fixSize:{} (key:{} agg:{})",
+            isTez,
+            isLlap,
+            LlapUtil.humanReadableByteCount(maxHashTblMemory),
+            LlapUtil.humanReadableByteCount(maxMemory),
+            memoryThreshold,
+            fixedHashEntrySize,
+            keyWrappersBatch.getKeysFixedSize(),
+            aggregationBatchInfo.getAggregatorsFixedSize());
       }
     }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorGroupByOperator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorGroupByOperator.java
@@ -103,6 +103,13 @@ public class TestVectorGroupByOperator {
 
   HiveConf hconf = new HiveConf();
 
+  private static GroupByDesc newGroupByDesc() {
+    GroupByDesc desc = new GroupByDesc();
+    long memoryAvailable = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
+    desc.setMaxMemoryAvailable(memoryAvailable);
+    return desc;
+  }
+
   private static ExprNodeDesc buildColumnDesc(
       VectorizationContext ctx,
       String column,
@@ -199,7 +206,7 @@ public class TestVectorGroupByOperator {
     ArrayList<String> outputColumnNames = new ArrayList<String>();
     outputColumnNames.add("_col0");
 
-    GroupByDesc desc = new GroupByDesc();
+    GroupByDesc desc = newGroupByDesc();
     VectorGroupByDesc vectorDesc = new VectorGroupByDesc();
 
     desc.setOutputColumnNames(outputColumnNames);
@@ -219,7 +226,7 @@ public class TestVectorGroupByOperator {
     ArrayList<String> outputColumnNames = new ArrayList<String>();
     outputColumnNames.add("_col0");
 
-    GroupByDesc desc = new GroupByDesc();
+    GroupByDesc desc = newGroupByDesc();
     VectorGroupByDesc vectorDesc = new VectorGroupByDesc();
     vectorDesc.setVecAggrDescs(
         new VectorAggregationDesc[] {
@@ -2425,7 +2432,7 @@ public class TestVectorGroupByOperator {
             TypeInfoFactory.getPrimitiveTypeInfo(columnTypes[i])));
     }
 
-    GroupByDesc desc = new GroupByDesc();
+    GroupByDesc desc = newGroupByDesc();
     VectorGroupByDesc vectorGroupByDesc = new VectorGroupByDesc();
 
     desc.setOutputColumnNames(outputColumnNames);
@@ -2542,7 +2549,7 @@ public class TestVectorGroupByOperator {
     outputColumnNames.add("_col0");
     outputColumnNames.add("_col1");
 
-    GroupByDesc desc = new GroupByDesc();
+    GroupByDesc desc = newGroupByDesc();
     VectorGroupByDesc vectorGroupByDesc = new VectorGroupByDesc();
 
     desc.setOutputColumnNames(outputColumnNames);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Let each operator know how much it can use at maximum.

### Why are the changes needed?

We observed OOM happens when SharedWorkOptimizer merges heavy operators such as GroupByOperators with a map-side hash aggregation. I guess it is hard for GroupByOperator to control its memory correctly in that case.

I confirmed Tez has a similar feature to reallocate memory when a task is connected to multiple edges.
https://github.com/apache/tez/blob/rel/release-0.10.4/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/resources/WeightedScalingMemoryDistributor.java

https://issues.apache.org/jira/browse/HIVE-28548

I also found it is still problematic when # of merged operators is huge, e.g. 100, because the assignment per operator gets tiny. I will handle such case in HIVE-28549.

### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

No.

### How was this patch tested?
Checked local logs.

```
--! qt:dataset:src

set hive.auto.convert.join=true;

SELECT *
FROM (SELECT key, count(*) AS num FROM src WHERE key LIKE '%1%' GROUP BY key) t1
LEFT OUTER JOIN (SELECT key, count(*) AS num FROM src WHERE key LIKE '%2%' GROUP BY key) t2 ON t1.key = t2.key
LEFT OUTER JOIN (SELECT key, count(*) AS num FROM src WHERE key LIKE '%3%' GROUP BY key) t3 ON t1.key = t3.key
LEFT OUTER JOIN (SELECT key, count(*) AS num FROM src WHERE key LIKE '%4%' GROUP BY key) t4 ON t1.key = t4.key
LEFT OUTER JOIN (SELECT key, count(*) AS num FROM src WHERE key LIKE '%5%' GROUP BY key) t5 ON t1.key = t5.key;

set hive.vectorized.execution.enabled=false;

SELECT *
FROM (SELECT key, count(*) AS num FROM src WHERE key LIKE '%1%' GROUP BY key) t1
LEFT OUTER JOIN (SELECT key, count(*) AS num FROM src WHERE key LIKE '%2%' GROUP BY key) t2 ON t1.key = t2.key
LEFT OUTER JOIN (SELECT key, count(*) AS num FROM src WHERE key LIKE '%3%' GROUP BY key) t3 ON t1.key = t3.key
LEFT OUTER JOIN (SELECT key, count(*) AS num FROM src WHERE key LIKE '%4%' GROUP BY key) t4 ON t1.key = t4.key
LEFT OUTER JOIN (SELECT key, count(*) AS num FROM src WHERE key LIKE '%5%' GROUP BY key) t5 ON t1.key = t5.key;
```

The total memory reduced from 358MB to 71MB.

```
% cat org.apache.hadoop.hive.cli.TestMiniLlapLocalCliDriver-output.txt | grep OperatorUtils | grep Assigning
2024-09-30T23:54:38,486  INFO [TezTR-672468_1_3_0_0_0] exec.OperatorUtils: Assigning 75161926 bytes to 5 operators
2024-09-30T23:54:38,831  INFO [TezTR-672468_1_3_0_0_1] exec.OperatorUtils: Assigning 75161926 bytes to 5 operators
2024-09-30T23:54:42,015  INFO [TezTR-672468_1_4_0_0_0] exec.OperatorUtils: Assigning 75161926 bytes to 5 operators
2024-09-30T23:54:42,310  INFO [TezTR-672468_1_4_0_0_1] exec.OperatorUtils: Assigning 75161926 bytes to 5 operators
```

```
% cat org.apache.hadoop.hive.cli.TestMiniLlapLocalCliDriver-output.txt | grep GroupByOperator | grep 'Max hash table'
2024-09-30T23:54:36,280  INFO [TezTR-672468_1_2_0_0_0] exec.GroupByOperator: Max hash table memory: 179.20MB (358.40MB * 0.5)
2024-09-30T23:54:42,015  INFO [TezTR-672468_1_4_0_0_0] exec.GroupByOperator: Max hash table memory: 35.84MB (71.68MB * 0.5)
2024-09-30T23:54:42,017  INFO [TezTR-672468_1_4_0_0_0] exec.GroupByOperator: Max hash table memory: 35.84MB (71.68MB * 0.5)
2024-09-30T23:54:42,018  INFO [TezTR-672468_1_4_0_0_0] exec.GroupByOperator: Max hash table memory: 35.84MB (71.68MB * 0.5)
2024-09-30T23:54:42,018  INFO [TezTR-672468_1_4_0_0_0] exec.GroupByOperator: Max hash table memory: 35.84MB (71.68MB * 0.5)
...
```

```
% cat org.apache.hadoop.hive.cli.TestMiniLlapLocalCliDriver-output.txt | grep VectorGroupByOperator | grep 'GBY memory limits'
2024-09-30T23:54:38,491  INFO [TezTR-672468_1_3_0_0_0] vector.VectorGroupByOperator: GBY memory limits - isTez: true isLlap: true maxHashTblMemory: 64.51MB (71.68MB * 0.9) fixSize:660 (key:472 agg:144)
2024-09-30T23:54:38,499  INFO [TezTR-672468_1_3_0_0_0] vector.VectorGroupByOperator: GBY memory limits - isTez: true isLlap: true maxHashTblMemory: 64.51MB (71.68MB * 0.9) fixSize:660 (key:472 agg:144)
2024-09-30T23:54:38,500  INFO [TezTR-672468_1_3_0_0_0] vector.VectorGroupByOperator: GBY memory limits - isTez: true isLlap: true maxHashTblMemory: 64.51MB (71.68MB * 0.9) fixSize:660 (key:472 agg:144)
2024-09-30T23:54:38,500  INFO [TezTR-672468_1_3_0_0_0] vector.VectorGroupByOperator: GBY memory limits - isTez: true isLlap: true maxHashTblMemory: 64.51MB (71.68MB * 0.9) fixSize:660 (key:472 agg:144)
...
```