### PR TITLE
HIVE-28613: OTEL: Collect & expose JVM metrics for LLAP daemons.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -330,6 +330,12 @@
       <groupId>javolution</groupId>
       <artifactId>javolution</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>${otel.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/common/src/java/org/apache/hadoop/hive/common/OTELJavaMetrics.java
+++ b/common/src/java/org/apache/hadoop/hive/common/OTELJavaMetrics.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.common;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.ThreadMXBean;
+
+import com.sun.management.UnixOperatingSystemMXBean;
+import io.opentelemetry.api.metrics.DoubleGauge;
+import io.opentelemetry.api.metrics.Meter;
+
+public class OTELJavaMetrics {
+
+  // The MXBean used to fetch values
+  private final MemoryMXBean memoryMXBean;
+  private final ThreadMXBean threadMXBean;
+  private final OperatingSystemMXBean osMXBean;
+
+  // Memory Level Gauge
+  private final DoubleGauge memNonHeapUsedMGauge;
+  private final DoubleGauge memNonHeapMaxM;
+  private final DoubleGauge memHeapUsedM;
+  private final DoubleGauge memHeapCommittedM;
+  private final DoubleGauge memHeapMaxM;
+  private final DoubleGauge memMaxM;
+  private final DoubleGauge memNonHeapCommittedM;
+
+  // Thread Level Gauge
+  private final DoubleGauge threadsNew;
+  private final DoubleGauge threadsRunnable;
+  private final DoubleGauge threadsBlocked;
+  private final DoubleGauge threadsWaiting;
+  private final DoubleGauge threadsTimedWaiting;
+  private final DoubleGauge threadsTerminated;
+
+  // OS Level Gauge
+  private final DoubleGauge systemLoadAverage;
+  private final DoubleGauge systemCpuLoad;
+  private final DoubleGauge committedVirtualMemorySize;
+  private final DoubleGauge processCpuTime;
+  private final DoubleGauge freePhysicalMemorySize;
+  private final DoubleGauge freeSwapSpaceSize;
+  private final DoubleGauge totalPhysicalMemorySize;
+  private final DoubleGauge processCpuLoad;
+
+  // 1 MB Constant
+  static final float M = 1024 * 1024;
+
+  public OTELJavaMetrics(Meter meter) {
+    memoryMXBean = ManagementFactory.getMemoryMXBean();
+    threadMXBean = ManagementFactory.getThreadMXBean();
+    osMXBean = ManagementFactory.getOperatingSystemMXBean();
+    memNonHeapUsedMGauge = meter.gaugeBuilder(JvmMetricsInfo.MemNonHeapUsedM.name()).build();
+    memNonHeapCommittedM = meter.gaugeBuilder(JvmMetricsInfo.MemNonHeapCommittedM.name()).build();
+    memNonHeapMaxM = meter.gaugeBuilder(JvmMetricsInfo.MemNonHeapMaxM.name()).build();
+    memHeapUsedM = meter.gaugeBuilder(JvmMetricsInfo.MemHeapUsedM.name()).build();
+    memHeapCommittedM = meter.gaugeBuilder(JvmMetricsInfo.MemHeapCommittedM.name()).build();
+    memHeapMaxM = meter.gaugeBuilder(JvmMetricsInfo.MemHeapMaxM.name()).build();
+    memMaxM = meter.gaugeBuilder(JvmMetricsInfo.MemMaxM.name()).build();
+
+    // Thread Level Counters
+    threadsNew = meter.gaugeBuilder(JvmMetricsInfo.ThreadsNew.name()).build();
+    threadsRunnable = meter.gaugeBuilder(JvmMetricsInfo.ThreadsRunnable.name()).build();
+    threadsBlocked = meter.gaugeBuilder(JvmMetricsInfo.ThreadsBlocked.name()).build();
+    threadsWaiting = meter.gaugeBuilder(JvmMetricsInfo.ThreadsWaiting.name()).build();
+    threadsTimedWaiting = meter.gaugeBuilder(JvmMetricsInfo.ThreadsTimedWaiting.name()).build();
+    threadsTerminated = meter.gaugeBuilder(JvmMetricsInfo.ThreadsTerminated.name()).build();
+
+    // Os Level Counters
+    systemLoadAverage = meter.gaugeBuilder("SystemLoadAverage").build();
+    systemCpuLoad = meter.gaugeBuilder("SystemCpuLoad").build();
+    committedVirtualMemorySize = meter.gaugeBuilder("CommittedVirtualMemorySize").build();
+
+    processCpuTime = meter.gaugeBuilder("ProcessCpuTime").build();
+    freePhysicalMemorySize = meter.gaugeBuilder("FreePhysicalMemorySize").build();
+
+    freeSwapSpaceSize = meter.gaugeBuilder("FreeSwapSpaceSize").build();
+    totalPhysicalMemorySize = meter.gaugeBuilder("TotalPhysicalMemorySize").build();
+    processCpuLoad = meter.gaugeBuilder("ProcessCpuLoad").build();
+  }
+
+  public void setJvmMetrics() {
+    setMemoryValuesValues();
+    setThreadCountValues();
+    setOsLevelValues();
+  }
+
+  private void setMemoryValuesValues() {
+    MemoryUsage memNonHeap = memoryMXBean.getNonHeapMemoryUsage();
+    MemoryUsage memHeap = memoryMXBean.getHeapMemoryUsage();
+    Runtime runtime = Runtime.getRuntime();
+    memNonHeapUsedMGauge.set(memNonHeap.getUsed() / M);
+    memNonHeapCommittedM.set(memNonHeap.getCommitted() / M);
+    memNonHeapMaxM.set(memNonHeap.getMax() / M);
+    memHeapUsedM.set(memHeap.getUsed() / M);
+    memHeapCommittedM.set(memHeap.getCommitted() / M);
+    memHeapMaxM.set(memHeap.getMax() / M);
+    memMaxM.set(runtime.maxMemory() / M);
+  }
+
+  private void setThreadCountValues() {
+    JvmMetrics.ThreadCountResult threadCountResult = JvmMetrics.getThreadCountResult(threadMXBean);
+    threadsNew.set(threadCountResult.threadsNew);
+    threadsRunnable.set(threadCountResult.threadsRunnable);
+    threadsBlocked.set(threadCountResult.threadsBlocked);
+    threadsWaiting.set(threadCountResult.threadsWaiting);
+    threadsTimedWaiting.set(threadCountResult.threadsTimedWaiting);
+    threadsTerminated.set(threadCountResult.threadsTerminated);
+  }
+
+  private void setOsLevelValues() {
+    systemLoadAverage.set(osMXBean.getSystemLoadAverage());
+    if (osMXBean instanceof UnixOperatingSystemMXBean) {
+      UnixOperatingSystemMXBean unixMxBean = (UnixOperatingSystemMXBean) osMXBean;
+      systemCpuLoad.set(unixMxBean.getSystemCpuLoad());
+      committedVirtualMemorySize.set(unixMxBean.getCommittedVirtualMemorySize());
+      processCpuTime.set(unixMxBean.getProcessCpuTime());
+      freePhysicalMemorySize.set(unixMxBean.getFreePhysicalMemorySize());
+      freeSwapSpaceSize.set(unixMxBean.getFreeSwapSpaceSize());
+      totalPhysicalMemorySize.set(unixMxBean.getTotalPhysicalMemorySize());
+      processCpuLoad.set(unixMxBean.getProcessCpuLoad());
+    }
+  }
+}

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -459,6 +459,17 @@
       <artifactId>hbase-hadoop-compat</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+      <version>${otel.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <version>${otel.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>${basedir}/src/java</sourceDirectory>

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.hive.llap.daemon.rpc.LlapDaemonProtocolProtos.SetCapaci
 import org.apache.hadoop.hive.llap.daemon.rpc.LlapDaemonProtocolProtos.SetCapacityResponseProto;
 import org.apache.hadoop.hive.llap.daemon.services.impl.LlapWebServices;
 import org.apache.hadoop.hive.llap.io.api.LlapProxy;
+import org.apache.hadoop.hive.llap.metrics.LLAPOTELExporter;
 import org.apache.hadoop.hive.llap.metrics.LlapDaemonExecutorMetrics;
 import org.apache.hadoop.hive.llap.metrics.LlapDaemonJvmMetrics;
 import org.apache.hadoop.hive.llap.metrics.LlapMetricsSystem;
@@ -89,6 +90,9 @@ import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hive.common.util.HiveVersionInfo;
 import org.apache.hive.common.util.ShutdownHookManager;
 import org.apache.logging.log4j.core.config.Configurator;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,6 +128,7 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
   private final DaemonId daemonId;
   private final SocketFactory socketFactory;
   private final LlapTokenManager llapTokenManager;
+  private LLAPOTELExporter otelExporter = null;
 
   // TODO Not the best way to share the address
   private final AtomicReference<InetSocketAddress> srvAddress = new AtomicReference<>(),
@@ -515,6 +520,17 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
         "LlapDaemon serviceStart complete. RPC Port={}, ManagementPort={}, ShuflePort={}, WebPort={}",
         server.getBindAddress().getPort(), server.getManagementBindAddress().getPort(),
         ShuffleHandler.get().getPort(), (webServices == null ? "" : webServices.getPort()));
+
+    long otelExporterFrequency =
+        HiveConf.getTimeVar(getConfig(), ConfVars.HIVE_OTEL_METRICS_FREQUENCY_SECONDS, TimeUnit.MILLISECONDS);
+    if (otelExporterFrequency > 0) {
+      this.otelExporter = new LLAPOTELExporter(GlobalOpenTelemetry.get(), otelExporterFrequency,
+          server.getBindAddress().toString());
+      otelExporter.setName("LLAP OTEL Exporter");
+      otelExporter.setDaemon(true);
+      otelExporter.start();
+      LOG.info("Started OTEL exporter with frequency {}", otelExporterFrequency);
+    }
   }
 
   public void serviceStop() throws Exception {
@@ -554,6 +570,10 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
 
     if (fnLocalizer != null) {
       fnLocalizer.close();
+    }
+
+    if (otelExporter != null) {
+      otelExporter.interrupt();
     }
   }
 

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LLAPOTELExporter.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LLAPOTELExporter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.llap.metrics;
+
+import io.opentelemetry.api.OpenTelemetry;
+
+import org.apache.hadoop.hive.common.OTELJavaMetrics;
+
+public class LLAPOTELExporter extends Thread {
+
+  private static final String JVM_SCOPE = OTELJavaMetrics.class.getName();
+  private final OTELJavaMetrics jvmMetrics;
+  private final long frequency;
+
+  public LLAPOTELExporter(OpenTelemetry openTelemetry, long frequency, String addr) {
+    this.jvmMetrics = new OTELJavaMetrics(openTelemetry.getMeter(JVM_SCOPE + ":" + addr));
+    this.frequency = frequency;
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      jvmMetrics.setJvmMetrics();
+      try {
+        Thread.sleep(frequency);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -136,6 +136,8 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooDefs.Perms;
 import org.apache.zookeeper.data.ACL;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 
@@ -513,8 +515,8 @@ public class HiveServer2 extends CompositeService {
     long otelExporterFrequency =
         hiveConf.getTimeVar(ConfVars.HIVE_OTEL_METRICS_FREQUENCY_SECONDS, TimeUnit.MILLISECONDS);
     if (otelExporterFrequency > 0) {
-      otelExporter = new OTELExporter(AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk(),
-          cliService.getSessionManager(), otelExporterFrequency);
+      otelExporter = new OTELExporter(GlobalOpenTelemetry.get(), cliService.getSessionManager(),
+          otelExporterFrequency, getServerHost());
 
       otelExporter.setName("OTEL Exporter");
       otelExporter.setDaemon(true);

--- a/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
+++ b/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
@@ -18,11 +18,6 @@
 
 package org.apache.hive.service.servlet;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
-import java.lang.management.MemoryUsage;
-import java.lang.management.OperatingSystemMXBean;
-import java.lang.management.ThreadMXBean;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,11 +25,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import com.sun.management.UnixOperatingSystemMXBean;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.metrics.DoubleGauge;
-import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
@@ -42,8 +34,7 @@ import io.opentelemetry.sdk.internal.AttributesMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.hive.common.JvmMetrics;
-import org.apache.hadoop.hive.common.JvmMetricsInfo;
+import org.apache.hadoop.hive.common.OTELJavaMetrics;
 import org.apache.hadoop.hive.ql.QueryDisplay;
 import org.apache.hadoop.hive.ql.QueryInfo;
 import org.apache.hive.service.cli.operation.OperationManager;
@@ -51,7 +42,7 @@ import org.apache.hive.service.cli.session.SessionManager;
 
 public class OTELExporter extends Thread {
   private static final String QUERY_SCOPE = OTELExporter.class.getName();
-  private static final String JVM_SCOPE = JVMMetrics.class.getName();
+  private static final String JVM_SCOPE = OTELJavaMetrics.class.getName();
   private static final Logger LOG = LoggerFactory.getLogger(OTELExporter.class);
   private final OperationManager operationManager;
   private final Set<String> historicalQueryId;
@@ -59,12 +50,11 @@ public class OTELExporter extends Thread {
   private final Tracer tracer;
   private final Map<String, Span> queryIdToSpanMap;
   private final Map<String, Set<String>> queryIdToTasksMap;
-  private final JVMMetrics jvmMetrics;
+  private final OTELJavaMetrics jvmMetrics;
 
-
-  public OTELExporter(OpenTelemetry openTelemetry, SessionManager sessionManager, long frequency) {
-    this.tracer = openTelemetry.getTracer(QUERY_SCOPE);
-    this.jvmMetrics = new JVMMetrics(openTelemetry.getMeter(JVM_SCOPE));
+  public OTELExporter(OpenTelemetry openTelemetry, SessionManager sessionManager, long frequency, String addr) {
+    this.tracer = openTelemetry.getTracer(QUERY_SCOPE + ":" + addr);
+    this.jvmMetrics = new OTELJavaMetrics(openTelemetry.getMeter(JVM_SCOPE + ":" + addr));
     this.operationManager = sessionManager.getOperationManager();
     this.historicalQueryId = new HashSet<>();
     this.frequency = frequency;
@@ -235,119 +225,5 @@ public class OTELExporter extends Thread {
     attributes.put(AttributeKey.longKey("ElapsedTime"), taskDisplay.getElapsedTime());
     attributes.put(AttributeKey.longKey("EndTime"), taskDisplay.getEndTime());
     return attributes;
-  }
-
-  static class JVMMetrics {
-
-    // The MXBean used to fetch values
-    private final MemoryMXBean memoryMXBean;
-    private final ThreadMXBean threadMXBean;
-    private final OperatingSystemMXBean osMXBean;
-
-    // Memory Level Gauge
-    private final DoubleGauge memNonHeapUsedMGauge;
-    private final DoubleGauge memNonHeapMaxM;
-    private final DoubleGauge memHeapUsedM;
-    private final DoubleGauge memHeapCommittedM;
-    private final DoubleGauge memHeapMaxM;
-    private final DoubleGauge memMaxM;
-    private final DoubleGauge memNonHeapCommittedM;
-
-    // Thread Level Gauge
-    private final DoubleGauge threadsNew;
-    private final DoubleGauge threadsRunnable;
-    private final DoubleGauge threadsBlocked;
-    private final DoubleGauge threadsWaiting;
-    private final DoubleGauge threadsTimedWaiting;
-    private final DoubleGauge threadsTerminated;
-
-    // OS Level Gauge
-    private final DoubleGauge systemLoadAverage;
-    private final DoubleGauge systemCpuLoad;
-    private final DoubleGauge committedVirtualMemorySize;
-    private final DoubleGauge processCpuTime;
-    private final DoubleGauge freePhysicalMemorySize;
-    private final DoubleGauge freeSwapSpaceSize;
-    private final DoubleGauge totalPhysicalMemorySize;
-    private final DoubleGauge processCpuLoad;
-
-    // 1 MB Constant
-    static final float M = 1024 * 1024;
-
-    public JVMMetrics(Meter meter) {
-      memoryMXBean = ManagementFactory.getMemoryMXBean();
-      threadMXBean = ManagementFactory.getThreadMXBean();
-      osMXBean = ManagementFactory.getOperatingSystemMXBean();
-      memNonHeapUsedMGauge = meter.gaugeBuilder(JvmMetricsInfo.MemNonHeapUsedM.name()).build();
-      memNonHeapCommittedM = meter.gaugeBuilder(JvmMetricsInfo.MemNonHeapCommittedM.name()).build();
-      memNonHeapMaxM = meter.gaugeBuilder(JvmMetricsInfo.MemNonHeapMaxM.name()).build();
-      memHeapUsedM = meter.gaugeBuilder(JvmMetricsInfo.MemHeapUsedM.name()).build();
-      memHeapCommittedM = meter.gaugeBuilder(JvmMetricsInfo.MemHeapCommittedM.name()).build();
-      memHeapMaxM = meter.gaugeBuilder(JvmMetricsInfo.MemHeapMaxM.name()).build();
-      memMaxM = meter.gaugeBuilder(JvmMetricsInfo.MemMaxM.name()).build();
-
-      // Thread Level Counters
-      threadsNew = meter.gaugeBuilder(JvmMetricsInfo.ThreadsNew.name()).build();
-      threadsRunnable = meter.gaugeBuilder(JvmMetricsInfo.ThreadsRunnable.name()).build();
-      threadsBlocked = meter.gaugeBuilder(JvmMetricsInfo.ThreadsBlocked.name()).build();
-      threadsWaiting = meter.gaugeBuilder(JvmMetricsInfo.ThreadsWaiting.name()).build();
-      threadsTimedWaiting = meter.gaugeBuilder(JvmMetricsInfo.ThreadsTimedWaiting.name()).build();
-      threadsTerminated = meter.gaugeBuilder(JvmMetricsInfo.ThreadsTerminated.name()).build();
-
-      // Os Level Counters
-      systemLoadAverage = meter.gaugeBuilder("SystemLoadAverage").build();
-      systemCpuLoad = meter.gaugeBuilder("SystemCpuLoad").build();
-      committedVirtualMemorySize = meter.gaugeBuilder("CommittedVirtualMemorySize").build();
-
-      processCpuTime = meter.gaugeBuilder("ProcessCpuTime").build();
-      freePhysicalMemorySize = meter.gaugeBuilder("FreePhysicalMemorySize").build();
-
-      freeSwapSpaceSize = meter.gaugeBuilder("FreeSwapSpaceSize").build();
-      totalPhysicalMemorySize = meter.gaugeBuilder("TotalPhysicalMemorySize").build();
-      processCpuLoad = meter.gaugeBuilder("ProcessCpuLoad").build();
-    }
-
-    public void setJvmMetrics() {
-      setMemoryValuesValues();
-      setThreadCountValues();
-      setOsLevelValues();
-    }
-
-    private void setMemoryValuesValues() {
-      MemoryUsage memNonHeap = memoryMXBean.getNonHeapMemoryUsage();
-      MemoryUsage memHeap = memoryMXBean.getHeapMemoryUsage();
-      Runtime runtime = Runtime.getRuntime();
-      memNonHeapUsedMGauge.set(memNonHeap.getUsed() / M);
-      memNonHeapCommittedM.set(memNonHeap.getCommitted() / M);
-      memNonHeapMaxM.set(memNonHeap.getMax() / M);
-      memHeapUsedM.set(memHeap.getUsed() / M);
-      memHeapCommittedM.set(memHeap.getCommitted() / M);
-      memHeapMaxM.set(memHeap.getMax() / M);
-      memMaxM.set(runtime.maxMemory() / M);
-    }
-
-    private void setThreadCountValues() {
-      JvmMetrics.ThreadCountResult threadCountResult = JvmMetrics.getThreadCountResult(threadMXBean);
-      threadsNew.set(threadCountResult.threadsNew);
-      threadsRunnable.set(threadCountResult.threadsRunnable);
-      threadsBlocked.set(threadCountResult.threadsBlocked);
-      threadsWaiting.set(threadCountResult.threadsWaiting);
-      threadsTimedWaiting.set(threadCountResult.threadsTimedWaiting);
-      threadsTerminated.set(threadCountResult.threadsTerminated);
-    }
-
-    private void setOsLevelValues() {
-      systemLoadAverage.set(osMXBean.getSystemLoadAverage());
-      if (osMXBean instanceof UnixOperatingSystemMXBean) {
-        UnixOperatingSystemMXBean unixMxBean = (UnixOperatingSystemMXBean) osMXBean;
-        systemCpuLoad.set(unixMxBean.getSystemCpuLoad());
-        committedVirtualMemorySize.set(unixMxBean.getCommittedVirtualMemorySize());
-        processCpuTime.set(unixMxBean.getProcessCpuTime());
-        freePhysicalMemorySize.set(unixMxBean.getFreePhysicalMemorySize());
-        freeSwapSpaceSize.set(unixMxBean.getFreeSwapSpaceSize());
-        totalPhysicalMemorySize.set(unixMxBean.getTotalPhysicalMemorySize());
-        processCpuLoad.set(unixMxBean.getProcessCpuLoad());
-      }
-    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Collect & expose JVM related metrics for LLAP daemons

### Why are the changes needed?

Better usability for OTEL


### Does this PR introduce _any_ user-facing change?

OTEL collectors can fetch details from LLAP daemons

### Is the change a dependency upgrade?

No


### How was this patch tested?
Manual 
