### PR TITLE
HIVE-28555: Adding custom plugins to ReExecution

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5684,6 +5684,11 @@ public class HiveConf extends Configuration {
             + "  recompile_without_cbo: recompiles query after a CBO failure\n"
             + "  reexecute_lost_am: reexecutes query if it failed due to tez am node gets decommissioned\n "
             + "  write_conflict: retries the query once if the query failed due to write_conflict"),
+    HIVE_QUERY_CUStOM_REEXECUTION_STRATEGIES("hive.query.custome.reexecution.strategies",
+        "",
+        "Define a custom reexecution strategies for hive.query.reexecution.strategies.:\n"
+            + "  e.g.\n"
+            + "    org.apache.hadoop.hive.ql.reexec.custom.CustomPlugin1,org.apache.hadoop.hive.ql.reexec.custom.CustomPlugin2"),
     HIVE_QUERY_REEXECUTION_STATS_PERSISTENCE("hive.query.reexecution.stats.persist.scope", "metastore",
         new StringSet("query", "hiveserver", "metastore"),
         "Sets the persistence scope of runtime statistics\n"

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecDriver.java
@@ -83,6 +83,11 @@ public class ReExecDriver implements IDriver {
     return coreDriver.compile(command, resetTaskIds);
   }
 
+  @VisibleForTesting
+  public List<IReExecutionPlugin> getPlugins() {
+    return plugins;
+  }
+
   private boolean firstExecution() {
     return executionIndex == 0;
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestDriverFactory.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestDriverFactory.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.ql.reexec.IReExecutionPlugin;
+import org.apache.hadoop.hive.ql.reexec.ReExecDriver;
+import org.apache.hadoop.hive.ql.reexec.ReExecutionStrategyType;
+import org.junit.Test;
+
+import com.google.common.base.Strings;
+
+public class TestDriverFactory {
+
+  @Test
+  public void testNormal() {
+    HiveConf conf = new HiveConf();
+    IDriver driver = DriverFactory.newDriver(conf);
+    ReExecDriver reDriver = (ReExecDriver) driver;
+
+    List<IReExecutionPlugin> plugins = getPlugins(conf);
+    for (IReExecutionPlugin original : plugins) {
+      boolean found = false;
+      for (IReExecutionPlugin instance : reDriver.getPlugins()) {
+        if (original.getClass().getName().equals(instance.getClass().getName())) {
+          found = true;
+        }
+      }
+
+      if (!found) {
+        fail("The ReExecutionPlugin defined has not been instantiated");
+      }
+    }
+  }
+
+  @Test
+  public void testNormalAndCustom() {
+    HiveConf conf = new HiveConf();
+    // ,recompile_without_cbo,write_conflict
+    conf.setVar(ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES,
+        "overlay,reoptimize,reexecute_lost_am,dagsubmit");
+
+    conf.setVar(ConfVars.HIVE_QUERY_CUStOM_REEXECUTION_STRATEGIES,
+        "org.apache.hadoop.hive.ql.reexec.ReCompileWithoutCBOPlugin" +
+        ",org.apache.hadoop.hive.ql.reexec.ReExecuteOnWriteConflictPlugin");
+
+    IDriver driver = DriverFactory.newDriver(conf);
+    ReExecDriver reDriver = (ReExecDriver) driver;
+
+    List<IReExecutionPlugin> plugins = getPlugins(conf);
+    for (IReExecutionPlugin original : plugins) {
+      boolean found = false;
+      for (IReExecutionPlugin instance : reDriver.getPlugins()) {
+        if (original.getClass().getName().equals(instance.getClass().getName())) {
+          found = true;
+        }
+      }
+
+      if (!found) {
+        fail("The ReExecutionPlugin defined has not been instantiated");
+      }
+    }
+
+    List<IReExecutionPlugin> customPlugins = getCustomPlugins(conf);
+    for (IReExecutionPlugin original : customPlugins) {
+      boolean found = false;
+      for (IReExecutionPlugin instance : reDriver.getPlugins()) {
+        if (original.getClass().getName().equals(instance.getClass().getName())) {
+          found = true;
+        }
+      }
+
+      if (!found) {
+        fail("The ReExecutionPlugin defined has not been instantiated");
+      }
+    }
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testCustomNotInstanceOfIReExecutionPlugin() {
+    HiveConf conf = new HiveConf();
+    conf.setVar(ConfVars.HIVE_QUERY_CUStOM_REEXECUTION_STRATEGIES,
+        "org.apache.hadoop.hive.conf.HiveConf");
+
+    DriverFactory.newDriver(conf);
+  }
+
+  private List<IReExecutionPlugin> getPlugins(HiveConf conf) {
+    String strategies = conf.getVar(ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES);
+    strategies = Strings.nullToEmpty(strategies).trim().toLowerCase();
+    List<IReExecutionPlugin> plugins = new ArrayList<>();
+    for (String string : strategies.split(",")) {
+      if (string.trim().isEmpty()) {
+        continue;
+      }
+      plugins.add(buildReExecPlugin(string));
+    }
+
+    return plugins;
+  }
+
+  private List<IReExecutionPlugin> getCustomPlugins(HiveConf conf) {
+    String customeStrategies = conf.getVar(ConfVars.HIVE_QUERY_CUStOM_REEXECUTION_STRATEGIES);
+    List<IReExecutionPlugin> plugins = new ArrayList<>();
+    for (String string : customeStrategies.split(",")) {
+      if (string.trim().isEmpty()) {
+        continue;
+      }
+      plugins.add(buildCustomReExecPlugin(string));
+    }
+
+    return plugins;
+  }
+
+  private IReExecutionPlugin buildReExecPlugin(String name) throws RuntimeException {
+    Class<? extends IReExecutionPlugin> pluginType = ReExecutionStrategyType.getPluginClassByName(name);
+    try {
+      return pluginType.newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(
+          "Unknown re-execution plugin: " + name + " (" + ConfVars.HIVE_QUERY_CUStOM_REEXECUTION_STRATEGIES.varname + ")");
+    }
+  }
+
+  private IReExecutionPlugin buildCustomReExecPlugin(String name) throws RuntimeException {
+    try {
+      Class<?> cls = Class.forName(name);
+      Object o = cls.newInstance();
+      if (!(o instanceof IReExecutionPlugin)) {
+        throw new RuntimeException(
+            "Not re-execution plugin: " + name);
+      }
+
+      return (IReExecutionPlugin) o;
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new RuntimeException(
+          "Unknown re-execution plugin: " + name + " (" + ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname + ")");
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
ReExecution currently only works with defined plugins. By extending this, it becomes possible to extend it so that only specific actions are taken when a specific failure occurs. For example, we can rewrite properties or prevent re-execution only when a specific exception occurs due to a specific cause.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We can write a plugin like this:
OOM has occurred, but we want to identify the message and turn off Vectorized only.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it might be a good idea to add this to the following documentation:
https://cwiki.apache.org/confluence/display/Hive/Query+ReExecution

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added a UnitTest to test it.