### PR TITLE
HIVE-28702: Statistics are inconsistent on time travel queries

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -585,7 +585,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   @Override
   public boolean canProvideColStatistics(org.apache.hadoop.hive.ql.metadata.Table hmsTable) {
     Table table = IcebergTableUtil.getTable(conf, hmsTable.getTTable());
-    return canSetColStatistics(hmsTable) && canProvideColStats(table, table.currentSnapshot().snapshotId());
+    long snapshotId = IcebergTableUtil.getTableSnapshot(hmsTable, table).snapshotId();
+    return canSetColStatistics(hmsTable) && canProvideColStats(table, snapshotId);
   }
 
   private boolean canProvideColStats(Table table, long snapshotId) {
@@ -595,7 +596,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   @Override
   public List<ColumnStatisticsObj> getColStatistics(org.apache.hadoop.hive.ql.metadata.Table hmsTable) {
     Table table = IcebergTableUtil.getTable(conf, hmsTable.getTTable());
-    return IcebergTableUtil.getColStatsPath(table).map(statsPath -> readColStats(table, statsPath))
+    long snapshotId = IcebergTableUtil.getTableSnapshot(hmsTable, table).snapshotId();
+    return IcebergTableUtil.getColStatsPath(table, snapshotId).map(statsPath -> readColStats(table, statsPath))
       .orElse(new ColumnStatistics()).getStatsObj();
   }
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/puffin_col_stats_with_time_travel.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/puffin_col_stats_with_time_travel.q
@@ -1,0 +1,25 @@
+set hive.fetch.task.conversion=none;
+
+create external table default.tbl_ice_puffin_time_travel(a int, b string, c int) stored by iceberg;
+insert into default.tbl_ice_puffin_time_travel values (1, 'one', 50), (2, 'two', 51);
+alter table default.tbl_ice_puffin_time_travel create tag checkpoint;
+
+explain select * from default.tbl_ice_puffin_time_travel;
+explain select * from default.tbl_ice_puffin_time_travel.tag_checkpoint;
+
+insert into tbl_ice_puffin_time_travel values
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null);
+
+explain select * from default.tbl_ice_puffin_time_travel;
+explain select * from default.tbl_ice_puffin_time_travel.tag_checkpoint;

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/puffin_col_stats_with_time_travel.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/puffin_col_stats_with_time_travel.q.out
@@ -201,14 +201,14 @@ STAGE PLANS:
                 TableScan
                   alias: tbl_ice_puffin_time_travel
                   Snapshot ref: tag_checkpoint
-                  Statistics: Num rows: 2 Data size: 8960 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: a (type: int), b (type: string), c (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 2 Data size: -855 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 2 Data size: -855 Basic stats: PARTIAL Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/puffin_col_stats_with_time_travel.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/puffin_col_stats_with_time_travel.q.out
@@ -1,0 +1,224 @@
+PREHOOK: query: create external table default.tbl_ice_puffin_time_travel(a int, b string, c int) stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl_ice_puffin_time_travel
+POSTHOOK: query: create external table default.tbl_ice_puffin_time_travel(a int, b string, c int) stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl_ice_puffin_time_travel
+PREHOOK: query: insert into default.tbl_ice_puffin_time_travel values (1, 'one', 50), (2, 'two', 51)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl_ice_puffin_time_travel
+POSTHOOK: query: insert into default.tbl_ice_puffin_time_travel values (1, 'one', 50), (2, 'two', 51)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl_ice_puffin_time_travel
+PREHOOK: query: alter table default.tbl_ice_puffin_time_travel create tag checkpoint
+PREHOOK: type: ALTERTABLE_CREATETAG
+PREHOOK: Input: default@tbl_ice_puffin_time_travel
+POSTHOOK: query: alter table default.tbl_ice_puffin_time_travel create tag checkpoint
+POSTHOOK: type: ALTERTABLE_CREATETAG
+POSTHOOK: Input: default@tbl_ice_puffin_time_travel
+PREHOOK: query: explain select * from default.tbl_ice_puffin_time_travel
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice_puffin_time_travel
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from default.tbl_ice_puffin_time_travel
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice_puffin_time_travel
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: tbl_ice_puffin_time_travel
+                  Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs (cache only)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from default.tbl_ice_puffin_time_travel.tag_checkpoint
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice_puffin_time_travel
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from default.tbl_ice_puffin_time_travel.tag_checkpoint
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice_puffin_time_travel
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: tbl_ice_puffin_time_travel
+                  Snapshot ref: tag_checkpoint
+                  Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs (cache only)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: insert into tbl_ice_puffin_time_travel values
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl_ice_puffin_time_travel
+POSTHOOK: query: insert into tbl_ice_puffin_time_travel values
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null),
+(null, null, null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl_ice_puffin_time_travel
+PREHOOK: query: explain select * from default.tbl_ice_puffin_time_travel
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice_puffin_time_travel
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from default.tbl_ice_puffin_time_travel
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice_puffin_time_travel
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: tbl_ice_puffin_time_travel
+                  Statistics: Num rows: 14 Data size: 285 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 285 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 14 Data size: 285 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs (cache only)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from default.tbl_ice_puffin_time_travel.tag_checkpoint
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice_puffin_time_travel
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from default.tbl_ice_puffin_time_travel.tag_checkpoint
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice_puffin_time_travel
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: tbl_ice_puffin_time_travel
+                  Snapshot ref: tag_checkpoint
+                  Statistics: Num rows: 2 Data size: 8960 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: -855 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 2 Data size: -855 Basic stats: PARTIAL Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs (cache only)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+

--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -423,6 +423,7 @@ iceberg.llap.query.files=\
   iceberg_merge_files.q,\
   llap_iceberg_read_orc.q,\
   llap_iceberg_read_parquet.q,\
+  puffin_col_stats_with_time_travel.q,\
   vectorized_iceberg_read_mixed.q,\
   vectorized_iceberg_read_multitable.q,\
   vectorized_iceberg_read_orc.q,\
@@ -457,7 +458,8 @@ iceberg.llap.only.query.files=\
   iceberg_merge_delete_files.q,\
   iceberg_merge_files.q,\
   llap_iceberg_read_orc.q,\
-  llap_iceberg_read_parquet.q
+  llap_iceberg_read_parquet.q,\
+  puffin_col_stats_with_time_travel.q
 
 compaction.query.files=\
   compaction_query_based.q,\


### PR DESCRIPTION
### What changes were proposed in this pull request?

Let `HiveIcebergStorageHandler` respect time travel conditions on fetching column statistics in Puffin files.

### Why are the changes needed?

Currently, `HiveIcebergStorageHandler#canProvideColStatistics` and `HiveIcebergStorageHandler#getColStatistics` retrieve statistics based on the current snapshot id while `HiveIcebergStorageHandler#getBasicStatistics` respects conditions of time travel features. It causes column statistics to be inconsistent with basic stats. For example, column stats can say there are 100 null values even though basic stats say the number of total rows is only 10. Hive can get confused when it builds an execution plan.

### Does this PR introduce _any_ user-facing change?

Yes. Users will see better execution plans when they submit time travel queries.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

I added a new qtest. [The first commit](https://github.com/apache/hive/commit/ee04e72f84006e81db7437b72a8a9952d1373ac5) includes a `q.out` reproducing the problem.