### PR TITLE
HIVE-28570: Iceberg: Aggregate queries on translated iceberg table fails post rename.

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_rename.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_rename.q
@@ -63,3 +63,10 @@ create table iceorginpart (id int) partitioned by (part string) Stored by Iceber
 insert into iceorginpart values (22, 'DER'),(2, 'KLM');
 
 select * from iceorginpart order by id;
+
+set metastore.metadata.transformer.class=org.apache.hadoop.hive.metastore.MetastoreDefaultTransformer;
+create table xtoy(a int) stored by iceberg stored as parquet tblproperties ('format-version'='2');
+insert into xtoy values (1),(2),(3);
+delete from xtoy where a=1;
+alter table xtoy rename to ytox;
+select count(*) from ytox;

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_rename.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_rename.q.out
@@ -263,3 +263,48 @@ POSTHOOK: Input: default@iceorginpart
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 2	KLM
 22	DER
+PREHOOK: query: create table xtoy(a int) stored by iceberg stored as parquet tblproperties ('format-version'='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@xtoy
+POSTHOOK: query: create table xtoy(a int) stored by iceberg stored as parquet tblproperties ('format-version'='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@xtoy
+PREHOOK: query: insert into xtoy values (1),(2),(3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@xtoy
+POSTHOOK: query: insert into xtoy values (1),(2),(3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@xtoy
+PREHOOK: query: delete from xtoy where a=1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@xtoy
+PREHOOK: Output: default@xtoy
+POSTHOOK: query: delete from xtoy where a=1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@xtoy
+POSTHOOK: Output: default@xtoy
+PREHOOK: query: alter table xtoy rename to ytox
+PREHOOK: type: ALTERTABLE_RENAME
+PREHOOK: Input: default@xtoy
+PREHOOK: Output: database:default
+PREHOOK: Output: default@xtoy
+PREHOOK: Output: default@ytox
+POSTHOOK: query: alter table xtoy rename to ytox
+POSTHOOK: type: ALTERTABLE_RENAME
+POSTHOOK: Input: default@xtoy
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@xtoy
+POSTHOOK: Output: default@ytox
+PREHOOK: query: select count(*) from ytox
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ytox
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from ytox
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ytox
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+2

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.CTAS_
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_TRANSACTIONAL;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.EXTERNAL_TABLE_PURGE;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.isIcebergTable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -750,7 +751,8 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
 
     Database oldDb = getDbForTable(oldTable);
     boolean isTranslatedToExternalFollowsRenames = MetastoreConf.getBoolVar(hmsHandler.getConf(),
-        ConfVars.METASTORE_METADATA_TRANSFORMER_TRANSLATED_TO_EXTERNAL_FOLLOWS_RENAMES);
+        ConfVars.METASTORE_METADATA_TRANSFORMER_TRANSLATED_TO_EXTERNAL_FOLLOWS_RENAMES) &&
+        !isIcebergTable(newTable.getParameters());
 
     if (isTranslatedToExternalFollowsRenames && isTableRename(oldTable, newTable)
         && isTranslatedToExternalTable(oldTable)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid MetdataTransformer to modify the table location in case the translated table is an iceberg table

### Why are the changes needed?

To make the aggregate query work post rename

### Does this PR introduce _any_ user-facing change?

Yes, count(*) on renamed iceberg tables work

### Is the change a dependency upgrade?

No

### How was this patch tested?
UT