### PR TITLE
HIVE-28691: Check if the path exists before deleting in FileUtils#moveToTrash

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
@@ -85,10 +85,10 @@ public class FileUtils {
     boolean result;
     try {
       if (!fs.exists(f)) {
-        LOG.info("The path to moveToTrash does not exist: " + f);
+        LOG.warn("The path to moveToTrash does not exist: " + f);
         return true;
       }
-      if(purge) {
+      if (purge) {
         LOG.debug("purge is set to true. Not moving to Trash " + f);
       } else {
         result = Trash.moveToAppropriateTrash(fs, f, conf);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hive.metastore.utils;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -85,6 +84,10 @@ public class FileUtils {
     LOG.debug("deleting  " + f);
     boolean result;
     try {
+      if (!fs.exists(f)) {
+        LOG.info("The path to moveToTrash does not exist: " + f);
+        return true;
+      }
       if(purge) {
         LOG.debug("purge is set to true. Not moving to Trash " + f);
       } else {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreFsImpl.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreFsImpl.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.hive.metastore;
 
-import java.io.FileNotFoundException;
-
 import org.apache.hadoop.hive.metastore.utils.FileUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.slf4j.Logger;
@@ -41,15 +39,9 @@ public class HiveMetaStoreFsImpl implements MetaStoreFS {
       if (FileUtils.moveToTrash(fs, f, conf, ifPurge)) {
         return true;
       }
-      if (fs.exists(f)) {
-        throw new MetaException("Unable to delete directory: " + f);
-      }
-      return true;
-    } catch (FileNotFoundException e) {
-      return true; // ok even if there is not data
     } catch (Exception e) {
       MetaStoreUtils.throwMetaException(e);
     }
-    return false;
+    throw new MetaException("Unable to delete directory: " + f);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently the `FileUtils#moveToTrash` would fallback to call `delete()` API even if encountering `FileNotFoundException`, we could fast return if the path does not exist.


### Why are the changes needed?
To reduce the hdfs calls and avoid the confusing failure log.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Pass existing tests.
