### PR TITLE
HIVE-28571: Basic UNIONTYPE support in CBO

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -56,7 +56,6 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
-import org.apache.hadoop.hive.ql.optimizer.calcite.CalciteSemanticException;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveTypeSystemImpl;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveRelNode;
@@ -421,13 +420,7 @@ public final class HiveMaterializedViewsRegistry {
     }
 
     // 1.3 Build row type from field <type, name>
-    RelDataType rowType;
-    try {
-      rowType = TypeConverter.getType(cluster, rr, null);
-    } catch (CalciteSemanticException e) {
-      // Bail out
-      return null;
-    }
+    RelDataType rowType = TypeConverter.getType(cluster, rr, null);
 
     // 2. Build RelOptAbstractTable
     List<String> fullyQualifiedTabName = new ArrayList<>();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/CalciteSemanticException.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/CalciteSemanticException.java
@@ -34,7 +34,7 @@ public class CalciteSemanticException extends SemanticException {
     Having_clause_without_any_groupby, Invalid_column_reference, Invalid_decimal,
     Less_than_equal_greater_than, Others, Same_name_in_multiple_expressions,
     Schema_less_table, Select_alias_in_having_clause, Select_transform, Subquery,
-    Table_sample_clauses, UDTF, Union_type, Unique_join,
+    Table_sample_clauses, UDTF, Unique_join,
     HighPrecisionTimestamp // CALCITE-1690
   };
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
@@ -33,7 +33,6 @@ import org.apache.calcite.util.ImmutableBeans;
 import org.apache.hadoop.hive.common.type.SnapshotContext;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
-import org.apache.hadoop.hive.ql.optimizer.calcite.CalciteSemanticException;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
 import org.apache.hadoop.hive.ql.optimizer.calcite.translator.TypeConverter;
@@ -95,13 +94,8 @@ public class HiveAugmentSnapshotMaterializationRule extends RelRule<HiveAugmentS
   @VisibleForTesting
   static RelDataType snapshotIdType(RelDataTypeFactory typeFactory) {
     if (snapshotIdType == null) {
-      try {
-        snapshotIdType = typeFactory.createSqlType(
-            TypeConverter.convert(VirtualColumn.SNAPSHOT_ID.getTypeInfo(),
-                typeFactory).getSqlTypeName());
-      } catch (CalciteSemanticException e) {
-        throw new RuntimeException(e);
-      }
+      snapshotIdType = typeFactory.createSqlType(
+          TypeConverter.convert(VirtualColumn.SNAPSHOT_ID.getTypeInfo(), typeFactory).getSqlTypeName());
     }
 
     return snapshotIdType;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -3355,12 +3355,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
         if(context == null) {
           // we have correlated column, build data type from outer rr
-          RelDataType rowType;
-          try {
-            rowType = TypeConverter.getType(cluster, outerRowResolver, null);
-          } catch (CalciteSemanticException e) {
-            throw new RuntimeException("Error converting type", e);
-          }
+          RelDataType rowType = TypeConverter.getType(cluster, outerRowResolver, null);
           int index = col.getIndex() - inputContext.inputRowType.getFieldList().size();
           if (outerPositionToColumnName.get(index) == null) {
             throw new RuntimeException(ErrorMsg.INVALID_COLUMN_NAME.getMsg());
@@ -3535,7 +3530,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
     }
 
     private AggregateCall convertGBAgg(AggregateInfo agg, List<RexNode> gbChildProjLst,
-        HashMap<String, Integer> rexNodeToPosMap, Integer childProjLstIndx) throws SemanticException {
+        HashMap<String, Integer> rexNodeToPosMap, Integer childProjLstIndx) {
       // 1. Get agg fn ret type in Calcite
       RelDataType aggFnRetType = TypeConverter.convert(agg.getReturnType(),
           this.cluster.getTypeFactory());

--- a/ql/src/test/queries/clientpositive/uniontype_cbo.q
+++ b/ql/src/test/queries/clientpositive/uniontype_cbo.q
@@ -1,0 +1,31 @@
+CREATE TABLE utable (cu UNIONTYPE<INTEGER, STRING>);
+DESCRIBE utable;
+
+EXPLAIN CBO 
+INSERT INTO utable values
+(create_union(0, 10, 'ten')),
+(create_union(1, 10, 'ten'));
+INSERT INTO utable values
+(create_union(0, 10, 'ten')),
+(create_union(1, 10, 'ten'));
+
+EXPLAIN CBO
+SELECT cu FROM utable;
+SELECT cu FROM utable;
+
+EXPLAIN CBO
+SELECT extract_union(cu) FROM utable;
+SELECT extract_union(cu) FROM utable;
+
+CREATE TABLE author (id INT, fname STRING, age INT);
+INSERT INTO author VALUES (0, 'Victor' , '37'), (1, 'Alexander' , '44');
+
+EXPLAIN CBO
+CREATE TABLE uauthor AS SELECT create_union(id % 2, age, fname) as u_age_name FROM author;
+CREATE TABLE uauthor AS SELECT create_union(id % 2, age, fname) as u_age_name FROM author;
+
+DESCRIBE uauthor;
+
+EXPLAIN CBO
+SELECT u_age_name FROM uauthor;
+SELECT u_age_name FROM uauthor;

--- a/ql/src/test/results/clientpositive/llap/join_thrift.q.out
+++ b/ql/src/test/results/clientpositive/llap/join_thrift.q.out
@@ -51,12 +51,16 @@ STAGE PLANS:
                   Filter Operator
                     predicate: aint is not null (type: boolean)
                     Statistics: Num rows: 11 Data size: 44 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: aint (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: aint (type: int)
+                    Select Operator
+                      expressions: aint (type: int)
+                      outputColumnNames: _col0
                       Statistics: Num rows: 11 Data size: 44 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 11 Data size: 44 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 3 
@@ -68,13 +72,17 @@ STAGE PLANS:
                   Filter Operator
                     predicate: aint is not null (type: boolean)
                     Statistics: Num rows: 11 Data size: 28204 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: aint (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: aint (type: int)
+                    Select Operator
+                      expressions: aint (type: int), lintstring (type: array<struct<myint:int,mystring:string,underscore_int:int>>)
+                      outputColumnNames: _col0, _col1
                       Statistics: Num rows: 11 Data size: 28204 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: lintstring (type: array<struct<myint:int,mystring:string,underscore_int:int>>)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 11 Data size: 28204 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: array<struct<myint:int,mystring:string,underscore_int:int>>)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -84,12 +92,12 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 aint (type: int)
-                  1 aint (type: int)
-                outputColumnNames: _col0, _col18
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col2
                 Statistics: Num rows: 12 Data size: 48 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
-                  expressions: _col0 (type: int), _col18 (type: array<struct<myint:int,mystring:string,underscore_int:int>>)
+                  expressions: _col0 (type: int), _col2 (type: array<struct<myint:int,mystring:string,underscore_int:int>>)
                   outputColumnNames: _col0, _col1
                   Statistics: Num rows: 12 Data size: 48 Basic stats: COMPLETE Column stats: NONE
                   File Output Operator

--- a/ql/src/test/results/clientpositive/llap/udf_isnull_isnotnull.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_isnull_isnotnull.q.out
@@ -110,7 +110,7 @@ STAGE PLANS:
             Limit
               Number of rows: 1
               Select Operator
-                expressions: lint is not null (type: boolean), lintstring is not null (type: boolean), mstringstring is not null (type: boolean)
+                expressions: true (type: boolean), lintstring is not null (type: boolean), true (type: boolean)
                 outputColumnNames: _col0, _col1, _col2
                 ListSink
 

--- a/ql/src/test/results/clientpositive/llap/union21.q.out
+++ b/ql/src/test/results/clientpositive/llap/union21.q.out
@@ -61,7 +61,7 @@ STAGE PLANS:
                     outputColumnNames: _col0
                     Statistics: Num rows: 500 Data size: 42500 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: count(1)
+                      aggregations: count()
                       keys: _col0 (type: string)
                       minReductionHashAggr: 0.99
                       mode: hash
@@ -86,7 +86,7 @@ STAGE PLANS:
                     outputColumnNames: _col0
                     Statistics: Num rows: 500 Data size: 92000 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: count(1)
+                      aggregations: count()
                       keys: _col0 (type: string)
                       minReductionHashAggr: 0.99
                       mode: hash
@@ -111,7 +111,7 @@ STAGE PLANS:
                     outputColumnNames: _col0
                     Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: count(1)
+                      aggregations: count()
                       keys: _col0 (type: string)
                       minReductionHashAggr: 0.99
                       mode: hash
@@ -136,7 +136,7 @@ STAGE PLANS:
                     outputColumnNames: _col0
                     Statistics: Num rows: 11 Data size: 2024 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
-                      aggregations: count(1)
+                      aggregations: count()
                       keys: _col0 (type: string)
                       minReductionHashAggr: 0.99
                       mode: hash
@@ -161,7 +161,7 @@ STAGE PLANS:
                     outputColumnNames: _col0
                     Statistics: Num rows: 11 Data size: 21120 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
-                      aggregations: count(1)
+                      aggregations: count()
                       keys: _col0 (type: string)
                       minReductionHashAggr: 0.99
                       mode: hash

--- a/ql/src/test/results/clientpositive/llap/unionDistinct_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/unionDistinct_3.q.out
@@ -2236,7 +2236,7 @@ STAGE PLANS:
                 outputColumnNames: _col0
                 Statistics: Num rows: 316 Data size: 58144 Basic stats: COMPLETE Column stats: PARTIAL
                 Group By Operator
-                  aggregations: count(1)
+                  aggregations: count()
                   keys: _col0 (type: string)
                   mode: complete
                   outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/uniontype_cbo.q.out
+++ b/ql/src/test/results/clientpositive/llap/uniontype_cbo.q.out
@@ -1,0 +1,171 @@
+PREHOOK: query: CREATE TABLE utable (cu UNIONTYPE<INTEGER, STRING>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@utable
+POSTHOOK: query: CREATE TABLE utable (cu UNIONTYPE<INTEGER, STRING>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@utable
+PREHOOK: query: DESCRIBE utable
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@utable
+POSTHOOK: query: DESCRIBE utable
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@utable
+cu                  	uniontype<int,string>	                    
+PREHOOK: query: EXPLAIN CBO 
+INSERT INTO utable values
+(create_union(0, 10, 'ten')),
+(create_union(1, 10, 'ten'))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@utable
+POSTHOOK: query: EXPLAIN CBO 
+INSERT INTO utable values
+(create_union(0, 10, 'ten')),
+(create_union(1, 10, 'ten'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@utable
+CBO PLAN:
+HiveTableFunctionScan(invocation=[inline(ARRAY(ROW(create_union(0, 10, _UTF-16LE'ten':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")), ROW(create_union(1, 10, _UTF-16LE'ten':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))))], rowType=[RecordType(RecordType(INTEGER $tag_0, VARCHAR(2147483647) $tag_1) col1)])
+  HiveTableScan(table=[[_dummy_database, _dummy_table]], table:alias=[_dummy_table])
+
+PREHOOK: query: INSERT INTO utable values
+(create_union(0, 10, 'ten')),
+(create_union(1, 10, 'ten'))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@utable
+POSTHOOK: query: INSERT INTO utable values
+(create_union(0, 10, 'ten')),
+(create_union(1, 10, 'ten'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@utable
+POSTHOOK: Lineage: utable.cu SCRIPT []
+PREHOOK: query: EXPLAIN CBO
+SELECT cu FROM utable
+PREHOOK: type: QUERY
+PREHOOK: Input: default@utable
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT cu FROM utable
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@utable
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(cu=[$0])
+  HiveTableScan(table=[[default, utable]], table:alias=[utable])
+
+PREHOOK: query: SELECT cu FROM utable
+PREHOOK: type: QUERY
+PREHOOK: Input: default@utable
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT cu FROM utable
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@utable
+#### A masked pattern was here ####
+{0:10}
+{1:"ten"}
+PREHOOK: query: EXPLAIN CBO
+SELECT extract_union(cu) FROM utable
+PREHOOK: type: QUERY
+PREHOOK: Input: default@utable
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT extract_union(cu) FROM utable
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@utable
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(_o__c0=[extract_union($0)])
+  HiveTableScan(table=[[default, utable]], table:alias=[utable])
+
+PREHOOK: query: SELECT extract_union(cu) FROM utable
+PREHOOK: type: QUERY
+PREHOOK: Input: default@utable
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT extract_union(cu) FROM utable
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@utable
+#### A masked pattern was here ####
+{"tag_0":10,"tag_1":null}
+{"tag_0":null,"tag_1":"ten"}
+PREHOOK: query: CREATE TABLE author (id INT, fname STRING, age INT)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@author
+POSTHOOK: query: CREATE TABLE author (id INT, fname STRING, age INT)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@author
+PREHOOK: query: INSERT INTO author VALUES (0, 'Victor' , '37'), (1, 'Alexander' , '44')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@author
+POSTHOOK: query: INSERT INTO author VALUES (0, 'Victor' , '37'), (1, 'Alexander' , '44')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@author
+POSTHOOK: Lineage: author.age SCRIPT []
+POSTHOOK: Lineage: author.fname SCRIPT []
+POSTHOOK: Lineage: author.id SCRIPT []
+PREHOOK: query: EXPLAIN CBO
+CREATE TABLE uauthor AS SELECT create_union(id % 2, age, fname) as u_age_name FROM author
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: default@author
+PREHOOK: Output: database:default
+PREHOOK: Output: default@uauthor
+POSTHOOK: query: EXPLAIN CBO
+CREATE TABLE uauthor AS SELECT create_union(id % 2, age, fname) as u_age_name FROM author
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: default@author
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@uauthor
+CBO PLAN:
+HiveProject(u_age_name=[create_union(MOD($0, 2), $2, $1)])
+  HiveTableScan(table=[[default, author]], table:alias=[author])
+
+PREHOOK: query: CREATE TABLE uauthor AS SELECT create_union(id % 2, age, fname) as u_age_name FROM author
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: default@author
+PREHOOK: Output: database:default
+PREHOOK: Output: default@uauthor
+POSTHOOK: query: CREATE TABLE uauthor AS SELECT create_union(id % 2, age, fname) as u_age_name FROM author
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: default@author
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@uauthor
+POSTHOOK: Lineage: uauthor.u_age_name EXPRESSION [(author)author.FieldSchema(name:id, type:int, comment:null), (author)author.FieldSchema(name:age, type:int, comment:null), (author)author.FieldSchema(name:fname, type:string, comment:null), ]
+PREHOOK: query: DESCRIBE uauthor
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@uauthor
+POSTHOOK: query: DESCRIBE uauthor
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@uauthor
+u_age_name          	uniontype<int,string>	                    
+PREHOOK: query: EXPLAIN CBO
+SELECT u_age_name FROM uauthor
+PREHOOK: type: QUERY
+PREHOOK: Input: default@uauthor
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT u_age_name FROM uauthor
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@uauthor
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(u_age_name=[$0])
+  HiveTableScan(table=[[default, uauthor]], table:alias=[uauthor])
+
+PREHOOK: query: SELECT u_age_name FROM uauthor
+PREHOOK: type: QUERY
+PREHOOK: Input: default@uauthor
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT u_age_name FROM uauthor
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@uauthor
+#### A masked pattern was here ####
+{0:37}
+{1:"Alexander"}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Model union as struct at the CBO layer
2. Remove CalciteSemanticException from TypeConverter APIs (no longer thrown)
3. Update q.out files since queries with UNIONTYPE can now use CBO

### Why are the changes needed?
Support UNIONTYPE in the CBO path to take advantage of the powerful optimizations that are performed in the CBO layer and avoid relying on the fallback mechanism. The changes do not aim to cover new use-cases but just to ensure that existing queries that involve UNIONTYPE can exploit the CBO.

### Does this PR introduce _any_ user-facing change?
Better plans

### Is the change a dependency upgrade?
No

### How was this patch tested?
```
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=unionDistinct_3.q,union21.q,join_thrift.q,udf_isnull_isnotnull.q,uniontype_cbo.q
```