### PR TITLE
HIVE-28609: HiveSequenceFileInputFormat should be cloned or not be cached

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.ValidReaderWriteIdList;
@@ -70,12 +68,10 @@ import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.InvalidInputException;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.JobConfigurable;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hive.common.util.AnnotationUtils;
-import org.apache.hive.common.util.ReflectionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -346,7 +342,7 @@ public class FetchOperator implements Serializable {
 
       Class<? extends InputFormat> formatter = currDesc.getInputFileFormatClass();
       Utilities.copyTableJobPropertiesToConf(currDesc.getTableDesc(), job);
-      InputFormat inputFormat = InputFormatCache.getInputFormatFromCache(formatter, job);
+      InputFormat inputFormat = InputFormatCache.getInputFormat(formatter, job);
 
       List<Path> dirs = new ArrayList<>(), dirsWithOriginals = new ArrayList<>();
       processCurrPathForMmWriteIds(inputFormat, dirs, dirsWithOriginals);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/InputFormatCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/InputFormatCache.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.JobConfigurable;
+import org.apache.hive.common.util.ReflectionUtil;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InputFormatCache {
+
+  /**
+   * Interface for InputFormat classes that want to introduce a special logic while retrieved from this cache.
+   * They can even return a new instance, apparently bypassing the cache, but still having the advantages of preventing
+   * to call the original, expensive reflection call for instantiation.
+   */
+  public interface CacheableInputFormat<K, V> extends InputFormat<K, V> {
+    default InputFormat<K, V> newInstance(InputFormat<K, V> cached){
+      return cached;
+    }
+  }
+
+  /**
+   * A cache of InputFormat instances.
+   */
+  private static final Map<String, InputFormat> inputFormats = new HashMap<String, InputFormat>();
+
+  public static InputFormat getInputFormatFromCache(
+      Class<? extends InputFormat> inputFormatClass, Configuration conf) throws IOException {
+    if (Configurable.class.isAssignableFrom(inputFormatClass) ||
+        JobConfigurable.class.isAssignableFrom(inputFormatClass)) {
+      return ReflectionUtil.newInstance(inputFormatClass, conf);
+    }
+    // TODO: why is this copy-pasted from HiveInputFormat?
+    InputFormat format = inputFormats.get(inputFormatClass.getName());
+
+    if (format == null) {
+      try {
+        format = ReflectionUtil.newInstance(inputFormatClass, conf);
+        // HBase input formats are not thread safe today. See HIVE-8808.
+        String inputFormatName = inputFormatClass.getName().toLowerCase();
+        if (!inputFormatName.contains("hbase")) {
+          inputFormats.put(inputFormatClass.getName(), format);
+        }
+      } catch (Exception e) {
+        throw new IOException("Cannot create an instance of InputFormat class: " + inputFormatClass.getName(), e);
+      }
+    }
+    if (CacheableInputFormat.class.isAssignableFrom(inputFormatClass)) {
+      format = ((CacheableInputFormat)format).newInstance(format);
+    }
+    return format;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveSequenceFileInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveSequenceFileInputFormat.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.io;
 import java.io.IOException;
 import java.util.Set;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hive.ql.exec.InputFormatCache;
 import org.apache.hadoop.hive.serde2.columnar.BytesRefArrayWritable;
@@ -67,6 +66,6 @@ public class HiveSequenceFileInputFormat<K extends LongWritable, V extends Bytes
 
   @Override
   public InputFormat<K, V> newInstance(InputFormat<K, V> cached){
-    return new HiveSequenceFileInputFormat();
+    return new HiveSequenceFileInputFormat<K, V>();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -1293,7 +1293,7 @@ public class Vectorizer implements PhysicalPlanResolver {
         TableDesc properties) {
 
       try {
-        InputFormat inputFormat = FetchOperator.getInputFormatFromCache(inputFileFormatClass, hiveConf);
+        InputFormat inputFormat = InputFormatCache.getInputFormat(inputFileFormatClass, hiveConf);
         if (inputFormat instanceof VectorizedInputFormatInterface) {
           return ((VectorizedInputFormatInterface) inputFormat).getSupportedFeatures(hiveConf, properties);
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce an InputFormatCache in hive and handle the caching behavior of the input formats.

### Why are the changes needed?
The code became cleaner and simpler by removing a ThreadLocal from a specific input format (HiveSequenceFileInputFormat) and separating the caching logic.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Precommit testing.
