### PR TITLE
HIVE-28671 : Upgrade MySQL connector jar version to 8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <log4j2.version>2.18.0</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
-    <mysql.version>8.0.31</mysql.version>
+    <mysql.version>8.2.0</mysql.version>
     <postgres.version>42.7.3</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <opencsv.version>5.9</opencsv.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -72,7 +72,7 @@
     <derby.version>10.14.2.0</derby.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
-    <mysql.version>8.0.31</mysql.version>
+    <mysql.version>8.2.0</mysql.version>
     <postgres.version>42.7.3</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2


### PR DESCRIPTION
### What changes were proposed in this pull request?
MySQL version upgrade from 8.0.31 to 8.2.0


### Why are the changes needed?
The current version of MySQL if 8.0.31, which has the following vulnerabilities associated with it:

Direct vulnerabilities:
The current version of MySQL connector jar is 8.0.31, which has the following vulnerabilities associated with it:

Direct vulnerabilities:
CVE-2023-22102

Vulnerabilities from dependencies:
CVE-2024-7254
CVE-2022-3510
CVE-2022-3509
CVE-2022-3171

So, this issue is to remedy this with the version upgrade as a fix.

https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-2-0.html
Mysql connector/J version 8.2.0 is the smallest upgrade that fixes the CVEs and can be used against MySQL Server version 5.7 and later.
Versions 8.3.0 and above are compatible with mysql server versions 8.0 and above, and since the current version is 5.7.37 (at least as long as [#5525](https://github.com/apache/hive/pull/5525) is not merged and upgrades it to 8.4.3) upgrading mysql connecter jar version to 8.2.0 instead of 8.4.0 is the present solution.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes


### How was this patch tested?
Existing tests
