### PR TITLE
HIVE-28770: Fix Session Directories Persisting After HiveServer2 Shutdown

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverUtils.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.hive.ql;
 
 import java.io.IOException;
 
-import org.apache.hadoop.hive.common.JavaUtils;
-import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.hooks.HookContext;
@@ -92,6 +90,14 @@ public final class DriverUtils {
     }
   }
 
+  public static SessionState setUpSessionState(HiveConf conf) {
+    return setUpSessionState(conf, null);
+  }
+
+  public static SessionState setUpSessionState(HiveConf conf, String user) {
+    return setUpSessionState(conf, user, true);
+  }
+
   public static SessionState setUpSessionState(HiveConf conf, String user, boolean doStart) {
     SessionState sessionState = SessionState.get();
     if (sessionState == null) {
@@ -104,8 +110,7 @@ public final class DriverUtils {
         SessionState.start(sessionState);
       }
       SessionState.setCurrentSessionState(sessionState);
-    }
-    else {
+    } else {
       sessionState.setConf(conf);
     }
     return sessionState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverUtils.java
@@ -90,11 +90,11 @@ public final class DriverUtils {
     }
   }
 
-  public static SessionState setUpSessionState(HiveConf conf) {
-    return setUpSessionState(conf, null);
+  public static SessionState setUpAndStartSessionState(HiveConf conf) {
+    return setUpAndStartSessionState(conf, null);
   }
 
-  public static SessionState setUpSessionState(HiveConf conf, String user) {
+  public static SessionState setUpAndStartSessionState(HiveConf conf, String user) {
     return setUpSessionState(conf, user, true);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/KillTriggerActionHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/KillTriggerActionHandler.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.ql.exec.tez;
 import java.io.IOException;
 import java.util.Map;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.session.KillQuery;
@@ -34,6 +35,11 @@ import org.slf4j.LoggerFactory;
  */
 public class KillTriggerActionHandler implements TriggerActionHandler<TezSessionState> {
   private static final Logger LOG = LoggerFactory.getLogger(KillTriggerActionHandler.class);
+  private final HiveConf conf;
+
+  public KillTriggerActionHandler() {
+      this.conf = new HiveConf();
+  }
 
   @Override
   public void applyAction(final Map<TezSessionState, Trigger> queriesViolated) {
@@ -43,7 +49,7 @@ public class KillTriggerActionHandler implements TriggerActionHandler<TezSession
             String queryId = sessionState.getWmContext().getQueryId();
             try {
                 UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-                DriverUtils.setUpSessionState(sessionState.getConf(), ugi.getShortUserName());
+                DriverUtils.setUpAndStartSessionState(conf, ugi.getShortUserName());
                 KillQuery killQuery = sessionState.getKillQuery();
                 // if kill query is null then session might have been released to pool or closed already
                 if (killQuery != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/KillTriggerActionHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/KillTriggerActionHandler.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hive.ql.exec.tez;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.session.KillQuery;
-import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.hive.ql.wm.Action;
 import org.apache.hadoop.hive.ql.wm.Trigger;
 import org.apache.hadoop.hive.ql.wm.TriggerActionHandler;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -38,28 +38,24 @@ public class KillTriggerActionHandler implements TriggerActionHandler<TezSession
   @Override
   public void applyAction(final Map<TezSessionState, Trigger> queriesViolated) {
     for (Map.Entry<TezSessionState, Trigger> entry : queriesViolated.entrySet()) {
-      switch (entry.getValue().getAction().getType()) {
-      case KILL_QUERY:
-        TezSessionState sessionState = entry.getKey();
-        String queryId = sessionState.getWmContext().getQueryId();
-        try {
-          UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-          SessionState ss = new SessionState(new HiveConf(), ugi.getShortUserName());
-          ss.setIsHiveServerQuery(true);
-          SessionState.start(ss);
-          KillQuery killQuery = sessionState.getKillQuery();
-          // if kill query is null then session might have been released to pool or closed already
-          if (killQuery != null) {
-            sessionState.getKillQuery().killQuery(queryId, entry.getValue().getViolationMsg(),
-                      sessionState.getConf());
-          }
-        } catch (HiveException|IOException e) {
-          LOG.warn("Unable to kill query {} for trigger violation", queryId);
+        if (entry.getValue().getAction().getType() == Action.Type.KILL_QUERY) {
+            TezSessionState sessionState = entry.getKey();
+            String queryId = sessionState.getWmContext().getQueryId();
+            try {
+                UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+                DriverUtils.setUpSessionState(sessionState.getConf(), ugi.getShortUserName());
+                KillQuery killQuery = sessionState.getKillQuery();
+                // if kill query is null then session might have been released to pool or closed already
+                if (killQuery != null) {
+                    sessionState.getKillQuery().killQuery(queryId, entry.getValue().getViolationMsg(),
+                            sessionState.getConf());
+                }
+            } catch (HiveException | IOException e) {
+                LOG.warn("Unable to kill query {} for trigger violation", queryId);
+            }
+        } else {
+            throw new RuntimeException("Unsupported action: " + entry.getValue());
         }
-        break;
-      default:
-        throw new RuntimeException("Unsupported action: " + entry.getValue());
-      }
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -487,7 +487,7 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
             LOG.info("Invoking KillQuery for " + queryId + ": " + reason);
             try {
               UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-              DriverUtils.setUpSessionState(conf, ugi.getShortUserName());
+              DriverUtils.setUpAndStartSessionState(conf, ugi.getShortUserName());
               kq.killQuery(queryId, reason, toKill.getConf());
               addKillQueryResult(toKill, true);
               killCtx.killSessionFuture.set(true);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.hive.metastore.api.WMFullResourcePlan;
 import org.apache.hadoop.hive.metastore.api.WMPool;
 import org.apache.hadoop.hive.metastore.api.WMPoolTrigger;
 import org.apache.hadoop.hive.metastore.api.WMTrigger;
+import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.exec.tez.AmPluginNode.AmPluginInfo;
 import org.apache.hadoop.hive.ql.exec.tez.TezSessionState.HiveResources;
 import org.apache.hadoop.hive.ql.exec.tez.UserPoolMapping.MappingInput;
@@ -486,9 +487,7 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
             LOG.info("Invoking KillQuery for " + queryId + ": " + reason);
             try {
               UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-              SessionState ss = new SessionState(new HiveConf(), ugi.getShortUserName());
-              ss.setIsHiveServerQuery(true);
-              SessionState.start(ss);
+              DriverUtils.setUpSessionState(conf, ugi.getShortUserName());
               kq.killQuery(queryId, reason, toKill.getConf());
               addKillQueryResult(toKill, true);
               killCtx.killSessionFuture.set(true);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hive.metastore.DefaultMetaStoreFilterHookImpl;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveTypeSystemImpl;
@@ -167,12 +168,10 @@ public final class HiveMaterializedViewsRegistry {
 
     @Override
     public void run() {
-      SessionState ss = new SessionState(db.getConf());
-      ss.setIsHiveServerQuery(true); // All is served from HS2, we do not need e.g. Tez sessions
-      SessionState.start(ss);
       PerfLogger perfLogger = SessionState.getPerfLogger();
-      perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.MATERIALIZED_VIEWS_REGISTRY_REFRESH);
       try {
+        DriverUtils.setUpSessionState(db.getConf());
+        perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.MATERIALIZED_VIEWS_REGISTRY_REFRESH);
         if (initialized.get()) {
           for (Table mvTable : db.getAllMaterializedViewObjectsForRewriting()) {
             RelOptMaterialization existingMV = getRewritingMaterializedView(

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -170,7 +170,7 @@ public final class HiveMaterializedViewsRegistry {
     public void run() {
       PerfLogger perfLogger = SessionState.getPerfLogger();
       try {
-        DriverUtils.setUpSessionState(db.getConf());
+        DriverUtils.setUpAndStartSessionState(db.getConf());
         perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.MATERIALIZED_VIEWS_REGISTRY_REFRESH);
         if (initialized.get()) {
           for (Table mvTable : db.getAllMaterializedViewObjectsForRewriting()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -44,7 +44,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -341,6 +346,14 @@ public class SessionState implements ISessionAuthState {
    * It is required to exclude compaction related queries from all Ranger policies that would otherwise apply.
    */
   private boolean compaction = false;
+
+  // A thread-safe set to hold all active session states
+  private static final Set<SessionState> sessionStates = ConcurrentHashMap.newKeySet();
+
+  // Static block to add a single shutdown hook to clean up all session states
+  static {
+    ShutdownHookManager.addShutdownHook(SessionState::cleanUpAllSessionStates);
+  }
 
   public QueryState getQueryState(String queryId) {
     return queryStateMap.get(queryId);
@@ -669,8 +682,8 @@ public class SessionState implements ISessionAuthState {
   public static SessionState start(SessionState startSs) {
     start(startSs, false, null);
 
-    //add shutdown hook to clean up the session related directories and objects
-    startSs.addSessionStateShutdownHook();
+    // Register the session state in the centralized set
+    sessionStates.add(startSs);
 
     return startSs;
   }
@@ -1911,6 +1924,8 @@ public class SessionState implements ISessionAuthState {
   }
 
   public void close() throws IOException {
+    // de-register session state
+    sessionStates.remove(this);
     for (Closeable cleanupItem : cleanupItems) {
       try {
         cleanupItem.close();
@@ -1974,16 +1989,30 @@ public class SessionState implements ISessionAuthState {
     dynamicVars.clear();
   }
 
-  private void addSessionStateShutdownHook() {
-    // Added shutdown hook to close the session.
-    ShutdownHookManager.addShutdownHook(() -> {
+  private static void cleanUpAllSessionStates() {
+    ExecutorService cleanupExecutor = Executors.newCachedThreadPool();
+    try {
+      CompletableFuture<Void> allCleanupTasks = CompletableFuture.allOf(sessionStates.stream()
+              .map(sessionState -> CompletableFuture.runAsync(() -> {
+                  try {
+                      LOG.info("Closing session state: {}", sessionState.getSessionId());
+                      sessionState.close();
+                  } catch (IOException e) {
+                      throw new CompletionException(e);
+                  }
+              }, cleanupExecutor).exceptionally(e -> {
+                  LOG.error("Problem closing session state", e);
+                  return null;
+              })).toArray(CompletableFuture[]::new));
       try {
-        LOG.info("Closing session state: {}", getSessionId());
-        close();
-      } catch (IOException e) {
-        LOG.error("Problem closing session state", e);
+        allCleanupTasks.get(60, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        LOG.error("Failed to close all session states", e);
       }
-    });
+    } finally {
+      // shutdown cleanup executor after all tasks finished/timeout
+      cleanupExecutor.shutdownNow();
+    }
   }
 
   private void clearReflectionUtilsCache() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactor.java
@@ -77,7 +77,7 @@ public abstract class QueryCompactor implements Compactor {
     Util.overrideConfProps(conf, compactionInfo, tblProperties);
     
     String user = compactionInfo.runAs;
-    SessionState sessionState = DriverUtils.setUpSessionState(conf, user, true);
+    SessionState sessionState = DriverUtils.setUpSessionState(conf, user);
     sessionState.setCompaction(true);
     
     return sessionState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactor.java
@@ -77,7 +77,7 @@ public abstract class QueryCompactor implements Compactor {
     Util.overrideConfProps(conf, compactionInfo, tblProperties);
     
     String user = compactionInfo.runAs;
-    SessionState sessionState = DriverUtils.setUpSessionState(conf, user);
+    SessionState sessionState = DriverUtils.setUpAndStartSessionState(conf, user);
     sessionState.setCompaction(true);
     
     return sessionState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hive.ql.txn.compactor;
 
 import org.apache.hadoop.hive.common.ValidTxnList;
-import org.apache.hadoop.hive.common.ValidTxnWriteIdList;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -91,7 +90,7 @@ public final class StatsUpdater {
             if (compactionQueueName != null && compactionQueueName.length() > 0) {
                 conf.set(TezConfiguration.TEZ_QUEUE_NAME, compactionQueueName);
             }
-            SessionState sessionState = DriverUtils.setUpSessionState(conf, userName);
+            SessionState sessionState = DriverUtils.setUpAndStartSessionState(conf, userName);
             DriverUtils.runOnDriver(conf, sessionState, sb.toString());
         } catch (Throwable t) {
             LOG.error(ci + ": gatherStats(" + ci.dbname + "," + ci.tableName + "," + ci.partName +

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -91,7 +91,7 @@ public final class StatsUpdater {
             if (compactionQueueName != null && compactionQueueName.length() > 0) {
                 conf.set(TezConfiguration.TEZ_QUEUE_NAME, compactionQueueName);
             }
-            SessionState sessionState = DriverUtils.setUpSessionState(conf, userName, true);
+            SessionState sessionState = DriverUtils.setUpSessionState(conf, userName);
             DriverUtils.runOnDriver(conf, sessionState, sb.toString());
         } catch (Throwable t) {
             LOG.error(ci + ": gatherStats(" + ci.dbname + "," + ci.tableName + "," + ci.partName +

--- a/ql/src/test/org/apache/hadoop/hive/ql/stats/TestStatsUpdaterThread.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/stats/TestStatsUpdaterThread.java
@@ -91,7 +91,7 @@ public class TestStatsUpdaterThread {
     if (!(new File(getTestDataDir()).mkdirs())) {
       throw new RuntimeException("Could not create " + getTestDataDir());
     }
-    this.ss = DriverUtils.setUpSessionState(hiveConf, "hive");
+    this.ss = DriverUtils.setUpAndStartSessionState(hiveConf, "hive");
     cleanUp();
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/stats/TestStatsUpdaterThread.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/stats/TestStatsUpdaterThread.java
@@ -91,7 +91,7 @@ public class TestStatsUpdaterThread {
     if (!(new File(getTestDataDir()).mkdirs())) {
       throw new RuntimeException("Could not create " + getTestDataDir());
     }
-    this.ss = DriverUtils.setUpSessionState(hiveConf, "hive", true);
+    this.ss = DriverUtils.setUpSessionState(hiveConf, "hive");
     cleanUp();
   }
 

--- a/service/src/java/org/apache/hive/service/cli/CLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/CLIService.java
@@ -32,6 +32,7 @@ import javax.security.auth.login.LoginException;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -129,9 +130,7 @@ public class CLIService extends CompositeService implements ICLIService {
       MetaException {
     // authorization setup using SessionState should be revisited eventually, as
     // authorization and authentication are not session specific settings
-    SessionState ss = new SessionState(newHiveConf);
-    ss.setIsHiveServerQuery(true);
-    SessionState.start(ss);
+    SessionState ss = DriverUtils.setUpSessionState(newHiveConf);
     ss.applyAuthorizationPolicy();
   }
 

--- a/service/src/java/org/apache/hive/service/cli/CLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/CLIService.java
@@ -130,7 +130,7 @@ public class CLIService extends CompositeService implements ICLIService {
       MetaException {
     // authorization setup using SessionState should be revisited eventually, as
     // authorization and authentication are not session specific settings
-    SessionState ss = DriverUtils.setUpSessionState(newHiveConf);
+    SessionState ss = DriverUtils.setUpAndStartSessionState(newHiveConf);
     ss.applyAuthorizationPolicy();
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ensures session related directories is properly cleaned up when HiveServer2 (HS2) shuts down, by adding a shutdown hook to call close() method, which ensures cleaning session related directories.

### Why are the changes needed?
Session related directories persist after HS2 shutdown, leading to disk bloat and performance degradation. This fix prevents unnecessary resource accumulation and improves cleanup.

### Does this PR introduce _any_ user-facing change?
No functional changes for users; it only enhances internal resource management. Temporary directories will now be cleaned up automatically.

### Is the change a dependency upgrade?
No, this PR does not introduce any dependency upgrades.

### How was this patch tested?
Manually verified that session directories on /tmp and /tmp/{user_dir}/ are created and removed correctly. 