### PR TITLE
HIVE-28766: EXECUTE IMMEDIATE with load data into table query displays ERROR on the console.

### DIFF
--- a/hplsql/src/main/java/org/apache/hive/hplsql/Stmt.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Stmt.java
@@ -1088,14 +1088,16 @@ public class Stmt {
       // Print the results
       else {
         int cols = query.columnCount();
-        while(query.next()) {
-          for(int i = 0; i < cols; i++) {
-            if(i > 1) {
-              console.print("\t");
+        if (cols > 0) {
+          while (query.next()) {
+            for (int i = 0; i < cols; i++) {
+              if (i > 1) {
+                console.print("\t");
+              }
+              console.print(query.column(i, String.class));
             }
-            console.print(query.column(i, String.class));
+            console.printLine("");
           }
-          console.printLine("");
         }
       }
     } catch(QueryException e) {

--- a/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
@@ -1376,6 +1376,26 @@ public class TestHplSqlViaBeeLine {
     testScriptFile(SCRIPT_TEXT, args(), "1");
   }
 
+  @Test
+  public void testExecuteImmediateLoadDataShouldNotThrowError() throws Throwable {
+    String scriptText =
+        "DROP TABLE IF EXISTS result;\n" +
+            "CREATE TABLE result (id bigint, name string) stored as textfile;\n" +
+            "EXECUTE IMMEDIATE 'load data local inpath ''../../data/files/hplsql.txt'' OVERWRITE INTO table result';";
+    // Inverted match, output should not have HPL/SQL error
+    testScriptFile(scriptText, args(), "^(.(?!(Error: Error running HPL/SQL operation)))*$", OutStream.ERR);
+  }
+
+  @Test
+  public void testExecuteImmediateLoadData() throws Throwable {
+    String scriptText =
+        "DROP TABLE IF EXISTS result;\n" +
+            "CREATE TABLE result (id bigint, name string);\n" +
+            "EXECUTE IMMEDIATE 'load data local inpath ''../../data/files/hplsql.txt'' OVERWRITE INTO table result';\n" +
+            "SELECT * FROM result;";
+    testScriptFile(scriptText, args(), "100.*Bob");
+  }
+
   private static List<String> args() {
     return Arrays.asList("-d", BeeLine.BEELINE_DEFAULT_JDBC_DRIVER,
             "-u", miniHS2.getBaseJdbcURL() + ";mode=hplsql", "-n", USER_NAME);

--- a/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlQueryExecutor.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlQueryExecutor.java
@@ -74,11 +74,13 @@ public class HplSqlQueryExecutor implements QueryExecutor {
 
   public Metadata metadata(OperationHandle operationHandle) {
     try {
-      TableSchema meta = hiveSession.getResultSetMetadata(operationHandle);
       List<ColumnMeta> colMeta = new ArrayList<>();
-      for (int i = 0; i < meta.getSize(); i++) {
-        ColumnDescriptor col = meta.getColumnDescriptorAt(i);
-        colMeta.add(new ColumnMeta(col.getName(), col.getTypeName(), col.getType().toJavaSQLType()));
+      if (operationHandle.hasResultSet()) {
+        TableSchema meta = hiveSession.getResultSetMetadata(operationHandle);
+        for (int i = 0; i < meta.getSize(); i++) {
+          ColumnDescriptor col = meta.getColumnDescriptorAt(i);
+          colMeta.add(new ColumnMeta(col.getName(), col.getTypeName(), col.getType().toJavaSQLType()));
+        }
       }
       return new Metadata(colMeta);
     } catch (HiveSQLException e) {


### PR DESCRIPTION
HIVE-28766: EXECUTE IMMEDIATE 'load data inpath ''/tmp/test.txt'' OVERWRITE INTO table test_table' displays ERROR on the console.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When EXECUTE IMMEDIATE 'load data inpath ''/tmp/test.txt'' OVERWRITE INTO table test_table' query is executed then the load data into table query will directly send to HS2 and its get executed. After the query is executed by HS2 the control will be back to HPLSQL code in which it is trying to check the resultset metadata but in this case there is no resultset as its a load data query so it throws NPE which resulting HPLSQL error on the console even though data is successfully loaded into the table. So here we need to check whether the query result has resultset then only access its metadata.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Without the changes, beeline console shows HPLSQL error even though the data is loaded into the table successfully which confuses the user.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
_mvn test -Dtest=TestHplSqlViaBeeLine -pl itests/hive-unit -Pitests_
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
