### PR TITLE
HIVE-24110: NullPointerException occurs in some UDFs

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFCharacterLength.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFCharacterLength.java
@@ -50,7 +50,7 @@ public class GenericUDFCharacterLength extends GenericUDF {
 
     if (arguments[0].getCategory() != ObjectInspector.Category.PRIMITIVE) {
       throw new UDFArgumentException(
-          "CHARACTER_LENGTH only takes primitive types, got " + argumentOI.getTypeName());
+          "CHARACTER_LENGTH only takes primitive types, got " + arguments[0].getTypeName());
     }
     argumentOI = (PrimitiveObjectInspector) arguments[0];
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFLength.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFLength.java
@@ -56,7 +56,7 @@ public class GenericUDFLength extends GenericUDF {
 
     if (arguments[0].getCategory() != ObjectInspector.Category.PRIMITIVE) {
       throw new UDFArgumentException(
-          "LENGTH only takes primitive types, got " + argumentOI.getTypeName());
+          "LENGTH only takes primitive types, got " + arguments[0].getTypeName());
     }
     argumentOI = (PrimitiveObjectInspector) arguments[0];
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOctetLength.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOctetLength.java
@@ -50,7 +50,7 @@ public class GenericUDFOctetLength extends GenericUDF {
 
     if (arguments[0].getCategory() != ObjectInspector.Category.PRIMITIVE) {
       throw new UDFArgumentException(
-          "OCTET_LENGTH only takes primitive types, got " + argumentOI.getTypeName());
+          "OCTET_LENGTH only takes primitive types, got " + arguments[0].getTypeName());
     }
     argumentOI = (PrimitiveObjectInspector) arguments[0];
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Since it refers to a variable that has not been initialized, NullPointerException occurs and the correct error message is not displayed.
```
if (arguments[0].getCategory() != ObjectInspector.Category.PRIMITIVE) {
  throw new UDFArgumentException(
                  "OCTET_LENGTH only takes primitive types, got " + argumentOI.getTypeName());
}
argumentOI = (PrimitiveObjectInspector) arguments[0];
```

### Why are the changes needed?
Correct error message is not displayed when an error occurs.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
At my Hadoop cluster.