### PR TITLE
HIVE-28639: Aggregate storage statistics in Hive LLAP

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/StatsRecordingThreadPool.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/StatsRecordingThreadPool.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hive.llap.LlapUtil;
 import org.apache.hadoop.hive.llap.counters.LlapIOCounters;
 import org.apache.hadoop.hive.llap.io.encoded.TezCounterSource;
 import org.apache.tez.common.CallableWithNdc;
+import org.apache.tez.common.counters.CounterGroup;
 import org.apache.tez.common.counters.FileSystemCounter;
 import org.apache.tez.common.counters.TezCounters;
 import org.apache.tez.runtime.task.TaskRunner2Callable;
@@ -262,19 +263,20 @@ public class StatsRecordingThreadPool extends ThreadPoolExecutor {
 
   private static void putIOStatisticsIntoCounters(TezCounters tezCounters) {
     IOStatistics ioStats = IOStatisticsContext.getCurrentIOStatisticsContext().getIOStatistics();
+    CounterGroup group = tezCounters.getGroup("Storage Statistics");
     ioStats.counters().forEach((key, value) -> {
       if (value > 0) {
-        tezCounters.findCounter("Storage Statistics", key.toUpperCase()).setValue(value);
+        group.findCounter(key.toUpperCase()).setValue(value);
       }
     });
     ioStats.minimums().forEach((key, value) -> {
       if (value > 0) {
-        tezCounters.findCounter("Storage Statistics", key.toUpperCase()).setValue(value);
+        group.findCounter(key.toUpperCase()).setValue(value);
       }
     });
     ioStats.maximums().forEach((key, value) -> {
       if (value > 0) {
-        tezCounters.findCounter("Storage Statistics", key.toUpperCase()).setValue(value);
+        group.findCounter(key.toUpperCase()).setValue(value);
       }
     });
     ioStats.meanStatistics().forEach((key, value) -> {
@@ -282,7 +284,7 @@ public class StatsRecordingThreadPool extends ThreadPoolExecutor {
       if (mean > 0){
         // double mean is intentionally truncated here to long as counters are long/integer based things
         // it's fair enough to see 26 instead of 26.1320 for e.g. average request duration
-        tezCounters.findCounter("Storage Statistics", key.toUpperCase()).setValue((long)mean);
+        group.findCounter(key.toUpperCase()).setValue((long)mean);
       }
     });
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add thread local statistics at the end of a task to the counters (so they're aggregated automatically on the query level). Further details on jira.


### Why are the changes needed?
Performance debugging, details on jira.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Tested on clusters, IO stats appeared in query summary:
```
INFO  : Storage Statistics:
INFO  :    ACTION_FILE_OPENED: 51
INFO  :    ACTION_FILE_OPENED.MEAN.SUM: 680
INFO  :    ACTION_HTTP_GET_REQUEST: 1397
INFO  :    ACTION_HTTP_GET_REQUEST.MEAN.SUM: 50330
INFO  :    OBJECT_PUT_REQUEST: 79
INFO  :    OBJECT_PUT_REQUEST.MEAN.SUM: 4419
INFO  :    STREAM_READ_BYTES: 1138805970
INFO  :    STREAM_READ_BYTES_BACKWARDS_ON_SEEK: 4440384384
INFO  :    STREAM_READ_BYTES_DISCARDED_IN_CLOSE: 39918759
INFO  :    STREAM_READ_CLOSED: 1397
INFO  :    STREAM_READ_CLOSE_OPERATIONS: 51
INFO  :    STREAM_READ_FULLY_OPERATIONS: 2091
INFO  :    STREAM_READ_OPENED: 1397
INFO  :    STREAM_READ_OPERATIONS: 127502
INFO  :    STREAM_READ_OPERATIONS_INCOMPLETE: 125411
INFO  :    STREAM_READ_REMOTE_STREAM_DRAIN: 1397
INFO  :    STREAM_READ_REMOTE_STREAM_DRAIN.MEAN.SUM: 614
INFO  :    STREAM_READ_SEEK_BACKWARD_OPERATIONS: 376
INFO  :    STREAM_READ_SEEK_BYTES_DISCARDED: 1727592
INFO  :    STREAM_READ_SEEK_BYTES_SKIPPED: 5369236654
INFO  :    STREAM_READ_SEEK_FORWARD_OPERATIONS: 1664
INFO  :    STREAM_READ_SEEK_OPERATIONS: 2040
INFO  :    STREAM_READ_SEEK_POLICY_CHANGED: 51
INFO  :    STREAM_READ_TOTAL_BYTES: 1180452321
INFO  :    STREAM_WRITE_BLOCK_UPLOADS: 79
INFO  :    STREAM_WRITE_BYTES: 39300113
INFO  :    STREAM_WRITE_TOTAL_DATA: 35142
```
