### PR TITLE
HIVE-28626: Display MoveTask/StatsTask duration on the query summary

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/log/PerfLogger.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/log/PerfLogger.java
@@ -101,6 +101,8 @@ public class PerfLogger {
   public static final String LOAD_PARTITION = "LoadPartition";
   public static final String LOAD_DYNAMIC_PARTITIONS = "LoadDynamicPartitions";
 
+  public static final String STATS_TASK = "StatsTask";
+
   public static final String HIVE_GET_TABLE = "getTablesByType";
   public static final String HIVE_GET_DATABASE = "getDatabase";
   public static final String HIVE_GET_DATABASE_2 = "getDatabase2";

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
@@ -78,6 +78,7 @@ import org.apache.hadoop.hive.ql.plan.api.StageType;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.util.DirectionUtils;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -688,7 +689,7 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
     Map<Path, Utilities.PartitionDetails> dps = Utilities.getFullDPSpecs(conf, dpCtx, dynamicPartitionSpecs);
 
     console.printInfo(System.getProperty("line.separator"));
-    long startTime = System.currentTimeMillis();
+    long startTime = Time.monotonicNow();
     // load the list of DP partitions and return the list of partition specs
     // TODO: In a follow-up to HIVE-1361, we should refactor loadDynamicPartitions
     // to use Utilities.getFullDPSpecs() to get the list of full partSpecs.
@@ -714,7 +715,7 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
     }
 
     String loadTime = String.format("Time taken to load dynamic partitions:\t %.3f seconds",
-        (System.currentTimeMillis() - startTime) / 1000.0);
+        (Time.monotonicNow() - startTime) / 1000.0);
     console.printInfo(loadTime);
     LOG.info(loadTime);
 
@@ -723,7 +724,7 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
           " To turn off this error, set hive.error.on.empty.partition=false.");
     }
 
-    startTime = System.currentTimeMillis();
+    startTime = Time.monotonicNow();
     // for each partition spec, get the partition
     // and put it to WriteEntity for post-exec hook
     for(Map.Entry<Map<String, String>, Partition> entry : dp.entrySet()) {
@@ -762,7 +763,7 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
       LOG.info("Loading partition " + entry.getKey());
     }
     console.printInfo(String.format("Time taken for adding to write entity:\t %.3f seconds",
-        (System.currentTimeMillis() - startTime) / 1000.0));
+        (Time.monotonicNow() - startTime) / 1000.0));
     dc = null; // reset data container to prevent it being added again.
     return dc;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -5150,7 +5150,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
     try {
       // rename cannot overwrite non empty destination directory, so deleting the destination before renaming.
       destFs.delete(destFile);
-      LOG.info("Deleted destination file" + destFile.toUri());
+      LOG.info("Deleted destination file: " + destFile.toUri());
     } catch (FileNotFoundException e) {
       // no worries
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -5150,7 +5150,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
     try {
       // rename cannot overwrite non empty destination directory, so deleting the destination before renaming.
       destFs.delete(destFile);
-      LOG.info("Deleted destination file: " + destFile.toUri());
+      LOG.info("Deleted destination file: {}", destFile.toUri());
     } catch (FileNotFoundException e) {
       // no worries
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
@@ -101,7 +101,6 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
 
   @Override
   public int process(Hive db, Table tbl) throws Exception {
-
     LOG.info("Executing stats task");
     table = tbl;
     return aggregateStats(db, tbl);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Display MoveTask's and StatsTask's duration on the console.


### Why are the changes needed?
Better observability.


### Does this PR introduce _any_ user-facing change?
Yes, query output on the console slightly changes.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
On cluster. Unfortunately, due to HIVE-28627, the console message is broken, works only intermittently, but in the logs, the very same messages appear.
