### PR TITLE
HIVE-28416: Another process is rebuilding the materialized view is thrown for subsequent MV rebuilds when the current MV rebuild is aborted for the same MV.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -67,6 +67,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1139,6 +1140,9 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
    */
   private static class MaterializationRebuildLockHeartbeater implements Runnable {
 
+    private static final List<TxnType> EXCLUDE_TXN_TYPES =
+        Arrays.asList(TxnType.DEFAULT, TxnType.REPL_CREATED, TxnType.READ_ONLY, TxnType.COMPACTION, TxnType.SOFT_DELETE,
+            TxnType.REBALANCE_COMPACTION);
     private final DbTxnManager txnMgr;
     private final String dbName;
     private final String tableName;
@@ -1165,7 +1169,7 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
           AcidUtils.getFullTableName(dbName, tableName), queryId);
       boolean refreshed = false;
       try {
-        if (!txnMgr.getValidTxns().isTxnAborted(txnId)) {
+        if (!txnMgr.getValidTxns(EXCLUDE_TXN_TYPES).isTxnAborted(txnId)) {
           refreshed = txnMgr.heartbeatMaterializationRebuildLock(dbName, tableName, txnId);
         } else {
           LOG.info(

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
@@ -4702,12 +4702,12 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase {
     driver.run("drop materialized view if exists mv_tab_acid");
     dropTable(new String[] { "tab_acid" });
 
-    driver.run(
-        "create table if not exists tab_acid (a int, b int) partitioned by (p string) " + "stored as orc TBLPROPERTIES ('transactional'='true')");
+    driver.run("create table if not exists tab_acid (a int, b int) partitioned by (p string) " +
+            "stored as orc TBLPROPERTIES ('transactional'='true')");
     driver.run("insert into tab_acid partition(p) (a,b,p) values(1,2,'foo'),(3,4,'bar')");
 
-    driver.run(
-        "create materialized view mv_tab_acid partitioned on (p) " + "stored as orc TBLPROPERTIES ('transactional'='true') as select a, p from tab_acid where b > 1");
+    driver.run("create materialized view mv_tab_acid partitioned on (p) " +
+            "stored as orc TBLPROPERTIES ('transactional'='true') as select a, p from tab_acid where b > 1");
 
     driver.run("insert into tab_acid partition(p) (a,b,p) values(1,2,'foo'),(3,4,'bar')");
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hive.common.util.ReflectionUtil;
 import org.junit.Assert;
 import org.apache.hadoop.hive.common.FileUtils;
@@ -4694,6 +4695,39 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase {
       LockState.ACQUIRED, "default", "mv_tab_acid", null, locks);
     // cleanup
     txnMgr.rollbackTxn();
+    driver.run("drop materialized view mv_tab_acid");
+  }
+
+  @Test
+  public void testMaterializedViewRebuildLockForSameMV() throws Exception {
+    driver.run("drop materialized view if exists mv_tab_acid");
+    dropTable(new String[]{"tab_acid"});
+
+    driver.run("create table if not exists tab_acid (a int, b int) partitioned by (p string) " +
+        "stored as orc TBLPROPERTIES ('transactional'='true')");
+    driver.run("insert into tab_acid partition(p) (a,b,p) values(1,2,'foo'),(3,4,'bar')");
+
+    driver.run("create materialized view mv_tab_acid partitioned on (p) " +
+        "stored as orc TBLPROPERTIES ('transactional'='true') as select a, p from tab_acid where b > 1");
+
+    driver.run("insert into tab_acid partition(p) (a,b,p) values(1,2,'foo'),(3,4,'bar')");
+
+    driver.compileAndRespond("alter materialized view mv_tab_acid rebuild");
+    driver.lockAndRespond();
+
+    // rollback the transaction
+    txnMgr.rollbackTxn();
+
+    try {
+      driver.compileAndRespond("alter materialized view mv_tab_acid rebuild");
+    }
+    catch (Exception se) {
+      Assert.assertEquals(
+          "FAILED: SemanticException org.apache.hadoop.hive.ql.parse.SemanticException: Another process is rebuilding the materialized view default.mv_tab_acid",
+          se.getMessage());
+      Assert.fail("Should not throw exception here");
+    }
+    // cleanup
     driver.run("drop materialized view mv_tab_acid");
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
@@ -4721,10 +4721,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase {
       driver.compileAndRespond("alter materialized view mv_tab_acid rebuild");
     }
     catch (Exception se) {
-      Assert.assertEquals(
-          "FAILED: SemanticException org.apache.hadoop.hive.ql.parse.SemanticException: Another process is rebuilding the materialized view default.mv_tab_acid",
-          se.getMessage());
-      Assert.fail("Should not throw exception here");
+      Assert.fail("Should not throw exception here. Exception message: " + se.getMessage());
     }
     // cleanup
     driver.run("drop materialized view mv_tab_acid");

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
-import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hive.common.util.ReflectionUtil;
 import org.junit.Assert;
 import org.apache.hadoop.hive.common.FileUtils;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/functions/AbortTxnsFunction.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/functions/AbortTxnsFunction.java
@@ -129,6 +129,13 @@ public class AbortTxnsFunction implements TransactionalFunction<Integer> {
       prefix.append("DELETE FROM \"HIVE_LOCKS\" WHERE ");
       TxnUtils.buildQueryWithINClause(conf, queries, prefix, suffix, txnids, "\"HL_TXNID\"", false, false);
 
+      // add delete mv rebuild locks queries to query list
+      prefix.setLength(0);
+      suffix.setLength(0);
+      prefix.append("DELETE FROM \"MATERIALIZATION_REBUILD_LOCKS\" WHERE ");
+      TxnUtils.buildQueryWithINClause(conf, queries, prefix, suffix, txnids, "\"MRL_TXN_ID\"", false, false);
+
+
       //If this abort is for REPL_CREATED TXN initiated outside the replication flow, then clean the corresponding entry
       //from REPL_TXN_MAP and mark that database as replication incompatible.
       if (!isReplReplayed) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Due to any issue if Materialized View Rebuild fails then the transaction will be aborted in that flow the MV rebuild lock entry is not getting removed from MATERIALIZATION_REBUILD_LOCKS table so subsequent rebuilds for that MV are failing. So as a part of this PR, in abort flow also deleting the MV rebuild lock from MATERIALIZATION_REBUILD_LOCKS table so that subsequent MV rebuild will not have any issue.

Actually there is one MaterializationsRebuildLockCleanerTask which cleans the outdated MV rebuild locks based on the lock heartbeat time but MaterializationRebuildLockHeartbeater heartbeating periodically without checking state of the transaction due to that MaterializationsRebuildLockCleanerTask is not cleaning the outdated locks. Now before heartbearing, checking transaction is aborted one or not, if not then only heartbearing the MV rebuild lock.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Without the changes, subsequent MV rebuild will always fail if previous MV rebuild had aborted due to any reason.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
Test cases added.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
