### PR TITLE
HIVE-28569: ReExecuteLostAMQueryPlugin doesn't kick in if the message contains line break and diagnostics

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
@@ -39,7 +39,7 @@ public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
   // Lost am container have exit code -100, due to node failures. This pattern of exception is thrown when
   // AM is managed by HS2.
   private static final Pattern LOST_AM_CONTAINER_ERROR_PATTERN =
-      Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*");
+      Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*", Pattern.DOTALL);
   // When HS2 does not manage the AMs, tez AMs are registered with zookeeper and HS2 discovers it,
   // failure of unmanaged AMs will throw AM record not being found in zookeeper.
   private static final String UNMANAGED_AM_FAILURE = "AM record not found (likely died)";

--- a/ql/src/test/org/apache/hadoop/hive/ql/reexec/TestReExecuteLostAMQueryPlugin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/reexec/TestReExecuteLostAMQueryPlugin.java
@@ -32,6 +32,16 @@ public class TestReExecuteLostAMQueryPlugin {
   }
 
   @Test
+  public void testRetryOnLostAmContainerMessageWithLineBreak() throws Exception {
+    testReExecuteWithExceptionMessage("Application application_1728328561547_0042 failed 1 times (global limit =5; " +
+        "local limit is =1) due to AM Container for appattempt_1728328561547_0042_000001 exited with  exitCode: " +
+        "-100\nFailing this attempt.Diagnostics: Container released on a *lost* nodeFor more detailed output, check " +
+        "the application tracking page: https://v2h0231.sjc.cloudera.com:8090/cluster/app/application_1728328561547_0042" +
+        " Then click on links to logs of each attempt.\n" +
+        ". Failing the application.");
+  }
+
+  @Test
   public void testRetryOnNoCurrentDAGException() throws Exception {
     testReExecuteWithExceptionMessage("No running DAG at present");
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the pattern matcher to consume a pattern with line breaks.


### Why are the changes needed?
Because the plugin didn't kick in if the message contains diagnostics which is separated from the original trigger message with line break

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Unit test added.