### PR TITLE
HIVE-28615: OTEL: Expose FS counters for queries

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -205,6 +205,7 @@ public class SQLOperation extends ExecuteStatementOperation {
       // case, when calling fetch queries since execute() has returned.
       // For now, we disable the test attempts.
       driver.compileAndRespond(statement);
+      queryInfo.setQueryPlan(driver.getPlan());
       if (queryState.getQueryTag() != null && queryState.getQueryId() != null) {
         parentSession.updateQueryTag(queryState.getQueryId(), queryState.getQueryTag());
       }

--- a/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
+++ b/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
@@ -204,6 +204,7 @@ public class OTELExporter extends Thread {
     attributes.put(AttributeKey.stringKey("UserName"), query.getUserName());
     attributes.put(AttributeKey.stringKey("State"), query.getState());
     attributes.put(AttributeKey.stringKey("SessionId"), query.getSessionId());
+    attributes.put(AttributeKey.stringKey("FileSystemCounters"), query.getFSCounters().toString());
     return attributes;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Expose FS counters information via OTEL at query level


### Why are the changes needed?
Better usability for OTEL


### Does this PR introduce _any_ user-facing change?
Yes, FS related information will be visible at OTEL recievers

### Is the change a dependency upgrade?
No


### How was this patch tested?
Manual testing
