### PR TITLE
HIVE-28642:column stats state unnecessarily created when hive.stats.c…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -2820,8 +2820,10 @@ public class Hive {
       if (oldPart == null) {
         newTPart.getTPartition().setParameters(new HashMap<String,String>());
         if (this.getConf().getBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER)) {
+          List<String> colNames = this.getConf().getBoolVar(ConfVars.HIVE_STATS_COL_AUTOGATHER)?
+              MetaStoreUtils.getColumnNames(tbl.getCols()) : null;
           StatsSetupConst.setStatsStateForCreateTable(newTPart.getParameters(),
-              MetaStoreUtils.getColumnNames(tbl.getCols()), StatsSetupConst.TRUE);
+              colNames, StatsSetupConst.TRUE);
         }
         // Note: we are creating a brand new the partition, so this is going to be valid for ACID.
         List<FileStatus> filesForStats = null;


### PR DESCRIPTION
do not set column stats state when load new partition if hive.stats.column.autogather=false



### What changes were proposed in this pull request?
simplify query string when load new partition by removing the column stats state setup when HIVE_STATS_COL_AUTOGATHER=false


### Why are the changes needed?
avoid PARAM_VALUE too long error from metastore db.


### Does this PR introduce _any_ user-facing change?
no

### Is the change a dependency upgrade?
no


### How was this patch tested?
tested locally
