### PR TITLE
HIVE-28682: Multiple Avro Versions on Classpath Can Cause Potential C…

### DIFF
--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -60,7 +60,6 @@
     <maven.surefire.plugin.version>3.5.1</maven.surefire.plugin.version>
     <!-- Dependency versions -->
     <antlr.version>4.9.3</antlr.version>
-    <avro.version>1.11.4</avro.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
@@ -125,11 +124,6 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro</artifactId>
-        <version>${avro.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.apache.orc</groupId>
         <artifactId>orc-core</artifactId>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -60,6 +60,7 @@
     <maven.surefire.plugin.version>3.5.1</maven.surefire.plugin.version>
     <!-- Dependency versions -->
     <antlr.version>4.9.3</antlr.version>
+    <avro.version>1.11.4</avro.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
@@ -124,6 +125,11 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.orc</groupId>
         <artifactId>orc-core</artifactId>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -208,6 +208,10 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
           </exclusion>
@@ -260,6 +264,10 @@
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>


### PR DESCRIPTION
…onflicts

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Align avro to a single version - 1.11.4 
The same can be achieved by adding avro in dependencyManagement section in standalone-metastore pom as this will ensure the transitive version of avro coming in from hadoop-common is 1.11.4


### Why are the changes needed?
Multiple avro versions on classpath can cause potential conflicts


### Does this PR introduce _any_ user-facing change?
No


### Is the change a dependency upgrade?
Yes
Old Dependency Tree: 
[dpn_old.txt](https://github.com/user-attachments/files/18269623/dpn_old.txt)
New Dependency Tree: 
[dpn_latest_1.txt](https://github.com/user-attachments/files/18279902/dpn_latest_1.txt)



### How was this patch tested?
Manual Testing by running few queries after local compilation
