### PR TITLE
HIVE-28701: OTEL: Fix race condition due to unavailability of Query Id.

### DIFF
--- a/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
+++ b/service/src/java/org/apache/hive/service/servlet/OTELExporter.java
@@ -34,6 +34,7 @@ import io.opentelemetry.sdk.internal.AttributesMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.common.OTELJavaMetrics;
 import org.apache.hadoop.hive.ql.QueryDisplay;
 import org.apache.hadoop.hive.ql.QueryInfo;
@@ -86,8 +87,8 @@ public class OTELExporter extends Thread {
 
     LOG.debug("Found {} liveQueries and {} historicalQueries", liveQueries.size(), historicalQueries.size());
 
-    for (QueryInfo lQuery: liveQueries){
-      if(lQuery.getQueryDisplay() == null){
+    for (QueryInfo lQuery : liveQueries) {
+      if (lQuery.getQueryDisplay() == null || StringUtils.isEmpty(lQuery.getQueryDisplay().getQueryId())) {
         continue;
       }
       String queryID = lQuery.getQueryDisplay().getQueryId();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip publishing LiveQuery until it has a QueryId allocated.
 
### Why are the changes needed?

To avoid orphan span due to `null` queryId


### Does this PR introduce _any_ user-facing change?

No

### Is the change a dependency upgrade?

No

### How was this patch tested?

Manual 