### PR TITLE
HIVE-28578: Fix concurrency issue in ObjectStore#updateTableColumnStatistics

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -10306,30 +10306,29 @@ public class ObjectStore implements RawStore, Configurable {
         // Set the table properties
         // No need to check again if it exists.
         String dbname = table.getDbName();
-        String name = table.getTableName();
-        MTable oldt = mTable;
+        String tableName = table.getTableName();
         StatsSetupConst.setColumnStatsState(newParams, colNames);
-        boolean isTxn = TxnUtils.isTransactionalTable(oldt.getParameters());
+        boolean isTxn = TxnUtils.isTransactionalTable(mTable.getParameters());
         if (isTxn) {
           if (!areTxnStatsSupported) {
             StatsSetupConst.setBasicStatsState(newParams, StatsSetupConst.FALSE);
           } else {
-          String errorMsg = verifyStatsChangeCtx(TableName.getDbTable(dbname, name),
-            oldt.getParameters(), newParams, writeId, validWriteIds, true);
+            String errorMsg = verifyStatsChangeCtx(TableName.getDbTable(dbname, tableName),
+            mTable.getParameters(), newParams, writeId, validWriteIds, true);
           if (errorMsg != null) {
             throw new MetaException(errorMsg);
           }
-          if (!isCurrentStatsValidForTheQuery(oldt, validWriteIds, true)) {
+          if (!isCurrentStatsValidForTheQuery(mTable, validWriteIds, true)) {
             // Make sure we set the flag to invalid regardless of the current value.
             StatsSetupConst.setBasicStatsState(newParams, StatsSetupConst.FALSE);
             LOG.info("Removed COLUMN_STATS_ACCURATE from the parameters of the table "
-              + dbname + "." + name);
+              + dbname + "." + tableName);
           }
-          oldt.setWriteId(writeId);
+          mTable.setWriteId(writeId);
         }
       }
         try {
-          oldt.setParameters(newParams);
+          mTable.setParameters(newParams);
           success = true;
         }
         catch (NucleusDataStoreException e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
There can be a concurrency issue and persisting table parameters can have duplicate key error when replication wants to store table column statistics and the table have statistics for multiple engines. In this change, in a parallel process already saved those, we retry it so that, DataNucleus will try to do update instead of insert. 

### Why are the changes needed?
To avoid duplicate key errors.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Repro and test process is described in the ticket: https://issues.apache.org/jira/browse/HIVE-28578?focusedCommentId=17901761&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17901761
Tested manually, on a cluster. 
