### PR TITLE
HIVE-28773: CBO fails when a materialized view is dropped but its pre-compiled plan remains in the registry.

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestHiveMaterializedViewRegistry.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestHiveMaterializedViewRegistry.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.txn.compactor;
+
+import org.apache.hadoop.hive.common.MaterializationSnapshot;
+import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.ql.ddl.view.create.CreateMaterializedViewDesc;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.HiveMaterializedViewsRegistry;
+import org.apache.hadoop.hive.ql.metadata.HiveRelOptMaterialization;
+import org.apache.hadoop.hive.ql.metadata.MaterializedViewMetadata;
+import org.apache.hadoop.hive.ql.metadata.RewriteAlgorithm;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveMaterializedViewUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriverSilently;
+
+public class TestHiveMaterializedViewRegistry extends CompactorOnTezTest {
+
+  private static final String DB = "default";
+  private static final String TABLE1 = "t1";
+  private static final String MV1 = "mat1";
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+
+    executeStatementOnDriverSilently("drop materialized view if exists " + MV1, driver);
+    executeStatementOnDriverSilently("drop table if exists" + TABLE1 , driver);
+
+    executeStatementOnDriver("create table " + TABLE1 + "(a int, b string, c float) stored as orc TBLPROPERTIES ('transactional'='true')", driver);
+    executeStatementOnDriver("insert into " + TABLE1 + "(a,b, c) values (1, 'one', 1.1), (2, 'two', 2.2), (NULL, NULL, NULL)", driver);
+  }
+
+  @Override
+  public void tearDown() {
+    executeStatementOnDriverSilently("drop materialized view " + MV1, driver);
+    executeStatementOnDriverSilently("drop table " + TABLE1 , driver);
+
+    super.tearDown();
+  }
+
+  @Test
+  public void testRefreshAddsNewMV() throws Exception {
+    CreateMaterializedViewDesc createMaterializedViewDesc = createMaterializedViewDesc();
+    Table mvTable = createMaterializedViewDesc.toTable(conf);
+    Hive.get().createTable(mvTable);
+
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    HiveRelOptMaterialization materialization =
+            HiveMaterializedViewsRegistry.get().getRewritingMaterializedView(DB, MV1, RewriteAlgorithm.ALL);
+
+    Assert.assertEquals(DB, materialization.qualifiedTableName.get(0));
+    Assert.assertEquals(MV1, materialization.qualifiedTableName.get(1));
+  }
+
+  @Test
+  public void testRefreshDoesNotAddMVDisabledForRewrite() throws Exception {
+    CreateMaterializedViewDesc createMaterializedViewDesc = createMaterializedViewDesc();
+    createMaterializedViewDesc.setRewriteEnabled(false);
+    Table mvTable = createMaterializedViewDesc.toTable(conf);
+    Hive.get().createTable(mvTable);
+
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    HiveRelOptMaterialization materialization =
+            HiveMaterializedViewsRegistry.get().getRewritingMaterializedView(DB, MV1, RewriteAlgorithm.ALL);
+    Assert.assertNull(materialization);
+  }
+
+  @Test
+  public void testRefreshUpdatesExistingMV() throws Exception {
+    // init the registry
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    executeStatementOnDriver("create materialized view " + MV1 + " as " +
+            "select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver);
+
+    // replace the MV
+    Hive.get().dropTable(DB, MV1);
+
+    CreateMaterializedViewDesc createMaterializedViewDesc = createMaterializedViewDesc();
+    Table mvTable = createMaterializedViewDesc.toTable(conf);
+    mvTable.setMaterializedViewMetadata(new MaterializedViewMetadata(
+            "hive", DB, MV1, new HashSet<>(), new MaterializationSnapshot("anything")));
+    Hive.get().createTable(mvTable);
+
+    // test refreshing the registry
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    HiveRelOptMaterialization materialization =
+            HiveMaterializedViewsRegistry.get().getRewritingMaterializedView(DB, MV1, RewriteAlgorithm.ALL);
+
+    Assert.assertEquals(DB, materialization.qualifiedTableName.get(0));
+    Assert.assertEquals(MV1, materialization.qualifiedTableName.get(1));
+    Table existingMVTable = HiveMaterializedViewUtils.extractTable(materialization);
+    Assert.assertEquals(mvTable.getTTable().getCreateTime(), existingMVTable.getCreateTime());
+  }
+
+  @Test
+  public void testRefreshRemovesMVDisabledForRewrite() throws Exception {
+    // init the registry
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    executeStatementOnDriver("create materialized view " + MV1 + " as " +
+            "select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver);
+
+    Table mvTable = Hive.get().getTable(DB, MV1);
+    mvTable.setRewriteEnabled(false);
+
+    EnvironmentContext environmentContext = new EnvironmentContext();
+    environmentContext.putToProperties(StatsSetupConst.DO_NOT_UPDATE_STATS, StatsSetupConst.TRUE);
+    Hive.get().alterTable(mvTable, false, environmentContext, true);
+
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    HiveRelOptMaterialization materialization =
+            HiveMaterializedViewsRegistry.get().getRewritingMaterializedView(DB, MV1, RewriteAlgorithm.ALL);
+    Assert.assertNull(materialization);
+  }
+
+  @Test
+  public void testRefreshAddsMVEnabledForRewrite() throws Exception {
+    // init the registry
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    executeStatementOnDriver("create materialized view " + MV1 + " disabled rewrite as " +
+            "select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver);
+
+    Table mvTable = Hive.get().getTable(DB, MV1);
+    mvTable.setRewriteEnabled(true);
+
+    EnvironmentContext environmentContext = new EnvironmentContext();
+    environmentContext.putToProperties(StatsSetupConst.DO_NOT_UPDATE_STATS, StatsSetupConst.TRUE);
+    Hive.get().alterTable(mvTable, false, environmentContext, true);
+
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    HiveRelOptMaterialization materialization =
+            HiveMaterializedViewsRegistry.get().getRewritingMaterializedView(DB, MV1, RewriteAlgorithm.ALL);
+
+    Assert.assertEquals(DB, materialization.qualifiedTableName.get(0));
+    Assert.assertEquals(MV1, materialization.qualifiedTableName.get(1));
+  }
+
+  @Test
+  public void testRefreshRemovesMVDoesNotExists() throws Exception {
+    // init the registry
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    executeStatementOnDriver("create materialized view " + MV1 + " as " +
+            "select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver);
+
+    Hive.get().dropTable(DB, MV1);
+
+    HiveMaterializedViewsRegistry.get().refresh(Hive.get());
+
+    HiveRelOptMaterialization materialization =
+            HiveMaterializedViewsRegistry.get().getRewritingMaterializedView(DB, MV1, RewriteAlgorithm.ALL);
+    Assert.assertNull(materialization);
+  }
+
+  private static CreateMaterializedViewDesc createMaterializedViewDesc() {
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("created_with_ctas", "true");
+
+    CreateMaterializedViewDesc createMaterializedViewDesc = new CreateMaterializedViewDesc(
+            MV1,
+            null,
+            null,
+            tableProperties,
+            null,
+            null,
+            null,
+            false,
+            true,
+            "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
+            "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
+            null,
+            "org.apache.hadoop.hive.ql.io.orc.OrcSerde",
+            null,
+            new HashMap<>());
+
+    createMaterializedViewDesc.setViewOriginalText("select a,b,c from " + TABLE1 + " where a > 0 or a is null");
+    createMaterializedViewDesc.setViewExpandedText("select `t1`.`a`,`t1`.`b`,`t1`.`c` from `" + DB + "`.`" + TABLE1 + "` where `t1`.`a` > 0 or `t1`.`a` is null");
+    createMaterializedViewDesc.setSchema(
+            asList(new FieldSchema("a", "int", null),
+                    new FieldSchema("b", "string", null),
+                    new FieldSchema("c", "float", null)));
+
+    return createMaterializedViewDesc;
+  }
+}

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestQueryRewrite.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestQueryRewrite.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.txn.compactor;
+
+import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.execSelectAndDumpData;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriverSilently;
+
+public class TestQueryRewrite extends CompactorOnTezTest {
+
+  private static final String DB = "default";
+  private static final String TABLE1 = "t1";
+  private static final String MV1 = "mat1";
+
+  private static final List<String> ORIGINAL_QUERY_PLAN = Arrays.asList(
+          "CBO PLAN:",
+          "HiveProject(a=[$0], b=[$1])",
+          "  HiveFilter(condition=[>($0, 0)])",
+          "    HiveTableScan(table=[[" + DB + ", " + TABLE1 + "]], table:alias=[" + TABLE1 + "])",
+          ""
+  );
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+
+    executeStatementOnDriverSilently("drop materialized view if exists " + MV1, driver);
+    executeStatementOnDriverSilently("drop table if exists" + TABLE1 , driver);
+
+    executeStatementOnDriver("create table " + TABLE1 + "(a int, b string, c float) stored as orc TBLPROPERTIES ('transactional'='true')", driver);
+    executeStatementOnDriver("insert into " + TABLE1 + "(a,b, c) values (1, 'one', 1.1), (2, 'two', 2.2), (NULL, NULL, NULL)", driver);
+    executeStatementOnDriver("create materialized view " + MV1 + " stored by iceberg tblproperties('format-version'='2') as " +
+            "select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver);
+  }
+
+  @Override
+  public void tearDown() {
+    executeStatementOnDriverSilently("drop materialized view " + MV1, driver);
+    executeStatementOnDriverSilently("drop table " + TABLE1 , driver);
+
+    super.tearDown();
+  }
+
+  @Test
+  public void testQueryIsNotRewrittenWhenMVIsDropped() throws Exception {
+
+    // Simulate a multi HS2 cluster.
+    // Drop the MV using a direct API call to HMS. This is similar what happening when the drop MV is executed by
+    // another HS2.
+    // In this case the MV is not removed from HiveMaterializedViewsRegistry of HS2 which runs the explain query.
+    msClient.dropTable(DB, MV1);
+
+    List<String> result = execSelectAndDumpData("explain cbo select a, b from " + TABLE1 + " where a > 0", driver, "");
+    Assert.assertEquals(ORIGINAL_QUERY_PLAN, result);
+  }
+
+  @Test
+  public void testQueryIsNotRewrittenWhenMVIsDisabledForRewrite() throws Exception {
+    Table mvTable = Hive.get().getTable(DB, MV1);
+    mvTable.setRewriteEnabled(false);
+
+    EnvironmentContext environmentContext = new EnvironmentContext();
+    environmentContext.putToProperties(StatsSetupConst.DO_NOT_UPDATE_STATS, StatsSetupConst.TRUE);
+    Hive.get().alterTable(mvTable, false, environmentContext, true);
+
+    List<String> result = execSelectAndDumpData("explain cbo select a, b from " + TABLE1 + " where a > 0", driver, "");
+    Assert.assertEquals(ORIGINAL_QUERY_PLAN, result);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -55,6 +55,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -2411,7 +2412,7 @@ public class Hive implements AutoCloseable {
   public List<HiveRelOptMaterialization> getMaterializedViewsByAST(
           ASTNode astNode, Set<TableName> tablesUsed,  Supplier<String> validTxnsList, HiveTxnManager txnMgr) throws HiveException {
 
-    List<HiveRelOptMaterialization> materializedViews =
+    Collection<HiveRelOptMaterialization> materializedViews =
             HiveMaterializedViewsRegistry.get().getRewritingMaterializedViews(astNode);
     if (materializedViews.isEmpty()) {
       return Collections.emptyList();

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveRelOptMaterialization.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveRelOptMaterialization.java
@@ -71,7 +71,7 @@ public class HiveRelOptMaterialization extends RelOptMaterialization {
    * @param scope Set of algorithms
    * @return true if applicable false otherwise
    */
-  public boolean isSupported(EnumSet<RewriteAlgorithm> scope) {
+  public boolean isSupported(Set<RewriteAlgorithm> scope) {
     return !intersection(this.scope, scope).isEmpty();
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewMap.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewMap.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -44,21 +45,19 @@ import static java.util.Collections.unmodifiableList;
  * which provides name based lookup. The map which provides query text based lookup is updated by lambda expressions
  * passed to {@link ConcurrentHashMap#compute(Object, BiFunction)}.
  */
-public class MaterializedViewsCache {
-  private static final Logger LOG = LoggerFactory.getLogger(MaterializedViewsCache.class);
+public class MaterializedViewMap {
+  private static final Logger LOG = LoggerFactory.getLogger(MaterializedViewMap.class);
 
   // Key is the database name. Value a map from the qualified name to the view object.
-  private final ConcurrentMap<String, ConcurrentMap<String, HiveRelOptMaterialization>> materializedViews =
+  private final ConcurrentMap<String, HiveRelOptMaterialization> materializedViews =
           new ConcurrentHashMap<>();
   // Map for looking up materialization by view query text
   private final Map<ASTKey, List<HiveRelOptMaterialization>> sqlToMaterializedView = new ConcurrentHashMap<>();
 
 
   public void putIfAbsent(Table materializedViewTable, HiveRelOptMaterialization materialization) {
-    ConcurrentMap<String, HiveRelOptMaterialization> dbMap = ensureDbMap(materializedViewTable);
-
     // You store the materialized view
-    dbMap.computeIfAbsent(materializedViewTable.getTableName(), (mvTableName) -> {
+    materializedViews.computeIfAbsent(genKey(materializedViewTable), mvTableName -> {
       List<HiveRelOptMaterialization> materializationList = sqlToMaterializedView.computeIfAbsent(
               new ASTKey(materialization.getAst()), s -> new ArrayList<>());
       materializationList.add(materialization);
@@ -69,24 +68,18 @@ public class MaterializedViewsCache {
             materializedViewTable.getDbName(), materializedViewTable.getTableName());
   }
 
-  private ConcurrentMap<String, HiveRelOptMaterialization> ensureDbMap(Table materializedViewTable) {
-    // We are going to create the map for each view in the given database
-    ConcurrentMap<String, HiveRelOptMaterialization> dbMap =
-            new ConcurrentHashMap<String, HiveRelOptMaterialization>();
-    // If we are caching the MV, we include it in the cache
-    final ConcurrentMap<String, HiveRelOptMaterialization> prevDbMap = materializedViews.putIfAbsent(
-            materializedViewTable.getDbName(), dbMap);
-    if (prevDbMap != null) {
-      dbMap = prevDbMap;
-    }
-    return dbMap;
+  private String genKey(Table materializedViewTable) {
+    return genKey(materializedViewTable.getDbName(), materializedViewTable.getTableName());
   }
 
-  public void refresh(
-          Table oldMaterializedViewTable, Table materializedViewTable, HiveRelOptMaterialization newMaterialization) {
-    ConcurrentMap<String, HiveRelOptMaterialization> dbMap = ensureDbMap(materializedViewTable);
+  private String genKey(String dbName, String viewName) {
+    return dbName + viewName;
+  }
 
-    dbMap.compute(materializedViewTable.getTableName(), (mvTableName, existingMaterialization) -> {
+  void refresh(
+          Table oldMaterializedViewTable, Table materializedViewTable, HiveRelOptMaterialization newMaterialization) {
+
+    materializedViews.compute(genKey(materializedViewTable), (mvTableName, existingMaterialization) -> {
       List<HiveRelOptMaterialization> optMaterializationList = sqlToMaterializedView.computeIfAbsent(
           new ASTKey(newMaterialization.getAst()), s -> new ArrayList<>());
 
@@ -121,23 +114,16 @@ public class MaterializedViewsCache {
   }
 
   public void remove(Table materializedViewTable) {
-    ConcurrentMap<String, HiveRelOptMaterialization> dbMap = materializedViews.get(materializedViewTable.getDbName());
-    if (dbMap != null) {
-      // Delete only if the create time for the input materialized view table and the table
-      // in the map match. Otherwise, keep the one in the map.
-      dbMap.computeIfPresent(materializedViewTable.getTableName(), (mvTableName, oldMaterialization) -> {
-        Table oldTable = HiveMaterializedViewUtils.extractTable(oldMaterialization);
-        if (materializedViewTable.equals(oldTable)) {
-          remove(oldMaterialization, oldTable);
-          return null;
-        }
-        return oldMaterialization;
-      });
-
-      if (dbMap.isEmpty()) {
-        materializedViews.remove(materializedViewTable.getDbName());
+    // Delete only if the create time for the input materialized view table and the table
+    // in the map match. Otherwise, keep the one in the map.
+    materializedViews.computeIfPresent(genKey(materializedViewTable), (mvTableName, oldMaterialization) -> {
+      Table oldTable = HiveMaterializedViewUtils.extractTable(oldMaterialization);
+      if (materializedViewTable.equals(oldTable)) {
+        remove(oldMaterialization, oldTable);
+        return null;
       }
-    }
+      return oldMaterialization;
+    });
 
     LOG.debug("Materialized view {}.{} removed from registry",
             materializedViewTable.getDbName(), materializedViewTable.getTableName());
@@ -148,50 +134,36 @@ public class MaterializedViewsCache {
       return;
     }
 
-    ASTKey ASTKey = new ASTKey(materialization.getAst());
-    List<HiveRelOptMaterialization> materializationList = sqlToMaterializedView.get(ASTKey);
+    ASTKey astKey = new ASTKey(materialization.getAst());
+    List<HiveRelOptMaterialization> materializationList = sqlToMaterializedView.get(astKey);
     if (materializationList == null) {
       return;
     }
 
     materializationList.remove(materialization);
     if (materializationList.isEmpty()) {
-      sqlToMaterializedView.remove(ASTKey);
+      sqlToMaterializedView.remove(astKey);
     }
   }
 
   public void remove(String dbName, String tableName) {
-    ConcurrentMap<String, HiveRelOptMaterialization> dbMap = materializedViews.get(dbName);
-    if (dbMap != null) {
-      dbMap.computeIfPresent(tableName, (mvTableName, materialization) -> {
-        remove(materialization, HiveMaterializedViewUtils.extractTable(materialization));
-        return null;
-      });
+    materializedViews.computeIfPresent(genKey(dbName, tableName), (mvTableName, materialization) -> {
+      remove(materialization, HiveMaterializedViewUtils.extractTable(materialization));
+      return null;
+    });
 
-      if (dbMap.isEmpty()) {
-        materializedViews.remove(dbName);
-      }
-
-      LOG.debug("Materialized view {}.{} removed from registry", dbName, tableName);
-    }
+    LOG.debug("Materialized view {}.{} removed from registry", dbName, tableName);
   }
 
-  public List<HiveRelOptMaterialization> values() {
-    List<HiveRelOptMaterialization> result = new ArrayList<>();
-    materializedViews.forEach((dbName, mvs) -> result.addAll(mvs.values()));
-    return unmodifiableList(result);
+  public Collection<HiveRelOptMaterialization> values() {
+    return materializedViews.values();
   }
 
   HiveRelOptMaterialization get(String dbName, String viewName) {
-    if (materializedViews.get(dbName) != null) {
-      LOG.debug("Found materialized view {}.{} in registry", dbName, viewName);
-      return materializedViews.get(dbName).get(viewName);
-    }
-    LOG.debug("Materialized view {}.{} not found in registry", dbName, viewName);
-    return null;
+    return materializedViews.get(genKey(dbName, viewName));
   }
 
-  public List<HiveRelOptMaterialization> get(ASTNode astNode) {
+  public Collection<HiveRelOptMaterialization> get(ASTNode astNode) {
     List<HiveRelOptMaterialization> relOptMaterializationList = sqlToMaterializedView.get(new ASTKey(astNode));
     if (relOptMaterializationList == null) {
       if (LOG.isTraceEnabled()) {
@@ -247,14 +219,14 @@ public class MaterializedViewsCache {
 
     @Override
     public int hashCode() {
-      return hashcode(root);
+      return hashcodeOf(root);
     }
 
-    private int hashcode(ASTNode node) {
+    private int hashcodeOf(ASTNode node) {
       int result = Objects.hash(node.getType(), node.getText());
 
       for (int i = 0; i < node.getChildCount(); ++i) {
-        result = 31 * result + hashcode((ASTNode) node.getChild(i));
+        result = 31 * result + hashcodeOf((ASTNode) node.getChild(i));
       }
 
       return result;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -2108,7 +2108,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
       for (RelOptMaterialization materialization : materializations) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Adding materialization {} to the planner; the plan is:\n{}", materialization.qualifiedTableName,
-              RelOptUtil.toString(materialization.queryRel));
+                  RelOptUtil.toString(materialization.queryRel));
         }
         planner.addMaterialization(materialization);
       }
@@ -2128,20 +2128,25 @@ public class CalcitePlanner extends SemanticAnalyzer {
       final String ruleExclusionRegex = conf.get(ConfVars.HIVE_CBO_RULE_EXCLUSION_REGEX.varname, "");
       if (!ruleExclusionRegex.isEmpty()) {
         LOG.info("The CBO rules matching the following regex are excluded from planning: {}",
-            ruleExclusionRegex);
+                ruleExclusionRegex);
         planner.setRuleDescExclusionFilter(Pattern.compile(ruleExclusionRegex));
       }
       planner.setRoot(basePlan);
-      basePlan = planner.findBestExp();
-      // Remove view-based rewriting rules from planner
-      planner.clear();
+      try {
+        return planner.findBestExp();
+      } catch (Exception ex) {
+        LOG.warn("Error while performing materialized view based query rewrite", ex);
+        return basePlan;
+      } finally {
+        // Remove view-based rewriting rules from planner
+        planner.clear();
 
-      // Restore default cost model
-      optCluster.invalidateMetadataQuery();
-      RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(mdProvider));
+        // Restore default cost model
+        optCluster.invalidateMetadataQuery();
+        RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(mdProvider));
 
-      perfLogger.perfLogEnd(this.getClass().getName(), PerfLogger.OPTIMIZER, "Calcite: View-based rewriting");
-      return basePlan;
+        perfLogger.perfLogEnd(this.getClass().getName(), PerfLogger.OPTIMIZER, "Calcite: View-based rewriting");
+      }
     }
 
     private RelNode applyCteRewriting(RelOptPlanner planner,  RelNode basePlan, RelMetadataProvider mdProvider, RexExecutor executorProvider) {

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_2.q.out
@@ -533,13 +533,13 @@ POSTHOOK: Input: default@src_txn_2
 PREHOOK: query: EXPLAIN
 SELECT * FROM src_txn_2 where key > 224 and key < 226
 PREHOOK: type: QUERY
-PREHOOK: Input: default@partition_mv_3
+PREHOOK: Input: default@partition_mv_1
 PREHOOK: Input: default@src_txn_2
 #### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN
 SELECT * FROM src_txn_2 where key > 224 and key < 226
 POSTHOOK: type: QUERY
-POSTHOOK: Input: default@partition_mv_3
+POSTHOOK: Input: default@partition_mv_1
 POSTHOOK: Input: default@src_txn_2
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
@@ -551,7 +551,7 @@ STAGE PLANS:
       limit: -1
       Processor Tree:
         TableScan
-          alias: default.partition_mv_3
+          alias: default.partition_mv_1
           filterExpr: ((UDFToDouble(key) > 224.0D) and (UDFToDouble(key) < 226.0D)) (type: boolean)
           Filter Operator
             predicate: ((UDFToDouble(key) > 224.0D) and (UDFToDouble(key) < 226.0D)) (type: boolean)
@@ -562,14 +562,14 @@ STAGE PLANS:
 
 PREHOOK: query: SELECT * FROM src_txn_2 where key > 223 and key < 225
 PREHOOK: type: QUERY
-PREHOOK: Input: default@partition_mv_3
-PREHOOK: Input: default@partition_mv_3@key=224
+PREHOOK: Input: default@partition_mv_1
+PREHOOK: Input: default@partition_mv_1@key=224
 PREHOOK: Input: default@src_txn_2
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT * FROM src_txn_2 where key > 223 and key < 225
 POSTHOOK: type: QUERY
-POSTHOOK: Input: default@partition_mv_3
-POSTHOOK: Input: default@partition_mv_3@key=224
+POSTHOOK: Input: default@partition_mv_1
+POSTHOOK: Input: default@partition_mv_1@key=224
 POSTHOOK: Input: default@src_txn_2
 #### A masked pattern was here ####
 224	val_224


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
* The materialized view registry is initialized by loading all MVs from HMS that are enabled for query rewrite and precompiled. Later, a scheduled thread refreshes the registry periodically in the same way. This patch adds logic to remove MVs from the registry that no longer exist in HMS or have been disabled for query rewrite since the last refresh.
* Rename `MaterializedViewCache` to `MaterializedViewMap` because it is not a cache.
* Modify the way MVs are stored in the map: remove the database grouping and add the database name as a key prefix to the MV name. Since all MVs are queried and added to the planner during query rewrite, this approach aligns better with the most common function of the registry/map.


### Why are the changes needed?
Dropped MVs may casue CBO failure. See jira [HIVE-28773](https://issues.apache.org/jira/browse/HIVE-28773) for details

### Does this PR introduce _any_ user-facing change?
Yes. CBO failure is intermittent in clusters with multiple HS2s and depending on the query the whole compilation process could fail. This patch fixes these intermittent issues.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest=TestQueryRewrite,TestHiveMaterializedViewRegistry -pl itests/hive-unit -Pitests
mvn test -Dtest=TestMaterializedViewMap -pl ql
```