### PR TITLE
HIVE-28631: Close opened iterables in HiveDeleteFilter to stop resource leak.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveDeleteFilter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveDeleteFilter.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.mr.hive.vector;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.NoSuchElementException;
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.iceberg.FileScanTask;
@@ -142,7 +143,7 @@ public class HiveDeleteFilter extends DeleteFilter<HiveRow> {
 
           @Override
           public void close() throws IOException {
-            srcIterator.close();
+            IOUtils.close(srcIterator, deleteInputIterable, deleteOutputIterable);
           }
         };
       }


### PR DESCRIPTION
### Why are the changes needed?

The Iterables created in HiveDeleteFilter are CloseableIterators and it actually opens multiple files during iteration, if left behind especially without finishing iteration it leaves opened resources behind.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?

Tested by deploying this change in a cluster and running a large merge query accessing files in HiveDeleteFilter across multiple mappers.
