### PR TITLE
HIVE-28693: Upgrade Atlas to 2.4.0 & spring-ldap-core to 2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
     <jansi.version>2.4.0</jansi.version>
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
     <spring.version>5.3.39</spring.version>
-    <spring.ldap.version>2.4.1</spring.ldap.version>
+    <spring.ldap.version>2.4.4</spring.ldap.version>
     <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
   <repositories>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
     <reflections.version>0.10.2</reflections.version>
-    <atlas.version>2.3.0</atlas.version>
+    <atlas.version>2.4.0</atlas.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -114,7 +114,7 @@
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
     <spring.version>5.3.39</spring.version>
-    <spring.ldap.version>2.4.1</spring.ldap.version>
+    <spring.ldap.version>2.4.4</spring.ldap.version>
     <!-- Thrift properties -->
     <thrift.home>you-must-set-this-to-run-thrift</thrift.home>
     <thrift.gen.dir>${basedir}/src/gen/thrift</thrift.gen.dir>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrading the Atlas to 2.4.0, details are in-detailed at [HIVE-28693](https://issues.apache.org/jira/browse/HIVE-28693)


### Why are the changes needed?
This change will fix the [CVE-2023-20863](https://nvd.nist.gov/vuln/detail/CVE-2023-20863).
And 
Upgrading to Apache Atlas 2.4.0 will not only resolve the vulnerability but also ensure alignment of spriongframework  with Apache Hive, which uses Spring Framework 5.3.39. This version of Spring Framework is included transitively by Hive.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes

### How was this patch tested?
Adding the image for packaged jars and the dependency tree for Spring
![Screenshot 2025-01-07 at 11 45 39](https://github.com/user-attachments/assets/acb3b6b0-50c9-4a21-892e-69f5a733a0bc)

And  complete dependency tree 
[hive_28693_dependency_tree.log](https://github.com/user-attachments/files/18328355/hive_28693_dependency_tree.log)

