### PR TITLE
[WIP: do not review] HIVE-28712: Fix error wrt maxParts in partition logs

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -810,10 +810,10 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
                     + maxParts);
   }
 
-  private void startPartitionFunction(String function, String catName, String db, String tbl, int maxParts,
+  private void startPartitionFunction(String function, String catName, String db, String tbl, int partitionLimit,
                                       String expression, String defaultPartitionName) {
     startFunction(function, " : tbl=" + TableName.getQualified(catName, db, tbl) + ": Expression=" + expression
-            + ": Default partition name=" + defaultPartitionName + ": Max partitions=" + maxParts);
+            + ": Default partition name=" + defaultPartitionName + ": Max partitions=" + partitionLimit);
   }
 
   private String getGroupsCountAndUsername(final String user_name, final List<String> group_names) {
@@ -7601,8 +7601,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     String catName = req.isSetCatName() ? req.getCatName() : getDefaultCatalog(conf);
     String expr = req.isSetExpr() ? Arrays.toString((req.getExpr())) : "";
     String defaultPartitionName = req.isSetDefaultPartitionName() ? req.getDefaultPartitionName() : "";
-    int maxParts = req.getMaxParts();
-    startPartitionFunction("get_partitions_by_expr", catName, dbName, tblName, maxParts, expr, defaultPartitionName);
+    int partitionLimit = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.LIMIT_PARTITION_REQUEST);
+    startPartitionFunction("get_partitions_by_expr", catName, dbName, tblName, partitionLimit, expr, defaultPartitionName);
     fireReadTablePreEvent(catName, dbName, tblName);
     PartitionsByExprResult ret = null;
     Exception ex = null;


### PR DESCRIPTION
### What changes were proposed in this pull request?
The changes include passing the config value LIMIT_PARTITION_REQUEST instead of maxparts (whose value is set to -1) in get_partitions_by_expr logging expression. This will help in reflecting the correct quantity in case the config is set and being honored with the filter/expr on the partition column
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Current partition logs display max partitions = -1, which is the default value. But on changing the value of LIMIT_PARTITION_REQUEST, the set value is not displayed, instead -1 continues to be logged. 
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?

Existing tests

Case 1: Test passing, before the fix:
![image](https://github.com/user-attachments/assets/d7c5d179-7800-4570-8ed2-f2d1eae19fed)


After the fix:
![image](https://github.com/user-attachments/assets/deec7264-5e21-4a55-bd6c-1cb2157c86ad)


Case 2: Test failing, before the fix:
![image](https://github.com/user-attachments/assets/94e504fe-f67a-41ef-9a6a-da8fc1500462)
![image](https://github.com/user-attachments/assets/a37d4df2-e2cf-4367-a35f-511523632dd2)



After the fix:
![image](https://github.com/user-attachments/assets/8dcdbe74-c4c3-4026-a2d4-1ad0321d9fc0)
![image](https://github.com/user-attachments/assets/2f9e4d30-9bb0-43a4-a5f5-400dcb650d69)


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
