### PR TITLE
HIVE-28437: Add documentation for initializing the system schemas for HiveServer2 for Docker Image

### DIFF
--- a/packaging/src/docker/entrypoint.sh
+++ b/packaging/src/docker/entrypoint.sh
@@ -31,9 +31,9 @@ function initialize_hive {
   fi
   $HIVE_HOME/bin/schematool -dbType $DB_DRIVER $COMMAND $VERBOSE_MODE
   if [ $? -eq 0 ]; then
-    echo "Initialized schema successfully.."
+    echo "Initialized Hive Metastore Server schema successfully.."
   else
-    echo "Schema initialization failed!"
+    echo "Hive Metastore Server schema initialization failed!"
     exit 1
   fi
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Add documentation for initializing the system schemas for HiveServer2 for Docker Image. See https://hive.apache.org/development/quickstart/ .


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- The result of my 6-month investigation on https://issues.apache.org/jira/browse/HIVE-28437 is that HiveServer2 definitely supports the use of the `INFORMATION_SCHEMA` database, but it is not enabled by default, which causes a lot of trouble for unit testing scenarios of third-party libraries such as testcontainers-java .
- Early investigations came from https://github.com/linghengqian/hive-server2-jdbc-driver/pull/22 , https://github.com/apache/shardingsphere/issues/29052 . It seems that the Hive documentation https://hive.apache.org/docs/latest/hive-schema-tool_34835119/ does not support viewing images. I will still refer to the documentation at https://cwiki.apache.org/confluence/display/hive/hive+schema+tool .
- Without the current PR, it would be very troublesome to use Hive's Docker Image to retrieve the `information_schema` database in unit tests. Because `/opt/hive/bin/schematool` is not part of the SQL command, `/opt/hive/bin/schematool` is part of the shell command, and using `/opt/hive/bin/schematool` requires entering the Hive Docker Image.
```java
import org.junit.jupiter.api.Test;
import org.testcontainers.containers.Container.ExecResult;
import org.testcontainers.containers.GenericContainer;
import org.testcontainers.junit.jupiter.Container;
import org.testcontainers.junit.jupiter.Testcontainers;
import org.testcontainers.utility.DockerImageName;
import java.io.IOException;
import java.sql.*;
import java.time.Duration;
import java.time.temporal.ChronoUnit;
import static org.awaitility.Awaitility.await;
import static org.hamcrest.MatcherAssert.assertThat;
import static org.hamcrest.Matchers.is;
import static org.junit.jupiter.api.Assertions.assertThrows;
@SuppressWarnings({"SqlNoDataSourceInspection", "resource"})
@Testcontainers
public class InformationSchemaTest {
    @Container
    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(DockerImageName.parse("apache/hive:4.0.1"))
            .withEnv("SERVICE_NAME", "hiveserver2")
            .withExposedPorts(10000);

    @Test
    void test() throws SQLException, IOException, InterruptedException {
        String jdbcUrlPrefix = "jdbc:hive2://" + CONTAINER.getHost() + ":" + CONTAINER.getMappedPort(10000);
        await().atMost(Duration.of(30L, ChronoUnit.SECONDS)).ignoreExceptions().until(() -> {
            DriverManager.getConnection(jdbcUrlPrefix).close();
            return true;
        });
        try (Connection connection = DriverManager.getConnection(jdbcUrlPrefix);
             Statement statement = connection.createStatement()) {
            statement.execute("CREATE DATABASE demo_ds_0");
        }
        try (Connection connection = DriverManager.getConnection(jdbcUrlPrefix + "/demo_ds_0");
             Statement statement = connection.createStatement()) {
            statement.execute("CREATE TABLE IF NOT EXISTS t_order (\n" +
                    "    order_id   BIGINT NOT NULL,\n" +
                    "    order_type INT,\n" +
                    "    user_id    INT    NOT NULL,\n" +
                    "    address_id BIGINT NOT NULL,\n" +
                    "    status     string,\n" +
                    "    PRIMARY KEY (order_id) disable novalidate\n" +
                    ") STORED BY ICEBERG STORED AS ORC TBLPROPERTIES ('format-version' = '2')");
            statement.execute("TRUNCATE TABLE t_order");
            statement.executeUpdate("INSERT INTO t_order (order_id, user_id, order_type, address_id, status) VALUES (1, 1, 1, 1, 'INSERT_TEST')");
            ResultSet resultSet = statement.executeQuery("select * from t_order");
            assertThat(resultSet.next(), is(true));
        }
        assertThrows(SQLException.class, () -> DriverManager.getConnection(jdbcUrlPrefix + "/information_schema").close());
        ExecResult infoResult = CONTAINER.execInContainer(
                "/opt/hive/bin/schematool",
                "-info",
                "-dbType", "hive",
                "-metaDbType", "derby",
                "-url", "jdbc:hive2://localhost:10000/default"
        );
        assertThat(infoResult.getStdout(), is("Metastore connection URL:\t jdbc:hive2://localhost:10000/default\n" +
                "Metastore connection Driver :\t org.apache.hive.jdbc.HiveDriver\n" +
                "Metastore connection User:\t APP\n"));
        ExecResult initResult = CONTAINER.execInContainer(
                "/opt/hive/bin/schematool",
                "-initSchema",
                "-dbType", "hive",
                "-metaDbType", "derby",
                "-url", "jdbc:hive2://localhost:10000/default"
        );
        assertThat(initResult.getStdout(), is("Initializing the schema to: 4.0.0\n" +
                "Metastore connection URL:\t jdbc:hive2://localhost:10000/default\n" +
                "Metastore connection Driver :\t org.apache.hive.jdbc.HiveDriver\n" +
                "Metastore connection User:\t APP\n" +
                "Starting metastore schema initialization to 4.0.0\n" +
                "Initialization script hive-schema-4.0.0.hive.sql\n" +
                "Initialization script completed\n"));
        try (Connection connection = DriverManager.getConnection(jdbcUrlPrefix + "/information_schema");
             Statement statement = connection.createStatement()) {
            ResultSet resultSet = statement.executeQuery("select * from information_schema.COLUMNS limit 100");
            assertThat(resultSet.next(), is(true));
        }
    }
}
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

- This will affect all users of the Hive Docker Image.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->

- No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

- CI tests the Docker Image for the master branch. https://github.com/linghengqian/hive-server2-jdbc-driver/pull/22 tests the Docker Image for Hive 4.0.1 .
