### PR TITLE
HIVE-28519: Upgrade Maven SureFire Plugin to latest version 3.5.1

### DIFF
--- a/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
+++ b/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
@@ -169,8 +169,11 @@ public class TestHiveCli {
 
   @Test
   public void testSqlFromCmdWithEmbeddedQuotes() {
+  // In Beeline.java, after upgrading the Maven SureFire plugin to 3.0.0-M5, InputStream inputStream = System.in
+  // no longer contains an EOT byte[]. This change causes an indefinite loop when calling
+  // beeLine.getConsoleReader().readLine(prompt.toString()). To resolve this, a delimiter has been added.
     verifyCMD(null, "hive", out,
-        new String[] { "-e", "select \"hive\"" }, ERRNO_OK, true);
+        new String[] { "-e", "select \"hive\";" }, ERRNO_OK, true);
   }
 
   @Test

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationMigrationTool.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationMigrationTool.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.util.ToolRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -45,6 +46,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+// Enable the test post fixing HIVE-28608
+@Ignore
 public class TestReplicationMigrationTool extends BaseReplicationAcrossInstances {
 
   String extraPrimaryDb;

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -371,6 +371,16 @@
       <version>${log4j2.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit-pioneer</groupId>
+          <artifactId>junit-pioneer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-commons</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -386,11 +396,13 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.vintage.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <maven.exec.plugin.version>3.1.0</maven.exec.plugin.version>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
     <maven.shade.plugin.version>3.5.0</maven.shade.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.5.1</maven.surefire.plugin.version>
     <maven.cyclonedx.plugin.version>2.7.10</maven.cyclonedx.plugin.version>
     <maven.license.plugin.version>2.3.0</maven.license.plugin.version>
     <!-- Library Dependency Versions -->
@@ -166,8 +166,8 @@
     <jodd.version>6.0.0</jodd.version>
     <json.version>1.8</json.version>
     <junit.version>4.13.2</junit.version>
-    <junit.jupiter.version>5.10.0</junit.jupiter.version>
-    <junit.vintage.version>5.6.3</junit.vintage.version>
+    <junit.jupiter.version>5.11.2</junit.jupiter.version>
+    <junit.vintage.version>5.11.2</junit.vintage.version>
     <kafka.version>2.5.0</kafka.version>
     <kryo.version>5.5.0</kryo.version>
     <reflectasm.version>1.11.9</reflectasm.version>
@@ -1753,6 +1753,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <enableOutErrElements>false</enableOutErrElements>
           <excludes>
             <exclude>**/TestSerDe.java</exclude>
             <exclude>**/TestHiveMetaStore.java</exclude>
@@ -1764,8 +1765,8 @@
           </excludes>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <reuseForks>false</reuseForks>
-          <failIfNoTests>false</failIfNoTests>
-          <argLine>${maven.test.jvm.args}</argLine>
+          <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+          <argLine>${maven.test.jvm.args} -Xshare:off</argLine>
           <trimStackTrace>false</trimStackTrace>
           <additionalClasspathElements>
             <additionalClasspathElement>${test.conf.dir}</additionalClasspathElement>

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestGetPartitionAuthWithBatches.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestGetPartitionAuthWithBatches.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.exec;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 
 import org.apache.hadoop.hive.metastore.api.GetPartitionsPsWithAuthRequest;
@@ -67,7 +68,7 @@ public class TestGetPartitionAuthWithBatches {
 
     @BeforeClass
     public static void setupClass() throws HiveException {
-        hiveConf = new HiveConf(TestGetPartitionAuthWithBatches.class);
+        hiveConf = new HiveConfForTest(TestGetPartitionAuthWithBatches.class);
         hiveConf.set("hive.security.authorization.enabled", "true");
         hiveConf.set("hive.security.authorization.manager","org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider");
         hive = Hive.get();

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestGetPartitionInBatches.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestGetPartitionInBatches.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.exec;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 
 import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesRequest;
@@ -64,9 +65,9 @@ public class TestGetPartitionInBatches {
 
     @BeforeClass
     public static void setupClass() throws HiveException {
-        hiveConf = new HiveConf(TestGetPartitionInBatches.class);
-        hive = Hive.get();
-        SessionState.start(hiveConf);
+        hiveConf = new HiveConfForTest(TestGetPartitionInBatches.class);
+        SessionState ss = SessionState.start(hiveConf);
+        hive = ss.getHiveDb();
         try {
             msc = new HiveMetaStoreClient(hiveConf);
         } catch (MetaException e) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestMsckCreatePartitionsInBatches.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestMsckCreatePartitionsInBatches.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.ql.exec;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.CheckResult.PartitionResult;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -62,7 +63,7 @@ public class TestMsckCreatePartitionsInBatches {
 
   @BeforeClass
   public static void setupClass() throws HiveException, MetaException {
-    hiveConf = new HiveConf(TestMsckCreatePartitionsInBatches.class);
+    hiveConf = new HiveConfForTest(TestMsckCreatePartitionsInBatches.class);
     hiveConf.setIntVar(ConfVars.HIVE_MSCK_REPAIR_BATCH_SIZE, 5);
     hiveConf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestMsckDropPartitionsInBatches.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestMsckDropPartitionsInBatches.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.ql.exec;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.CheckResult.PartitionResult;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -65,7 +66,7 @@ public class TestMsckDropPartitionsInBatches {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    hiveConf = new HiveConf(TestMsckCreatePartitionsInBatches.class);
+    hiveConf = new HiveConfForTest(TestMsckCreatePartitionsInBatches.class);
     hiveConf.setIntVar(ConfVars.HIVE_MSCK_REPAIR_BATCH_SIZE, 5);
     hiveConf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
       "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");

--- a/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestHooks.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestHooks.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.hooks;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.Before;
@@ -31,7 +32,7 @@ public class TestHooks {
 
   @BeforeClass
   public static void onetimeSetup() throws Exception {
-    HiveConf conf = new HiveConf(TestHooks.class);
+    HiveConf conf = new HiveConfForTest(TestHooks.class);
     conf
     .setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
@@ -41,7 +42,7 @@ public class TestHooks {
 
   @AfterClass
   public static void onetimeTeardown() throws Exception {
-    HiveConf conf = new HiveConf(TestHooks.class);
+    HiveConf conf = new HiveConfForTest(TestHooks.class);
     Driver driver = createDriver(conf);
     driver.run("drop table t1");
   }
@@ -52,7 +53,7 @@ public class TestHooks {
 
   @Test
   public void testRedactLogString() throws Exception {
-    HiveConf conf = new HiveConf(TestHooks.class);
+    HiveConf conf = new HiveConfForTest(TestHooks.class);
     String str;
 
     HiveConf.setVar(conf, HiveConf.ConfVars.QUERY_REDACTOR_HOOKS, SimpleQueryRedactor.class.getName());
@@ -69,7 +70,7 @@ public class TestHooks {
 
   @Test
   public void testQueryRedactor() throws Exception {
-    HiveConf conf = new HiveConf(TestHooks.class);
+    HiveConf conf = new HiveConfForTest(TestHooks.class);
     HiveConf.setVar(conf, HiveConf.ConfVars.QUERY_REDACTOR_HOOKS,
       SimpleQueryRedactor.class.getName());
     conf

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveCopyFiles.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveCopyFiles.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.metadata;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -62,7 +63,7 @@ public class TestHiveCopyFiles {
 
   @BeforeClass
   public static void setUp() {
-    hiveConf = new HiveConf(TestHiveCopyFiles.class);
+    hiveConf = new HiveConfForTest(TestHiveCopyFiles.class);
     SessionState.start(hiveConf);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestTempAcidTable.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestTempAcidTable.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.metadata;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
@@ -47,7 +48,7 @@ public class TestTempAcidTable {
   @BeforeClass
   public static void setUp() throws Exception {
     hive = Hive.get();
-    HiveConf hiveConf = hive.getConf();
+    HiveConf hiveConf = new HiveConfForTest(TestTempAcidTable.class);
     hiveConf.setVar(ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
     hiveConf.setBoolVar(ConfVars.HIVE_IN_TEST, true);

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestColumnAccess.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestColumnAccess.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.junit.Assert;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.QueryPlan;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
@@ -196,7 +197,7 @@ public class TestColumnAccess {
   }
 
   private static Driver createDriver() {
-    HiveConf conf = new HiveConf(Driver.class);
+    HiveConf conf = new HiveConfForTest(TestColumnAccess.class);
     conf
     .setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQBCompact.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQBCompact.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
@@ -50,7 +51,7 @@ public class TestQBCompact {
   @BeforeClass
   public static void init() throws Exception {
     queryState = new QueryState.Builder().build();
-    conf = queryState.getConf();
+    conf = new HiveConfForTest(TestQBCompact.class);
     conf
     .setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQBJoinTreeApplyPredicate.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQBJoinTreeApplyPredicate.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.junit.Assert;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.Before;
@@ -39,8 +40,8 @@ public class TestQBJoinTreeApplyPredicate {
   @BeforeClass
   public static void initialize() {
     queryState =
-        new QueryState.Builder().withHiveConf(new HiveConf(SemanticAnalyzer.class)).build();
-    conf = queryState.getConf();
+        new QueryState.Builder().build();
+    conf = new HiveConfForTest(TestQBJoinTreeApplyPredicate.class);
     SessionState.start(conf);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQBSubQuery.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQBSubQuery.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.Assert;
@@ -49,8 +50,8 @@ public class TestQBSubQuery {
   @BeforeClass
   public static void initialize() {
     queryState =
-        new QueryState.Builder().withHiveConf(new HiveConf(SemanticAnalyzer.class)).build();
-    conf = queryState.getConf();
+        new QueryState.Builder().build();
+    conf = new HiveConfForTest(TestQBSubQuery.class);
     SessionState.start(conf);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/plan/TestReadEntityDirect.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/plan/TestReadEntityDirect.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
@@ -174,7 +175,7 @@ public class TestReadEntityDirect {
    * Create driver with the test hook set in config
    */
   private static Driver createDriver() {
-    HiveConf conf = new HiveConf(Driver.class);
+    HiveConf conf = new HiveConfForTest(TestReadEntityDirect.class);
     conf
     .setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");

--- a/ql/src/test/org/apache/hadoop/hive/ql/plan/TestViewEntity.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/plan/TestViewEntity.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
@@ -57,7 +58,7 @@ public class TestViewEntity {
 
   @BeforeClass
   public static void onetimeSetup() throws Exception {
-    HiveConf conf = new HiveConf(Driver.class);
+    HiveConf conf = new HiveConfForTest(TestViewEntity.class);
     conf
     .setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");

--- a/ql/src/test/org/apache/hadoop/hive/ql/processors/TestSetProcessor.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/processors/TestSetProcessor.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.hadoop.hive.common.io.SessionStream;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.conf.SystemVariables;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.Assert;
@@ -49,7 +50,7 @@ public class TestSetProcessor {
     env.put(TEST_ENV_VAR_PASSWORD, TEST_ENV_VAR_PASSWORD_VALUE);
     setEnv(env);
     System.setProperty(TEST_SYSTEM_PROPERTY, TEST_SYSTEM_PROPERTY_VALUE);
-    HiveConf conf = new HiveConf();
+    HiveConf conf = new HiveConfForTest(TestSetProcessor.class);
     SessionState.start(conf);
     state = SessionState.get();
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHivePrivilegeObjectOwnerNameAndType.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHivePrivilegeObjectOwnerNameAndType.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.security.authorization.plugin;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.Driver;
@@ -68,7 +69,7 @@ public class TestHivePrivilegeObjectOwnerNameAndType {
   @BeforeClass
   public static void beforeTest() throws Exception {
     UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser("hive"));
-    conf = new HiveConf();
+    conf = new HiveConfForTest(TestHivePrivilegeObjectOwnerNameAndType.class);
 
     // Turn on mocked authorization
     conf.setVar(ConfVars.HIVE_AUTHORIZATION_MANAGER, MockedHiveAuthorizerFactory.class.getName());
@@ -79,6 +80,8 @@ public class TestHivePrivilegeObjectOwnerNameAndType {
     conf.setVar(ConfVars.HIVE_TXN_MANAGER, DbTxnManager.class.getName());
     conf.setVar(ConfVars.HIVE_MAPRED_MODE, "nonstrict");
     conf.setVar(ConfVars.DYNAMIC_PARTITIONING_MODE, "nonstrict");
+    // TODO: HIVE-28619: TestHivePrivilegeObjectOwnerNameAndType to run on Tez
+    conf.set("hive.execution.engine", "mr");
 
     TestTxnDbUtil.prepDb(conf);
     SessionState.start(conf);

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDTFGetSQLSchema.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDTFGetSQLSchema.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -39,9 +40,11 @@ public class TestGenericUDTFGetSQLSchema {
 
   private static SessionState sessionState;
 
+  public static HiveConf conf;
+
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    HiveConf conf = new HiveConf();
+    conf = new HiveConfForTest(TestGenericUDTFGetSQLSchema.class);
     conf.set("hive.security.authorization.manager",
         "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider");
     sessionState = SessionState.start(conf);
@@ -84,6 +87,9 @@ public class TestGenericUDTFGetSQLSchema {
 
   @Test
   public void testWithDDL() throws Exception {
+    // Set the execution engine to mr to avoid the NPE exception in stats flow
+    // TODO: HIVE-28618: TestGenericUDTFGetSQLSchema to run on Tez
+    conf.set("hive.execution.engine", "mr");
     invokeUDTFAndTest("show tables", new String[]{});
   }
 

--- a/service/src/test/org/apache/hive/service/server/TestHS2HttpServerLDAP.java
+++ b/service/src/test/org/apache/hive/service/server/TestHS2HttpServerLDAP.java
@@ -61,7 +61,7 @@ public class TestHS2HttpServerLDAP {
     HiveConf hiveConf = new HiveConf();
     hiveConf.setBoolVar(ConfVars.HIVE_IN_TEST, true);
     hiveConf.set(ConfVars.HIVE_SERVER2_WEBUI_PORT.varname, webUIPort.toString());
-    hiveConf.setBoolVar(ConfVars.HIVE_SERVER2_WEBUI_AUTH_METHOD, true);
+    hiveConf.set(ConfVars.HIVE_SERVER2_WEBUI_AUTH_METHOD.varname, "LDAP");
     hiveConf.set(ConfVars.METASTORE_PWD.varname, METASTORE_PASSWD);
     hiveConf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -57,7 +57,7 @@
     <ant.contrib.version>1.0b3</ant.contrib.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.5.1</maven.surefire.plugin.version>
     <!-- Dependency versions -->
     <antlr.version>4.9.3</antlr.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
@@ -85,8 +85,8 @@
     <jexl.version>3.3</jexl.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13.2</junit.version>
-    <junit.jupiter.version>5.6.2</junit.jupiter.version>
-    <junit.vintage.version>5.6.3</junit.vintage.version>
+    <junit.jupiter.version>5.11.2</junit.jupiter.version>
+    <junit.vintage.version>5.11.2</junit.vintage.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
     <log4j2.version>2.18.0</log4j2.version>
@@ -516,7 +516,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven.surefire.plugin.version}</version>
           <configuration>
-            <failIfNoTests>false</failIfNoTests>
+            <enableOutErrElements>false</enableOutErrElements>
+            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           </configuration>
         </plugin>
         <plugin>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -32,14 +32,14 @@
     <guava.version>22.0</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
     <junit.version>4.13.2</junit.version>
-    <junit.jupiter.version>5.6.3</junit.jupiter.version>
-    <junit.vintage.version>5.6.3</junit.vintage.version>
+    <junit.jupiter.version>5.11.2</junit.jupiter.version>
+    <junit.vintage.version>5.11.2</junit.vintage.version>
     <slf4j.version>1.7.30</slf4j.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.cyclonedx.plugin.version>2.7.10</maven.cyclonedx.plugin.version>
     <checkstyle.conf.dir>${basedir}/checkstyle/</checkstyle.conf.dir>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.5.1</maven.surefire.plugin.version>
     <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
   <dependencies>
@@ -201,7 +201,8 @@
         <configuration>
           <reuseForks>false</reuseForks>
           <argLine>-Xmx3g</argLine>
-          <failIfNoTests>false</failIfNoTests>
+          <enableOutErrElements>false</enableOutErrElements>
+          <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <systemPropertyVariables>
             <test.tmp.dir>${project.build.directory}/tmp</test.tmp.dir>
           </systemPropertyVariables>


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Upgraded Maven SureFire Plugin to latest version 3.5.1
- Upgraded junit-jupiter-engine and junit.vintage.version to latest versions
- Fixed multiple test case failures post upgrading Maven SureFire Plugin
   - Currently in master branch, all testcases are not running in the pipeline and getting unnoticed because of lower maven surefire plugin. Current report is mentioned below
      **Test Result - 0 failures , 2,364 skipped Passed- 49,317 tests**
   - Many test cases are failing in BeforeClass post [HIVE-27972](https://issues.apache.org/jira/browse/HIVE-27972) and are getting skipped, instead of failing because of lower Maven surefire plugin. Testcases failures are due to incorrect hive configuration settings when running with Tez.


### Why are the changes needed?

1. To ensure all test cases are executed correctly.
2. To leverage the latest features and improvements of the Maven SureFire Plugin.

### Does this PR introduce _any_ user-facing change?
No. This change only affects the build and test process of the project, with no direct impact on the end users.

### Is the change a dependency upgrade?
Yes. The Maven SureFire Plugin is being upgraded from its current version to 3.5.1.


### How was this patch tested?

1. Verified that all existing unit and integration tests pass successfully with the upgraded plugin.
2. Ensured the build process completes without errors using the new plugin version.
