### PR TITLE
HIVE-28619: TestHivePrivilegeObjectOwnerNameAndType to run on Tez

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHivePrivilegeObjectOwnerNameAndType.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHivePrivilegeObjectOwnerNameAndType.java
@@ -26,10 +26,8 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
-import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObject;
 import org.apache.hadoop.hive.ql.security.HiveAuthenticationProvider;
 import org.apache.hadoop.hive.ql.session.SessionState;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -68,20 +66,16 @@ public class TestHivePrivilegeObjectOwnerNameAndType {
 
   @BeforeClass
   public static void beforeTest() throws Exception {
-    UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser("hive"));
     conf = new HiveConfForTest(TestHivePrivilegeObjectOwnerNameAndType.class);
 
     // Turn on mocked authorization
     conf.setVar(ConfVars.HIVE_AUTHORIZATION_MANAGER, MockedHiveAuthorizerFactory.class.getName());
-    //conf.setVar(ConfVars.HIVE_AUTHENTICATOR_MANAGER, SessionStateUserAuthenticator.class.getName());
     conf.setBoolVar(ConfVars.HIVE_AUTHORIZATION_ENABLED, true);
     conf.setBoolVar(ConfVars.HIVE_SERVER2_ENABLE_DOAS, false);
     conf.setBoolVar(ConfVars.HIVE_SUPPORT_CONCURRENCY, true);
     conf.setVar(ConfVars.HIVE_TXN_MANAGER, DbTxnManager.class.getName());
     conf.setVar(ConfVars.HIVE_MAPRED_MODE, "nonstrict");
     conf.setVar(ConfVars.DYNAMIC_PARTITIONING_MODE, "nonstrict");
-    // TODO: HIVE-28619: TestHivePrivilegeObjectOwnerNameAndType to run on Tez
-    conf.set("hive.execution.engine", "mr");
 
     TestTxnDbUtil.prepDb(conf);
     SessionState.start(conf);


### PR DESCRIPTION


### What changes were proposed in this pull request?
This test class is intended to validate the HivePrivilegeObject for queries. If the current user is changed, insert queries fail when executed on Tez due to the validation of the staging directory's owner. The staging directory is created by the system user when the test is executed in local file system mode. Since the main goal is to validate the privilege object type and count, without checking the owner name, the simplest fix is to run the tests as the system user.

### Why are the changes needed?
Since MR is deprecated, remove the test dependency as well, by running with Tez

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Test pipeline