### PR TITLE
HIVE-28633: Insert to Bucketed Partition table fails with CBO=false and dynamic sort partition optimization enabled

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -19,6 +19,7 @@ minitez.query.files=\
   acid_vectorization_original_tez.q,\
   bucketmapjoin_with_subquery.q,\
   delete_orig_table.q,\
+  dynpart_bucket.q,\
   explainanalyze_1.q,\
   explainanalyze_3.q,\
   explainanalyze_4.q,\

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
@@ -204,7 +204,8 @@ public class TezCompiler extends TaskCompiler {
     // run Sorted dynamic partition optimization
     if(HiveConf.getBoolVar(procCtx.conf, HiveConf.ConfVars.DYNAMIC_PARTITIONING) &&
         HiveConf.getVar(procCtx.conf, HiveConf.ConfVars.DYNAMIC_PARTITIONING_MODE).equals("nonstrict") &&
-        !HiveConf.getBoolVar(procCtx.conf, HiveConf.ConfVars.HIVE_OPT_LIST_BUCKETING)) {
+        !HiveConf.getBoolVar(procCtx.conf, HiveConf.ConfVars.HIVE_OPT_LIST_BUCKETING) &&
+         HiveConf.getBoolVar(procCtx.conf, HiveConf.ConfVars.HIVE_CBO_ENABLED)) {
       perfLogger.perfLogBegin(this.getClass().getName(), PerfLogger.TEZ_COMPILER);
       new SortedDynPartitionOptimizer().transform(procCtx.parseContext);
       perfLogger.perfLogEnd(this.getClass().getName(), PerfLogger.TEZ_COMPILER, "Sorted dynamic partition optimization");

--- a/ql/src/test/queries/clientpositive/dynpart_bucket.q
+++ b/ql/src/test/queries/clientpositive/dynpart_bucket.q
@@ -1,0 +1,9 @@
+set hive.cbo.enable=false;
+
+drop table if exists dynpart_bucket;
+CREATE TABLE dynpart_bucket (bn string) PARTITIONED BY (br string) CLUSTERED BY (bn) INTO 2 BUCKETS ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE ;
+INSERT into TABLE dynpart_bucket VALUES ('tv_0', 'tv');
+set hive.cbo.enable=true;
+INSERT into TABLE dynpart_bucket VALUES ('tv_1', 'tv');
+select * from dynpart_bucket;
+

--- a/ql/src/test/results/clientpositive/tez/dynpart_bucket.q.out
+++ b/ql/src/test/results/clientpositive/tez/dynpart_bucket.q.out
@@ -1,0 +1,46 @@
+PREHOOK: query: drop table if exists dynpart_bucket
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: drop table if exists dynpart_bucket
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: CREATE TABLE dynpart_bucket (bn string) PARTITIONED BY (br string) CLUSTERED BY (bn) INTO 2 BUCKETS ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@dynpart_bucket
+POSTHOOK: query: CREATE TABLE dynpart_bucket (bn string) PARTITIONED BY (br string) CLUSTERED BY (bn) INTO 2 BUCKETS ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@dynpart_bucket
+PREHOOK: query: INSERT into TABLE dynpart_bucket VALUES ('tv_0', 'tv')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@dynpart_bucket
+POSTHOOK: query: INSERT into TABLE dynpart_bucket VALUES ('tv_0', 'tv')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@dynpart_bucket
+POSTHOOK: Output: default@dynpart_bucket@br=tv
+POSTHOOK: Lineage: dynpart_bucket PARTITION(br=tv).bn SCRIPT []
+PREHOOK: query: INSERT into TABLE dynpart_bucket VALUES ('tv_1', 'tv')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@dynpart_bucket
+POSTHOOK: query: INSERT into TABLE dynpart_bucket VALUES ('tv_1', 'tv')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@dynpart_bucket
+POSTHOOK: Output: default@dynpart_bucket@br=tv
+POSTHOOK: Lineage: dynpart_bucket PARTITION(br=tv).bn SCRIPT []
+PREHOOK: query: select * from dynpart_bucket
+PREHOOK: type: QUERY
+PREHOOK: Input: default@dynpart_bucket
+PREHOOK: Input: default@dynpart_bucket@br=tv
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from dynpart_bucket
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@dynpart_bucket
+POSTHOOK: Input: default@dynpart_bucket@br=tv
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+tv_0	tv
+tv_1	tv


### PR DESCRIPTION

### What changes were proposed in this pull request?
Disabled Dynamic sorting partition optimization with non-cbo flow.

### Why are the changes needed?
Post [HIVE-20703](https://issues.apache.org/jira/browse/HIVE-20703), Dynamic Sorting Partition Optimization  was integrated into the Tez query flow. However, for non-CBO query plans, the RowSchema is not populated correctly, leading to NullPointerException (NPE) errors. Addressing this would require extensive changes to the query plan, which is not necessary since Dynamic Sorting Partition Optimization is based on cost-based decisions.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Test case added
