### PR TITLE
HIVE-28792: Wrong results when query has function call with char parameter type in case expression

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRexExecutorImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRexExecutorImpl.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.hadoop.hive.ql.optimizer.ConstantPropagateProcFactory;
 import org.apache.hadoop.hive.ql.optimizer.calcite.translator.ExprNodeConverter;
 import org.apache.hadoop.hive.ql.optimizer.calcite.translator.RexNodeConverter;
+import org.apache.hadoop.hive.ql.parse.type.FunctionHelper;
 import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
@@ -40,14 +41,17 @@ public class HiveRexExecutorImpl extends RexExecutorImpl {
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveRexExecutorImpl.class);
 
+  private final FunctionHelper functionHelper;
 
-  public HiveRexExecutorImpl() {
+
+  public HiveRexExecutorImpl(FunctionHelper functionHelper) {
     super(null);
+    this.functionHelper = functionHelper;
   }
 
   @Override
   public void reduce(RexBuilder rexBuilder, List<RexNode> constExps, List<RexNode> reducedValues) {
-    RexNodeConverter rexNodeConverter = new RexNodeConverter(rexBuilder, rexBuilder.getTypeFactory());
+    RexNodeConverter rexNodeConverter = new RexNodeConverter(rexBuilder, functionHelper);
     for (RexNode rexNode : constExps) {
       // initialize the converter
       ExprNodeConverter converter = new ExprNodeConverter("", null, null, null,

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/SqlFunctionConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/SqlFunctionConverter.java
@@ -95,7 +95,7 @@ public class SqlFunctionConverter {
 
   static final Map<String, SqlOperator>    hiveToCalcite;
   static final Map<SqlOperator, HiveToken> calciteToHiveToken;
-  static final Map<SqlOperator, String>    reverseOperatorMap;
+  public static final Map<SqlOperator, String>    reverseOperatorMap;
 
   static {
     StaticBlockBuilder builder = new StaticBlockBuilder();

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1652,7 +1652,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
       perfLogger.perfLogBegin(this.getClass().getName(), PerfLogger.MV_REWRITE_FIELD_TRIMMER);
       // Create executor
-      RexExecutor executorProvider = new HiveRexExecutorImpl();
+      RexExecutor executorProvider = new HiveRexExecutorImpl(functionHelper);
       calcitePlan.getCluster().getPlanner().setExecutor(executorProvider);
 
       // Create and set MD provider

--- a/ql/src/test/queries/clientpositive/cbo_case_when_type_conversion.q
+++ b/ql/src/test/queries/clientpositive/cbo_case_when_type_conversion.q
@@ -1,0 +1,17 @@
+CREATE EXTERNAL TABLE t1 (col1 char(3));
+
+INSERT INTO t1 VALUES ('A'),('b'),('c'),(null);
+
+explain cbo
+select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1;
+explain
+select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1;
+
+select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1;
+
+select col1,
+  case
+    when 'b' <> lower(col1) then 'not OK'
+    when 'b' = lower(col1) then 'OK'
+    else 'N/A'
+    end as col2 from t1;

--- a/ql/src/test/results/clientpositive/llap/cbo_case_when_type_conversion.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_case_when_type_conversion.q.out
@@ -1,0 +1,90 @@
+PREHOOK: query: CREATE EXTERNAL TABLE t1 (col1 char(3))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: CREATE EXTERNAL TABLE t1 (col1 char(3))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: INSERT INTO t1 VALUES ('A'),('b'),('c'),(null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: INSERT INTO t1 VALUES ('A'),('b'),('c'),(null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.col1 SCRIPT []
+PREHOOK: query: explain cbo
+select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(col1=[$0], col2=[CASE(=(CAST(UPPER($0)):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'A'), _UTF-16LE'OK':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'N/A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
+  HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: explain
+select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: t1
+          Select Operator
+            expressions: col1 (type: char(3)), if((CAST( upper(col1) AS STRING) = 'A'), 'OK', 'N/A') (type: string)
+            outputColumnNames: _col0, _col1
+            ListSink
+
+PREHOOK: query: select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select col1, case upper(col1) when 'A' then 'OK' else 'N/A' end as col2 from t1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+A  	OK
+b  	N/A
+c  	N/A
+NULL	N/A
+PREHOOK: query: select col1,
+  case
+    when 'b' <> lower(col1) then 'not OK'
+    when 'b' = lower(col1) then 'OK'
+    else 'N/A'
+    end as col2 from t1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select col1,
+  case
+    when 'b' <> lower(col1) then 'not OK'
+    when 'b' = lower(col1) then 'OK'
+    else 'N/A'
+    end as col2 from t1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+A  	not OK
+b  	OK
+c  	not OK
+NULL	N/A

--- a/ql/src/test/results/clientpositive/llap/cbo_case_when_wrong_type.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_case_when_wrong_type.q.out
@@ -56,7 +56,7 @@ POSTHOOK: Input: default@t
 #### A masked pattern was here ####
 CBO PLAN:
 HiveProject($f0=[1])
-  HiveFilter(condition=[IN($0, 1:SMALLINT, 2:SMALLINT)])
+  HiveFilter(condition=[AND(CASE(=(CAST($0):INTEGER, 1), true, =(CAST($0):INTEGER, 2), true, false), IN($0, 1:SMALLINT, 2:SMALLINT, 3:SMALLINT))])
     HiveTableScan(table=[[default, t]], table:alias=[t])
 
 PREHOOK: query: select 1 from t where a in (1,2,3) and case when a = 1 then true when a = 2 then true end

--- a/ql/src/test/results/clientpositive/llap/vectorized_case.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_case.q.out
@@ -68,13 +68,13 @@ STAGE PLANS:
                     predicate: (csmallint) IN (418S, 12205S, 10583S) (type: boolean)
                     Statistics: Num rows: 7 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: csmallint (type: smallint), CASE WHEN ((csmallint = 418S)) THEN ('a') WHEN ((csmallint = 12205S)) THEN ('b') ELSE ('c') END (type: string), CASE WHEN ((csmallint = 418S)) THEN ('a') WHEN ((csmallint = 12205S)) THEN ('b') ELSE ('c') END (type: string)
+                      expressions: csmallint (type: smallint), CASE WHEN ((csmallint = 418S)) THEN ('a') WHEN ((csmallint = 12205S)) THEN ('b') ELSE ('c') END (type: string), CASE WHEN ((UDFToInteger(csmallint) = 418)) THEN ('a') WHEN ((UDFToInteger(csmallint) = 12205)) THEN ('b') ELSE ('c') END (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Select Vectorization:
                           className: VectorSelectOperator
                           native: true
                           projectedOutputColumnNums: [1, 18, 23]
-                          selectExpressions: IfExprColumnCondExpr(col 14:boolean, col 15:stringcol 17:string)(children: LongColEqualLongScalar(col 1:smallint, val 418) -> 14:boolean, ConstantVectorExpression(val a) -> 15:string, IfExprStringScalarStringScalar(col 16:boolean, val b, val c)(children: LongColEqualLongScalar(col 1:smallint, val 12205) -> 16:boolean) -> 17:string) -> 18:string, IfExprColumnCondExpr(col 19:boolean, col 20:stringcol 22:string)(children: LongColEqualLongScalar(col 1:smallint, val 418) -> 19:boolean, ConstantVectorExpression(val a) -> 20:string, IfExprStringScalarStringScalar(col 21:boolean, val b, val c)(children: LongColEqualLongScalar(col 1:smallint, val 12205) -> 21:boolean) -> 22:string) -> 23:string
+                          selectExpressions: IfExprColumnCondExpr(col 14:boolean, col 15:stringcol 17:string)(children: LongColEqualLongScalar(col 1:smallint, val 418) -> 14:boolean, ConstantVectorExpression(val a) -> 15:string, IfExprStringScalarStringScalar(col 16:boolean, val b, val c)(children: LongColEqualLongScalar(col 1:smallint, val 12205) -> 16:boolean) -> 17:string) -> 18:string, IfExprColumnCondExpr(col 19:boolean, col 20:stringcol 22:string)(children: LongColEqualLongScalar(col 1:int, val 418)(children: col 1:smallint) -> 19:boolean, ConstantVectorExpression(val a) -> 20:string, IfExprStringScalarStringScalar(col 21:boolean, val b, val c)(children: LongColEqualLongScalar(col 1:int, val 12205)(children: col 1:smallint) -> 21:boolean) -> 22:string) -> 23:string
                       Statistics: Num rows: 7 Data size: 1214 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false
@@ -222,13 +222,13 @@ STAGE PLANS:
                     predicate: (csmallint) IN (418S, 12205S, 10583S) (type: boolean)
                     Statistics: Num rows: 7 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: csmallint (type: smallint), CASE WHEN ((csmallint = 418S)) THEN ('a') WHEN ((csmallint = 12205S)) THEN ('b') ELSE (null) END (type: string), CASE WHEN ((csmallint = 418S)) THEN ('a') WHEN ((csmallint = 12205S)) THEN (null) ELSE ('c') END (type: string)
+                      expressions: csmallint (type: smallint), CASE WHEN ((csmallint = 418S)) THEN ('a') WHEN ((csmallint = 12205S)) THEN ('b') ELSE (null) END (type: string), CASE WHEN ((UDFToInteger(csmallint) = 418)) THEN ('a') WHEN ((UDFToInteger(csmallint) = 12205)) THEN (null) ELSE ('c') END (type: string)
                       outputColumnNames: _col0, _col1, _col2
                       Select Vectorization:
                           className: VectorSelectOperator
                           native: true
                           projectedOutputColumnNums: [1, 19, 25]
-                          selectExpressions: IfExprColumnCondExpr(col 14:boolean, col 15:stringcol 18:string)(children: LongColEqualLongScalar(col 1:smallint, val 418) -> 14:boolean, ConstantVectorExpression(val a) -> 15:string, IfExprColumnNull(col 16:boolean, col 17:string, null)(children: LongColEqualLongScalar(col 1:smallint, val 12205) -> 16:boolean, ConstantVectorExpression(val b) -> 17:string) -> 18:string) -> 19:string, IfExprColumnCondExpr(col 20:boolean, col 21:stringcol 24:string)(children: LongColEqualLongScalar(col 1:smallint, val 418) -> 20:boolean, ConstantVectorExpression(val a) -> 21:string, IfExprNullColumn(col 22:boolean, null, col 23)(children: LongColEqualLongScalar(col 1:smallint, val 12205) -> 22:boolean, ConstantVectorExpression(val c) -> 23:string) -> 24:string) -> 25:string
+                          selectExpressions: IfExprColumnCondExpr(col 14:boolean, col 15:stringcol 18:string)(children: LongColEqualLongScalar(col 1:smallint, val 418) -> 14:boolean, ConstantVectorExpression(val a) -> 15:string, IfExprColumnNull(col 16:boolean, col 17:string, null)(children: LongColEqualLongScalar(col 1:smallint, val 12205) -> 16:boolean, ConstantVectorExpression(val b) -> 17:string) -> 18:string) -> 19:string, IfExprColumnCondExpr(col 20:boolean, col 21:stringcol 24:string)(children: LongColEqualLongScalar(col 1:int, val 418)(children: col 1:smallint) -> 20:boolean, ConstantVectorExpression(val a) -> 21:string, IfExprNullColumn(col 22:boolean, null, col 23)(children: LongColEqualLongScalar(col 1:int, val 12205)(children: col 1:smallint) -> 22:boolean, ConstantVectorExpression(val c) -> 23:string) -> 24:string) -> 25:string
                       Statistics: Num rows: 7 Data size: 194 Basic stats: COMPLETE Column stats: COMPLETE
                       File Output Operator
                         compressed: false


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Hive translates case expressions from
```
CASE x + y WHEN 1 THEN 'fee' WHEN 2 THEN 'fie' END
```
to
```
CASE WHEN =(x + y, 1) THEN 'fee' WHEN =(x + y, 2) THEN 'fie' ELSE null END
```
because Calcite supports only the latter. During the conversion, equality operators are added for each branch. This patch reuses the logic implemented in `FunctionHelper.convertInputs` to determine the common type of the newly added equality operator's operands and adds a cast if necessary.

The cast always adds the nullable version of the common type because `FunctionHelper.convertInputs` uses `FunctionRegistry.getCommonClassForComparison` to determine the common type, storing it in `org.apache.hadoop.hive.serde2.typeinfo.TypeInfo`, which does not retain nullability information.

### Why are the changes needed?
The current logic always converts the literals in the `WHEN` branches of a `CASE` statement to the type of the expression in the `CASE` clause. If these literals are of type `CHAR`, they are padded with trailing spaces.

During the AST conversion, type information is lost, and in the second non-CBO compiler phase, these literals are treated as `STRING` instead of `CHAR`. At execution, the expression in the CASE clause is converted to `STRING`, and during this conversion, whitespace characters are trimmed. As a result, the values are never equal to the literals, leading to data corruption.

### Does this PR introduce _any_ user-facing change?
Yes. Such queries will return correct results.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=cbo_case_when_type_conversion.q,cbo_case_when_wrong_type.q -pl itests/qtest -Pitests
mvn test -Dtest=TestRexNodeConverter -pl ql
```