### PR TITLE
HIVE-28716: Add owner information in HivePrivilegeObject for create database query

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/create/CreateDatabaseAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/create/CreateDatabaseAnalyzer.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.hadoop.hive.metastore.api.DataConnector;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.DatabaseType;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
 import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
@@ -115,6 +116,7 @@ public class CreateDatabaseAnalyzer extends BaseSemanticAnalyzer {
       database.setRemote_dbname(remoteDbName);
     }
     database.setOwnerName(SessionState.getUserFromAuthenticator());
+    database.setOwnerType(PrincipalType.USER);
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
     outputs.add(new WriteEntity(database, WriteEntity.WriteType.DDL_NO_LOCK));
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/create/CreateDatabaseAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/create/CreateDatabaseAnalyzer.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.session.SessionState;
 
 /**
  * Analyzer for database creation commands.
@@ -113,6 +114,7 @@ public class CreateDatabaseAnalyzer extends BaseSemanticAnalyzer {
       database.setType(DatabaseType.REMOTE);
       database.setRemote_dbname(remoteDbName);
     }
+    database.setOwnerName(SessionState.getUserFromAuthenticator());
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
     outputs.add(new WriteEntity(database, WriteEntity.WriteType.DDL_NO_LOCK));
   }

--- a/ql/src/test/results/clientpositive/llap/authorization_privilege_objects.q.out
+++ b/ql/src/test/results/clientpositive/llap/authorization_privilege_objects.q.out
@@ -1,5 +1,5 @@
 outputHObjs:
-HIVE PRIVILEGE OBJECT { type: DATABASE actionType: OTHER dbName: test_auth_obj_db}
+HIVE PRIVILEGE OBJECT { type: DATABASE actionType: OTHER dbName: test_auth_obj_db OWNER: testuser}
 PREHOOK: query: CREATE DATABASE test_auth_obj_db
 PREHOOK: type: CREATEDATABASE
 PREHOOK: Output: database:test_auth_obj_db

--- a/ql/src/test/results/clientpositive/llap/authorization_privilege_objects.q.out
+++ b/ql/src/test/results/clientpositive/llap/authorization_privilege_objects.q.out
@@ -1,5 +1,5 @@
 outputHObjs:
-HIVE PRIVILEGE OBJECT { type: DATABASE actionType: OTHER dbName: test_auth_obj_db OWNER: testuser}
+HIVE PRIVILEGE OBJECT { type: DATABASE actionType: OTHER dbName: test_auth_obj_db OWNER: testuser OWNERTYPE: USER}
 PREHOOK: query: CREATE DATABASE test_auth_obj_db
 PREHOOK: type: CREATEDATABASE
 PREHOOK: Output: database:test_auth_obj_db


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refer to [HIVE-28716](https://issues.apache.org/jira/browse/HIVE-28716) and [RANGER-5097](https://issues.apache.org/jira/browse/RANGER-5097) for the info


### Why are the changes needed?
Currently we are not passing the owner information for database in HivePrivilegeObject. This object is passed to ranger and ranger is using this owner information but as it is missing, NoSuchObjectException is thrown HS2 logs. Check the above mentioned JIRA for stacktrace and debugging screenshot. 

**NOTE: There is no impact on the functionality, table/db is getting created in hive. It more of a noise in the HS2 logs coming from ranger.** 


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
On Cluster testing and monitoring HS2 logs
