### PR TITLE
HIVE-28601: Leverage configurable getPartitions API in HMS to decrease memory footprint in HS2

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/AbstractCreateViewAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/AbstractCreateViewAnalyzer.java
@@ -18,12 +18,16 @@
 
 package org.apache.hadoop.hive.ql.ddl.view.create;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
+import org.apache.hadoop.hive.metastore.api.GetProjectionsSpec;
+import org.apache.hadoop.hive.metastore.client.builder.GetPartitionProjectionsSpecBuilder;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
@@ -37,6 +41,7 @@ import org.apache.hadoop.hive.ql.parse.SemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.SemanticAnalyzerFactory;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.PlanUtils;
+import org.apache.thrift.TException;
 
 /**
  * Abstract ancestor of analyzers that can create a view.
@@ -112,9 +117,15 @@ public abstract class AbstractCreateViewAnalyzer extends BaseSemanticAnalyzer {
 
     String partitionViewErrorMsg = "The following view has partition, it could not be replaced: " + viewName;
     List<Partition> partitions = null;
+    GetProjectionsSpec getProjectionsSpec = new GetPartitionProjectionsSpecBuilder()
+            .addProjectFieldList(Arrays.asList("values")).build();
+
+    GetPartitionsRequest request = new GetPartitionsRequest(oldView.getDbName(), oldView.getTableName(),
+            getProjectionsSpec, null);
+    request.setCatName(oldView.getCatName());
     try {
-      partitions = db.getPartitions(oldView);
-    } catch (HiveException e) {
+      partitions = db.getPartitionsWithSpecs(oldView, request);
+    } catch (HiveException | TException e) {
       throw new SemanticException(ErrorMsg.REPLACE_VIEW_WITH_PARTITION.getMsg(partitionViewErrorMsg));
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplExternalTables.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplExternalTables.java
@@ -23,7 +23,10 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
+import org.apache.hadoop.hive.metastore.api.GetProjectionsSpec;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.client.builder.GetPartitionProjectionsSpecBuilder;
 import org.apache.hadoop.hive.metastore.utils.StringUtils;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.repl.util.FileList;
@@ -36,6 +39,7 @@ import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.repl.PathBuilder;
 import org.apache.hadoop.hive.ql.parse.repl.dump.Utils;
+import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +47,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,15 +102,20 @@ public class ReplExternalTables {
     }
     if (table.isPartitioned()) {
       List<Partition> partitions;
+      GetProjectionsSpec projectionSpec = new GetPartitionProjectionsSpecBuilder()
+              .addProjectFieldList(Arrays.asList("sd.location")).build();
+      GetPartitionsRequest request = new GetPartitionsRequest(table.getDbName(), table.getTableName(),
+              projectionSpec, null);
+      request.setCatName(table.getCatName());
       try {
-        partitions = Hive.get(hiveConf).getPartitions(table);
-      } catch (HiveException e) {
+        partitions = Hive.get(hiveConf).getPartitionsWithSpecs(table, request);
+      } catch (HiveException | TException e) {
         if (e.getCause() instanceof NoSuchObjectException) {
           // If table is dropped when dump in progress, just skip partitions data location dump
           LOG.debug(e.getMessage());
           return;
         }
-        throw e;
+        throw new HiveException(e);
       }
 
       for (Partition partition : partitions) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionIterable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionIterable.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.hive.ql.metadata;
 
+import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
+import org.apache.hadoop.hive.metastore.api.PartitionFilterMode;
+import org.apache.thrift.TException;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -99,12 +103,16 @@ public class PartitionIterable implements Iterable<Partition> {
           batchCounter++;
         }
         try {
-          if (isAuthRequired) {
-            batchIter = db.getPartitionsAuthByNames(table, nameBatch, userName, groupNames).iterator();
+          if (getPartitionsRequest == null) {
+            if (isAuthRequired) {
+              batchIter = db.getPartitionsAuthByNames(table, nameBatch, userName, groupNames).iterator();
+            } else {
+              batchIter = db.getPartitionsByNames(table, nameBatch, getColStats).iterator();
+            }
           } else {
-            batchIter = db.getPartitionsByNames(table, nameBatch, getColStats).iterator();
+            batchIter = db.getPartitionsWithSpecsByNames(table, nameBatch, getPartitionsRequest).iterator();
           }
-        } catch (HiveException e) {
+        } catch (HiveException | TException e) {
           throw new RuntimeException(e);
         }
       }
@@ -137,6 +145,7 @@ public class PartitionIterable implements Iterable<Partition> {
   private boolean isAuthRequired = false;
   private String userName;
   private List<String> groupNames;
+  private GetPartitionsRequest getPartitionsRequest;
 
   /**
    * Dummy constructor, which simply acts as an iterator on an already-present
@@ -171,6 +180,42 @@ public class PartitionIterable implements Iterable<Partition> {
   public PartitionIterable(Hive db, Table table, Map<String, String> partialPartitionSpec,
                            int batchSize, boolean getColStats) throws HiveException {
     this(db, table, partialPartitionSpec, batchSize, getColStats, false, null, null);
+  }
+
+  public PartitionIterable(Hive db, GetPartitionsRequest getPartitionsRequest, int batchSize)
+      throws HiveException {
+    if (batchSize < 1) {
+      throw new HiveException("Invalid batch size for partition iterable. Please use a batch size greater than 0");
+    }
+    this.currType = Type.LAZY_FETCH_PARTITIONS;
+    this.db = db;
+    this.table = db.getTable(getPartitionsRequest.getDbName(), getPartitionsRequest.getTblName());
+    this.batchSize = batchSize;
+    this.getPartitionsRequest = getPartitionsRequest;
+    List<String> pVals = null;
+    if (getPartitionsRequest.isSetFilterSpec()) {
+      pVals = this.getPartitionsRequest.getFilterSpec().getFilters();
+    }
+    if (pVals == null) {
+      partitionNames = db.getPartitionNames(
+          table.getDbName(),table.getTableName(), (short) -1);
+    } else {
+      PartitionFilterMode filterMode = getPartitionsRequest.getFilterSpec().getFilterMode();
+      switch (filterMode) {
+        case BY_NAMES:
+          partitionNames = pVals;
+          break;
+        case BY_VALUES:
+          partitionNames = db.getPartitionNamesByPartitionVals(
+                  table.getDbName(),table.getTableName(),pVals,(short)-1);
+          break;
+        case BY_EXPR:
+          // TO-DO: this can be dealt with in a seperate PR. The current changes does not have a particular use case for this.
+          throw new HiveException("getpartitionsbyexpr is currently unsupported for the getpartitionswithspecs API");
+        default:
+          throw new HiveException("No such partition filter mode: " + filterMode);
+      }
+    }
   }
 
   private PartitionIterable(Hive db, Table table, Map<String, String> partialPartitionSpec,

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
@@ -71,6 +71,8 @@ import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesRequest;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesResult;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsPsWithAuthRequest;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsPsWithAuthResponse;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsResponse;
 import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.GetTableResult;
 import org.apache.hadoop.hive.metastore.api.GetValidWriteIdsRequest;
@@ -1126,6 +1128,17 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
     TempTable tt = getPartitionedTempTable(table);
     List<Partition> parts = tt.listPartitionsByPartitionValsWithAuthInfo(partialPvals, userName, groupNames);
     return getPartitionsForMaxParts(tableName, parts, maxParts);
+  }
+
+  @Override
+  public GetPartitionsResponse getPartitionsWithSpecs(GetPartitionsRequest request)
+          throws TException {
+    org.apache.hadoop.hive.metastore.api.Table table = getTempTable(request.getDbName(), request.getTblName());
+    if (table == null) {
+      return super.getPartitionsWithSpecs(request);
+    }
+    TempTable tt = getPartitionedTempTable(table);
+    return tt.getPartitionsWithSpecs(request);
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/TempTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/TempTable.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hive.ql.metadata;
 
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsResponse;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -198,6 +200,10 @@ public final class TempTable {
 
   List<Partition> listPartitionsByFilter(String filter) throws MetaException {
     return pTree.getPartitionsByFilter(filter);
+  }
+
+  GetPartitionsResponse getPartitionsWithSpecs(GetPartitionsRequest getPartitionsRequest) throws MetaException {
+    return pTree.getPartitionsWithSpecs(getPartitionsRequest);
   }
 
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestGetPartitionsWithSpecsInBatches.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestGetPartitionsWithSpecsInBatches.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.*;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.PartitionIterable;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.*;
+
+public class TestGetPartitionsWithSpecsInBatches {
+  private final String catName = "hive";
+  private final String dbName = "default";
+  private final String tableName = "test_partition_batch";
+  private static HiveConf hiveConf;
+  private static HiveMetaStoreClient msc;
+  private static Hive hive;
+  private Table table;
+  private static final int NUM_PARTITIONS = 30;
+
+  @BeforeClass
+  public static void setupClass() throws HiveException {
+    hiveConf = new HiveConfForTest(TestGetPartitionsWithSpecsInBatches.class);
+    SessionState ss = SessionState.start(hiveConf);
+    hive = ss.getHiveDb();
+    try {
+      msc = new HiveMetaStoreClient(hiveConf);
+    } catch (MetaException e) {
+      throw new HiveException(e);
+    }
+  }
+
+  @Before
+  public void before() throws Exception {
+    PartitionUtil.createPartitionedTable(msc, catName, dbName, tableName);
+    table = msc.getTable(catName, dbName, tableName);
+    PartitionUtil.addPartitions(msc, dbName, tableName, table.getSd().getLocation(), hiveConf, NUM_PARTITIONS);
+  }
+
+  @After
+  public void after() {
+    PartitionUtil.cleanUpTableQuietly(msc, catName, dbName, tableName);
+  }
+
+  @Test
+  public void testNumberOfGetPartitionCalls() throws Exception {
+    HiveMetaStoreClient spyMSC = spy(msc);
+    hive.setMSC(spyMSC);
+    // test with a batch size of 10 and decaying factor of 2
+    hive.getAllPartitionsWithSpecsInBatches(hive.getTable(dbName, tableName),10, 2, 0, new GetPartitionsRequest(dbName, tableName, new GetProjectionsSpec(), new GetPartitionsFilterSpec()));
+    ArgumentCaptor<GetPartitionsRequest> req = ArgumentCaptor.forClass(GetPartitionsRequest.class);
+    // there should be 3 calls to get partitions
+    verify(spyMSC, times(3)).getPartitionsWithSpecs(req.capture());
+    Assert.assertEquals(10, req.getValue().getFilterSpec().getFiltersSize());
+  }
+
+  @Test
+  public void testUnevenNumberOfGetPartitionCalls() throws Exception {
+    HiveMetaStoreClient spyMSC = spy(msc);
+    hive.setMSC(spyMSC);
+
+    List<GetPartitionsRequest> capturedRequests = new ArrayList<>();
+    doAnswer((Answer<GetPartitionsResponse>) invocation -> {
+      GetPartitionsRequest request = invocation.getArgument(0);
+      capturedRequests.add(new GetPartitionsRequest(request));
+      return (GetPartitionsResponse) invocation.callRealMethod();
+    }).when(spyMSC).getPartitionsWithSpecs(any(GetPartitionsRequest.class));
+
+    // there should be 2 calls to get partitions with batch sizes of 19, 11
+    hive.getAllPartitionsWithSpecsInBatches(hive.getTable(dbName, tableName),19, 2, 0, new GetPartitionsRequest(dbName, tableName, new GetProjectionsSpec(), new GetPartitionsFilterSpec()));
+    ArgumentCaptor<GetPartitionsRequest> req = ArgumentCaptor.forClass(GetPartitionsRequest.class);
+    // there should be 2 calls to get partitions
+    verify(spyMSC, times(2)).getPartitionsWithSpecs(req.capture());
+    // confirm the batch sizes were 19, 11 in the two calls to get partitions
+    Assert.assertEquals(19, capturedRequests.get(0).getFilterSpec().getFiltersSize());
+    Assert.assertEquals(11, capturedRequests.get(1).getFilterSpec().getFiltersSize());
+  }
+
+  @Test
+  public void testSmallNumberOfPartitions() throws Exception {
+    HiveMetaStoreClient spyMSC = spy(msc);
+    hive.setMSC(spyMSC);
+    hive.getAllPartitionsWithSpecsInBatches(hive.getTable(dbName, tableName),100, 2, 0, new GetPartitionsRequest(dbName, tableName, new GetProjectionsSpec(), new GetPartitionsFilterSpec()));
+    ArgumentCaptor<GetPartitionsRequest> req = ArgumentCaptor.forClass(GetPartitionsRequest.class);
+    // there should be 1 call to get partitions
+    verify(spyMSC, times(1)).getPartitionsWithSpecs(req.capture());
+    Assert.assertEquals(30, req.getValue().getFilterSpec().getFiltersSize());
+  }
+
+  @Test
+  public void testRetriesExhaustedBatchSize() throws Exception {
+    HiveMetaStoreClient spyMSC = spy(msc);
+    hive.setMSC(spyMSC);
+
+    List<GetPartitionsRequest> capturedRequests = new ArrayList<>();
+    doAnswer((Answer<Void>) invocation -> {
+      GetPartitionsRequest request = invocation.getArgument(0);
+      capturedRequests.add(new GetPartitionsRequest(request));
+      throw new MetaException("MetaException to test retries");
+    }).when(spyMSC).getPartitionsWithSpecs(any(GetPartitionsRequest.class));
+
+    try {
+      hive.getAllPartitionsWithSpecsInBatches(hive.getTable(dbName, tableName), 30, 2, 0, new GetPartitionsRequest(dbName, tableName, new GetProjectionsSpec(), new GetPartitionsFilterSpec()));
+    } catch (Exception ignored) {}
+    ArgumentCaptor<GetPartitionsRequest> req = ArgumentCaptor.forClass(GetPartitionsRequest.class);
+    // there should be 5 call to get partitions with batch sizes as 30, 15, 7, 3, 1
+    verify(spyMSC, times(5)).getPartitionsWithSpecs(req.capture());
+
+    Assert.assertEquals(5, capturedRequests.size());
+
+    Assert.assertEquals(30, capturedRequests.get(0).getFilterSpec().getFiltersSize());
+    Assert.assertEquals(15, capturedRequests.get(1).getFilterSpec().getFiltersSize());
+    Assert.assertEquals(7, capturedRequests.get(2).getFilterSpec().getFiltersSize());
+    Assert.assertEquals(3, capturedRequests.get(3).getFilterSpec().getFiltersSize());
+    Assert.assertEquals(1, capturedRequests.get(4).getFilterSpec().getFiltersSize());
+  }
+
+  @Test
+  public void testMaxRetriesReached() throws Exception {
+    HiveMetaStoreClient spyMSC = spy(msc);
+    hive.setMSC(spyMSC);
+
+    List<GetPartitionsRequest> capturedRequests = new ArrayList<>();
+    doAnswer((Answer<Void>) invocation -> {
+      GetPartitionsRequest request = invocation.getArgument(0);
+      capturedRequests.add(new GetPartitionsRequest(request));
+      throw new MetaException("MetaException to test retries");
+    }).when(spyMSC).getPartitionsWithSpecs(any(GetPartitionsRequest.class));
+
+    try {
+      hive.getAllPartitionsWithSpecsInBatches(hive.getTable(dbName, tableName), 30, 2, 2, new GetPartitionsRequest(dbName, tableName, new GetProjectionsSpec(), new GetPartitionsFilterSpec()));
+    } catch (Exception ignored) {}
+    ArgumentCaptor<GetPartitionsRequest> req = ArgumentCaptor.forClass(GetPartitionsRequest.class);
+    // there should be 2 call to get partitions with batch sizes as 30, 15
+    verify(spyMSC, times(2)).getPartitionsWithSpecs(req.capture());
+
+    Assert.assertEquals(2, capturedRequests.size());
+
+    Assert.assertEquals(30, capturedRequests.get(0).getFilterSpec().getFiltersSize());
+    Assert.assertEquals(15, capturedRequests.get(1).getFilterSpec().getFiltersSize());
+  }
+
+  @Test
+  public void testBatchingWhenException() throws Exception {
+    HiveMetaStoreClient spyMSC = spy(msc);
+    hive.setMSC(spyMSC);
+
+    List<GetPartitionsRequest> capturedRequests = new ArrayList<>();
+    AtomicInteger invocationCount = new AtomicInteger();
+    // This will throw exception only the first time.
+    doAnswer((Answer<GetPartitionsResponse>) invocation -> {
+      invocationCount.getAndIncrement();
+      GetPartitionsRequest request = invocation.getArgument(0);
+      capturedRequests.add(new GetPartitionsRequest(request));
+
+      if (invocationCount.get() == 1) {
+        throw new MetaException();
+      } else {
+        return (GetPartitionsResponse) invocation.callRealMethod();
+      }
+    }).when(spyMSC).getPartitionsWithSpecs(any(GetPartitionsRequest.class));
+
+    hive.getAllPartitionsWithSpecsInBatches(hive.getTable(dbName, tableName), 30, 2, 5, new GetPartitionsRequest(dbName, tableName, new GetProjectionsSpec(), new GetPartitionsFilterSpec()));
+    ArgumentCaptor<GetPartitionsRequest> req = ArgumentCaptor.forClass(GetPartitionsRequest.class);
+    // The first call with batch size of 30 will fail, the rest two call will be of size 15 each. Total 3 calls
+    verify(spyMSC, times(3)).getPartitionsWithSpecs(req.capture());
+
+    Assert.assertEquals(3, capturedRequests.size());
+
+    Assert.assertEquals(30, capturedRequests.get(0).getFilterSpec().getFiltersSize());
+    Assert.assertEquals(15, capturedRequests.get(1).getFilterSpec().getFiltersSize());
+    Assert.assertEquals(15, capturedRequests.get(2).getFilterSpec().getFiltersSize());
+
+    Set<String> partNames = new HashSet<>(capturedRequests.get(1).getFilterSpec().getFilters());
+    partNames.addAll(capturedRequests.get(2).getFilterSpec().getFilters());
+    assert(partNames.size() == 30);
+
+    List<String> partitionNames = hive.getPartitionNames(table.getDbName(),table.getTableName(), (short) -1);
+    assert(partitionNames.size() == 30);
+    partitionNames.forEach(partNames::remove);
+    assert(partitionNames.size() == 30);
+    // In case any duplicate/incomplete list is given by hive.getAllPartitionsWithSpecsInBatches, the below assertion will fail
+    assert(partNames.size() == 0);
+  }
+
+  @Test
+  public void testBatchingWhenBatchSizeIsZero() throws MetaException {
+    HiveMetaStoreClient spyMSC = spy(msc);
+    hive.setMSC(spyMSC);
+    int batchSize = 0;
+    try {
+      org.apache.hadoop.hive.ql.metadata.Table t = hive.getTable(dbName, tableName);
+      new PartitionIterable(hive,
+          new GetPartitionsRequest(t.getDbName(), t.getTableName(), new GetProjectionsSpec(), new GetPartitionsFilterSpec())
+          ,batchSize);
+    } catch (HiveException e) {
+      Assert.assertTrue(e.getMessage().contains("Invalid batch size for partition iterable." +
+          " Please use a batch size greater than 0"));
+    }
+    try {
+      new org.apache.hadoop.hive.metastore.PartitionIterable(msc, table, batchSize).withProjectSpec(new GetPartitionsRequest(dbName, tableName, new GetProjectionsSpec(), new GetPartitionsFilterSpec()));
+    } catch (MetastoreException e) {
+      Assert.assertTrue(e.getMessage().contains("Invalid batch size for partition iterable." +
+          " Please use a batch size greater than 0"));
+    }
+  }
+}

--- a/ql/src/test/results/clientnegative/exchange_partition_neg_partition_missing.q.out
+++ b/ql/src/test/results/clientnegative/exchange_partition_neg_partition_missing.q.out
@@ -20,4 +20,4 @@ PREHOOK: Input: default@exchange_part_test1
 POSTHOOK: query: SHOW PARTITIONS exchange_part_test1
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@exchange_part_test1
-FAILED: SemanticException [Error 10006]: Partition not found {ds=2013-04-05}
+FAILED: SemanticException [Error 10006]: Partition not found GetPartitionsFilterSpec(filterMode:BY_VALUES, filters:[2013-04-05]) for the following partition keys: [FieldSchema(name:ds, type:string, comment:null)]

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -270,11 +270,10 @@ public class HiveMetaStoreChecker {
             MetastoreConf.getVar(conf, MetastoreConf.ConfVars.DEFAULTPARTITIONNAME), results);
         parts = new PartitionIterable(results);
       } else {
+        GetProjectionsSpec projectionsSpec = new GetPartitionProjectionsSpecBuilder()
+                .addProjectFieldList(Arrays.asList("sd.location","createTime","values")).build();
         GetPartitionsRequest request = new GetPartitionsRequest(table.getDbName(), table.getTableName(),
-            null, null);
-        request.setProjectionSpec(new GetPartitionProjectionsSpecBuilder().addProjectField("sd.location")
-            .addProjectField("createTime").addProjectField("tableName")
-            .addProjectField("values").build());
+                projectionsSpec, null);
         request.setCatName(table.getCatName());
         int batchSize = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.BATCH_RETRIEVE_MAX);
         if (batchSize > 0) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/GetPartitionProjectionsSpecBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/GetPartitionProjectionsSpecBuilder.java
@@ -18,8 +18,11 @@
 
 package org.apache.hadoop.hive.metastore.client.builder;
 
+import org.apache.commons.collections.CollectionUtils;
+
 import org.apache.hadoop.hive.metastore.api.GetProjectionsSpec;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +41,14 @@ public class GetPartitionProjectionsSpecBuilder {
 
     public GetPartitionProjectionsSpecBuilder addProjectField(String field) {
         fieldList.add(field);
+        return this;
+    }
+
+    public GetPartitionProjectionsSpecBuilder addProjectFieldList(List<String> fields) {
+        fieldList.addAll(Arrays.asList("catName","dbName","tableName"));
+        if (CollectionUtils.isNotEmpty(fields)) {
+            fieldList.addAll(fields);
+        }
         return this;
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Leverage configurable getPartitionsWithSpecs API in HMS to decrease memory footprint in HS2

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The primary motivation behind these changes is to optimize the performance of certain API calls within HS2. These calls often require specific elements, such as say location, without needing the complete storage descriptor in partition object. Transmitting the full object in these cases results in unnecessary overhead and resource consumption. By leveraging the getPartitionsWithSpecs API, we can fetch only the necessary Partition's sub-objects, thereby reducing the memory footprint and hence reducing unnecessary network usage. (A document is added with the jira for more details on how the APIs work, and performance impact it can make)

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Provided tests and added JUnit test class