### PR TITLE
Revert "HIVE-28417: Bump Log4j2 to 2.24.1 to facilitate compilation of GraalVM Native Image"

### DIFF
--- a/data/conf/hive-log4j2.properties
+++ b/data/conf/hive-log4j2.properties
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+status = INFO
 name = HiveLog4j2Test
+packages = org.apache.hadoop.hive.ql.log
 
 # list of properties
 property.hive.log.level = DEBUG
@@ -22,6 +24,9 @@ property.hive.root.logger = DRFA
 property.hive.log.dir = ${sys:test.tmp.dir}/log
 property.hive.log.file = hive.log
 property.hive.test.console.log.level = INFO
+
+# list of all appenders
+appenders = console, DRFA
 
 # console appender
 appender.console.type = Console
@@ -43,6 +48,9 @@ appender.DRFA.policies.time.interval = 1
 appender.DRFA.policies.time.modulate = true
 appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
+
+# list of all loggers
+loggers = HadoopIPC, HadoopSecurity, Hdfs, HdfsServer, HadoopMetrics2, Mortbay, Yarn, YarnServer, Tez, HadoopConf, Zookeeper, ServerCnxn, NIOServerCnxn, ClientCnxn, ClientCnxnSocket, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, Operator, Serde2Lazy, ObjectStore, CalcitePlanner, AmazonAws, ApacheHttp, Thrift, Jetty, BlockStateChange, swo, CBORuleLogger
 
 logger.HadoopIPC.name = org.apache.hadoop.ipc
 logger.HadoopIPC.level = WARN
@@ -120,7 +128,7 @@ logger.CBORuleLogger.filter.marker.type = MarkerFilter
 logger.CBORuleLogger.filter.marker.marker = FULL_PLAN
 # Change filter to ACCEPT, to see the produced plan after every rule invocation using the EXPLAIN CBO format
 logger.CBORuleLogger.filter.marker.onMatch = DENY
-logger.CBORuleLogger.filter.marker.onMismatch = NEUTRAL
+logger.CBORuleLogger.filter.marker.onMisMatch = NEUTRAL
 
 logger.AmazonAws.name=com.amazonaws
 logger.AmazonAws.level = INFO

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -367,8 +367,9 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core-test</artifactId>
+      <artifactId>log4j-core</artifactId>
       <version>${log4j2.version}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryTracker.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryTracker.java
@@ -48,9 +48,8 @@ import org.apache.tez.common.security.JobTokenIdentifier;
 import org.apache.tez.common.security.TokenCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.slf4j.Marker;
-import org.slf4j.impl.StaticMarkerBinder;
+import org.slf4j.MDC;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -71,7 +70,7 @@ public class QueryTracker extends AbstractService {
 
   private static final Logger LOG = LoggerFactory.getLogger(QueryTracker.class);
   private static final Marker QUERY_COMPLETE_MARKER =
-      new Log4jMarker(StaticMarkerBinder.getSingleton().getMarkerFactory(), new Log4jQueryCompleteMarker());
+      new Log4jMarker(new Log4jQueryCompleteMarker());
 
   /// Shared singleton MetricsSource instance for all DAG locks
   private static final MetricsSource LOCK_METRICS;

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestLlapDaemonLogging.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestLlapDaemonLogging.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hive.testutils.junit.extensions.DoNothingTCPServer;
 import org.apache.hive.testutils.junit.extensions.DoNothingTCPServerExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.junit.LoggerContextSource;
 import org.apache.tez.common.security.TokenCache;
 
 import org.junit.jupiter.api.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.24.1</log4j2.version>
+    <log4j2.version>2.18.0</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.31</mysql.version>
@@ -1797,6 +1797,7 @@
             <log4j.configurationFile>${test.log4j.scheme}${test.conf.dir}/hive-log4j2.properties</log4j.configurationFile>
             <hive.test.console.log.level>${test.console.log.level}</hive.test.console.log.level>
             <hive.cluster.id>hive-test-cluster-id-cli</hive.cluster.id>
+            <log4j.debug>true</log4j.debug>
             <!-- don't dirty up /tmp -->
             <java.io.tmpdir>${test.tmp.dir}</java.io.tmpdir>
             <!-- Hadoop's minidfs class uses this -->

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -418,13 +418,9 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core-test</artifactId>
+      <artifactId>log4j-core</artifactId>
       <version>${log4j2.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.test.appender.ListAppender;
 import org.apache.thrift.TException;
 import org.hamcrest.core.IsNot;
 import org.junit.After;

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -89,7 +89,7 @@
     <junit.vintage.version>5.6.3</junit.vintage.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.24.1</log4j2.version>
+    <log4j2.version>2.18.0</log4j2.version>
     <mockito-core.version>3.4.4</mockito-core.version>
     <orc.version>1.9.4</orc.version>
     <protobuf.version>3.25.5</protobuf.version>


### PR DESCRIPTION
Reverts apache/hive#5375

Try to resolve [HIVE-28611](https://issues.apache.org/jira/browse/HIVE-28611)