### PR TITLE
HIVE-28677: Implement direct sql for delete table/partition column stats

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3260,7 +3260,7 @@ class MetaStoreDirectSql {
 
   public boolean deletePartitionColumnStats(String catName, String dbName, String tblName,
       String partName, String colName, String engine) throws MetaException {
-    String sqlFilter = "" + PARTITIONS + ".\"PART_NAME\" = ? ";
+    String sqlFilter = PARTITIONS + ".\"PART_NAME\" = ? ";
     List<Long> partitionIds = getPartitionIdsViaSqlFilter(catName, dbName, tblName, sqlFilter,
         Arrays.asList(partName), Collections.emptyList(), -1);
     assert(partitionIds.size() == 1);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3241,6 +3241,46 @@ class MetaStoreDirectSql {
     }
   }
 
+  public boolean deleteTableColumnStatistics(long tableId, String colName, String engine) {
+    String deleteSql = "delete from " + TAB_COL_STATS + " where \"TBL_ID\" = " + tableId;
+    if (colName != null) {
+      deleteSql += " and \"COLUMN_NAME\" = '" + colName + "'";
+    }
+    if (engine != null) {
+      deleteSql += " and \"ENGINE\" = '" + engine + "'";
+    }
+    try {
+      executeNoResult(deleteSql);
+    } catch (SQLException e) {
+      LOG.warn("Error removing table column stats. ", e);
+      return false;
+    }
+    return true;
+  }
+
+  public boolean deletePartitionColumnStats(String catName, String dbName, String tblName,
+      String partName, String colName, String engine) throws MetaException {
+    String sqlFilter = "" + PARTITIONS + ".\"PART_NAME\" = ? ";
+    List<Long> partitionIds = getPartitionIdsViaSqlFilter(catName, dbName, tblName, sqlFilter,
+        Arrays.asList(partName), Collections.emptyList(), -1);
+    assert(partitionIds.size() == 1);
+
+    String deleteSql = "delete from " + PART_COL_STATS + " where \"PART_ID\" = " + partitionIds.get(0);
+    if (colName != null) {
+      deleteSql += " and \"COLUMN_NAME\" = '" + colName + "'";
+    }
+    if (engine != null) {
+      deleteSql += " and \"ENGINE\" = '" + engine + "'";
+    }
+    try {
+      executeNoResult(deleteSql);
+    } catch (SQLException e) {
+      LOG.warn("Error removing partition column stats. ", e);
+      return false;
+    }
+    return true;
+  }
+
   public Map<String, Map<String, String>> updatePartitionColumnStatisticsBatch(
                                                       Map<String, ColumnStatistics> partColStatsMap,
                                                       Table tbl,

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -10251,7 +10251,7 @@ public class ObjectStore implements RawStore, Configurable {
     return new GetHelper<Boolean>(catName, dbName, tableName, true, true) {
       @Override
       protected String describeResult() {
-        return "delete prtition column stats";
+        return "delete partition column stats";
       }
 
       @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the performance of deleting column stats for wide table.

### Why are the changes needed?
The JDO implementation of deleting column stats needs to retrieve the column stats objects, it could be slow if the table has many columns. 

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Add some unit tests:
```bash
mvn test -Dtest.groups= -Dtest=org.apache.hadoop.hive.metastore.TestObjectStore#testPartitionStatisticsOps -pl :hive-standalone-metastore-server
```
