### PR TITLE
HIVE-28661: OTEL: Latency in retrieving query end time leads to threa…

### DIFF
--- a/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
+++ b/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
@@ -69,7 +69,7 @@ public class OTELExporter extends Thread {
         jvmMetrics.setJvmMetrics();
         exposeMetricsToOTEL();
       } catch (Throwable e) {
-        LOG.error("Exception occurred in OTELExporter thread: " + e);
+        LOG.error("Exception occurred in OTELExporter thread ", e);
       }
       
       try {


### PR DESCRIPTION
…d interruption

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Changes to address OTEL thread running into NullPointerException


### Why are the changes needed?
Needed to ensure the OTEL thread does not get interrupted in case of NullPointerException arising because query end time is not available at the time it is fetched. Additionally, a try-catch block is introduced to avoid OTEL thread interruption.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Manual testing, by running the OTEL service with Jaeger and Zipkin recievers.
