### PR TITLE
HIVE-28763: Iceberg: Support functions while expiring snapshots.

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergExpireSnapshots.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergExpireSnapshots.java
@@ -27,6 +27,7 @@ import org.apache.commons.collections4.IterableUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.functional.RemoteIterators;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -183,6 +184,9 @@ public class TestHiveIcebergExpireSnapshots extends HiveIcebergStorageHandlerWit
         "(CURRENT_DATE - 1) AND '" + toTime + "'");
     table.refresh();
     Assert.assertEquals(1, IterableUtils.size(table.snapshots()));
+    AssertHelpers.assertThrows("Invalid timestamp expression", IllegalArgumentException.class, () ->
+        shell.executeStatement("ALTER TABLE " + identifier.name() + " EXECUTE EXPIRE_SNAPSHOTS BETWEEN " +
+        "(RAND()) AND '" + toTime + "'"));
   }
 
   @Test

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
@@ -493,7 +493,7 @@ alterStatementSuffixExecute
 @after { gParent.popMsg(state); }
     : KW_EXECUTE KW_ROLLBACK LPAREN (rollbackParam=(StringLiteral | Number)) RPAREN
     -> ^(TOK_ALTERTABLE_EXECUTE KW_ROLLBACK $rollbackParam)
-    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS (LPAREN (expireParam=StringLiteral) RPAREN)?
+    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS (LPAREN (expireParam=expression) RPAREN)?
     -> ^(TOK_ALTERTABLE_EXECUTE KW_EXPIRE_SNAPSHOTS $expireParam?)
     | KW_EXECUTE KW_SET_CURRENT_SNAPSHOT LPAREN (snapshotParam=expression) RPAREN
     -> ^(TOK_ALTERTABLE_EXECUTE KW_SET_CURRENT_SNAPSHOT $snapshotParam)
@@ -501,12 +501,18 @@ alterStatementSuffixExecute
     -> ^(TOK_ALTERTABLE_EXECUTE KW_FAST_FORWARD $sourceBranch $targetBranch?)
     | KW_EXECUTE KW_CHERRY_PICK snapshotId=Number
     -> ^(TOK_ALTERTABLE_EXECUTE KW_CHERRY_PICK $snapshotId)
-    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS KW_BETWEEN (fromTimestamp=StringLiteral) KW_AND (toTimestamp=StringLiteral)
+    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS  KW_BETWEEN
+      fromTimestamp=timestampExpression KW_AND toTimestamp=timestampExpression
     -> ^(TOK_ALTERTABLE_EXECUTE KW_EXPIRE_SNAPSHOTS $fromTimestamp $toTimestamp)
     | KW_EXECUTE KW_EXPIRE_SNAPSHOTS KW_RETAIN KW_LAST numToRetain=Number
     -> ^(TOK_ALTERTABLE_EXECUTE KW_EXPIRE_SNAPSHOTS KW_RETAIN $numToRetain)
     | KW_EXECUTE KW_DELETE KW_ORPHAN_FILES (KW_OLDER KW_THAN LPAREN (timestamp=StringLiteral) RPAREN)?
     -> ^(TOK_ALTERTABLE_EXECUTE KW_ORPHAN_FILES $timestamp?)
+    ;
+
+timestampExpression
+    : StringLiteral                    -> StringLiteral
+    | LPAREN expression RPAREN         -> expression
     ;
 
 alterStatementSuffixRenameBranch

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
@@ -501,7 +501,7 @@ alterStatementSuffixExecute
     -> ^(TOK_ALTERTABLE_EXECUTE KW_FAST_FORWARD $sourceBranch $targetBranch?)
     | KW_EXECUTE KW_CHERRY_PICK snapshotId=Number
     -> ^(TOK_ALTERTABLE_EXECUTE KW_CHERRY_PICK $snapshotId)
-    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS  KW_BETWEEN
+    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS KW_BETWEEN
       fromTimestamp=timestampExpression KW_AND toTimestamp=timestampExpression
     -> ^(TOK_ALTERTABLE_EXECUTE KW_EXPIRE_SNAPSHOTS $fromTimestamp $toTimestamp)
     | KW_EXECUTE KW_EXPIRE_SNAPSHOTS KW_RETAIN KW_LAST numToRetain=Number

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/execute/AlterTableExecuteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/execute/AlterTableExecuteAnalyzer.java
@@ -181,6 +181,9 @@ public class AlterTableExecuteAnalyzer extends AbstractAlterTableAnalyzer {
       QueryState queryState = new QueryState.Builder().withGenerateNewQueryId(false).withHiveConf(conf).build();
       SemanticAnalyzer sem = (SemanticAnalyzer) SemanticAnalyzerFactory.get(queryState, node);
       ExprNodeDesc desc = sem.genExprNodeDesc(node, new RowResolver(), false, true);
+      if(!(desc instanceof ExprNodeConstantDesc))  {
+        throw new SemanticException("Invalid timestamp expression");
+      }
       ExprNodeConstantDesc constantDesc = (ExprNodeConstantDesc) desc;
       return String.valueOf(constantDesc.getValue());
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/execute/AlterTableExecuteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/execute/AlterTableExecuteAnalyzer.java
@@ -39,7 +39,12 @@ import org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec.DeleteOrphanFilesDe
 import org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec.ExpireSnapshotsSpec;
 import org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec.FastForwardSpec;
 import org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec.RollbackSpec;
+import org.apache.hadoop.hive.ql.parse.RowResolver;
+import org.apache.hadoop.hive.ql.parse.SemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.SemanticAnalyzerFactory;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
@@ -85,7 +90,7 @@ public class AlterTableExecuteAnalyzer extends AbstractAlterTableAnalyzer {
         desc = getRollbackDesc(tableName, partitionSpec, (ASTNode) command.getChild(1));
         break;
       case HiveParser.KW_EXPIRE_SNAPSHOTS:
-        desc = getExpireSnapshotDesc(tableName, partitionSpec,  command.getChildren());
+        desc = getExpireSnapshotDesc(tableName, partitionSpec,  command.getChildren(), queryState.getConf());
         break;
       case HiveParser.KW_SET_CURRENT_SNAPSHOT:
         desc = getSetCurrentSnapshotDesc(tableName, partitionSpec, (ASTNode) command.getChild(1));
@@ -98,7 +103,7 @@ public class AlterTableExecuteAnalyzer extends AbstractAlterTableAnalyzer {
         break;
       case HiveParser.KW_ORPHAN_FILES:
         desc = getDeleteOrphanFilesDesc(tableName, partitionSpec,  command.getChildren());
-        break;        
+        break;
     }
 
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
@@ -139,7 +144,7 @@ public class AlterTableExecuteAnalyzer extends AbstractAlterTableAnalyzer {
   }
 
   private static AlterTableExecuteDesc getExpireSnapshotDesc(TableName tableName, Map<String, String> partitionSpec,
-      List<Node> children) throws SemanticException {
+      List<Node> children, HiveConf conf) throws SemanticException {
     AlterTableExecuteSpec<ExpireSnapshotsSpec> spec;
     if (children.size() == 1) {
       spec = new AlterTableExecuteSpec(EXPIRE_SNAPSHOT, null);
@@ -158,17 +163,28 @@ public class AlterTableExecuteAnalyzer extends AbstractAlterTableAnalyzer {
     } else if (children.size() == 3) {
       ASTNode secondNode = (ASTNode) children.get(2);
       String secondNodeText = PlanUtils.stripQuotes(secondNode.getText().trim());
-      TimestampTZ fromTime = TimestampTZUtil.parse(firstNodeText, timeZone);
-      TimestampTZ toTime = TimestampTZUtil.parse(secondNodeText, timeZone);
+      TimestampTZ fromTime = TimestampTZUtil.parse(getTimeStampString(conf, firstNode, firstNodeText), timeZone);
+      TimestampTZ toTime = TimestampTZUtil.parse(getTimeStampString(conf, secondNode, secondNodeText), timeZone);
       spec = new AlterTableExecuteSpec(EXPIRE_SNAPSHOT,
           new ExpireSnapshotsSpec(fromTime.toEpochMilli(), toTime.toEpochMilli()));
     } else if (EXPIRE_SNAPSHOT_BY_ID_REGEX.matcher(firstNodeText).matches()) {
       spec = new AlterTableExecuteSpec(EXPIRE_SNAPSHOT, new ExpireSnapshotsSpec(firstNodeText));
     } else {
-      TimestampTZ time = TimestampTZUtil.parse(firstNodeText, timeZone);
+      TimestampTZ time = TimestampTZUtil.parse(getTimeStampString(conf, firstNode, firstNodeText), timeZone);
       spec = new AlterTableExecuteSpec(EXPIRE_SNAPSHOT, new ExpireSnapshotsSpec(time.toEpochMilli()));
     }
     return new AlterTableExecuteDesc(tableName, partitionSpec, spec);
+  }
+
+  private static String getTimeStampString(HiveConf conf, ASTNode node, String nodeText) throws SemanticException {
+    if (node.getChildCount() > 0) {
+      QueryState queryState = new QueryState.Builder().withGenerateNewQueryId(false).withHiveConf(conf).build();
+      SemanticAnalyzer sem = (SemanticAnalyzer) SemanticAnalyzerFactory.get(queryState, node);
+      ExprNodeDesc desc = sem.genExprNodeDesc(node, new RowResolver(), false, true);
+      ExprNodeConstantDesc constantDesc = (ExprNodeConstantDesc) desc;
+      return String.valueOf(constantDesc.getValue());
+    }
+    return nodeText;
   }
 
   private static AlterTableExecuteDesc getRollbackDesc(TableName tableName, Map<String, String> partitionSpec,

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13533,7 +13533,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return genExprNodeDesc(expr, input, true, false);
   }
 
-  ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input, boolean useCaching,
+  public ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input, boolean useCaching,
                                       boolean foldExpr) throws SemanticException {
     TypeCheckCtx tcCtx = new TypeCheckCtx(input, useCaching, foldExpr);
     return genExprNodeDesc(expr, input, tcCtx);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow specifying functions while expiring snapshots

### Why are the changes needed?

Better Usability

### Does this PR introduce _any_ user-facing change?

Yes, Expire Snapshots allows valid expressions

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT