### PR TITLE
HIVE-28630: Upgrade ORC to 1.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <postgres.version>42.7.3</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <opencsv.version>5.9</opencsv.version>
-    <orc.version>1.9.4</orc.version>
+    <orc.version>1.9.5</orc.version>
     <otel.version>1.42.0</otel.version>
     <mockito-core.version>3.4.4</mockito-core.version>
     <mockito-inline.version>4.11.0</mockito-inline.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 1.9.5.

### Why are the changes needed?

To bring the latest bug fixes:
- https://orc.apache.org/news/2024/11/14/ORC-1.9.5/
  - https://github.com/apache/orc/pull/1960

### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

Yes.

### How was this patch tested?

Pass the CIs.