### PR TITLE
HIVE-28557: Eliminate a lot of metrics null check from LlapTaskSchedulerService

### DIFF
--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/DummyLlapTaskSchedulerMetrics.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/DummyLlapTaskSchedulerMetrics.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.llap.tezplugins.metrics;
+
+import org.apache.hadoop.conf.Configuration;
+
+public class DummyLlapTaskSchedulerMetrics extends LlapTaskSchedulerMetrics {
+  public DummyLlapTaskSchedulerMetrics(Configuration conf) {
+    super(conf);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Introduce a DummyLlapTaskSchedulerMetrics to eliminate 29 null checks.
2. Moving all metrics system initialization to the LlapTaskSchedulerMetrics class where it belongs.

### Why are the changes needed?
Eliminate boilerplate.
Repeating null check is a code smell that implies there is no clear contract about whether the field is null. This is now handled by initializing a dummy instance and letting the rest of the code ignore what's going on with metrics actually.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Precommit.
