### PR TITLE
HIVE-28779: Add ozone filesystem to the exim uri schema whitelist.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3732,7 +3732,7 @@ public class HiveConf extends Configuration {
     HIVE_ERROR_ON_EMPTY_PARTITION("hive.error.on.empty.partition", false,
         "Whether to throw an exception if dynamic partition insert generates empty results."),
 
-    HIVE_EXIM_URI_SCHEME_WL("hive.exim.uri.scheme.whitelist", "hdfs,pfile,file,s3,s3a,gs",
+    HIVE_EXIM_URI_SCHEME_WL("hive.exim.uri.scheme.whitelist", "hdfs,pfile,file,s3,s3a,gs,ofs,o3fs",
         "A comma separated list of acceptable URI schemes for import and export."),
     // temporary variable for testing. This is added just to turn off this feature in case of a bug in
     // deployment. It has not been documented in hive-default.xml intentionally, this should be removed


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add Ozone filesystems to Exim URI whitelist, same as [HIVE-20763](https://issues.apache.org/jira/browse/HIVE-20763) for gcs

### Why are the changes needed?

To Support Ozone filesystems. The Ozone Filesystem scheme are defined here
https://github.com/apache/ozone/blob/e2bf5998c1e109bf9dbe28e0ad56b69220086814/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java#L82-L84

### Does this PR introduce _any_ user-facing change?

Yes, export can work OOTB for Ozone FileSystems

### Is the change a dependency upgrade?
No

### How was this patch tested?

Manual 