### PR TITLE
HIVE-28616: OrcReader is not closed in OrcEncodedDataReader

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/LlapRecordReaderUtils.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/LlapRecordReaderUtils.java
@@ -404,6 +404,11 @@ public class LlapRecordReaderUtils {
     }
 
     @Override
+    public boolean isOpen() {
+      return isOpen;
+    }
+
+    @Override
     public boolean isTrackingDiskRanges() {
       return zcr != null;
     }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/LlapRecordReaderUtils.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/LlapRecordReaderUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.llap.io.encoded;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -394,13 +395,9 @@ public class LlapRecordReaderUtils {
       if (pool != null) {
         pool.clear();
       }
-      // close both zcr and file
-      try (HadoopShims.ZeroCopyReaderShim myZcr = zcr) {
-        if (file != null) {
-          file.close();
-          file = null;
-        }
-      }
+      IOUtils.close(zcr, file);
+      zcr = null;
+      file = null;
     }
 
     @Override

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/OrcEncodedDataReader.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/OrcEncodedDataReader.java
@@ -956,7 +956,6 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
   private class DataWrapperForOrc implements LlapDataReader, DataCache, BufferObjectFactory {
     /** A reference to parent DataReader not owned by this object. */
     private final LlapDataReader orcDataReaderRef;
-    private boolean isOpen;
 
     public DataWrapperForOrc() throws IOException {
       ensureRawDataReader(false);
@@ -1024,7 +1023,7 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
 
     @Override
     public boolean isOpen() {
-      return isOpen;
+      return orcDataReaderRef.isOpen();
     }
 
     @Override
@@ -1061,7 +1060,6 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
       long startTime = counters.startTimeCounter();
       orcDataReaderRef.open();
       counters.recordHdfsTime(startTime);
-      isOpen = true;
     }
 
     @Override

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/OrcEncodedDataReader.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/OrcEncodedDataReader.java
@@ -275,15 +275,20 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
 
   @Override
   protected Void callInternal() throws IOException, InterruptedException {
-    return ugi.doAs(new PrivilegedExceptionAction<Void>() {
-      @Override
-      public Void run() throws Exception {
-        try {
-          return performDataRead();
-        } finally {
-          cleanupReaders();
-        }
+    return ugi.doAs((PrivilegedExceptionAction<Void>) () -> {
+      long startTime = counters.startTimeCounter();
+      try {
+        performDataRead();
+        consumer.setDone();
+      } catch (Throwable t) {
+        consumer.setError(t);
+        trace.dumpLog(LOG);
+      } finally {
+        cleanupReaders();
+        recordReaderTime(startTime);
+        tracePool.offer(trace);
       }
+      return null;
     });
   }
 
@@ -298,31 +303,22 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
     };
   }
 
-  protected Void performDataRead() throws IOException, InterruptedException {
-    long startTime = counters.startTimeCounter();
+  protected void performDataRead() throws IOException, InterruptedException {
     LlapIoImpl.LOG.info("Processing data for file {}: {}", fileKey, split.getPath());
     if (processStop()) {
-      recordReaderTime(startTime);
-      return null;
+      return;
     }
     counters.setDesc(QueryFragmentCounters.Desc.TABLE, cacheTag.getTableName());
     counters.setDesc(QueryFragmentCounters.Desc.FILE, split.getPath()
         + (fileKey == null ? "" : " (" + fileKey + ")"));
-    try {
-      validateFileMetadata();
 
-      // 2. Determine which stripes to read based on the split.
-      determineStripesToRead();
-    } catch (Throwable t) {
-      handleReaderError(startTime, t);
-      return null;
-    }
+    validateFileMetadata();
+
+    // 2. Determine which stripes to read based on the split.
+    determineStripesToRead();
 
     if (stripeRgs.length == 0) {
-      consumer.setDone();
-      recordReaderTime(startTime);
-      tracePool.offer(trace);
-      return null; // No data to read.
+      return;
     }
     counters.setDesc(QueryFragmentCounters.Desc.STRIPES,
         stripeIxFrom + "," + stripeRgs.length);
@@ -330,51 +326,37 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
     // 3. Apply SARG if needed, and otherwise determine what RGs to read.
     int stride = fileMetadata.getRowIndexStride();
     ArrayList<OrcStripeMetadata> stripeMetadatas = null;
-    try {
-      if (sarg != null && stride != 0) {
-        // TODO: move this to a common method
-        // Note: this gets IDs by name, so we assume indices don't need to be adjusted for ACID.
-        int[] filterColumns = RecordReaderImpl.mapSargColumnsToOrcInternalColIdx(
-          sarg.getLeaves(), evolution);
-        // included will not be null, row options will fill the array with trues if null
-        sargColumns = new boolean[evolution.getFileSchema().getMaximumId() + 1];
-        for (int i : filterColumns) {
-          // filter columns may have -1 as index which could be partition column in SARG.
-          // TODO: should this then be >=?
-          if (i > 0) {
-            sargColumns[i] = true;
-          }
+    if (sarg != null && stride != 0) {
+      // TODO: move this to a common method
+      // Note: this gets IDs by name, so we assume indices don't need to be adjusted for ACID.
+      int[] filterColumns = RecordReaderImpl.mapSargColumnsToOrcInternalColIdx(
+        sarg.getLeaves(), evolution);
+      // included will not be null, row options will fill the array with trues if null
+      sargColumns = new boolean[evolution.getFileSchema().getMaximumId() + 1];
+      for (int i : filterColumns) {
+        // filter columns may have -1 as index which could be partition column in SARG.
+        // TODO: should this then be >=?
+        if (i > 0) {
+          sargColumns[i] = true;
         }
-
-        // If SARG is present, get relevant stripe metadata from cache or readers.
-        stripeMetadatas = readStripesMetadata(fileIncludes, sargColumns);
       }
 
-      // Now, apply SARG if any; w/o sarg, this will just initialize stripeRgs.
-      boolean hasData = determineRgsToRead(stride, stripeMetadatas);
-      if (!hasData) {
-        consumer.setDone();
-        recordReaderTime(startTime);
-        tracePool.offer(trace);
-        return null; // No data to read.
-      }
-    } catch (Throwable t) {
-      handleReaderError(startTime, t);
-      return null;
+      // If SARG is present, get relevant stripe metadata from cache or readers.
+      stripeMetadatas = readStripesMetadata(fileIncludes, sargColumns);
+    }
+
+    // Now, apply SARG if any; w/o sarg, this will just initialize stripeRgs.
+    boolean hasData = determineRgsToRead(stride, stripeMetadatas);
+    if (!hasData) {
+      return; // No data to read.
     }
 
     if (processStop()) {
-      recordReaderTime(startTime);
-      return null;
+      return;
     }
 
     // 4. Create encoded data reader.
-    try {
-      ensureDataReader();
-    } catch (Throwable t) {
-      handleReaderError(startTime, t);
-      return null;
-    }
+    ensureDataReader();
 
     // 6. Read data.
     // TODO: I/O threadpool could be here - one thread per stripe; for now, linear.
@@ -383,85 +365,55 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
     pathCache.touch(fileKey, split.getPath().toUri().toString());
     for (int stripeIxMod = 0; stripeIxMod < stripeRgs.length; ++stripeIxMod) {
       if (processStop()) {
-        recordReaderTime(startTime);
-        return null;
+        return;
       }
       int stripeIx = stripeIxFrom + stripeIxMod;
       boolean[] rgs = null;
       OrcStripeMetadata stripeMetadata = null;
       StripeInformation si;
-      try {
-        si = fileMetadata.getStripes().get(stripeIx);
-        LlapIoImpl.ORC_LOGGER.trace("Reading stripe {}: {}, {}", stripeIx, si.getOffset(),
-            si.getLength());
-        trace.logReadingStripe(stripeIx, si.getOffset(), si.getLength());
-        rgs = stripeRgs[stripeIxMod];
-        if (LlapIoImpl.ORC_LOGGER.isTraceEnabled()) {
-          LlapIoImpl.ORC_LOGGER.trace("stripeRgs[{}]: {}", stripeIxMod, Arrays.toString(rgs));
-        }
-        // We assume that NO_RGS value is only set from SARG filter and for all columns;
-        // intermediate changes for individual columns will unset values in the array.
-        // Skip this case for 0-column read. We could probably special-case it just like we do
-        // in EncodedReaderImpl, but for now it's not that important.
-        if (rgs == RecordReaderImpl.SargApplier.READ_NO_RGS) continue;
+      si = fileMetadata.getStripes().get(stripeIx);
+      LlapIoImpl.ORC_LOGGER.trace("Reading stripe {}: {}, {}", stripeIx, si.getOffset(),
+          si.getLength());
+      trace.logReadingStripe(stripeIx, si.getOffset(), si.getLength());
+      rgs = stripeRgs[stripeIxMod];
+      if (LlapIoImpl.ORC_LOGGER.isTraceEnabled()) {
+        LlapIoImpl.ORC_LOGGER.trace("stripeRgs[{}]: {}", stripeIxMod, Arrays.toString(rgs));
+      }
+      // We assume that NO_RGS value is only set from SARG filter and for all columns;
+      // intermediate changes for individual columns will unset values in the array.
+      // Skip this case for 0-column read. We could probably special-case it just like we do
+      // in EncodedReaderImpl, but for now it's not that important.
+      if (rgs == RecordReaderImpl.SargApplier.READ_NO_RGS) continue;
 
-        // 6.2. Ensure we have stripe metadata. We might have read it before for RG filtering.
-        if (stripeMetadatas != null) {
-          stripeMetadata = stripeMetadatas.get(stripeIxMod);
-        } else {
-          stripeKey.stripeIx = stripeIx;
-          OrcProto.StripeFooter footer = getStripeFooterFromCacheOrDisk(si, stripeKey);
-          stripeMetadata = createOrcStripeMetadataObject(
-              stripeIx, si, footer, fileIncludes, sargColumns);
-          ensureDataReader();
-          stripeReader.readIndexStreams(stripeMetadata.getIndex(),
-              si, footer.getStreamsList(), fileIncludes, sargColumns);
-          consumer.setStripeMetadata(stripeMetadata);
-        }
-      } catch (Throwable t) {
-        handleReaderError(startTime, t);
-        return null;
+      // 6.2. Ensure we have stripe metadata. We might have read it before for RG filtering.
+      if (stripeMetadatas != null) {
+        stripeMetadata = stripeMetadatas.get(stripeIxMod);
+      } else {
+        stripeKey.stripeIx = stripeIx;
+        OrcProto.StripeFooter footer = getStripeFooterFromCacheOrDisk(si, stripeKey);
+        stripeMetadata = createOrcStripeMetadataObject(
+            stripeIx, si, footer, fileIncludes, sargColumns);
+        ensureDataReader();
+        stripeReader.readIndexStreams(stripeMetadata.getIndex(),
+            si, footer.getStreamsList(), fileIncludes, sargColumns);
+        consumer.setStripeMetadata(stripeMetadata);
       }
       if (processStop()) {
-        recordReaderTime(startTime);
-        return null;
+        return;
       }
 
       // 5.2. Finally, hand off to the stripe reader to produce the data.
       //      This is a sync call that will feed data to the consumer.
-      try {
-        // TODO: readEncodedColumns is not supposed to throw; errors should be propagated thru
-        // consumer. It is potentially holding locked buffers, and must perform its own cleanup.
-        // Also, currently readEncodedColumns is not stoppable. The consumer will discard the
-        // data it receives for one stripe. We could probably interrupt it, if it checked that.
-        stripeReader.readEncodedColumns(stripeIx, si, stripeMetadata.getRowIndexes(),
-            stripeMetadata.getEncodings(), stripeMetadata.getStreams(), fileIncludes,
-            rgs, consumer);
-      } catch (Throwable t) {
-        handleReaderError(startTime, t);
-        return null;
-      }
+      // TODO: readEncodedColumns is not supposed to throw; errors should be propagated thru
+      // consumer. It is potentially holding locked buffers, and must perform its own cleanup.
+      // Also, currently readEncodedColumns is not stoppable. The consumer will discard the
+      // data it receives for one stripe. We could probably interrupt it, if it checked that.
+      stripeReader.readEncodedColumns(stripeIx, si, stripeMetadata.getRowIndexes(),
+          stripeMetadata.getEncodings(), stripeMetadata.getStreams(), fileIncludes,
+          rgs, consumer);
     }
 
-    // Done with all the things.
-    recordReaderTime(startTime);
-    consumer.setDone();
-
     LlapIoImpl.LOG.trace("done processing {}", split);
-    tracePool.offer(trace);
-    return null;
-  }
-
-  /*
-   * Basic error handling logic in case of any errors while performDataRead.
-   * Reader cleanup is not supposed to be done here as long as performDataRead is enclosed with a safe try-finally
-   * that takes care of the same.
-   */
-  private void handleReaderError(long startTime, Throwable t) throws InterruptedException {
-    recordReaderTime(startTime);
-    consumer.setError(t);
-    trace.dumpLog(LOG);
-    tracePool.offer(trace);
   }
 
   private void ensureDataReader() throws IOException {
@@ -499,8 +451,6 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
   private boolean processStop() {
     if (!isStopped.get()) return false;
     LOG.info("Encoded data reader is stopping");
-    tracePool.offer(trace);
-    cleanupReaders();
     return true;
   }
 
@@ -521,23 +471,12 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
    * Closes the stripe readers (on error).
    */
   private void cleanupReaders() {
-    if (stripeReader != null) {
-      try {
-        stripeReader.close();
-      } catch (IOException ex) {
-        // Ignore.
-      }
+    try {
+      IOUtils.close(stripeReader, rawDataReader, orcReader);
+    } catch (IOException e) {
+      LOG.warn("Error while closing readers: ", e);
     }
-    if (rawDataReader != null) {
-      try {
-        rawDataReader.close();
-        rawDataReader = null;
-      } catch (IOException ex) {
-        // Ignore.
-      }
-    }
-
-    IOUtils.closeQuietly(orcReader);
+    rawDataReader = null;
     orcReader = null;
   }
 
@@ -840,10 +779,10 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
     }
   }
 
-  private void ensureRawDataReader(boolean isOpen) throws IOException {
+  private void ensureRawDataReader(boolean shouldOpen) throws IOException {
     ensureOrcReader();
     if (rawDataReader != null) {
-      if (!rawDataReader.isOpen() && isOpen) {
+      if (shouldOpen && !rawDataReader.isOpen()) {
         long startTime = counters.startTimeCounter();
         rawDataReader.open();
         counters.incrWallClockCounter(LlapIOCounters.HDFS_TIME_NS, startTime);
@@ -865,7 +804,7 @@ public class OrcEncodedDataReader extends CallableWithNdc<Void>
         .withZeroCopy(useZeroCopy)
         .build());
 
-    if (isOpen) {
+    if (shouldOpen) {
       rawDataReader.open();
     }
     counters.incrWallClockCounter(LlapIOCounters.HDFS_TIME_NS, startTime);

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/cache/TestIncrementalObjectSizeEstimator.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/cache/TestIncrementalObjectSizeEstimator.java
@@ -158,6 +158,11 @@ public class TestIncrementalObjectSizeEstimator {
     }
 
     @Override
+    public boolean isOpen() {
+      return false;
+    }
+
+    @Override
     public CompressionCodec getCompressionCodec() {
       return null;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/EncodedReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/EncodedReader.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.io.orc.encoded;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,7 +28,7 @@ import org.apache.hadoop.hive.ql.io.orc.encoded.Reader.OrcEncodedColumnBatch;
 import org.apache.orc.OrcProto;
 import org.apache.orc.impl.OrcIndex;
 
-public interface EncodedReader {
+public interface EncodedReader extends Closeable {
 
   /**
    * Reads encoded data from ORC file.
@@ -45,11 +46,6 @@ public interface EncodedReader {
       OrcProto.RowIndex[] index, List<OrcProto.ColumnEncoding> encodings,
       List<OrcProto.Stream> streams, boolean[] physicalFileIncludes, boolean[] rgs,
       Consumer<OrcEncodedColumnBatch> consumer) throws IOException;
-
-  /**
-   * Closes the reader.
-   */
-  void close() throws IOException;
 
   /**
    * Controls the low-level debug tracing. (Hopefully) allows for optimization where tracing

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/LlapDataReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/LlapDataReader.java
@@ -84,6 +84,8 @@ public interface LlapDataReader extends AutoCloseable, Cloneable {
   @Override
   void close() throws IOException;
 
+  boolean isOpen();
+
   /**
    * Returns the compression codec used by this datareader.
    * We should consider removing this from the interface.

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/LlapDataReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/LlapDataReader.java
@@ -26,11 +26,12 @@ import org.apache.orc.StripeInformation;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.OrcIndex;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /** An abstract data reader that IO formats can use to read bytes from underlying storage. */
-public interface LlapDataReader extends AutoCloseable, Cloneable {
+public interface LlapDataReader extends Closeable, Cloneable {
 
   /** Opens the DataReader, making it ready to use. */
   void open() throws IOException;
@@ -81,9 +82,9 @@ public interface LlapDataReader extends AutoCloseable, Cloneable {
    */
   LlapDataReader clone();
 
-  @Override
-  void close() throws IOException;
-
+  /**
+   * @return true if the reader was opened.
+   */
   boolean isOpen();
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
OrcEncodedDataReader fully owns the OrcReader instance it creates, so it should be closed there too


### Why are the changes needed?
It causes connection leaks in case of FileSystems like S3 (where an HTTP connection pool is utilized)


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Tested on cluster.
