### PR TITLE
HIVE-28040: Upgrade netty to 4.1.116.Final due to CVEs

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCopyLocalJars.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCopyLocalJars.java
@@ -66,7 +66,7 @@ class AsyncTaskCopyLocalJars implements Callable<Void> {
         io.netty.handler.codec.http.HttpObjectAggregator.class, //
         org.apache.arrow.vector.types.pojo.ArrowType.class, //arrow-vector
         org.apache.arrow.memory.RootAllocator.class, //arrow-memory
-        org.apache.arrow.memory.NettyAllocationManager.class, //arrow-memory-netty
+        org.apache.arrow.memory.netty.NettyAllocationManager.class, //arrow-memory-netty
         io.netty.handler.codec.http.HttpObjectAggregator.class, // netty-all
         org.apache.arrow.flatbuf.Schema.class, //arrow-format
         com.google.flatbuffers.Table.class, //flatbuffers

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCopyLocalJars.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCopyLocalJars.java
@@ -66,7 +66,7 @@ class AsyncTaskCopyLocalJars implements Callable<Void> {
         io.netty.handler.codec.http.HttpObjectAggregator.class, //
         org.apache.arrow.vector.types.pojo.ArrowType.class, //arrow-vector
         org.apache.arrow.memory.RootAllocator.class, //arrow-memory
-        org.apache.arrow.memory.netty.NettyAllocationManager.class, //arrow-memory-netty
+        org.apache.arrow.memory.NettyAllocationManager.class, //arrow-memory-netty
         io.netty.handler.codec.http.HttpObjectAggregator.class, // netty-all
         org.apache.arrow.flatbuf.Schema.class, //arrow-format
         com.google.flatbuffers.Table.class, //flatbuffers

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <antlr4.version>4.9.3</antlr4.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
-    <arrow.version>15.0.0</arrow.version>
+    <arrow.version>12.0.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>
     <avro.version>1.11.4</avro.version>
     <bcprov-jdk18on.version>1.78</bcprov-jdk18on.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <antlr4.version>4.9.3</antlr4.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
-    <arrow.version>12.0.0</arrow.version>
+    <arrow.version>16.0.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>
     <avro.version>1.11.4</avro.version>
     <bcprov-jdk18on.version>1.78</bcprov-jdk18on.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <antlr4.version>4.9.3</antlr4.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
-    <arrow.version>16.1.0</arrow.version>
+    <arrow.version>12.0.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>
     <avro.version>1.11.4</avro.version>
     <bcprov-jdk18on.version>1.78</bcprov-jdk18on.version>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <mockito-core.version>3.4.4</mockito-core.version>
     <mockito-inline.version>4.11.0</mockito-inline.version>
     <mina.version>2.0.0-M5</mina.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.108.Final</netty.version>
     <netty3.version>3.10.5.Final</netty3.version>
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.5</pac4j-saml.version>
@@ -1015,7 +1015,7 @@
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
+            <artifactId>netty-all</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <antlr4.version>4.9.3</antlr4.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
-    <arrow.version>12.0.0</arrow.version>
+    <arrow.version>16.1.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>
     <avro.version>1.11.4</avro.version>
     <bcprov-jdk18on.version>1.78</bcprov-jdk18on.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <antlr4.version>4.9.3</antlr4.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
-    <arrow.version>12.0.0</arrow.version>
+    <arrow.version>15.0.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>
     <avro.version>1.11.4</avro.version>
     <bcprov-jdk18on.version>1.78</bcprov-jdk18on.version>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <mockito-core.version>3.4.4</mockito-core.version>
     <mockito-inline.version>4.11.0</mockito-inline.version>
     <mina.version>2.0.0-M5</mina.version>
-    <netty.version>4.1.108.Final</netty.version>
+    <netty.version>4.1.116.Final</netty.version>
     <netty3.version>3.10.5.Final</netty3.version>
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.5</pac4j-saml.version>

--- a/ql/src/java/org/apache/hadoop/hive/llap/WritableByteChannelAdapter.java
+++ b/ql/src/java/org/apache/hadoop/hive/llap/WritableByteChannelAdapter.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.Semaphore;
-import org.apache.arrow.memory.ArrowByteBufAllocator;
+import org.apache.arrow.memory.patch.ArrowByteBufAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 
 import org.slf4j.Logger;

--- a/ql/src/java/org/apache/hadoop/hive/llap/WritableByteChannelAdapter.java
+++ b/ql/src/java/org/apache/hadoop/hive/llap/WritableByteChannelAdapter.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.Semaphore;
-import org.apache.arrow.memory.patch.ArrowByteBufAllocator;
+import org.apache.arrow.memory.ArrowByteBufAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 
 import org.slf4j.Logger;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrade Netty due to CVEs

### Why are the changes needed?
Fixing CVEs

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes
Dependency tree: 
[dpn_netty_116.txt](https://github.com/user-attachments/files/18327748/dpn_netty_116.txt)




### How was this patch tested?
Manual Testing by running few queries after local compilation
