### PR TITLE
HIVE-28793: Set default expiry time for query history snapshots

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/queryhistory/repository/IcebergRepository.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/queryhistory/repository/IcebergRepository.java
@@ -89,6 +89,9 @@ public class IcebergRepository extends AbstractRepository implements QueryHistor
         ICEBERG_STORAGE_HANDLER);
     table.setProperty("table_type", "ICEBERG");
     table.setProperty("write.format.default", "orc");
+    // set the default max snapshot age to 1 day for query history
+    // this is applied only during table creation, it can be manually altered afterward.
+    table.setProperty("history.expire.max-snapshot-age-ms", Integer.toString(24 * 60 * 60 * 1000));
     table.setProperty(hive_metastoreConstants.META_TABLE_NAME, QUERY_HISTORY_DB_TABLE_NAME);
 
     table.setFields(schema.getFields());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set history.expire.max-snapshot-age-ms for query history table upon creation.

### Why are the changes needed?
To let the service (introduced in [HIVE-28930](https://issues.apache.org/jira/browse/HIVE-28930)) expire snapshots of this table.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Final patch wasn't tested separately, but table property was tested in the early stages of the patch.
