### PR TITLE
HIVE-28768: Remove hardcoded post exec hooks

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -64,6 +64,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -7301,6 +7302,12 @@ public class HiveConf extends Configuration {
       }
     }
     return ret;
+  }
+
+  public static boolean shouldComputeLineage(HiveConf conf) {
+    Collection<String> lineage_filter =
+      conf.getTrimmedStringCollection(HiveConf.ConfVars.HIVE_LINEAGE_STATEMENT_FILTER.varname);
+    return !(lineage_filter.isEmpty() || lineage_filter.contains("NONE"));
   }
 
   // sync all configs from given conf

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -7305,9 +7305,10 @@ public class HiveConf extends Configuration {
   }
 
   public static boolean shouldComputeLineage(HiveConf conf) {
-    Collection<String> lineage_filter =
+    Collection<String> lineageFilter =
       conf.getTrimmedStringCollection(HiveConf.ConfVars.HIVE_LINEAGE_STATEMENT_FILTER.varname);
-    return !(lineage_filter.isEmpty() || lineage_filter.contains("NONE"));
+    return !(lineageFilter.isEmpty() || lineageFilter.contains("NONE"))
+      || conf.getBoolVar(ConfVars.HIVE_LINEAGE_INFO);
   }
 
   // sync all configs from given conf

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3881,7 +3881,7 @@ public class HiveConf extends Configuration {
     HIVE_LINEAGE_INFO("hive.lineage.hook.info.enabled", false,
         "Whether Hive provides lineage information to hooks." +
             "Deprecated: use hive.lineage.statement.filter instead."),
-    HIVE_LINEAGE_STATEMENT_FILTER("hive.lineage.statement.filter", "ALL",
+    HIVE_LINEAGE_STATEMENT_FILTER("hive.lineage.statement.filter", "NONE",
         "Whether Hive provides lineage information to hooks for the specified statements only, " +
             "the value is a comma-separated list (ex.: CREATE_MATERIALIZED_VIEW," +
             "CREATE_TABLE,CREATE_TABLE_AS_SELECT). Possible values are: CREATE_TABLE, CREATE_TABLE_AS_SELECT, " +

--- a/data/conf/hive-site.xml
+++ b/data/conf/hive-site.xml
@@ -155,6 +155,12 @@
 </property>
 
 <property>
+  <name>hive.lineage.statement.filter</name>
+  <value>ALL</value>
+  <description>Lineage information filter</description>
+</property>
+
+<property>
   <name>hive.exec.post.hooks</name>
   <value>org.apache.hadoop.hive.ql.hooks.PostExecutePrinter</value>
   <description>Post Execute Hook for Tests</description>

--- a/data/conf/hive-site.xml
+++ b/data/conf/hive-site.xml
@@ -157,7 +157,7 @@
 <property>
   <name>hive.lineage.statement.filter</name>
   <value>ALL</value>
-  <description>Lineage information filter</description>
+  <description>Specify the types of statements for which column lineage information is generated</description>
 </property>
 
 <property>

--- a/data/conf/iceberg/llap/hive-site.xml
+++ b/data/conf/iceberg/llap/hive-site.xml
@@ -155,6 +155,12 @@
     </property>
 
     <property>
+      <name>hive.lineage.statement.filter</name>
+      <value>ALL</value>
+      <description>Lineage information filter</description>
+    </property>
+
+    <property>
         <name>hive.exec.post.hooks</name>
         <value>org.apache.hadoop.hive.ql.hooks.PostExecutePrinter</value>
         <description>Post Execute Hook for Tests</description>

--- a/data/conf/iceberg/llap/hive-site.xml
+++ b/data/conf/iceberg/llap/hive-site.xml
@@ -157,7 +157,7 @@
     <property>
       <name>hive.lineage.statement.filter</name>
       <value>ALL</value>
-      <description>Lineage information filter</description>
+      <description>Specify the types of statements for which column lineage information is generated</description>
     </property>
 
     <property>

--- a/data/conf/iceberg/tez/hive-site.xml
+++ b/data/conf/iceberg/tez/hive-site.xml
@@ -146,6 +146,12 @@
 </property>
 
 <property>
+  <name>hive.lineage.statement.filter</name>
+  <value>ALL</value>
+  <description>Lineage information filter</description>
+</property>
+
+<property>
   <name>hive.exec.pre.hooks</name>
   <value>org.apache.hadoop.hive.ql.hooks.PreExecutePrinter, org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyTables</value>
   <description>Pre Execute Hook for Tests</description>

--- a/data/conf/iceberg/tez/hive-site.xml
+++ b/data/conf/iceberg/tez/hive-site.xml
@@ -148,7 +148,7 @@
 <property>
   <name>hive.lineage.statement.filter</name>
   <value>ALL</value>
-  <description>Lineage information filter</description>
+  <description>Specify the types of statements for which column lineage information is generated</description>
 </property>
 
 <property>

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -163,7 +163,7 @@
 <property>
   <name>hive.lineage.statement.filter</name>
   <value>ALL</value>
-  <description>Lineage information filter</description>
+  <description>Specify the types of statements for which column lineage information is generated</description>
 </property>
 
 <property>

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -161,6 +161,12 @@
 </property>
 
 <property>
+  <name>hive.lineage.statement.filter</name>
+  <value>ALL</value>
+  <description>Lineage information filter</description>
+</property>
+
+<property>
   <name>hive.exec.pre.hooks</name>
   <value>org.apache.hadoop.hive.ql.hooks.PreExecutePrinter, org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyTables</value>
   <description>Pre Execute Hook for Tests</description>

--- a/data/conf/mr/hive-site.xml
+++ b/data/conf/mr/hive-site.xml
@@ -140,6 +140,12 @@
 </property>
 
 <property>
+  <name>hive.lineage.statement.filter</name>
+  <value>ALL</value>
+  <description>Lineage information filter</description>
+</property>
+
+<property>
   <name>hive.exec.pre.hooks</name>
   <value>org.apache.hadoop.hive.ql.hooks.PreExecutePrinter, org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyTables, org.apache.hadoop.hive.ql.hooks.MaterializedViewRegistryPropertiesHook</value>
   <description>Pre Execute Hook for Tests</description>

--- a/data/conf/mr/hive-site.xml
+++ b/data/conf/mr/hive-site.xml
@@ -142,7 +142,7 @@
 <property>
   <name>hive.lineage.statement.filter</name>
   <value>ALL</value>
-  <description>Lineage information filter</description>
+  <description>Specify the types of statements for which column lineage information is generated</description>
 </property>
 
 <property>

--- a/data/conf/rlist/hive-site.xml
+++ b/data/conf/rlist/hive-site.xml
@@ -144,7 +144,7 @@
 <property>
   <name>hive.lineage.statement.filter</name>
   <value>ALL</value>
-  <description>Lineage information filter</description>
+  <description>Specify the types of statements for which column lineage information is generated</description>
 </property>
 
 <property>

--- a/data/conf/rlist/hive-site.xml
+++ b/data/conf/rlist/hive-site.xml
@@ -142,6 +142,12 @@
 </property>
 
 <property>
+  <name>hive.lineage.statement.filter</name>
+  <value>ALL</value>
+  <description>Lineage information filter</description>
+</property>
+
+<property>
   <name>hive.exec.pre.hooks</name>
   <value>org.apache.hadoop.hive.ql.hooks.PreExecutePrinter, org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyTables</value>
   <description>Pre Execute Hook for Tests</description>

--- a/data/conf/tez/hive-site.xml
+++ b/data/conf/tez/hive-site.xml
@@ -153,6 +153,12 @@
 </property>
 
 <property>
+  <name>hive.lineage.statement.filter</name>
+  <value>ALL</value>
+  <description>Lineage information filter</description>
+</property>
+
+<property>
   <name>hive.exec.post.hooks</name>
   <value>org.apache.hadoop.hive.ql.hooks.PostExecutePrinter</value>
   <description>Post Execute Hook for Tests</description>

--- a/data/conf/tez/hive-site.xml
+++ b/data/conf/tez/hive-site.xml
@@ -155,7 +155,7 @@
 <property>
   <name>hive.lineage.statement.filter</name>
   <value>ALL</value>
-  <description>Lineage information filter</description>
+  <description>Specify the types of statements for which column lineage information is generated</description>
 </property>
 
 <property>

--- a/itests/hive-blobstore/src/test/resources/hive-site.xml
+++ b/itests/hive-blobstore/src/test/resources/hive-site.xml
@@ -153,6 +153,12 @@
   </property>
 
   <property>
+    <name>hive.lineage.statement.filter</name>
+    <value>ALL</value>
+    <description>Lineage information filter</description>
+  </property>
+
+  <property>
     <name>hive.exec.pre.hooks</name>
     <value>org.apache.hadoop.hive.ql.hooks.PreExecutePrinter, org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyTables</value>
     <description>Pre Execute Hook for Tests</description>

--- a/itests/hive-blobstore/src/test/resources/hive-site.xml
+++ b/itests/hive-blobstore/src/test/resources/hive-site.xml
@@ -155,7 +155,7 @@
   <property>
     <name>hive.lineage.statement.filter</name>
     <value>ALL</value>
-    <description>Lineage information filter</description>
+    <description>Specify the types of statements for which column lineage information is generated.</description>
   </property>
 
   <property>

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/Optimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/Optimizer.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
+import static org.apache.hadoop.hive.conf.HiveConf.shouldComputeLineage;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.optimizer.calcite.translator.HiveOpConverterPostProc;
@@ -42,10 +42,6 @@ import org.apache.hadoop.hive.ql.ppd.SimplePredicatePushDown;
 import org.apache.hadoop.hive.ql.ppd.SyntheticJoinPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.Sets;
 
 /**
  * Implementation of the optimizer.
@@ -72,13 +68,7 @@ public class Optimizer {
     transformations.add(new HiveOpConverterPostProc());
 
     // Add the transformation that computes the lineage information.
-    Set<String> postExecHooks = Sets.newHashSet(
-      Splitter.on(",").trimResults().omitEmptyStrings().split(
-        Strings.nullToEmpty(HiveConf.getVar(hiveConf, HiveConf.ConfVars.POST_EXEC_HOOKS))));
-    if (hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_LINEAGE_INFO)
-        || postExecHooks.contains("org.apache.hadoop.hive.ql.hooks.PostExecutePrinter")
-        || postExecHooks.contains("org.apache.hadoop.hive.ql.hooks.LineageLogger")
-        || postExecHooks.contains("org.apache.atlas.hive.hook.HiveHook")) {
+    if (shouldComputeLineage(hiveConf)) {
       transformations.add(Generator.fromConf(hiveConf));
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/Generator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/Generator.java
@@ -90,7 +90,7 @@ public class Generator extends Transform {
   static Predicate<ParseContext> createFilterPredicateFromConf(Configuration conf) {
     Set<LineageInfoFilter> operations = new HashSet<>();
     boolean noneSpecified = false;
-    for (String valueText : conf.getStringCollection(HiveConf.ConfVars.HIVE_LINEAGE_STATEMENT_FILTER.varname)) {
+    for (String valueText : conf.getTrimmedStringCollection(HiveConf.ConfVars.HIVE_LINEAGE_STATEMENT_FILTER.varname)) {
       LineageInfoFilter enumValue = EnumUtils.getEnumIgnoreCase(LineageInfoFilter.class, valueText);
       if (enumValue == null) {
         throw new EnumConstantNotPresentException(LineageInfoFilter.class, valueText);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13261,16 +13261,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // Set the mapjoin hint if it needs to be disabled.
     pCtx.setDisableMapJoin(disableMapJoinWithHint(getQB().getParseInfo().getHintList()));
 
-    if (forViewCreation) {
+    if (forViewCreation && shouldComputeLineage(conf)) {
       // Generate lineage info if LineageLogger hook is configured.
       // Add the transformation that computes the lineage information.
-      if (shouldComputeLineage(conf)) {
-        List<Transform> transformations = new ArrayList<Transform>();
-        transformations.add(new HiveOpConverterPostProc());
-        transformations.add(Generator.fromConf(conf));
-        for (Transform t : transformations) {
-          pCtx = t.transform(pCtx);
-        }
+      List<Transform> transformations = new ArrayList<Transform>();
+      transformations.add(new HiveOpConverterPostProc());
+      transformations.add(Generator.fromConf(conf));
+      for (Transform t : transformations) {
+        pCtx = t.transform(pCtx);
       }
     }
     perfLogger.perfLogEnd(this.getClass().getName(), PerfLogger.PARSE_CONTEXT_GENERATION);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.DYNAMIC_PARTITION_CO
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_ARCHIVE_ENABLED;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_DEFAULT_STORAGE_HANDLER;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_STATS_DBCLASS;
+import static org.apache.hadoop.hive.conf.HiveConf.shouldComputeLineage;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_LOCATION;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
@@ -328,7 +329,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ReflectionUtils;
 
-import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -13264,12 +13264,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     if (forViewCreation) {
       // Generate lineage info if LineageLogger hook is configured.
       // Add the transformation that computes the lineage information.
-      Set<String> postExecHooks = Sets.newHashSet(Splitter.on(",").trimResults()
-          .omitEmptyStrings()
-          .split(Strings.nullToEmpty(HiveConf.getVar(conf, HiveConf.ConfVars.POST_EXEC_HOOKS))));
-      if (postExecHooks.contains("org.apache.hadoop.hive.ql.hooks.PostExecutePrinter")
-          || postExecHooks.contains("org.apache.hadoop.hive.ql.hooks.LineageLogger")
-          || postExecHooks.contains("org.apache.atlas.hive.hook.HiveHook")) {
+      if (shouldComputeLineage(conf)) {
         List<Transform> transformations = new ArrayList<Transform>();
         transformations.add(new HiveOpConverterPostProc());
         transformations.add(Generator.fromConf(conf));


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HIVE-28768](https://issues.apache.org/jira/browse/HIVE-28768), Use HIVE_LINEAGE_STATEMENT_FILTER configuration to determine whether to compute lineage information or not and for which query type (CTAS, Create View etc) the lineage should be computed.

### Why are the changes needed?
Currently, lineage information is computed only if few post exec hooks are configured or HIVE_LINEAGE_INFO (doesn't capture "views" related lineage) is set to true. In [HIVE-28409](https://issues.apache.org/jira/browse/HIVE-28409), fine grain control over lineage was introduced and its better to utilize that.

**Point to Ponder**: The lineage information computation will be by-default enabled for ALL query.
For more info please check the discussion [here](https://issues.apache.org/jira/browse/HIVE-28409?focusedCommentId=17927788&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17927788)

### Does this PR introduce _any_ user-facing change?
YES

### Is the change a dependency upgrade?
NO

### How was this patch tested?
On local mac setup and running lineage{1...6}.q and other lineage related q files.