### PR TITLE
HIVE-28720: EXPLAIN CBO is empty when hive.cbo.returnpath.hiveop is true

### DIFF
--- a/ql/src/test/queries/clientpositive/cbo_rp_explain.q
+++ b/ql/src/test/queries/clientpositive/cbo_rp_explain.q
@@ -1,0 +1,13 @@
+set hive.cbo.returnpath.hiveop=true;
+
+CREATE TABLE author (id INT, fname STRING, lname STRING, birth DATE);
+CREATE TABLE book (id INT, title STRING, author INT);
+
+EXPLAIN CBO
+SELECT lname, MAX(birth) FROM author GROUP BY lname;
+
+EXPLAIN CBO
+SELECT author.lname, book.title
+FROM author 
+INNER JOIN book ON author.id=book.author
+WHERE author.fname = 'Victor';

--- a/ql/src/test/results/clientpositive/llap/cbo_rp_explain.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_rp_explain.q.out
@@ -1,0 +1,61 @@
+PREHOOK: query: CREATE TABLE author (id INT, fname STRING, lname STRING, birth DATE)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@author
+POSTHOOK: query: CREATE TABLE author (id INT, fname STRING, lname STRING, birth DATE)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@author
+PREHOOK: query: CREATE TABLE book (id INT, title STRING, author INT)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@book
+POSTHOOK: query: CREATE TABLE book (id INT, title STRING, author INT)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@book
+PREHOOK: query: EXPLAIN CBO
+SELECT lname, MAX(birth) FROM author GROUP BY lname
+PREHOOK: type: QUERY
+PREHOOK: Input: default@author
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT lname, MAX(birth) FROM author GROUP BY lname
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@author
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAggregate(group=[{0}], agg#0=[max($1)])
+  HiveProject(lname=[$2], birth=[$3])
+    HiveTableScan(table=[[default, author]], qbid:alias=[author])
+
+PREHOOK: query: EXPLAIN CBO
+SELECT author.lname, book.title
+FROM author 
+INNER JOIN book ON author.id=book.author
+WHERE author.fname = 'Victor'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@author
+PREHOOK: Input: default@book
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT author.lname, book.title
+FROM author 
+INNER JOIN book ON author.id=book.author
+WHERE author.fname = 'Victor'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@author
+POSTHOOK: Input: default@book
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(lname=[$2], title=[$3])
+  HiveJoin(condition=[=($0, $4)], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveSortExchange(distribution=[hash[0]], collation=[[0]])
+      HiveProject(id=[$0], fname=[CAST(_UTF-16LE'Victor':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"], lname=[$2])
+        HiveFilter(condition=[AND(=($1, _UTF-16LE'Victor'), IS NOT NULL($0))])
+          HiveTableScan(table=[[default, author]], qbid:alias=[author])
+    HiveSortExchange(distribution=[hash[1]], collation=[[1]])
+      HiveProject(title=[$1], author=[$2])
+        HiveFilter(condition=[IS NOT NULL($2)])
+          HiveTableScan(table=[[default, book]], qbid:alias=[book])
+

--- a/ql/src/test/results/clientpositive/llap/groupby_ppr_multi_distinct.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_ppr_multi_distinct.q.out
@@ -340,6 +340,10 @@ POSTHOOK: Input: default@srcpart
 POSTHOOK: Input: default@srcpart@ds=2008-04-08/hr=11
 POSTHOOK: Input: default@srcpart@ds=2008-04-08/hr=12
 POSTHOOK: Output: default@dest1
+OPTIMIZED SQL: SELECT SUBSTR(`key`, 1, 1) AS `_o__c0`, COUNT(DISTINCT SUBSTR(`value`, 5)) AS `_o__c1`, SUBSTR(`key`, 1, 1) || SUM(SUBSTR(`value`, 5)) AS `_o__c2`, SUM(DISTINCT SUBSTR(`value`, 5)) AS `_o__c3`, COUNT(DISTINCT `value`) AS `_o__c4`
+FROM `default`.`srcpart`
+WHERE `ds` = '2008-04-08'
+GROUP BY SUBSTR(`key`, 1, 1)
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-2 depends on stages: Stage-1


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Refactor enrichment of explain context for all branches with CBO plans
2. Extract PlanModifierForReturnPath outside getOptimizedHiveOPDag to make the effects visible in `EXPLAIN CBO`
3. Move some debug/trace messages and make them more uniform.

### Why are the changes needed?
Display CBO plan when hive.cbo.returnpath.hiveop is true

### Does this PR introduce _any_ user-facing change?
EXPLAIN CBO will show the plan as expected.

### Is the change a dependency upgrade?
No

### How was this patch tested?
```
mvn test -Dtest=TestMiniLlapLocalCliDriver.java -Dqfile="cbo_rp_explain.q"
```