### PR TITLE
HIVE-28704: Upgrade pac4j core and opensamlv3 and exclude Javax.json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <netty.version>4.1.116.Final</netty.version>
     <netty3.version>3.10.5.Final</netty3.version>
     <!-- used by druid storage handler -->
-    <pac4j-saml.version>4.5.5</pac4j-saml.version>
+    <pac4j-saml.version>4.5.8</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
     <parquet.version>1.14.4</parquet.version>
     <pig.version>0.16.0</pig.version>
@@ -879,6 +879,10 @@
           <exclusion>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
           </exclusion>
           <exclusion>
             <!-- The dependency included in pac4j is old and has known CVEs.

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -190,6 +190,10 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcprov-jdk15on</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.glassfish</groupId>
+          <artifactId>javax.json</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -108,7 +108,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <httpcomponents.core.version>4.4.13</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
-    <pac4j-core.version>4.5.5</pac4j-core.version>
+    <pac4j-core.version>4.5.8</pac4j-core.version>
     <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
     <jetty.version>9.4.45.v20220203</jetty.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Before:
[INFO] +- org.pac4j:pac4j-saml-opensamlv3:jar:4.5.5:compile
[INFO] |  +- org.pac4j:pac4j-core:jar:4.5.5:compile
[INFO] |  +- org.opensaml:opensaml-storage-impl:jar:3.4.6:compile
[INFO] |  |  +- org.ldaptive:ldaptive:jar:1.0.13:compile
[INFO] |  |  +- javax.json:javax.json-api:jar:1.0:compile
[INFO] |  |  +- net.spy:spymemcached:jar:2.12.3:compile
[INFO] |  |  \- **org.glassfish:javax.json:jar:1.0.4:runtime**

After: 
[INFO] +- org.pac4j:pac4j-saml-opensamlv3:jar:4.5.8:compile
[INFO] |  +- org.pac4j:pac4j-core:jar:4.5.8:compile
[INFO] |  +- org.opensaml:opensaml-storage-impl:jar:3.4.6:compile
[INFO] |  |  +- org.ldaptive:ldaptive:jar:1.0.13:compile
[INFO] |  |  +- javax.json:javax.json-api:jar:1.0:compile
[INFO] |  |  \- net.spy:spymemcached:jar:2.12.3:compile


### Why are the changes needed?
To fix [CVE-2023-7272](https://nvd.nist.gov/vuln/detail/cve-2023-7272)

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes

### How was this patch tested?
Existing testcases. Also tested this in cluster, by removing the jar
