### PR TITLE
HIVE-28603 Fixing Multiple Flaky tests in module serde which are due to non determinism

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -1666,7 +1666,7 @@ public final class ObjectInspectorUtils {
       slotField.setAccessible(true);
       return slotField.getInt(field);
     } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
-      LOG.info("Field not found: {}", e);
+      LOG.info("Field not found:", e);
       return 0; // Default value if there's an error
     }
   }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -1666,8 +1666,8 @@ public final class ObjectInspectorUtils {
       slotField.setAccessible(true);
       return slotField.getInt(field);
     } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
-      LOG.info("Field not found:", e);
-      return 0; // Default value if there's an error
+      LOG.error("Error getting a slot value:", e);
+      throw new RuntimeException("Error getting a slot value");
     }
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -1661,13 +1661,20 @@ public final class ObjectInspectorUtils {
    * @return
    */
   private static int getSlotValue(Field field) {
+    Field slotField = null;
+    boolean originalAccessible = false;
     try {
-      Field slotField = Field.class.getDeclaredField("slot");
+      slotField = Field.class.getDeclaredField("slot");
+      originalAccessible = slotField.isAccessible();
       slotField.setAccessible(true);
       return slotField.getInt(field);
     } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
       LOG.error("Error getting a slot value:", e);
       throw new RuntimeException("Error getting a slot value");
+    } finally {
+      if (slotField != null) {
+        slotField.setAccessible(originalAccessible);
+      }
     }
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -558,6 +559,7 @@ public final class ObjectInspectorUtils {
   public static Field[] getDeclaredNonStaticFields(Class<?> c) {
     Field[] f = c.getDeclaredFields();
     ArrayList<Field> af = new ArrayList<Field>();
+    Arrays.sort(f, Comparator.comparingInt(ObjectInspectorUtils::getSlotValue));
     for (int i = 0; i < f.length; ++i) {
       if (!Modifier.isStatic(f[i].getModifiers())) {
         af.add(f[i]);
@@ -1651,5 +1653,21 @@ public final class ObjectInspectorUtils {
 
   private ObjectInspectorUtils() {
     // prevent instantiation
+  }
+
+  /**
+   * Returns slot value used for ordering the fields to make it deterministic
+   * @param field : field of a given class
+   * @return
+   */
+  private static int getSlotValue(Field field) {
+    try {
+      Field slotField = Field.class.getDeclaredField("slot");
+      slotField.setAccessible(true);
+      return slotField.getInt(field);
+    } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
+      LOG.info("Field not found: {}", e);
+      return 0; // Default value if there's an error
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Sorting the fields in function `getDeclaredNonStaticFields()` in ObjectInspectorUtils.java class in order to make the function deterministic. The below flaky tests will be fixed by this.

### Why are the changes needed?
Multiple flaky tests were detected in _serde_ module while trying to run the tests using the nondex tool. [NonDex](https://github.com/TestingResearchIllinois/NonDex) is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. 

#### Steps to reproduce flakiness using nondex -
```
mvn install -pl serde -DskipTests

mvn -pl serde test -Dtest=org.apache.hadoop.hive.serde2.objectinspector.TestProtocolBuffersObjectInspectors#testProtocolBuffersObjectInspectors

mvn -pl serde edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.hadoop.hive.serde2.objectinspector.TestProtocolBuffersObjectInspectors#testProtocolBuffersObjectInspectors
```

#### ERROR logs: 
 

```
[ERROR] Failures: 
[ERROR]   TestProtocolBuffersObjectInspectors.testProtocolBuffersObjectInspectors:71 expected:<test> but was:<[one, two]>
```


<img width="1021" alt="Screenshot 2024-11-02 at 2 48 35 PM" src="https://github.com/user-attachments/assets/0ffae340-4d5f-4deb-94af-1742474c2adf">

### Reason for Failure 

The method **getDeclaredNonStaticFields(Class<?> c)** in class **ObjectInspectorUtils.java** uses class.getDeclaredFields() method which is nondeterministic as per [java docs](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--). 

` Field[] f = c.getDeclaredFields();`

<img width="705" alt="Screenshot 2024-11-02 at 4 26 58 PM" src="https://github.com/user-attachments/assets/9d4a43ea-7bca-4679-ba1a-7d3a7672c221">

As per the test cases, it is assumed that the return order of the fields will always be the same, which may not be the case.


All the below test cases are impacted because of the same reason : 

- org.apache.hadoop.hive.serde2.objectinspector.TestProtocolBuffersObjectInspectors.testProtocolBuffersObjectInspectors
- org.apache.hadoop.hive.serde2.objectinspector.TestThriftObjectInspectors.testThriftObjectInspectors
- org.apache.hadoop.hive.serde2.objectinspector.TestReflectionObjectInspectors.testReflectionObjectInspectors
- org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testLazyBinaryColumnarSerDeWithEmptyBinary
- org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDeInnerNulls
- org.apache.hadoop.hive.serde2.lazybinary.TestLazyBinarySerDe.testLazyBinarySerDe
- org.apache.hadoop.hive.serde2.TestStatsSerde.testLazyBinarySerDe
- org.apache.hadoop.hive.serde2.lazy.TestLazySimpleSerDe#testSerDeParameters
- org.apache.hadoop.hive.serde2.binarysortable.TestBinarySortableSerDe#testBinarySortableSerDe



### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
The changes were tested by running the unit tests locally. The code is already covered in the above test cases and is actually fixing the flaky tests.

Please let me know if you have any questions or would like to discuss this further for any clarificaitions. 