### PR TITLE
HIVE-28566: Simplify version identifier in patched-iceberg modules

### DIFF
--- a/iceberg/patched-iceberg-api/pom.xml
+++ b/iceberg/patched-iceberg-api/pom.xml
@@ -20,9 +20,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.hive</groupId>
   <artifactId>patched-iceberg-api</artifactId>
-  <version>patched-${iceberg.version}-${project.parent.version}</version>
   <name>Patched Iceberg API</name>
   <!-- Temporary package until we need unreleased Iceberg changes for development purposes. -->
   <!-- We should periodically clean this package during rebasing to newer Iceberg releases. -->

--- a/iceberg/patched-iceberg-core/pom.xml
+++ b/iceberg/patched-iceberg-core/pom.xml
@@ -20,9 +20,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.hive</groupId>
   <artifactId>patched-iceberg-core</artifactId>
-  <version>patched-${iceberg.version}-${project.parent.version}</version>
   <name>Patched Iceberg Core</name>
   <!-- Temporary package until we need unreleased Iceberg changes for development purposes. -->
   <!-- We should periodically clean this package during rebasing to newer Iceberg releases. -->

--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -60,12 +60,12 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>patched-iceberg-api</artifactId>
-        <version>patched-${iceberg.version}-${project.parent.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>patched-iceberg-core</artifactId>
-        <version>patched-${iceberg.version}-${project.parent.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.iceberg</groupId>


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
1. Drop redundant groupId specification
2. Use project.version in patched-iceberg modules


### Why are the changes needed?
Align the patched-iceberg versioning with the rest of Hive modules and get rid of maven warnings.
```
[WARNING] 'version' contains an expression but should be a constant.
```
More info under HIVE-28566.

### Does this PR introduce _any_ user-facing change?
It may affect only projects using patched-iceberg modules via Maven.

In the next release the patched-iceberg-api and patched-iceberg-core modules will use the same version identifier as every other Hive module.

For instance, the next version for `org.apache.hive:patched-iceberg-api` will be `4.1.0` instead of `patched-1.6.1-4.1.0`

### Is the change a dependency upgrade?
No

### How was this patch tested?
```
mvn clean install -DskipTests
Inspect content of:
ls ~/.m2/repository/org/apache/hive/patched-iceberg-*/4.1.0-SNAPSHOT/
```