### PR TITLE
HIVE-28799: Q Test: Incorrect Tag Provided in DROP Query, Should Use …

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/alter_table_create_tag.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/alter_table_create_tag.q
@@ -31,8 +31,8 @@ explain alter table iceTbl drop tag test_tag_2;
 alter table iceTbl drop tag test_tag_2;
 
 -- drop a tag with if exists
-explain alter table iceTbl drop tag if exists test_tag_3;
-alter table iceTbl drop tag if exists test_tag_3;
+explain alter table iceTbl drop tag if exists test_tag_1;
+alter table iceTbl drop tag if exists test_tag_1;
 
 -- drop a non-exist tag with if exists
 alter table iceTbl drop tag if exists test_tag_4;

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_table_create_tag.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_table_create_tag.q.out
@@ -156,10 +156,10 @@ PREHOOK: Input: default@icetbl
 POSTHOOK: query: alter table iceTbl drop tag test_tag_2
 POSTHOOK: type: ALTERTABLE_DROPTAG
 POSTHOOK: Input: default@icetbl
-PREHOOK: query: explain alter table iceTbl drop tag if exists test_tag_3
+PREHOOK: query: explain alter table iceTbl drop tag if exists test_tag_1
 PREHOOK: type: ALTERTABLE_DROPTAG
 PREHOOK: Input: default@icetbl
-POSTHOOK: query: explain alter table iceTbl drop tag if exists test_tag_3
+POSTHOOK: query: explain alter table iceTbl drop tag if exists test_tag_1
 POSTHOOK: type: ALTERTABLE_DROPTAG
 POSTHOOK: Input: default@icetbl
 STAGE DEPENDENCIES:
@@ -169,12 +169,12 @@ STAGE PLANS:
   Stage: Stage-0
     SnapshotRef Operation
       table name: default.iceTbl
-      spec: AlterTableSnapshotRefSpec{operationType=DROP_TAG, operationParams=DropSnapshotRefSpec{refName=test_tag_3, ifExists=true}}
+      spec: AlterTableSnapshotRefSpec{operationType=DROP_TAG, operationParams=DropSnapshotRefSpec{refName=test_tag_1, ifExists=true}}
 
-PREHOOK: query: alter table iceTbl drop tag if exists test_tag_3
+PREHOOK: query: alter table iceTbl drop tag if exists test_tag_1
 PREHOOK: type: ALTERTABLE_DROPTAG
 PREHOOK: Input: default@icetbl
-POSTHOOK: query: alter table iceTbl drop tag if exists test_tag_3
+POSTHOOK: query: alter table iceTbl drop tag if exists test_tag_1
 POSTHOOK: type: ALTERTABLE_DROPTAG
 POSTHOOK: Input: default@icetbl
 PREHOOK: query: alter table iceTbl drop tag if exists test_tag_4


### PR DESCRIPTION
…Existing Tag

### What changes were proposed in this pull request?
Change in q test to delete an existing tag using "if exists" keyword.

### Why are the changes needed
drop tag in qtest where it is supposed to delete an existing tag.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Q test
