### PR TITLE
fix: Fix the FileNotFoundException when clean up a deleted old partition directory by Try-Catch.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4194,10 +4194,16 @@ private void constructOneLBLocationMap(FileStatus fSta,
     if (isNeedRecycle && conf.getBoolVar(HiveConf.ConfVars.REPLCMENABLED)) {
       recycleDirToCmPath(path, purge);
     }
-    FileStatus[] statuses = fs.listStatus(path, pathFilter);
+    FileStatus[] statuses = null;
+    try {
+      statuses = fs.listStatus(path, pathFilter);
+    } catch (IOException e) {
+      LOG.warn("Error listing files under " + path.toString() + ". It could be deleted already. This path will be created automatically.");
+    }
     if (statuses == null || statuses.length == 0) {
       return;
     }
+
     if (Utilities.FILE_OP_LOGGER.isTraceEnabled()) {
       String s = "Deleting files under " + path + " for replace: ";
       for (FileStatus file : statuses) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When executing org.apache.hadoop.hive.ql.metadata.Hive#cleanUpOneDirectoryForReplace, to avoid task failures caused by fs.listStatus throwing a FileNotFoundException when the partition directory has already been deleted in certain scenarios, we wrapped fs.listStatus in a try-catch block to handle the exception. This ensures that no exception is thrown in org.apache.hadoop.hive.ql.metadata.Hive#replaceFiles, allowing the downstream logic (creating the partition directory) to continue and ensuring the task executes successfully.


### Why are the changes needed?
In certain scenarios, such as using Spark SQL to perform an INSERT OVERWRITE operation on a dynamically partitioned Hive table, Spark's internal logic will first delete the partition directories. When Hive starts writing data and executes org.apache.hadoop.hive.ql.metadata.Hive#replaceFiles, a FileNotFoundException may be thrown, causing the task to fail. However, org.apache.hadoop.hive.ql.metadata.Hive#replaceFiles contains logic to create the partition directories, which cannot be executed due to the error causing an early exit. Therefore, it is necessary to catch and handle this exception.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Replace the hive-exec-3.1.3.jar file in the hive cluster after rebuilding and tested locally.
