### PR TITLE
HIVE-28565: Set lock.numretries to small value for tests

### DIFF
--- a/conf/hive-site.xml
+++ b/conf/hive-site.xml
@@ -19,4 +19,8 @@
 
 <configuration>
 
+  <property>
+    <name>hive.lock.sleep.between.retries</name>
+    <value>2</value>
+  </property>
 </configuration>

--- a/data/conf/hivemetastore-site.xml
+++ b/data/conf/hivemetastore-site.xml
@@ -43,4 +43,9 @@
   <value>  </value>
 </property>
 
+<property>
+  <name>metastore.lock.sleep.between.retries</name>
+  <value>2</value>
+</property>
+  
 </configuration>

--- a/data/conf/iceberg/llap/hive-site.xml
+++ b/data/conf/iceberg/llap/hive-site.xml
@@ -392,4 +392,8 @@
         <value>false</value>
     </property>
 
+    <property>
+        <name>hive.lock.sleep.between.retries</name>
+        <value>2</value>
+    </property>
 </configuration>

--- a/data/conf/iceberg/tez/hive-site.xml
+++ b/data/conf/iceberg/tez/hive-site.xml
@@ -315,4 +315,8 @@
   <name>hive.txn.xlock.ctas</name>
   <value>false</value>
 </property>
+<property>
+  <name>hive.lock.sleep.between.retries</name>
+  <value>2</value>
+</property>
 </configuration>

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -398,4 +398,8 @@
   <value>false</value>
 </property>
 
+<property>
+  <name>hive.lock.sleep.between.retries</name>
+  <value>2</value>
+</property>
 </configuration>

--- a/data/conf/llap/hivemetastore-site.xml
+++ b/data/conf/llap/hivemetastore-site.xml
@@ -24,4 +24,9 @@
   <value> </value>
 </property>
 
+<property>
+  <name>metastore.lock.sleep.between.retries</name>
+  <value>2</value>
+</property>
+
 </configuration>

--- a/data/conf/perf/tpcds30tb/tez/hive-site.xml
+++ b/data/conf/perf/tpcds30tb/tez/hive-site.xml
@@ -211,4 +211,8 @@
         <name>hive.explain.user</name>
         <value>false</value>
     </property>
+    <property>
+        <name>hive.lock.sleep.between.retries</name>
+        <value>2</value>
+    </property>
 </configuration>

--- a/data/conf/rlist/hivemetastore-site.xml
+++ b/data/conf/rlist/hivemetastore-site.xml
@@ -32,4 +32,9 @@
   <description>Using dummy param to test server specific configuration</description>
 </property>
 
+<property>
+  <name>metastore.lock.sleep.between.retries</name>
+  <value>2</value>
+</property>
+
 </configuration>

--- a/data/conf/tez/hive-site.xml
+++ b/data/conf/tez/hive-site.xml
@@ -165,6 +165,11 @@
 </property>
 
 <property>
+  <name>hive.lock.sleep.between.retries</name>
+  <value>2</value>
+</property>
+
+<property>
   <name>fs.pfile.impl</name>
   <value>org.apache.hadoop.fs.ProxyLocalFileSystem</value>
   <description>A proxy for local file system used for cross file system testing</description>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set `hive.lock.sleep.between.retries` and `metastore.lock.sleep.between.retries` to 2 similar to what was done HIVE-6464.

### Why are the changes needed?
Fail fast when there is problem to obtain a lock saving resources and providing quick feedback to the developpers instead of waiting ~1.6hrs.

### Does this PR introduce _any_ user-facing change?
No
### Is the change a dependency upgrade?
No

### How was this patch tested?
Existing tests