### PR TITLE
HIVE-28660: OTEL: Modify span names to remove inconsistency in case o…

### DIFF
--- a/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
+++ b/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
@@ -94,7 +94,7 @@ public class OTELExporter extends Thread {
           if (task.getReturnValue() != null && task.getEndTime() != null
                   && queryIdToTasksMap.get(queryID).add(task.getTaskId())) {
             Context parentContext = Context.current().with(rootspan);
-            tracer.spanBuilder(queryID + " - " + task.getTaskId() + " - live")
+            tracer.spanBuilder(queryID + " - " + task.getTaskId())
                     .setParent(parentContext).setAllAttributes(addTaskAttributes(task))
                     .setStartTimestamp(task.getBeginTime(), TimeUnit.MILLISECONDS).startSpan()
                     .end(task.getEndTime(), TimeUnit.MILLISECONDS);
@@ -102,12 +102,12 @@ public class OTELExporter extends Thread {
         }
       } else {
         // In case of live queries being seen for first time and has initialized its queryDisplay
-        rootspan = tracer.spanBuilder(queryID + " - live")
+        rootspan = tracer.spanBuilder(queryID)
                 .setStartTimestamp(lQuery.getBeginTime(), TimeUnit.MILLISECONDS).startSpan();
         Set<String> completedTasks = new HashSet<>();
         Context parentContext = Context.current().with(rootspan);
 
-        Span initSpan = tracer.spanBuilder(queryID + " - live").setParent(parentContext)
+        Span initSpan = tracer.spanBuilder(queryID).setParent(parentContext)
                 .setStartTimestamp(lQuery.getBeginTime(), TimeUnit.MILLISECONDS).startSpan()
                 .setAttribute("QueryId", queryID)
                 .setAttribute("QueryString", lQuery.getQueryDisplay().getQueryString())
@@ -122,7 +122,7 @@ public class OTELExporter extends Thread {
           if (task.getReturnValue() != null && task.getEndTime() != null) {
             completedTasks.add(task.getTaskId());
             parentContext = Context.current().with(rootspan);
-            tracer.spanBuilder(queryID + " - " + task.getTaskId() + " - live")
+            tracer.spanBuilder(queryID + " - " + task.getTaskId())
                     .setParent(parentContext).setAllAttributes(addTaskAttributes(task))
                     .setStartTimestamp(task.getBeginTime(), TimeUnit.MILLISECONDS).startSpan()
                     .end(task.getEndTime(), TimeUnit.MILLISECONDS);
@@ -146,7 +146,7 @@ public class OTELExporter extends Thread {
         for (QueryDisplay.TaskDisplay task : hQuery.getQueryDisplay().getTaskDisplays()) {
           if (!completedTasks.contains(task.getTaskId())) {
             Context parentContext = Context.current().with(rootspan);
-            tracer.spanBuilder(hQueryId + " - " + task.getTaskId() + " - completed")
+            tracer.spanBuilder(hQueryId + " - " + task.getTaskId())
                     .setParent(parentContext).setAllAttributes(addTaskAttributes(task))
                     .setStartTimestamp(task.getBeginTime(), TimeUnit.MILLISECONDS).startSpan()
                     .end(task.getEndTime(), TimeUnit.MILLISECONDS);
@@ -165,7 +165,7 @@ public class OTELExporter extends Thread {
                 .setStartTimestamp(hQuery.getBeginTime(), TimeUnit.MILLISECONDS).startSpan();
         Context parentContext = Context.current().with(rootspan);
 
-        Span initSpan = tracer.spanBuilder(hQueryId + " - completed").setParent(parentContext)
+        Span initSpan = tracer.spanBuilder(hQueryId).setParent(parentContext)
                 .setStartTimestamp(hQuery.getBeginTime(), TimeUnit.MILLISECONDS).startSpan()
                 .setAttribute("QueryId", hQueryId)
                 .setAttribute("QueryString", hQuery.getQueryDisplay().getQueryString())
@@ -178,7 +178,7 @@ public class OTELExporter extends Thread {
 
         for (QueryDisplay.TaskDisplay task : hQuery.getQueryDisplay().getTaskDisplays()) {
           parentContext = Context.current().with(rootspan);
-          tracer.spanBuilder(hQueryId + " - " + task.getTaskId() + " - completed")
+          tracer.spanBuilder(hQueryId + " - " + task.getTaskId())
                   .setParent(parentContext).setAllAttributes(addTaskAttributes(task))
                   .setStartTimestamp(task.getBeginTime(), TimeUnit.MILLISECONDS).startSpan()
                   .end(task.getEndTime(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
…f completed queries

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
OTEL span names are modified such that live/completed identifiers causing inconsistencies in case of completed queries are addressed.

### Why are the changes needed?
Current names not well understood/taken by the end user.

### Does this PR introduce _any_ user-facing change?
Yes, Changes in the OTEL span names.

### Is the change a dependency upgrade?
No


### How was this patch tested?
Manual testing, by running the OTEL service with Jaeger and Zipkin recievers. 
