### PR TITLE
HIVE-28749: The default hikaricp.leakDetectionThreshold is not valid

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hive.metastore.datasource;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-
 import com.codahale.metrics.MetricRegistry;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -42,8 +40,6 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
   private static final Logger LOG = LoggerFactory.getLogger(HikariCPDataSourceProvider.class);
 
   static final String HIKARI = "hikaricp";
-  private static final String LEAK_DETECTION_THRESHOLD = "leakDetectionThreshold";
-  private static final long DEFAULT_LEAK_DETECTION_THRESHOLD = MINUTES.toMillis(10);
 
   @Override
   public DataSource create(Configuration hdpConfig, int maxPoolSize) throws SQLException {
@@ -55,7 +51,6 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     String passwd = DataSourceProvider.getMetastoreJdbcPasswd(hdpConfig);
 
     Properties properties = replacePrefix(DataSourceProvider.getPrefixedProperties(hdpConfig, HIKARI));
-    properties.putIfAbsent(LEAK_DETECTION_THRESHOLD, DEFAULT_LEAK_DETECTION_THRESHOLD);
 
     HikariConfig config;
     try {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -41,6 +41,7 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
 
   static final String HIKARI = "hikaricp";
   private static final String CONNECTION_TIMEOUT_PROPERTY = HIKARI + ".connectionTimeout";
+  private static final String MAX_LIFETIME = HIKARI + ".maxLifetime";
   private static final String LEAK_DETECTION_THRESHOLD = HIKARI + ".leakDetectionThreshold";
 
   @Override
@@ -55,6 +56,7 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     Properties properties = replacePrefix(
         DataSourceProvider.getPrefixedProperties(hdpConfig, HIKARI));
     long connectionTimeout = hdpConfig.getLong(CONNECTION_TIMEOUT_PROPERTY, 30000L);
+    long maxLifetime = hdpConfig.getLong(MAX_LIFETIME, 3600000L);
     long leakDetectionThreshold = hdpConfig.getLong(LEAK_DETECTION_THRESHOLD, 3600000L);
 
     HikariConfig config;
@@ -67,6 +69,7 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     config.setJdbcUrl(driverUrl);
     config.setUsername(user);
     config.setPassword(passwd);
+    config.setMaxLifetime(maxLifetime);
     config.setLeakDetectionThreshold(leakDetectionThreshold);
     if (!StringUtils.isEmpty(poolName)) {
       config.setPoolName(poolName);
@@ -79,7 +82,7 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     // so that the connection pool can retire the idle connection aggressively,
     // this will make Metastore more scalable especially if there is a leader in the warehouse.
     if ("mutex".equals(poolName)) {
-      int minimumIdle = Integer.valueOf(hdpConfig.get(HIKARI + ".minimumIdle", "2"));
+      int minimumIdle = Integer.parseInt(hdpConfig.get(HIKARI + ".minimumIdle", "2"));
       config.setMinimumIdle(Math.min(maxPoolSize, minimumIdle));
     }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
@@ -63,9 +63,27 @@ public class TestDataSourceProviderFactory {
   }
 
   @Test
-  public void testSetHikariCpLeakDetectionThresholdProperty() throws SQLException {
+  public void testDefaultHikariCpProperties() throws SQLException {
+    MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
+
+    DataSourceProvider dsp = DataSourceProviderFactory.tryGetDataSourceProviderOrNull(conf);
+    Assert.assertNotNull(dsp);
+
+    DataSource ds = dsp.create(conf);
+    Assert.assertTrue(ds instanceof HikariDataSource);
+    HikariDataSource hds = (HikariDataSource) ds;
+    Assert.assertEquals(30000L, hds.getConnectionTimeout());
+    Assert.assertEquals(1800000L, hds.getMaxLifetime());
+    Assert.assertEquals(600000L, hds.getLeakDetectionThreshold());
+    Assert.assertEquals(1L, hds.getInitializationFailTimeout());
+  }
+
+  @Test
+  public void testSetHikariCpProperties() throws SQLException {
 
     MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
+    conf.set(HikariCPDataSourceProvider.HIKARI + ".connectionTimeout", "2000");
+    conf.set(HikariCPDataSourceProvider.HIKARI + ".maxLifetime", "50000");
     conf.set(HikariCPDataSourceProvider.HIKARI + ".leakDetectionThreshold", "3600");
     conf.set(HikariCPDataSourceProvider.HIKARI + ".initializationFailTimeout", "-1");
 
@@ -74,7 +92,11 @@ public class TestDataSourceProviderFactory {
 
     DataSource ds = dsp.create(conf);
     Assert.assertTrue(ds instanceof HikariDataSource);
-    Assert.assertEquals(3600L, ((HikariDataSource)ds).getLeakDetectionThreshold());
+    HikariDataSource hds = (HikariDataSource) ds;
+    Assert.assertEquals(2000L, hds.getConnectionTimeout());
+    Assert.assertEquals(50000L, hds.getMaxLifetime());
+    Assert.assertEquals(3600L, hds.getLeakDetectionThreshold());
+    Assert.assertEquals(-1L, hds.getInitializationFailTimeout());
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
@@ -74,7 +74,7 @@ public class TestDataSourceProviderFactory {
     HikariDataSource hds = (HikariDataSource) ds;
     Assert.assertEquals(30000L, hds.getConnectionTimeout());
     Assert.assertEquals(1800000L, hds.getMaxLifetime());
-    Assert.assertEquals(600000L, hds.getLeakDetectionThreshold());
+    Assert.assertEquals(0L, hds.getLeakDetectionThreshold());
     Assert.assertEquals(1L, hds.getInitializationFailTimeout());
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

HicariConfig's leak detection threshold has to be smaller than the max lifetime. Our default leak detection threshold is greater than the maximum lifetime defined on the HikariCP side and is disabled by default. Please check the JIRA for details.

https://issues.apache.org/jira/browse/HIVE-28749

### Why are the changes needed?

Make our default value effective.

### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

- I verified the warning disappears with default configurations
- I tested `hikaricp.maxLifetime` was configurable in my local machine