### PR TITLE
HIVE-28705: Fix Data Inconsistency due to missing 'IS NOT? TRUE/FALSE' parsing in Partition Filter Pruning

### DIFF
--- a/ql/src/test/queries/clientpositive/casewhen_isnot_boolean_partition.q
+++ b/ql/src/test/queries/clientpositive/casewhen_isnot_boolean_partition.q
@@ -1,0 +1,95 @@
+create table t1(id int) partitioned by (month int, year string);
+insert into t1 select 2,2,'2020';
+insert into t1 select 3,3,'2024';
+insert into t1 select 4,4,'2020';
+
+select id from t1 where (CASE WHEN (month=3) THEN true else false END);
+select id from t1 where (CASE WHEN (month=3) THEN false else true END);
+select id from t1 where (CASE WHEN (year='2024') THEN true else false END);
+select id from t1 where (CASE WHEN (year='2024') THEN false else true END);
+
+select id from t1 where (CASE WHEN (month=3 and year='2024') THEN true else false END);
+select id from t1 where (CASE WHEN (month=3 and year='2024') THEN false else true END);
+
+select id from t1 where (CASE WHEN (month=3 or month=4) THEN true else false END);
+select id from t1 where (CASE WHEN (month=3 or month=4) THEN false else true END);
+
+select id from t1 where (month=3) is not true;
+select id from t1 where (month=3) is true;
+select id from t1 where (month=3) is not false;
+select id from t1 where (month=3) is false;
+
+select id from t1 where (month=3 or month=4) is not true;
+select id from t1 where (month=3 or month=4) is true;
+select id from t1 where (month=3 or month=4) is not false;
+select id from t1 where (month=3 or month=4) is false;
+
+select id from t1 where (month=3 and id=3) is not true;
+select id from t1 where (month=3 and id=3) is true;
+select id from t1 where (month=3 and id=3) is not false;
+select id from t1 where (month=3 and id=3) is false;
+
+select id from t1 where (month=3) and (id=3) is not true;
+select id from t1 where (month=3) and (id=3) is true;
+select id from t1 where (month=3) and (id=3) is not false;
+select id from t1 where (month=3) and (id=3) is false;
+
+select id from t1 where ((month=3 or month=4) and year='2024') is not true;
+select id from t1 where ((month=3 or month=4) and year='2024') is true;
+select id from t1 where ((month=3 or month=4) and year='2024') is not false;
+select id from t1 where ((month=3 or month=4) and year='2024') is false;
+
+select id from t1 where month in (3,4) is not true;
+select id from t1 where month not in (3,4) is not true;
+select id from t1 where month in (3,4) is not false;
+select id from t1 where month not in (3,4) is not false;
+select id from t1 where month in (3,4) is  true;
+select id from t1 where month not in (3,4) is true;
+select id from t1 where month in (3,4) is  false;
+select id from t1 where month not in (3,4) is false;
+
+set hive.cbo.enable=false;
+select id from t1 where (CASE WHEN (month=3) THEN true else false END);
+select id from t1 where (CASE WHEN (month=3) THEN false else true END);
+select id from t1 where (CASE WHEN (year='2024') THEN true else false END);
+select id from t1 where (CASE WHEN (year='2024') THEN false else true END);
+
+select id from t1 where (CASE WHEN (month=3 and year='2024') THEN true else false END);
+select id from t1 where (CASE WHEN (month=3 and year='2024') THEN false else true END);
+
+select id from t1 where (CASE WHEN (month=3 or month=4) THEN true else false END);
+select id from t1 where (CASE WHEN (month=3 or month=4) THEN false else true END);
+
+select id from t1 where (month=3) is not true;
+select id from t1 where (month=3) is true;
+select id from t1 where (month=3) is not false;
+select id from t1 where (month=3) is false;
+
+select id from t1 where (month=3 or month=4) is not true;
+select id from t1 where (month=3 or month=4) is true;
+select id from t1 where (month=3 or month=4) is not false;
+select id from t1 where (month=3 or month=4) is false;
+
+select id from t1 where (month=3 and id=3) is not true;
+select id from t1 where (month=3 and id=3) is true;
+select id from t1 where (month=3 and id=3) is not false;
+select id from t1 where (month=3 and id=3) is false;
+
+select id from t1 where (month=3) and (id=3) is not true;
+select id from t1 where (month=3) and (id=3) is true;
+select id from t1 where (month=3) and (id=3) is not false;
+select id from t1 where (month=3) and (id=3) is false;
+
+select id from t1 where ((month=3 or month=4) and year='2024') is not true;
+select id from t1 where ((month=3 or month=4) and year='2024') is true;
+select id from t1 where ((month=3 or month=4) and year='2024') is not false;
+select id from t1 where ((month=3 or month=4) and year='2024') is false;
+
+select id from t1 where month in (3,4) is not true;
+select id from t1 where month not in (3,4) is not true;
+select id from t1 where month in (3,4) is not false;
+select id from t1 where month not in (3,4) is not false;
+select id from t1 where month in (3,4) is  true;
+select id from t1 where month not in (3,4) is true;
+select id from t1 where month in (3,4) is  false;
+select id from t1 where month not in (3,4) is false;

--- a/ql/src/test/results/clientpositive/llap/casewhen_isnot_boolean_partition.q.out
+++ b/ql/src/test/results/clientpositive/llap/casewhen_isnot_boolean_partition.q.out
@@ -1,0 +1,924 @@
+PREHOOK: query: create table t1(id int) partitioned by (month int, year string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(id int) partitioned by (month int, year string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1 select 2,2,'2020'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1 select 2,2,'2020'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Output: default@t1@month=2/year=2020
+POSTHOOK: Lineage: t1 PARTITION(month=2,year=2020).id SIMPLE []
+PREHOOK: query: insert into t1 select 3,3,'2024'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1 select 3,3,'2024'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Output: default@t1@month=3/year=2024
+POSTHOOK: Lineage: t1 PARTITION(month=3,year=2024).id SIMPLE []
+PREHOOK: query: insert into t1 select 4,4,'2020'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1 select 4,4,'2020'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Output: default@t1@month=4/year=2020
+POSTHOOK: Lineage: t1 PARTITION(month=4,year=2020).id SIMPLE []
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3) THEN true else false END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3) THEN true else false END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3) THEN false else true END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3) THEN false else true END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (year='2024') THEN true else false END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (year='2024') THEN true else false END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (CASE WHEN (year='2024') THEN false else true END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (year='2024') THEN false else true END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3 and year='2024') THEN true else false END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3 and year='2024') THEN true else false END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3 and year='2024') THEN false else true END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3 and year='2024') THEN false else true END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3 or month=4) THEN true else false END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3 or month=4) THEN true else false END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3 or month=4) THEN false else true END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3 or month=4) THEN false else true END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where (month=3) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (month=3) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (month=3 or month=4) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 or month=4) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where (month=3 or month=4) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 or month=4) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where (month=3 or month=4) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 or month=4) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where (month=3 or month=4) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 or month=4) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where (month=3 and id=3) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 and id=3) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (month=3 and id=3) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 and id=3) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3 and id=3) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 and id=3) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3 and id=3) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 and id=3) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (month=3) and (id=3) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) and (id=3) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+PREHOOK: query: select id from t1 where (month=3) and (id=3) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) and (id=3) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3) and (id=3) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) and (id=3) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3) and (id=3) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) and (id=3) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+PREHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where month in (3,4) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month in (3,4) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where month not in (3,4) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month not in (3,4) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where month in (3,4) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month in (3,4) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where month not in (3,4) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month not in (3,4) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where month in (3,4) is  true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month in (3,4) is  true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where month not in (3,4) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month not in (3,4) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where month in (3,4) is  false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month in (3,4) is  false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where month not in (3,4) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month not in (3,4) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3) THEN true else false END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3) THEN true else false END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3) THEN false else true END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3) THEN false else true END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (year='2024') THEN true else false END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (year='2024') THEN true else false END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (CASE WHEN (year='2024') THEN false else true END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (year='2024') THEN false else true END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3 and year='2024') THEN true else false END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3 and year='2024') THEN true else false END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3 and year='2024') THEN false else true END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3 and year='2024') THEN false else true END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3 or month=4) THEN true else false END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3 or month=4) THEN true else false END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where (CASE WHEN (month=3 or month=4) THEN false else true END)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (CASE WHEN (month=3 or month=4) THEN false else true END)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where (month=3) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (month=3) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (month=3 or month=4) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 or month=4) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where (month=3 or month=4) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 or month=4) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where (month=3 or month=4) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 or month=4) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where (month=3 or month=4) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 or month=4) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where (month=3 and id=3) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 and id=3) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (month=3 and id=3) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 and id=3) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3 and id=3) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 and id=3) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3 and id=3) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3 and id=3) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where (month=3) and (id=3) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) and (id=3) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+PREHOOK: query: select id from t1 where (month=3) and (id=3) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) and (id=3) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3) and (id=3) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) and (id=3) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where (month=3) and (id=3) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where (month=3) and (id=3) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+PREHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+#### A masked pattern was here ####
+3
+PREHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where ((month=3 or month=4) and year='2024') is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+2
+4
+PREHOOK: query: select id from t1 where month in (3,4) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month in (3,4) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where month not in (3,4) is not true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month not in (3,4) is not true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where month in (3,4) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month in (3,4) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where month not in (3,4) is not false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month not in (3,4) is not false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where month in (3,4) is  true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month in (3,4) is  true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4
+PREHOOK: query: select id from t1 where month not in (3,4) is true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month not in (3,4) is true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where month in (3,4) is  false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month in (3,4) is  false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=2/year=2020
+#### A masked pattern was here ####
+2
+PREHOOK: query: select id from t1 where month not in (3,4) is false
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t1@month=3/year=2024
+PREHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+POSTHOOK: query: select id from t1 where month not in (3,4) is false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t1@month=3/year=2024
+POSTHOOK: Input: default@t1@month=4/year=2020
+#### A masked pattern was here ####
+3
+4

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/PartitionFilter.g4
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/PartitionFilter.g4
@@ -39,6 +39,9 @@ conditionExpression
     | key=identifier NOT? BETWEEN lower=constant AND upper=constant         #betweenCondition
     | LPAREN key=identifier RPAREN NOT? IN LPAREN values=constantSeq RPAREN #inCondition
     | LPAREN STRUCT identifierList RPAREN NOT? IN constStructList           #multiColInExpression
+    | LPAREN expression RPAREN IS NOT? booleanLiteral                       #booleanCondition
+    | LPAREN orExpression RPAREN IS NOT? booleanLiteral                     #booleanWrappedExpression
+    | LPAREN key=identifier RPAREN NOT? IN LPAREN values=constantSeq RPAREN IS NOT? booleanLiteral  # inConditionWithBoolean
     ;
 
 comparisonOperator
@@ -87,6 +90,11 @@ timestamp
     | value=TIMESTAMP_VALUE
     ;
 
+booleanLiteral
+    : TRUE
+    | FALSE
+    ;
+
 // Keywords
 LPAREN : '(' ;
 RPAREN : ')' ;
@@ -101,6 +109,9 @@ CONST : 'CONST';
 MINUS : '-';
 DATE : 'DATE';
 TIMESTAMP : 'TIMESTAMP';
+IS : 'IS';
+TRUE : 'TRUE';
+FALSE : 'FALSE';
 
 EQ : '=' | '==';
 NSEQ : '<=>';


### PR DESCRIPTION

### What changes were proposed in this pull request?
Added missing support for parsing '**IS NOT? TRUE/FALSE**' conditions in partition filter pruning. Specifically, it handles cases where partition filters with boolean expressions such as IS NOT TRUE or IS NOT FALSE are involved, ensuring correct partition pruning behaviour.

### Why are the changes needed?
These changes address data inconsistencies in queries involving partition filter pushdown to the Hive Metastore (HMS), especially when dealing with boolean expressions like **IS NOT? TRUE** or **IS NOT? FALSE**. Previously, the partition pruning logic failed to correctly interpret these expressions, leading to incorrect results and inefficient query execution. With the new parsing logic, partition pruning now handles these complex boolean conditions properly, ensuring accurate data retrieval and better query performance.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Test scenarios added
