### PR TITLE
HIVE-28675: Maximize the removal of redundant columns from GROUP BY clauses

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRelFieldTrimmer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRelFieldTrimmer.java
@@ -502,28 +502,15 @@ public class HiveRelFieldTrimmer extends RelFieldTrimmer {
       return generateGroupSetIfCardinalitySame(aggregate, originalGroupSet, fieldsUsed);
     }
 
-    // we have set of unique key, get to the key which is same as group by key
-    ImmutableBitSet groupByUniqueKey = null;
-
+    // Find the maximum number of columns that can be removed by retaining a certain unique key
+    ImmutableBitSet columnsToRemove = ImmutableBitSet.of();
     for (ImmutableBitSet key : uniqueKeys) {
-      if (aggregate.getGroupSet().contains(key)) {
-        groupByUniqueKey = key;
-        break;
+      ImmutableBitSet removableCols = originalGroupSet.except(key).except(fieldsUsed);
+      if (aggregate.getGroupSet().contains(key) && removableCols.cardinality() > columnsToRemove.cardinality()) {
+        columnsToRemove = removableCols;
       }
     }
-
-    if (groupByUniqueKey == null) {
-      // group by keys do not represent unique keys
-      return originalGroupSet;
-    }
-
-    // we know group by key contains primary key and there is at least one column in group by which is not being used
-    // if that column is not part of key it should be removed
-    ImmutableBitSet nonKeyColumns = aggregate.getGroupSet().except(groupByUniqueKey);
-    ImmutableBitSet columnsToRemove = nonKeyColumns.except(fieldsUsed);
-    ImmutableBitSet newGroupSet = aggregate.getGroupSet().except(columnsToRemove);
-
-    return  newGroupSet;
+    return aggregate.getGroupSet().except(columnsToRemove);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRelFieldTrimmer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRelFieldTrimmer.java
@@ -504,10 +504,11 @@ public class HiveRelFieldTrimmer extends RelFieldTrimmer {
 
     // Find the maximum number of columns that can be removed by retaining a certain unique key
     ImmutableBitSet columnsToRemove = ImmutableBitSet.of();
+    final ImmutableBitSet unusedGroupingColumns = aggregate.getGroupSet().except(fieldsUsed);
     for (ImmutableBitSet key : uniqueKeys) {
-      ImmutableBitSet removableCols = originalGroupSet.except(key).except(fieldsUsed);
-      if (aggregate.getGroupSet().contains(key) && removableCols.cardinality() > columnsToRemove.cardinality()) {
-        columnsToRemove = removableCols;
+      ImmutableBitSet removeCandidate = unusedGroupingColumns.except(key);
+      if (aggregate.getGroupSet().contains(key) && removeCandidate.cardinality() > columnsToRemove.cardinality()) {
+        columnsToRemove = removeCandidate;
       }
     }
     return aggregate.getGroupSet().except(columnsToRemove);

--- a/ql/src/test/queries/clientpositive/cbo_groupby_remove_key.q
+++ b/ql/src/test/queries/clientpositive/cbo_groupby_remove_key.q
@@ -1,0 +1,18 @@
+CREATE TABLE passenger
+(
+    id       INT    NOT NULL,
+    fname    STRING NOT NULL,
+    lname    STRING NOT NULL,
+    passport STRING NOT NULL,
+    UNIQUE (id) DISABLE RELY,
+    UNIQUE (passport) DISABLE RELY,
+    UNIQUE (fname, lname) DISABLE RELY
+);
+
+EXPLAIN CBO SELECT id, COUNT(1) FROM passenger GROUP BY id, passport;
+EXPLAIN CBO SELECT passport, COUNT(1) FROM passenger GROUP BY id, passport;
+EXPLAIN CBO SELECT id, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport;
+EXPLAIN CBO SELECT passport, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport;
+EXPLAIN CBO SELECT fname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport;
+EXPLAIN CBO SELECT lname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport;
+EXPLAIN CBO SELECT fname, lname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport;

--- a/ql/src/test/results/clientpositive/llap/cbo_groupby_remove_key.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_groupby_remove_key.q.out
@@ -1,0 +1,112 @@
+PREHOOK: query: CREATE TABLE passenger
+(
+    id       INT    NOT NULL,
+    fname    STRING NOT NULL,
+    lname    STRING NOT NULL,
+    passport STRING NOT NULL,
+    UNIQUE (id) DISABLE RELY,
+    UNIQUE (passport) DISABLE RELY,
+    UNIQUE (fname, lname) DISABLE RELY
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@passenger
+POSTHOOK: query: CREATE TABLE passenger
+(
+    id       INT    NOT NULL,
+    fname    STRING NOT NULL,
+    lname    STRING NOT NULL,
+    passport STRING NOT NULL,
+    UNIQUE (id) DISABLE RELY,
+    UNIQUE (passport) DISABLE RELY,
+    UNIQUE (fname, lname) DISABLE RELY
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@passenger
+PREHOOK: query: EXPLAIN CBO SELECT id, COUNT(1) FROM passenger GROUP BY id, passport
+PREHOOK: type: QUERY
+PREHOOK: Input: default@passenger
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT id, COUNT(1) FROM passenger GROUP BY id, passport
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@passenger
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAggregate(group=[{0}], agg#0=[count()])
+  HiveTableScan(table=[[default, passenger]], table:alias=[passenger])
+
+PREHOOK: query: EXPLAIN CBO SELECT passport, COUNT(1) FROM passenger GROUP BY id, passport
+PREHOOK: type: QUERY
+PREHOOK: Input: default@passenger
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT passport, COUNT(1) FROM passenger GROUP BY id, passport
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@passenger
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAggregate(group=[{3}], agg#0=[count()])
+  HiveTableScan(table=[[default, passenger]], table:alias=[passenger])
+
+PREHOOK: query: EXPLAIN CBO SELECT id, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+PREHOOK: type: QUERY
+PREHOOK: Input: default@passenger
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT id, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@passenger
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAggregate(group=[{0}], agg#0=[count()])
+  HiveTableScan(table=[[default, passenger]], table:alias=[passenger])
+
+PREHOOK: query: EXPLAIN CBO SELECT passport, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+PREHOOK: type: QUERY
+PREHOOK: Input: default@passenger
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT passport, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@passenger
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAggregate(group=[{3}], agg#0=[count()])
+  HiveTableScan(table=[[default, passenger]], table:alias=[passenger])
+
+PREHOOK: query: EXPLAIN CBO SELECT fname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+PREHOOK: type: QUERY
+PREHOOK: Input: default@passenger
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT fname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@passenger
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(fname=[$1], _o__c1=[$2])
+  HiveAggregate(group=[{0, 1}], agg#0=[count()])
+    HiveTableScan(table=[[default, passenger]], table:alias=[passenger])
+
+PREHOOK: query: EXPLAIN CBO SELECT lname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+PREHOOK: type: QUERY
+PREHOOK: Input: default@passenger
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT lname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@passenger
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(lname=[$1], _o__c1=[$2])
+  HiveAggregate(group=[{0, 2}], agg#0=[count()])
+    HiveTableScan(table=[[default, passenger]], table:alias=[passenger])
+
+PREHOOK: query: EXPLAIN CBO SELECT fname, lname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+PREHOOK: type: QUERY
+PREHOOK: Input: default@passenger
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT fname, lname, COUNT(1) FROM passenger GROUP BY id, fname, lname, passport
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@passenger
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAggregate(group=[{1, 2}], agg#0=[count()])
+  HiveTableScan(table=[[default, passenger]], table:alias=[passenger])
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enhance `HiveRelFieldTrimmer` to remove the maximum number of redundant columns from the `GROUP BY` clause.

### Why are the changes needed?
1. Generate more efficient plans by pruning as many columns as possible (less CPU/IO/network cost).
2. Avoid missing optimization opportunities by examining all candidates.

For more see HIVE-28675.

### Does this PR introduce _any_ user-facing change?
More efficient query plans.

### Is the change a dependency upgrade?
No

### How was this patch tested?
```
mvn test -Dtest=TestMiniLlapLocalCliDriver.java -Dqfile="cbo_groupby_remove_key.q"
```