### PR TITLE
HIVE-28800: Improve LongColumnStatsAggregator by preventing the overestimation of NDV

### DIFF
--- a/ql/src/test/results/clientpositive/llap/vector_count_distinct.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_count_distinct.q.out
@@ -1337,10 +1337,10 @@ STAGE PLANS:
                           vectorProcessingMode: HASH
                           projectedOutputColumnNums: []
                       keys: ws_order_number (type: int)
-                      minReductionHashAggr: 0.915
+                      minReductionHashAggr: 0.9155
                       mode: hash
                       outputColumnNames: _col0
-                      Statistics: Num rows: 170 Data size: 680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 169 Data size: 676 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
@@ -1350,7 +1350,7 @@ STAGE PLANS:
                             className: VectorReduceSinkLongOperator
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                        Statistics: Num rows: 170 Data size: 680 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 169 Data size: 676 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -1382,7 +1382,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: int)
                 mode: mergepartial
                 outputColumnNames: _col0
-                Statistics: Num rows: 170 Data size: 680 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 169 Data size: 676 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: count(_col0)
                   Group By Vectorization:

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query13.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query13.q.out
@@ -16,7 +16,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: (ss_cdemo_sk is not null and ss_addr_sk is not null and ss_hdemo_sk is not null and ss_store_sk is not null and ((ss_sales_price >= 100) or (ss_sales_price <= 150) or (ss_sales_price >= 50) or (ss_sales_price <= 100) or (ss_sales_price >= 150) or (ss_sales_price <= 200)) and ((ss_net_profit >= 100) or (ss_net_profit <= 200) or (ss_net_profit >= 150) or (ss_net_profit <= 300) or (ss_net_profit >= 50) or (ss_net_profit <= 250))) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_89_container, bigKeyColName:ss_hdemo_sk, smallTablePos:1, keyRatio:8.246185236456299E-8
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_89_container, bigKeyColName:ss_hdemo_sk, smallTablePos:1, keyRatio:7.945618813963477E-8
                   Statistics: Num rows: 82510879939 Data size: 39653754183252 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (ss_cdemo_sk is not null and ss_addr_sk is not null and ss_hdemo_sk is not null and ss_store_sk is not null and ((ss_sales_price >= 100) or (ss_sales_price <= 150) or (ss_sales_price >= 50) or (ss_sales_price <= 100) or (ss_sales_price >= 150) or (ss_sales_price <= 200)) and ((ss_net_profit >= 100) or (ss_net_profit <= 200) or (ss_net_profit >= 150) or (ss_net_profit <= 300) or (ss_net_profit >= 50) or (ss_net_profit <= 250))) (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query23.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query23.q.out
@@ -427,19 +427,19 @@ STAGE PLANS:
                             minReductionHashAggr: 0.99
                             mode: hash
                             outputColumnNames: _col0
-                            Statistics: Num rows: 64646121 Data size: 517168968 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 64255141 Data size: 514041128 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: bigint)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: bigint)
-                              Statistics: Num rows: 64646121 Data size: 517168968 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 64255141 Data size: 514041128 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: bigint)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: bigint)
-                              Statistics: Num rows: 64646121 Data size: 517168968 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 64255141 Data size: 514041128 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 13 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query24.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query24.q.out
@@ -290,7 +290,7 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col4
                 input vertices:
                   1 Map 8
-                Statistics: Num rows: 94077750532 Data size: 12340583852888 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 94492919160 Data size: 12397046786296 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Map Join Operator
                   condition map:
@@ -301,7 +301,7 @@ STAGE PLANS:
                   outputColumnNames: _col0, _col4, _col9, _col10, _col13, _col17, _col18
                   input vertices:
                     1 Map 11
-                  Statistics: Num rows: 9561873173 Data size: 4957439598608 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 9604070077 Data size: 4981069864848 Basic stats: COMPLETE Column stats: COMPLETE
                   Map Join Operator
                     condition map:
                          Inner Join 0 to 1
@@ -311,20 +311,20 @@ STAGE PLANS:
                     outputColumnNames: _col4, _col9, _col10, _col13, _col17, _col18, _col21, _col22, _col23, _col24
                     input vertices:
                       1 Map 13
-                    Statistics: Num rows: 100648033 Data size: 73674358992 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 101092197 Data size: 73999487040 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: sum(_col4)
                       keys: _col9 (type: char(20)), _col10 (type: char(30)), _col17 (type: varchar(50)), _col13 (type: char(2)), _col18 (type: char(2)), _col21 (type: decimal(7,2)), _col22 (type: char(20)), _col23 (type: char(10)), _col24 (type: int)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
-                      Statistics: Num rows: 100648033 Data size: 84946938576 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 101092197 Data size: 85321812992 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: char(20)), _col1 (type: char(30)), _col2 (type: varchar(50)), _col3 (type: char(2)), _col4 (type: char(2)), _col5 (type: decimal(7,2)), _col6 (type: char(20)), _col7 (type: char(10)), _col8 (type: int)
                         null sort order: zzzzzzzzz
                         sort order: +++++++++
                         Map-reduce partition columns: _col0 (type: char(20)), _col1 (type: char(30)), _col2 (type: varchar(50)), _col3 (type: char(2)), _col4 (type: char(2)), _col5 (type: decimal(7,2)), _col6 (type: char(20)), _col7 (type: char(10)), _col8 (type: int)
-                        Statistics: Num rows: 100648033 Data size: 84946938576 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 101092197 Data size: 85321812992 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col9 (type: decimal(17,2))
         Reducer 3 
             Execution mode: vectorized, llap
@@ -334,24 +334,24 @@ STAGE PLANS:
                 keys: KEY._col0 (type: char(20)), KEY._col1 (type: char(30)), KEY._col2 (type: varchar(50)), KEY._col3 (type: char(2)), KEY._col4 (type: char(2)), KEY._col5 (type: decimal(7,2)), KEY._col6 (type: char(20)), KEY._col7 (type: char(10)), KEY._col8 (type: int)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
-                Statistics: Num rows: 100648033 Data size: 84946938576 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 101092197 Data size: 85321812992 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: char(20)), _col1 (type: char(30)), _col2 (type: varchar(50)), _col9 (type: decimal(17,2))
                   outputColumnNames: _col0, _col1, _col3, _col9
-                  Statistics: Num rows: 100648033 Data size: 84946938576 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 101092197 Data size: 85321812992 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
                     aggregations: sum(_col9)
                     keys: _col0 (type: char(20)), _col1 (type: char(30)), _col3 (type: varchar(50))
                     minReductionHashAggr: 0.99
                     mode: hash
                     outputColumnNames: _col0, _col1, _col2, _col3
-                    Statistics: Num rows: 11952 Data size: 4541760 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 12024 Data size: 4569120 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: char(20)), _col1 (type: char(30)), _col2 (type: varchar(50))
                       null sort order: zzz
                       sort order: +++
                       Map-reduce partition columns: _col0 (type: char(20)), _col1 (type: char(30)), _col2 (type: varchar(50))
-                      Statistics: Num rows: 11952 Data size: 4541760 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 12024 Data size: 4569120 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col3 (type: decimal(27,2))
         Reducer 4 
             Execution mode: vectorized, llap
@@ -386,7 +386,7 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col4
                 input vertices:
                   1 Map 15
-                Statistics: Num rows: 94077750532 Data size: 12340583852888 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 94492919160 Data size: 12397046786296 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Map Join Operator
                   condition map:
@@ -397,7 +397,7 @@ STAGE PLANS:
                   outputColumnNames: _col0, _col4, _col9, _col10, _col13, _col17, _col18
                   input vertices:
                     1 Map 11
-                  Statistics: Num rows: 9561873173 Data size: 4957439598608 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 9604070077 Data size: 4981069864848 Basic stats: COMPLETE Column stats: COMPLETE
                   Map Join Operator
                     condition map:
                          Inner Join 0 to 1
@@ -407,20 +407,20 @@ STAGE PLANS:
                     outputColumnNames: _col4, _col9, _col10, _col13, _col17, _col18, _col21, _col22, _col23, _col24, _col25
                     input vertices:
                       1 Map 13
-                    Statistics: Num rows: 9561873173 Data size: 8524018157053 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 9604070077 Data size: 8563387868485 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: sum(_col4)
                       keys: _col9 (type: char(20)), _col10 (type: char(30)), _col13 (type: char(2)), _col17 (type: varchar(50)), _col18 (type: char(2)), _col21 (type: decimal(7,2)), _col22 (type: char(20)), _col23 (type: char(20)), _col24 (type: char(10)), _col25 (type: int)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                      Statistics: Num rows: 9561873173 Data size: 8921227535325 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 9604070077 Data size: 8960597246757 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: char(20)), _col1 (type: char(30)), _col2 (type: char(2)), _col3 (type: varchar(50)), _col4 (type: char(2)), _col5 (type: decimal(7,2)), _col6 (type: char(20)), _col7 (type: char(20)), _col8 (type: char(10)), _col9 (type: int)
                         null sort order: zzzzzzzzzz
                         sort order: ++++++++++
                         Map-reduce partition columns: _col0 (type: char(20)), _col1 (type: char(30)), _col2 (type: char(2)), _col3 (type: varchar(50)), _col4 (type: char(2)), _col5 (type: decimal(7,2)), _col6 (type: char(20)), _col7 (type: char(20)), _col8 (type: char(10)), _col9 (type: int)
-                        Statistics: Num rows: 9561873173 Data size: 8921227535325 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 9604070077 Data size: 8960597246757 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col10 (type: decimal(17,2))
         Reducer 6 
             Execution mode: vectorized, llap
@@ -430,11 +430,11 @@ STAGE PLANS:
                 keys: KEY._col0 (type: char(20)), KEY._col1 (type: char(30)), KEY._col2 (type: char(2)), KEY._col3 (type: varchar(50)), KEY._col4 (type: char(2)), KEY._col5 (type: decimal(7,2)), KEY._col6 (type: char(20)), KEY._col7 (type: char(20)), KEY._col8 (type: char(10)), KEY._col9 (type: int)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                Statistics: Num rows: 9561873173 Data size: 8921227535325 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 9604070077 Data size: 8960597246757 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col10 (type: decimal(17,2))
                   outputColumnNames: _col10
-                  Statistics: Num rows: 9561873173 Data size: 8921227535325 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 9604070077 Data size: 8960597246757 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
                     aggregations: sum(_col10), count(_col10)
                     minReductionHashAggr: 0.99

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query27.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query27.q.out
@@ -17,7 +17,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: (ss_cdemo_sk is not null and ss_store_sk is not null) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_96_container, bigKeyColName:ss_store_sk, smallTablePos:1, keyRatio:2.2057697134553887E-9
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_96_container, bigKeyColName:ss_store_sk, smallTablePos:1, keyRatio:2.1936500996451943E-9
                   Statistics: Num rows: 82510879939 Data size: 30001917572116 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (ss_cdemo_sk is not null and ss_store_sk is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query28.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query28.q.out
@@ -34,129 +34,129 @@ STAGE PLANS:
                   Statistics: Num rows: 86404891377 Data size: 28054250053192 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (ss_quantity BETWEEN 0 AND 5 and (ss_list_price BETWEEN 11 AND 21 or ss_coupon_amt BETWEEN 460 AND 1460 or ss_wholesale_cost BETWEEN 14 AND 34)) (type: boolean)
-                    Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_list_price (type: decimal(7,2))
                       outputColumnNames: ss_list_price
-                      Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_list_price), count(ss_list_price)
                         keys: ss_list_price (type: decimal(7,2))
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2
-                        Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: decimal(7,2))
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: decimal(7,2))
-                          Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: decimal(17,2)), _col2 (type: bigint)
                   Filter Operator
                     predicate: (ss_quantity BETWEEN 16 AND 20 and (ss_list_price BETWEEN 142 AND 152 or ss_coupon_amt BETWEEN 3054 AND 4054 or ss_wholesale_cost BETWEEN 80 AND 100)) (type: boolean)
-                    Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_list_price (type: decimal(7,2))
                       outputColumnNames: ss_list_price
-                      Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_list_price), count(ss_list_price)
                         keys: ss_list_price (type: decimal(7,2))
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2
-                        Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: decimal(7,2))
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: decimal(7,2))
-                          Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: decimal(17,2)), _col2 (type: bigint)
                   Filter Operator
                     predicate: (ss_quantity BETWEEN 21 AND 25 and (ss_list_price BETWEEN 135 AND 145 or ss_coupon_amt BETWEEN 14180 AND 15180 or ss_wholesale_cost BETWEEN 38 AND 58)) (type: boolean)
-                    Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_list_price (type: decimal(7,2))
                       outputColumnNames: ss_list_price
-                      Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_list_price), count(ss_list_price)
                         keys: ss_list_price (type: decimal(7,2))
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2
-                        Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: decimal(7,2))
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: decimal(7,2))
-                          Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: decimal(17,2)), _col2 (type: bigint)
                   Filter Operator
                     predicate: (ss_quantity BETWEEN 26 AND 30 and (ss_list_price BETWEEN 28 AND 38 or ss_coupon_amt BETWEEN 2513 AND 3513 or ss_wholesale_cost BETWEEN 42 AND 62)) (type: boolean)
-                    Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_list_price (type: decimal(7,2))
                       outputColumnNames: ss_list_price
-                      Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_list_price), count(ss_list_price)
                         keys: ss_list_price (type: decimal(7,2))
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2
-                        Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: decimal(7,2))
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: decimal(7,2))
-                          Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: decimal(17,2)), _col2 (type: bigint)
                   Filter Operator
                     predicate: (ss_quantity BETWEEN 11 AND 15 and (ss_list_price BETWEEN 66 AND 76 or ss_coupon_amt BETWEEN 920 AND 1920 or ss_wholesale_cost BETWEEN 4 AND 24)) (type: boolean)
-                    Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_list_price (type: decimal(7,2))
                       outputColumnNames: ss_list_price
-                      Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_list_price), count(ss_list_price)
                         keys: ss_list_price (type: decimal(7,2))
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2
-                        Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: decimal(7,2))
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: decimal(7,2))
-                          Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: decimal(17,2)), _col2 (type: bigint)
                   Filter Operator
                     predicate: (ss_quantity BETWEEN 6 AND 10 and (ss_list_price BETWEEN 91 AND 101 or ss_coupon_amt BETWEEN 1430 AND 2430 or ss_wholesale_cost BETWEEN 32 AND 52)) (type: boolean)
-                    Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_list_price (type: decimal(7,2))
                       outputColumnNames: ss_list_price
-                      Statistics: Num rows: 4154081316 Data size: 1348762021916 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4277469870 Data size: 1388824260284 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_list_price), count(ss_list_price)
                         keys: ss_list_price (type: decimal(7,2))
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2
-                        Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: decimal(7,2))
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: decimal(7,2))
-                          Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: decimal(17,2)), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -168,7 +168,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: decimal(7,2))
                 mode: partial2
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: sum(_col1), count(_col2), count(_col0)
                   mode: partial2
@@ -204,7 +204,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: decimal(7,2))
                 mode: partial2
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: sum(_col1), count(_col2), count(_col0)
                   mode: partial2
@@ -240,7 +240,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: decimal(7,2))
                 mode: partial2
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: sum(_col1), count(_col2), count(_col0)
                   mode: partial2
@@ -332,7 +332,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: decimal(7,2))
                 mode: partial2
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: sum(_col1), count(_col2), count(_col0)
                   mode: partial2
@@ -368,7 +368,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: decimal(7,2))
                 mode: partial2
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: sum(_col1), count(_col2), count(_col0)
                   mode: partial2
@@ -404,7 +404,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: decimal(7,2))
                 mode: partial2
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2077040658 Data size: 471392400864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2138734935 Data size: 485394155352 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: sum(_col1), count(_col2), count(_col0)
                   mode: partial2

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query32.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query32.q.out
@@ -165,13 +165,13 @@ STAGE PLANS:
                           minReductionHashAggr: 0.99
                           mode: hash
                           outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 113253099 Data size: 14496396672 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 112566690 Data size: 14408536320 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: bigint)
                             null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: bigint)
-                            Statistics: Num rows: 113253099 Data size: 14496396672 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 112566690 Data size: 14408536320 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: decimal(17,2)), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -196,14 +196,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 51643 Data size: 6610304 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 51330 Data size: 6570240 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: CAST( (_col1 / _col2) AS decimal(11,6)) is not null (type: boolean)
-                  Statistics: Num rows: 51643 Data size: 6610304 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 51330 Data size: 6570240 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: (1.3 * CAST( (_col1 / _col2) AS decimal(11,6))) (type: decimal(14,7)), _col0 (type: bigint)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 51643 Data size: 6197160 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 51330 Data size: 6159600 Basic stats: COMPLETE Column stats: COMPLETE
                     Map Join Operator
                       condition map:
                            Inner Join 0 to 1
@@ -213,14 +213,14 @@ STAGE PLANS:
                       outputColumnNames: _col1, _col5
                       input vertices:
                         0 Map 1
-                      Statistics: Num rows: 51643 Data size: 5784128 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 51330 Data size: 5749072 Basic stats: COMPLETE Column stats: COMPLETE
                       Filter Operator
                         predicate: (_col1 > _col5) (type: boolean)
-                        Statistics: Num rows: 17214 Data size: 1928080 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 17110 Data size: 1916432 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col1 (type: decimal(7,2))
                           outputColumnNames: _col1
-                          Statistics: Num rows: 17214 Data size: 1928080 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 17110 Data size: 1916432 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(_col1)
                             minReductionHashAggr: 0.99

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query33.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query33.q.out
@@ -25,7 +25,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: ss_addr_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_271_container, bigKeyColName:ss_addr_sk, smallTablePos:1, keyRatio:1.5949411774215885E-8
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_271_container, bigKeyColName:ss_addr_sk, smallTablePos:1, keyRatio:1.585245486373433E-8
                   Statistics: Num rows: 82510879939 Data size: 10987909046272 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ss_addr_sk is not null (type: boolean)
@@ -198,7 +198,7 @@ STAGE PLANS:
                 TableScan
                   alias: web_sales
                   filterExpr: ws_bill_addr_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_277_container, bigKeyColName:ws_bill_addr_sk, smallTablePos:1, keyRatio:6.09410527196747E-8
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_277_container, bigKeyColName:ws_bill_addr_sk, smallTablePos:1, keyRatio:6.057059039311133E-8
                   Statistics: Num rows: 21594638446 Data size: 2936546611376 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ws_bill_addr_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query36.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query36.q.out
@@ -18,7 +18,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: ss_store_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_74_container, bigKeyColName:ss_store_sk, smallTablePos:1, keyRatio:2.0622734859426863E-7
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_74_container, bigKeyColName:ss_store_sk, smallTablePos:1, keyRatio:2.049790283718186E-7
                   Statistics: Num rows: 82510879939 Data size: 20011209733336 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ss_store_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query44.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query44.q.out
@@ -99,14 +99,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 464811 Data size: 59495808 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 462000 Data size: 59136000 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: CAST( (_col1 / _col2) AS decimal(11,6)) is not null (type: boolean)
-                  Statistics: Num rows: 464811 Data size: 59495808 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 462000 Data size: 59136000 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: bigint), CAST( (_col1 / _col2) AS decimal(11,6)) (type: decimal(11,6))
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 464811 Data size: 55777320 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 462000 Data size: 55440000 Basic stats: COMPLETE Column stats: COMPLETE
                     Map Join Operator
                       condition map:
                            Inner Join 0 to 1
@@ -116,35 +116,35 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1, _col2
                       input vertices:
                         1 Reducer 6
-                      Statistics: Num rows: 464811 Data size: 107836152 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 462000 Data size: 107184000 Basic stats: COMPLETE Column stats: COMPLETE
                       Filter Operator
                         predicate: (_col1 > (0.9 * _col2)) (type: boolean)
-                        Statistics: Num rows: 154937 Data size: 35945384 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 154000 Data size: 35728000 Basic stats: COMPLETE Column stats: COMPLETE
                         Top N Key Operator
                           sort order: +
                           keys: _col1 (type: decimal(11,6))
                           null sort order: z
-                          Statistics: Num rows: 154937 Data size: 35945384 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 154000 Data size: 35728000 Basic stats: COMPLETE Column stats: COMPLETE
                           top n: 11
                           Reduce Output Operator
                             key expressions: 0 (type: int), _col1 (type: decimal(11,6))
                             null sort order: az
                             sort order: ++
                             Map-reduce partition columns: 0 (type: int)
-                            Statistics: Num rows: 154937 Data size: 35945384 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 154000 Data size: 35728000 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col0 (type: bigint)
                         Top N Key Operator
                           sort order: -
                           keys: _col1 (type: decimal(11,6))
                           null sort order: a
-                          Statistics: Num rows: 154937 Data size: 35945384 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 154000 Data size: 35728000 Basic stats: COMPLETE Column stats: COMPLETE
                           top n: 11
                           Reduce Output Operator
                             key expressions: 0 (type: int), _col1 (type: decimal(11,6))
                             null sort order: aa
                             sort order: +-
                             Map-reduce partition columns: 0 (type: int)
-                            Statistics: Num rows: 154937 Data size: 35945384 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 154000 Data size: 35728000 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col0 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -152,7 +152,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey1 (type: decimal(11,6))
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 154937 Data size: 18592440 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 154000 Data size: 18480000 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -173,14 +173,14 @@ STAGE PLANS:
                               window function: GenericUDAFRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 154937 Data size: 18592440 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 154000 Data size: 18480000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (rank_window_0 < 11) (type: boolean)
-                    Statistics: Num rows: 51645 Data size: 6197400 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 51333 Data size: 6159960 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: bigint), rank_window_0 (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 51645 Data size: 619740 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 51333 Data size: 615996 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
@@ -190,7 +190,7 @@ STAGE PLANS:
                         outputColumnNames: _col0, _col1, _col2
                         input vertices:
                           1 Reducer 5
-                        Statistics: Num rows: 51645 Data size: 1032900 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 51333 Data size: 1026660 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -200,7 +200,7 @@ STAGE PLANS:
                           outputColumnNames: _col1, _col2, _col5
                           input vertices:
                             1 Reducer 8
-                          Statistics: Num rows: 51645 Data size: 6145755 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 51333 Data size: 6108627 Basic stats: COMPLETE Column stats: COMPLETE
                           Map Join Operator
                             condition map:
                                  Inner Join 0 to 1
@@ -210,22 +210,22 @@ STAGE PLANS:
                             outputColumnNames: _col1, _col5, _col7
                             input vertices:
                               1 Map 7
-                            Statistics: Num rows: 51645 Data size: 11258610 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 51333 Data size: 11190594 Basic stats: COMPLETE Column stats: COMPLETE
                             Top N Key Operator
                               sort order: +
                               keys: _col1 (type: int)
                               null sort order: z
-                              Statistics: Num rows: 51645 Data size: 11258610 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 51333 Data size: 11190594 Basic stats: COMPLETE Column stats: COMPLETE
                               top n: 100
                               Select Operator
                                 expressions: _col1 (type: int), _col5 (type: char(50)), _col7 (type: char(50))
                                 outputColumnNames: _col0, _col1, _col2
-                                Statistics: Num rows: 51645 Data size: 11258610 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 51333 Data size: 11190594 Basic stats: COMPLETE Column stats: COMPLETE
                                 Reduce Output Operator
                                   key expressions: _col0 (type: int)
                                   null sort order: z
                                   sort order: +
-                                  Statistics: Num rows: 51645 Data size: 11258610 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Statistics: Num rows: 51333 Data size: 11190594 Basic stats: COMPLETE Column stats: COMPLETE
                                   value expressions: _col1 (type: char(50)), _col2 (type: char(50))
         Reducer 4 
             Execution mode: vectorized, llap
@@ -233,7 +233,7 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: char(50)), VALUE._col1 (type: char(50))
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 51645 Data size: 11258610 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 51333 Data size: 11190594 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 100
                   Statistics: Num rows: 100 Data size: 21800 Basic stats: COMPLETE Column stats: COMPLETE
@@ -250,7 +250,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey1 (type: decimal(11,6))
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 154937 Data size: 18592440 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 154000 Data size: 18480000 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -271,20 +271,20 @@ STAGE PLANS:
                               window function: GenericUDAFRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 154937 Data size: 18592440 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 154000 Data size: 18480000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (rank_window_0 < 11) (type: boolean)
-                    Statistics: Num rows: 51645 Data size: 6197400 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 51333 Data size: 6159960 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: bigint), rank_window_0 (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 51645 Data size: 619740 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 51333 Data size: 615996 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
-                        Statistics: Num rows: 51645 Data size: 619740 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 51333 Data size: 615996 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query49.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query49.q.out
@@ -327,7 +327,7 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: bigint), VALUE._col1 (type: decimal(35,20)), KEY.reducesinkkey1 (type: int), KEY.reducesinkkey2 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 15744 Data size: 3447936 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 15648 Data size: 3426912 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 100
                   Statistics: Num rows: 100 Data size: 21900 Basic stats: COMPLETE Column stats: COMPLETE
@@ -375,13 +375,13 @@ STAGE PLANS:
                     minReductionHashAggr: 0.99
                     mode: hash
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                    Statistics: Num rows: 3338136 Data size: 827857728 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 3317688 Data size: 822786624 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: bigint)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: bigint)
-                      Statistics: Num rows: 3338136 Data size: 827857728 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3317688 Data size: 822786624 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 15 
             Execution mode: vectorized, llap
@@ -391,13 +391,13 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 7836 Data size: 1943328 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7788 Data size: 1931424 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: 0 (type: int), (CAST( _col1 AS decimal(15,4)) / CAST( _col2 AS decimal(15,4))) (type: decimal(35,20))
                   null sort order: az
                   sort order: ++
                   Map-reduce partition columns: 0 (type: int)
-                  Statistics: Num rows: 7836 Data size: 1943328 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7788 Data size: 1931424 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 16 
             Execution mode: vectorized, llap
@@ -405,7 +405,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: bigint), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: decimal(17,2)), VALUE._col4 (type: decimal(17,2))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 7836 Data size: 1943328 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7788 Data size: 1931424 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -426,17 +426,17 @@ STAGE PLANS:
                               window function: GenericUDAFRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 7836 Data size: 1943328 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7788 Data size: 1931424 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: rank_window_0 (type: int), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
                     outputColumnNames: rank_window_0, _col0, _col1, _col2, _col3, _col4
-                    Statistics: Num rows: 7836 Data size: 1943328 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 7788 Data size: 1931424 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: 0 (type: int), (CAST( _col3 AS decimal(15,4)) / CAST( _col4 AS decimal(15,4))) (type: decimal(35,20))
                       null sort order: az
                       sort order: ++
                       Map-reduce partition columns: 0 (type: int)
-                      Statistics: Num rows: 7836 Data size: 1943328 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 7788 Data size: 1931424 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: rank_window_0 (type: int), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 17 
             Execution mode: vectorized, llap
@@ -444,7 +444,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: bigint), VALUE._col4 (type: decimal(17,2)), VALUE._col5 (type: decimal(17,2))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 7836 Data size: 1974672 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7788 Data size: 1962576 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -464,26 +464,26 @@ STAGE PLANS:
                               window function: GenericUDAFRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 7836 Data size: 1974672 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7788 Data size: 1962576 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((_col0 <= 10) or (rank_window_1 <= 10)) (type: boolean)
-                    Statistics: Num rows: 5224 Data size: 1316448 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5192 Data size: 1308384 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: 'catalog' (type: string), _col1 (type: bigint), (CAST( _col2 AS decimal(15,4)) / CAST( _col3 AS decimal(15,4))) (type: decimal(35,20)), _col0 (type: int), rank_window_1 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                      Statistics: Num rows: 5224 Data size: 1144056 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5192 Data size: 1137048 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: _col0 (type: string), _col3 (type: int), _col4 (type: int), _col1 (type: bigint), _col2 (type: decimal(35,20))
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                        Statistics: Num rows: 10484 Data size: 2295996 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10420 Data size: 2281980 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: decimal(35,20))
                           null sort order: zzzzz
                           sort order: +++++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: decimal(35,20))
-                          Statistics: Num rows: 10484 Data size: 2295996 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10420 Data size: 2281980 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 18 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -521,13 +521,13 @@ STAGE PLANS:
                     minReductionHashAggr: 0.99
                     mode: hash
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                    Statistics: Num rows: 1736020 Data size: 430532960 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1725680 Data size: 427968640 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: bigint)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: bigint)
-                      Statistics: Num rows: 1736020 Data size: 430532960 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1725680 Data size: 427968640 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 22 
             Execution mode: vectorized, llap
@@ -553,13 +553,13 @@ STAGE PLANS:
                     minReductionHashAggr: 0.99
                     mode: hash
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                    Statistics: Num rows: 2154243 Data size: 534252264 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2141412 Data size: 531070176 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: bigint)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: bigint)
-                      Statistics: Num rows: 2154243 Data size: 534252264 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2141412 Data size: 531070176 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 23 
             Execution mode: vectorized, llap
@@ -569,13 +569,13 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: 0 (type: int), (CAST( _col1 AS decimal(15,4)) / CAST( _col2 AS decimal(15,4))) (type: decimal(35,20))
                   null sort order: az
                   sort order: ++
                   Map-reduce partition columns: 0 (type: int)
-                  Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 24 
             Execution mode: vectorized, llap
@@ -583,7 +583,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: bigint), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: decimal(17,2)), VALUE._col4 (type: decimal(17,2))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -604,17 +604,17 @@ STAGE PLANS:
                               window function: GenericUDAFRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: rank_window_0 (type: int), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
                     outputColumnNames: rank_window_0, _col0, _col1, _col2, _col3, _col4
-                    Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: 0 (type: int), (CAST( _col3 AS decimal(15,4)) / CAST( _col4 AS decimal(15,4))) (type: decimal(35,20))
                       null sort order: az
                       sort order: ++
                       Map-reduce partition columns: 0 (type: int)
-                      Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: rank_window_0 (type: int), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 25 
             Execution mode: vectorized, llap
@@ -622,7 +622,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: bigint), VALUE._col4 (type: decimal(17,2)), VALUE._col5 (type: decimal(17,2))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 7891 Data size: 1988532 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7844 Data size: 1976688 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -642,32 +642,32 @@ STAGE PLANS:
                               window function: GenericUDAFRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 7891 Data size: 1988532 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7844 Data size: 1976688 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((_col0 <= 10) or (rank_window_1 <= 10)) (type: boolean)
-                    Statistics: Num rows: 5260 Data size: 1325520 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5228 Data size: 1317456 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: 'store' (type: string), _col1 (type: bigint), (CAST( _col2 AS decimal(15,4)) / CAST( _col3 AS decimal(15,4))) (type: decimal(35,20)), _col0 (type: int), rank_window_1 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                      Statistics: Num rows: 5260 Data size: 1141420 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5228 Data size: 1134476 Basic stats: COMPLETE Column stats: COMPLETE
                       Top N Key Operator
                         sort order: +++++
                         keys: _col0 (type: string), _col3 (type: int), _col4 (type: int), _col1 (type: bigint), _col2 (type: decimal(35,20))
                         null sort order: zzzzz
-                        Statistics: Num rows: 15744 Data size: 3437416 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 15648 Data size: 3416456 Basic stats: COMPLETE Column stats: COMPLETE
                         top n: 100
                         Group By Operator
                           keys: _col0 (type: string), _col3 (type: int), _col4 (type: int), _col1 (type: bigint), _col2 (type: decimal(35,20))
                           minReductionHashAggr: 0.4
                           mode: hash
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                          Statistics: Num rows: 15744 Data size: 3447936 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 15648 Data size: 3426912 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: decimal(35,20))
                             null sort order: zzzzz
                             sort order: +++++
                             Map-reduce partition columns: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: decimal(35,20))
-                            Statistics: Num rows: 15744 Data size: 3447936 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 15648 Data size: 3426912 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 26 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -689,13 +689,13 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: 0 (type: int), (CAST( _col1 AS decimal(15,4)) / CAST( _col2 AS decimal(15,4))) (type: decimal(35,20))
                   null sort order: az
                   sort order: ++
                   Map-reduce partition columns: 0 (type: int)
-                  Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 4 
             Execution mode: vectorized, llap
@@ -703,7 +703,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: bigint), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: decimal(17,2)), VALUE._col4 (type: decimal(17,2))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -724,17 +724,17 @@ STAGE PLANS:
                               window function: GenericUDAFRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: rank_window_0 (type: int), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
                     outputColumnNames: rank_window_0, _col0, _col1, _col2, _col3, _col4
-                    Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: 0 (type: int), (CAST( _col3 AS decimal(15,4)) / CAST( _col4 AS decimal(15,4))) (type: decimal(35,20))
                       null sort order: az
                       sort order: ++
                       Map-reduce partition columns: 0 (type: int)
-                      Statistics: Num rows: 7891 Data size: 1956968 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 7844 Data size: 1945312 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: rank_window_0 (type: int), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 5 
             Execution mode: vectorized, llap
@@ -742,7 +742,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: bigint), VALUE._col4 (type: decimal(17,2)), VALUE._col5 (type: decimal(17,2))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 7891 Data size: 1988532 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7844 Data size: 1976688 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -762,26 +762,26 @@ STAGE PLANS:
                               window function: GenericUDAFRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 7891 Data size: 1988532 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7844 Data size: 1976688 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((_col0 <= 10) or (rank_window_1 <= 10)) (type: boolean)
-                    Statistics: Num rows: 5260 Data size: 1325520 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5228 Data size: 1317456 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: 'web' (type: string), _col1 (type: bigint), (CAST( _col2 AS decimal(15,4)) / CAST( _col3 AS decimal(15,4))) (type: decimal(35,20)), _col0 (type: int), rank_window_1 (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                      Statistics: Num rows: 5260 Data size: 1130900 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5228 Data size: 1124020 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: _col0 (type: string), _col3 (type: int), _col4 (type: int), _col1 (type: bigint), _col2 (type: decimal(35,20))
                         minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                        Statistics: Num rows: 10484 Data size: 2295996 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10420 Data size: 2281980 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: decimal(35,20))
                           null sort order: zzzzz
                           sort order: +++++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: decimal(35,20))
-                          Statistics: Num rows: 10484 Data size: 2295996 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10420 Data size: 2281980 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -789,29 +789,29 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: bigint), KEY._col4 (type: decimal(35,20))
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 10484 Data size: 2295996 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 10420 Data size: 2281980 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), _col3 (type: bigint), _col4 (type: decimal(35,20)), _col1 (type: int), _col2 (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 10484 Data size: 2295996 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 10420 Data size: 2281980 Basic stats: COMPLETE Column stats: COMPLETE
                   Top N Key Operator
                     sort order: +++++
                     keys: _col0 (type: string), _col3 (type: int), _col4 (type: int), _col1 (type: bigint), _col2 (type: decimal(35,20))
                     null sort order: zzzzz
-                    Statistics: Num rows: 15744 Data size: 3437416 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 15648 Data size: 3416456 Basic stats: COMPLETE Column stats: COMPLETE
                     top n: 100
                     Group By Operator
                       keys: _col0 (type: string), _col3 (type: int), _col4 (type: int), _col1 (type: bigint), _col2 (type: decimal(35,20))
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                      Statistics: Num rows: 15744 Data size: 3447936 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 15648 Data size: 3426912 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: decimal(35,20))
                         null sort order: zzzzz
                         sort order: +++++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: decimal(35,20))
-                        Statistics: Num rows: 15744 Data size: 3447936 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 15648 Data size: 3426912 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -819,16 +819,16 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: bigint), KEY._col4 (type: decimal(35,20))
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 15744 Data size: 3447936 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 15648 Data size: 3426912 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), _col3 (type: bigint), _col4 (type: decimal(35,20)), _col1 (type: int), _col2 (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 15744 Data size: 3447936 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 15648 Data size: 3426912 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: string), _col3 (type: int), _col4 (type: int)
                     null sort order: zzz
                     sort order: +++
-                    Statistics: Num rows: 15744 Data size: 3447936 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 15648 Data size: 3426912 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint), _col2 (type: decimal(35,20))
         Union 6 
             Vertex: Union 6

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query5.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query5.q.out
@@ -149,7 +149,7 @@ STAGE PLANS:
                 TableScan
                   alias: web_sales
                   filterExpr: ws_web_site_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_235_container, bigKeyColName:ws_web_site_sk, smallTablePos:1, keyRatio:2.1438795429601423
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_235_container, bigKeyColName:ws_web_site_sk, smallTablePos:1, keyRatio:2.1458761134564632
                   Statistics: Num rows: 21594638446 Data size: 5182388988880 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ws_web_site_sk is not null (type: boolean)
@@ -167,7 +167,7 @@ STAGE PLANS:
                         outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col7
                         input vertices:
                           1 Map 20
-                        Statistics: Num rows: 46296303602 Data size: 25729253693544 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 46339418820 Data size: 25753225754752 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -177,20 +177,20 @@ STAGE PLANS:
                           outputColumnNames: _col2, _col3, _col4, _col5, _col7
                           input vertices:
                             1 Map 21
-                          Statistics: Num rows: 5143681594 Data size: 2807246404344 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5148471846 Data size: 2809871462440 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(_col2), sum(_col4), sum(_col3), sum(_col5)
                             keys: _col7 (type: string)
                             minReductionHashAggr: 0.99
                             mode: hash
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                            Statistics: Num rows: 54830 Data size: 30046840 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 54885 Data size: 30076980 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 54830 Data size: 30046840 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 54885 Data size: 30076980 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: decimal(17,2)), _col2 (type: decimal(17,2)), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -610,12 +610,12 @@ STAGE PLANS:
                 outputColumnNames: _col1, _col5, _col6, _col7
                 input vertices:
                   1 Map 19
-                Statistics: Num rows: 24704368985 Data size: 5918119413760 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 24747484203 Data size: 5928467066080 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Select Operator
                   expressions: _col1 (type: bigint), _col7 (type: bigint), 0 (type: decimal(7,2)), 0 (type: decimal(7,2)), _col5 (type: decimal(7,2)), _col6 (type: decimal(7,2))
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 24704368985 Data size: 11451898066400 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 24747484203 Data size: 11471903527552 Basic stats: COMPLETE Column stats: COMPLETE
                   Map Join Operator
                     condition map:
                          Inner Join 0 to 1
@@ -625,7 +625,7 @@ STAGE PLANS:
                     outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col7
                     input vertices:
                       1 Map 20
-                    Statistics: Num rows: 46296303602 Data size: 25729253693544 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 46339418820 Data size: 25753225754752 Basic stats: COMPLETE Column stats: COMPLETE
                     Map Join Operator
                       condition map:
                            Inner Join 0 to 1
@@ -635,20 +635,20 @@ STAGE PLANS:
                       outputColumnNames: _col2, _col3, _col4, _col5, _col7
                       input vertices:
                         1 Map 21
-                      Statistics: Num rows: 5143681594 Data size: 2807246404344 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5148471846 Data size: 2809871462440 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(_col2), sum(_col4), sum(_col3), sum(_col5)
                         keys: _col7 (type: string)
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                        Statistics: Num rows: 54830 Data size: 30046840 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 54885 Data size: 30076980 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string)
                           null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 54830 Data size: 30046840 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 54885 Data size: 30076980 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: decimal(17,2)), _col2 (type: decimal(17,2)), _col3 (type: decimal(17,2)), _col4 (type: decimal(17,2))
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query50.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query50.q.out
@@ -164,7 +164,7 @@ STAGE PLANS:
                 outputColumnNames: _col3, _col7, _col9
                 input vertices:
                   0 Map 1
-                Statistics: Num rows: 1378224220 Data size: 22051587528 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1384306375 Data size: 22148902008 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Map Join Operator
                   condition map:
@@ -175,30 +175,30 @@ STAGE PLANS:
                   outputColumnNames: _col3, _col9, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20
                   input vertices:
                     1 Map 8
-                  Statistics: Num rows: 1378224220 Data size: 1149438999432 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1384306375 Data size: 1154511516702 Basic stats: COMPLETE Column stats: COMPLETE
                   Top N Key Operator
                     sort order: ++++++++++
                     keys: _col11 (type: varchar(50)), _col12 (type: int), _col13 (type: varchar(10)), _col14 (type: varchar(60)), _col15 (type: char(15)), _col16 (type: char(10)), _col17 (type: varchar(60)), _col18 (type: varchar(30)), _col19 (type: char(2)), _col20 (type: char(10))
                     null sort order: zzzzzzzzzz
-                    Statistics: Num rows: 1378224220 Data size: 1149438999432 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1384306375 Data size: 1154511516702 Basic stats: COMPLETE Column stats: COMPLETE
                     top n: 100
                     Select Operator
                       expressions: _col11 (type: varchar(50)), _col12 (type: int), _col13 (type: varchar(10)), _col14 (type: varchar(60)), _col15 (type: char(15)), _col16 (type: char(10)), _col17 (type: varchar(60)), _col18 (type: varchar(30)), _col19 (type: char(2)), _col20 (type: char(10)), if(((_col3 - _col9) <= 30L), 1, 0) (type: int), if((((_col3 - _col9) > 30L) and ((_col3 - _col9) <= 60L)), 1, 0) (type: int), if((((_col3 - _col9) > 60L) and ((_col3 - _col9) <= 90L)), 1, 0) (type: int), if((((_col3 - _col9) > 90L) and ((_col3 - _col9) <= 120L)), 1, 0) (type: int), if(((_col3 - _col9) > 120L), 1, 0) (type: int)
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14
-                      Statistics: Num rows: 1378224220 Data size: 1149438999432 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1384306375 Data size: 1154511516702 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(_col10), sum(_col11), sum(_col12), sum(_col13), sum(_col14)
                         keys: _col0 (type: varchar(50)), _col1 (type: int), _col2 (type: varchar(10)), _col3 (type: varchar(60)), _col4 (type: char(15)), _col5 (type: char(10)), _col6 (type: varchar(60)), _col7 (type: varchar(30)), _col8 (type: char(2)), _col9 (type: char(10))
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14
-                        Statistics: Num rows: 1378224220 Data size: 1182516380660 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1384306375 Data size: 1187734869650 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: varchar(50)), _col1 (type: int), _col2 (type: varchar(10)), _col3 (type: varchar(60)), _col4 (type: char(15)), _col5 (type: char(10)), _col6 (type: varchar(60)), _col7 (type: varchar(30)), _col8 (type: char(2)), _col9 (type: char(10))
                           null sort order: zzzzzzzzzz
                           sort order: ++++++++++
                           Map-reduce partition columns: _col0 (type: varchar(50)), _col1 (type: int), _col2 (type: varchar(10)), _col3 (type: varchar(60)), _col4 (type: char(15)), _col5 (type: char(10)), _col6 (type: varchar(60)), _col7 (type: varchar(30)), _col8 (type: char(2)), _col9 (type: char(10))
-                          Statistics: Num rows: 1378224220 Data size: 1182516380660 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 1384306375 Data size: 1187734869650 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col10 (type: bigint), _col11 (type: bigint), _col12 (type: bigint), _col13 (type: bigint), _col14 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
@@ -208,12 +208,12 @@ STAGE PLANS:
                 keys: KEY._col0 (type: varchar(50)), KEY._col1 (type: int), KEY._col2 (type: varchar(10)), KEY._col3 (type: varchar(60)), KEY._col4 (type: char(15)), KEY._col5 (type: char(10)), KEY._col6 (type: varchar(60)), KEY._col7 (type: varchar(30)), KEY._col8 (type: char(2)), KEY._col9 (type: char(10))
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14
-                Statistics: Num rows: 1378224220 Data size: 1182516380660 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1384306375 Data size: 1187734869650 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: varchar(50)), _col1 (type: int), _col2 (type: varchar(10)), _col3 (type: varchar(60)), _col4 (type: char(15)), _col5 (type: char(10)), _col6 (type: varchar(60)), _col7 (type: varchar(30)), _col8 (type: char(2)), _col9 (type: char(10))
                   null sort order: zzzzzzzzzz
                   sort order: ++++++++++
-                  Statistics: Num rows: 1378224220 Data size: 1182516380660 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1384306375 Data size: 1187734869650 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col10 (type: bigint), _col11 (type: bigint), _col12 (type: bigint), _col13 (type: bigint), _col14 (type: bigint)
         Reducer 7 
             Execution mode: vectorized, llap
@@ -221,7 +221,7 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: varchar(50)), KEY.reducesinkkey1 (type: int), KEY.reducesinkkey2 (type: varchar(10)), KEY.reducesinkkey3 (type: varchar(60)), KEY.reducesinkkey4 (type: char(15)), KEY.reducesinkkey5 (type: char(10)), KEY.reducesinkkey6 (type: varchar(60)), KEY.reducesinkkey7 (type: varchar(30)), KEY.reducesinkkey8 (type: char(2)), KEY.reducesinkkey9 (type: char(10)), VALUE._col0 (type: bigint), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: bigint), VALUE._col4 (type: bigint)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14
-                Statistics: Num rows: 1378224220 Data size: 1182516380660 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1384306375 Data size: 1187734869650 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 100
                   Statistics: Num rows: 100 Data size: 85800 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query51.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query51.q.out
@@ -202,13 +202,13 @@ STAGE PLANS:
                   0 _col0 (type: bigint), _col1 (type: date)
                   1 _col0 (type: bigint), _col1 (type: date)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 47102852585509 Data size: 16580204110099168 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 47389106998950 Data size: 16680965663630400 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: CASE WHEN (_col3 is not null) THEN (_col3) ELSE (_col0) END (type: bigint), CASE WHEN (_col4 is not null) THEN (_col4) ELSE (_col1) END (type: date)
                   null sort order: az
                   sort order: ++
                   Map-reduce partition columns: CASE WHEN (_col3 is not null) THEN (_col3) ELSE (_col0) END (type: bigint)
-                  Statistics: Num rows: 47102852585509 Data size: 16580204110099168 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 47389106998950 Data size: 16680965663630400 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col1 (type: date), _col2 (type: decimal(27,2)), _col3 (type: bigint), _col4 (type: date), _col5 (type: decimal(27,2))
         Reducer 4 
             Execution mode: vectorized, llap
@@ -216,7 +216,7 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: bigint), VALUE._col1 (type: date), VALUE._col2 (type: decimal(27,2)), VALUE._col3 (type: bigint), VALUE._col4 (type: date), VALUE._col5 (type: decimal(27,2))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 47102852585509 Data size: 16580204110099168 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 47389106998950 Data size: 16680965663630400 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -242,25 +242,25 @@ STAGE PLANS:
                               name: max
                               window function: GenericUDAFMaxEvaluator
                               window frame: ROWS PRECEDING(MAX)~CURRENT
-                  Statistics: Num rows: 47102852585509 Data size: 16580204110099168 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 47389106998950 Data size: 16680965663630400 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (max_window_0 > max_window_1) (type: boolean)
-                    Statistics: Num rows: 15700950861836 Data size: 5526734703366272 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 15796368999650 Data size: 5560321887876800 Basic stats: COMPLETE Column stats: COMPLETE
                     Top N Key Operator
                       sort order: ++
                       keys: if(_col3 is not null, _col3, _col0) (type: bigint), if(_col4 is not null, _col4, _col1) (type: date)
                       null sort order: zz
-                      Statistics: Num rows: 15700950861836 Data size: 5526734703366272 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 15796368999650 Data size: 5560321887876800 Basic stats: COMPLETE Column stats: COMPLETE
                       top n: 100
                       Select Operator
                         expressions: if(_col3 is not null, _col3, _col0) (type: bigint), if(_col4 is not null, _col4, _col1) (type: date), _col5 (type: decimal(27,2)), _col2 (type: decimal(27,2)), max_window_0 (type: decimal(27,2)), max_window_1 (type: decimal(27,2))
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                        Statistics: Num rows: 15700950861836 Data size: 8038886841260032 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 15796368999650 Data size: 8087740927820800 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: bigint), _col1 (type: date)
                           null sort order: zz
                           sort order: ++
-                          Statistics: Num rows: 15700950861836 Data size: 8038886841260032 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 15796368999650 Data size: 8087740927820800 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col2 (type: decimal(27,2)), _col3 (type: decimal(27,2)), _col4 (type: decimal(27,2)), _col5 (type: decimal(27,2))
         Reducer 5 
             Execution mode: vectorized, llap
@@ -268,7 +268,7 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: bigint), KEY.reducesinkkey1 (type: date), VALUE._col0 (type: decimal(27,2)), VALUE._col1 (type: decimal(27,2)), VALUE._col2 (type: decimal(27,2)), VALUE._col3 (type: decimal(27,2))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 15700950861836 Data size: 8038886841260032 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 15796368999650 Data size: 8087740927820800 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 100
                   Statistics: Num rows: 100 Data size: 51200 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query56.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query56.q.out
@@ -25,7 +25,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: ss_addr_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_268_container, bigKeyColName:ss_addr_sk, smallTablePos:1, keyRatio:1.5949411774215885E-8
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_268_container, bigKeyColName:ss_addr_sk, smallTablePos:1, keyRatio:1.585245486373433E-8
                   Statistics: Num rows: 82510879939 Data size: 10987909046272 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ss_addr_sk is not null (type: boolean)
@@ -198,7 +198,7 @@ STAGE PLANS:
                 TableScan
                   alias: web_sales
                   filterExpr: ws_bill_addr_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_274_container, bigKeyColName:ws_bill_addr_sk, smallTablePos:1, keyRatio:6.09410527196747E-8
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_274_container, bigKeyColName:ws_bill_addr_sk, smallTablePos:1, keyRatio:6.057059039311133E-8
                   Statistics: Num rows: 21594638446 Data size: 2936546611376 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ws_bill_addr_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query60.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query60.q.out
@@ -25,7 +25,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: ss_addr_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_273_container, bigKeyColName:ss_addr_sk, smallTablePos:1, keyRatio:1.5949411774215885E-8
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_273_container, bigKeyColName:ss_addr_sk, smallTablePos:1, keyRatio:1.585245486373433E-8
                   Statistics: Num rows: 82510879939 Data size: 10987909046272 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ss_addr_sk is not null (type: boolean)
@@ -198,7 +198,7 @@ STAGE PLANS:
                 TableScan
                   alias: web_sales
                   filterExpr: ws_bill_addr_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_279_container, bigKeyColName:ws_bill_addr_sk, smallTablePos:1, keyRatio:6.09410527196747E-8
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_279_container, bigKeyColName:ws_bill_addr_sk, smallTablePos:1, keyRatio:6.057059039311133E-8
                   Statistics: Num rows: 21594638446 Data size: 2936546611376 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ws_bill_addr_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query64.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query64.q.out
@@ -569,20 +569,20 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 450359 Data size: 104483288 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 447635 Data size: 103851320 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col1 > (2 * _col2)) (type: boolean)
-                  Statistics: Num rows: 150119 Data size: 34827608 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 149211 Data size: 34616952 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: bigint)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 150119 Data size: 1200952 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 149211 Data size: 1193688 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: bigint)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: bigint)
-                      Statistics: Num rows: 150119 Data size: 1200952 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 149211 Data size: 1193688 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 15 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1152,13 +1152,13 @@ STAGE PLANS:
                   minReductionHashAggr: 0.99
                   mode: hash
                   outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 17049691022 Data size: 3955528317104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 16946565830 Data size: 3931603272560 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: bigint)
                     null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
-                    Statistics: Num rows: 17049691022 Data size: 3955528317104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 16946565830 Data size: 3931603272560 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: decimal(17,2)), _col2 (type: decimal(19,2))
         Reducer 8 
             Execution mode: vectorized, llap
@@ -1168,20 +1168,20 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 450359 Data size: 104483288 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 447635 Data size: 103851320 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (_col1 > (2 * _col2)) (type: boolean)
-                  Statistics: Num rows: 150119 Data size: 34827608 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 149211 Data size: 34616952 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: bigint)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 150119 Data size: 1200952 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 149211 Data size: 1193688 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: bigint)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: bigint)
-                      Statistics: Num rows: 150119 Data size: 1200952 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 149211 Data size: 1193688 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1202,13 +1202,13 @@ STAGE PLANS:
                   minReductionHashAggr: 0.99
                   mode: hash
                   outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 17049691022 Data size: 3955528317104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 16946565830 Data size: 3931603272560 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: bigint)
                     null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
-                    Statistics: Num rows: 17049691022 Data size: 3955528317104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 16946565830 Data size: 3931603272560 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: decimal(17,2)), _col2 (type: decimal(19,2))
 
   Stage: Stage-0

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query65.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query65.q.out
@@ -197,10 +197,10 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint), KEY._col1 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 15809259 Data size: 2008447072 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 15713763 Data size: 1996315024 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: _col2 is not null (type: boolean)
-                  Statistics: Num rows: 15809259 Data size: 2008447072 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 15713763 Data size: 1996315024 Basic stats: COMPLETE Column stats: COMPLETE
                   Map Join Operator
                     condition map:
                          Inner Join 0 to 1
@@ -210,10 +210,10 @@ STAGE PLANS:
                     outputColumnNames: _col0, _col1, _col2, _col4
                     input vertices:
                       1 Reducer 6
-                    Statistics: Num rows: 15901173 Data size: 3801143440 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 15805122 Data size: 3778182640 Basic stats: COMPLETE Column stats: COMPLETE
                     Filter Operator
                       predicate: (_col2 <= _col4) (type: boolean)
-                      Statistics: Num rows: 5300391 Data size: 1267047816 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5268374 Data size: 1259394216 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
@@ -223,7 +223,7 @@ STAGE PLANS:
                         outputColumnNames: _col1, _col2, _col6
                         input vertices:
                           1 Map 9
-                        Statistics: Num rows: 5300391 Data size: 1102481328 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5268374 Data size: 1095821792 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -233,22 +233,22 @@ STAGE PLANS:
                           outputColumnNames: _col2, _col6, _col8, _col9, _col10, _col11
                           input vertices:
                             1 Map 10
-                          Statistics: Num rows: 5300391 Data size: 3752420908 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5268374 Data size: 3729752872 Basic stats: COMPLETE Column stats: COMPLETE
                           Top N Key Operator
                             sort order: ++
                             keys: _col6 (type: varchar(50)), _col8 (type: varchar(200))
                             null sort order: zz
-                            Statistics: Num rows: 5300391 Data size: 3752420908 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5268374 Data size: 3729752872 Basic stats: COMPLETE Column stats: COMPLETE
                             top n: 100
                             Select Operator
                               expressions: _col6 (type: varchar(50)), _col8 (type: varchar(200)), _col2 (type: decimal(17,2)), _col9 (type: decimal(7,2)), _col10 (type: decimal(7,2)), _col11 (type: char(50))
                               outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                              Statistics: Num rows: 5300391 Data size: 3752164764 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 5268374 Data size: 3729496728 Basic stats: COMPLETE Column stats: COMPLETE
                               Reduce Output Operator
                                 key expressions: _col0 (type: varchar(50)), _col1 (type: varchar(200))
                                 null sort order: zz
                                 sort order: ++
-                                Statistics: Num rows: 5300391 Data size: 3752164764 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 5268374 Data size: 3729496728 Basic stats: COMPLETE Column stats: COMPLETE
                                 value expressions: _col2 (type: decimal(17,2)), _col3 (type: decimal(7,2)), _col4 (type: decimal(7,2)), _col5 (type: char(50))
         Reducer 3 
             Execution mode: vectorized, llap
@@ -256,7 +256,7 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: varchar(50)), KEY.reducesinkkey1 (type: varchar(200)), VALUE._col0 (type: decimal(17,2)), VALUE._col1 (type: decimal(7,2)), VALUE._col2 (type: decimal(7,2)), VALUE._col3 (type: char(50))
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 5300391 Data size: 3752164764 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5268374 Data size: 3729496728 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 100
                   Statistics: Num rows: 100 Data size: 70800 Basic stats: COMPLETE Column stats: COMPLETE
@@ -275,11 +275,11 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint), KEY._col1 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 15809259 Data size: 2008447072 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 15713763 Data size: 1996315024 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: bigint), _col2 (type: decimal(17,2))
                   outputColumnNames: _col1, _col2
-                  Statistics: Num rows: 15809259 Data size: 2008447072 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 15713763 Data size: 1996315024 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
                     aggregations: sum(_col2), count(_col2)
                     keys: _col1 (type: bigint)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query67.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query67.q.out
@@ -19,7 +19,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: ss_store_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_75_container, bigKeyColName:ss_store_sk, smallTablePos:1, keyRatio:1.1075266688169988E-6
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_75_container, bigKeyColName:ss_store_sk, smallTablePos:1, keyRatio:1.1008366419937714E-6
                   Statistics: Num rows: 82510879939 Data size: 11310614692868 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ss_store_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query7.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query7.q.out
@@ -17,7 +17,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: (ss_cdemo_sk is not null and ss_promo_sk is not null) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_94_container, bigKeyColName:ss_cdemo_sk, smallTablePos:1, keyRatio:1.617968443660958E-8
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_94_container, bigKeyColName:ss_cdemo_sk, smallTablePos:1, keyRatio:1.6082727526128025E-8
                   Statistics: Num rows: 82510879939 Data size: 30001935686500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (ss_cdemo_sk is not null and ss_promo_sk is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query78.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query78.q.out
@@ -269,7 +269,7 @@ STAGE PLANS:
                     Group By Operator
                       aggregations: sum(_col3), sum(_col4), sum(_col5)
                       keys: _col1 (type: bigint), _col2 (type: bigint)
-                      minReductionHashAggr: 0.90168124
+                      minReductionHashAggr: 0.90198845
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4
                       Statistics: Num rows: 266197845 Data size: 65173417496 Basic stats: COMPLETE Column stats: COMPLETE
@@ -455,7 +455,7 @@ STAGE PLANS:
                     Group By Operator
                       aggregations: sum(_col3), sum(_col4), sum(_col5)
                       keys: _col2 (type: bigint), _col1 (type: bigint)
-                      minReductionHashAggr: 0.7020926
+                      minReductionHashAggr: 0.7029948
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4
                       Statistics: Num rows: 16192399916 Data size: 4000523044608 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query80.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query80.q.out
@@ -546,7 +546,7 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6, _col9, _col10
                 input vertices:
                   1 Map 7
-                Statistics: Num rows: 125690246562 Data size: 52704730158864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 125628165446 Data size: 52781691423024 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Map Join Operator
                   condition map:
@@ -557,7 +557,7 @@ STAGE PLANS:
                   outputColumnNames: _col1, _col2, _col4, _col5, _col6, _col9, _col10
                   input vertices:
                     1 Map 14
-                  Statistics: Num rows: 64102024548 Data size: 22629567395760 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 64070363180 Data size: 22721383429904 Basic stats: COMPLETE Column stats: COMPLETE
                   Map Join Operator
                     condition map:
                          Inner Join 0 to 1
@@ -567,7 +567,7 @@ STAGE PLANS:
                     outputColumnNames: _col1, _col4, _col5, _col6, _col9, _col10
                     input vertices:
                       1 Map 15
-                    Statistics: Num rows: 32051012274 Data size: 7261741124624 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 32035181590 Data size: 7359290078528 Basic stats: COMPLETE Column stats: COMPLETE
                     Map Join Operator
                       condition map:
                            Inner Join 0 to 1
@@ -577,7 +577,7 @@ STAGE PLANS:
                       outputColumnNames: _col1, _col4, _col5, _col9, _col10
                       input vertices:
                         1 Map 8
-                      Statistics: Num rows: 3560979800 Data size: 395645492464 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3559220955 Data size: 395237440424 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
@@ -587,24 +587,24 @@ STAGE PLANS:
                         outputColumnNames: _col4, _col5, _col9, _col10, _col15
                         input vertices:
                           1 Map 9
-                        Statistics: Num rows: 3560979800 Data size: 738066718256 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 3559220955 Data size: 737496852476 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col15 (type: string), _col4 (type: decimal(7,2)), if(_col9 is not null, _col9, 0) (type: decimal(7,2)), (_col5 - if(_col10 is not null, _col10, 0)) (type: decimal(8,2))
                           outputColumnNames: _col0, _col1, _col2, _col3
-                          Statistics: Num rows: 3560979800 Data size: 738066718256 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 3559220955 Data size: 737496852476 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(_col1), sum(_col2), sum(_col3)
                             keys: _col0 (type: string)
                             minReductionHashAggr: 0.99
                             mode: hash
                             outputColumnNames: _col0, _col1, _col2, _col3
-                            Statistics: Num rows: 2535036 Data size: 1105275696 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 2532399 Data size: 1104125964 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 2535036 Data size: 1105275696 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 2532399 Data size: 1104125964 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: decimal(17,2)), _col2 (type: decimal(17,2)), _col3 (type: decimal(18,2))
         Reducer 21 
             Execution mode: vectorized, llap
@@ -618,7 +618,7 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6, _col9, _col10
                 input vertices:
                   1 Map 23
-                Statistics: Num rows: 33638432926 Data size: 14382415234448 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 33633305448 Data size: 14391212980304 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Map Join Operator
                   condition map:
@@ -629,7 +629,7 @@ STAGE PLANS:
                   outputColumnNames: _col1, _col2, _col4, _col5, _col6, _col9, _col10
                   input vertices:
                     1 Map 14
-                  Statistics: Num rows: 17155600472 Data size: 6333410852752 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 17152985458 Data size: 6343435501440 Basic stats: COMPLETE Column stats: COMPLETE
                   Map Join Operator
                     condition map:
                          Inner Join 0 to 1
@@ -639,7 +639,7 @@ STAGE PLANS:
                     outputColumnNames: _col1, _col4, _col5, _col6, _col9, _col10
                     input vertices:
                       1 Map 15
-                    Statistics: Num rows: 8577800236 Data size: 2216088348040 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 8576492729 Data size: 2226740600088 Basic stats: COMPLETE Column stats: COMPLETE
                     Map Join Operator
                       condition map:
                            Inner Join 0 to 1
@@ -649,7 +649,7 @@ STAGE PLANS:
                       outputColumnNames: _col1, _col4, _col5, _col9, _col10
                       input vertices:
                         1 Map 8
-                      Statistics: Num rows: 953023671 Data size: 220777334864 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 952878402 Data size: 220743632456 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
@@ -659,11 +659,11 @@ STAGE PLANS:
                         outputColumnNames: _col4, _col5, _col9, _col10, _col15
                         input vertices:
                           1 Map 24
-                        Statistics: Num rows: 953023671 Data size: 308477137804 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 952878402 Data size: 308430070648 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col15 (type: string), _col4 (type: decimal(7,2)), if(_col9 is not null, _col9, 0) (type: decimal(7,2)), (_col5 - if(_col10 is not null, _col10, 0)) (type: decimal(8,2))
                           outputColumnNames: _col0, _col1, _col2, _col3
-                          Statistics: Num rows: 953023671 Data size: 308477137804 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 952878402 Data size: 308430070648 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(_col1), sum(_col2), sum(_col3)
                             keys: _col0 (type: string)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query85.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query85.q.out
@@ -108,7 +108,7 @@ STAGE PLANS:
                 TableScan
                   alias: web_returns
                   filterExpr: (wr_returning_cdemo_sk is not null and wr_refunded_cdemo_sk is not null and wr_reason_sk is not null and wr_refunded_addr_sk is not null) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_188_container, bigKeyColName:wr_returning_cdemo_sk, smallTablePos:1, keyRatio:4.698595133712381E-6
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_188_container, bigKeyColName:wr_returning_cdemo_sk, smallTablePos:1, keyRatio:4.669891527614227E-6
                   Statistics: Num rows: 2160007345 Data size: 562637317992 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (wr_returning_cdemo_sk is not null and wr_refunded_cdemo_sk is not null and wr_reason_sk is not null and wr_refunded_addr_sk is not null) (type: boolean)
@@ -251,11 +251,11 @@ STAGE PLANS:
                 outputColumnNames: _col2, _col4, _col5, _col6, _col7, _col8, _col9, _col15, _col17, _col18, _col20, _col21, _col22, _col29, _col30, _col31, _col32, _col33, _col34
                 input vertices:
                   1 Map 6
-                Statistics: Num rows: 469711109 Data size: 129923394292 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 470530871 Data size: 130166043844 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Filter Operator
                   predicate: (((_col20 and _col4) or (_col21 and _col5) or (_col22 and _col6)) and ((_col29 and _col30 and _col7) or (_col31 and _col32 and _col8) or (_col33 and _col34 and _col9))) (type: boolean)
-                  Statistics: Num rows: 132106248 Data size: 36540954392 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 132336804 Data size: 36609198968 Basic stats: COMPLETE Column stats: COMPLETE
                   Map Join Operator
                     condition map:
                          Inner Join 0 to 1
@@ -265,7 +265,7 @@ STAGE PLANS:
                     outputColumnNames: _col2, _col17, _col18, _col36
                     input vertices:
                       1 Map 11
-                    Statistics: Num rows: 132106248 Data size: 40460293048 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 132336804 Data size: 40535223748 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: sum(_col2), count(_col2), sum(_col18), count(_col18), sum(_col17), count(_col17)
                       keys: _col36 (type: char(100))

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query9.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query9.q.out
@@ -222,11 +222,11 @@ STAGE PLANS:
                   Statistics: Num rows: 86404891377 Data size: 9571495477368 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ss_quantity BETWEEN 1 AND 20 (type: boolean)
-                    Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_ext_list_price (type: decimal(7,2))
                       outputColumnNames: ss_ext_list_price
-                      Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_ext_list_price), count(ss_ext_list_price)
                         minReductionHashAggr: 0.99
@@ -241,7 +241,7 @@ STAGE PLANS:
                     Select Operator
                       expressions: ss_net_paid_inc_tax (type: decimal(7,2))
                       outputColumnNames: ss_net_paid_inc_tax
-                      Statistics: Num rows: 16616325265 Data size: 1840645264444 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895317896036 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_net_paid_inc_tax), count(ss_net_paid_inc_tax)
                         minReductionHashAggr: 0.99
@@ -254,7 +254,7 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: decimal(17,2)), _col1 (type: bigint)
                     Select Operator
-                      Statistics: Num rows: 16616325265 Data size: 63470890476 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 65356164452 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         minReductionHashAggr: 0.99
@@ -268,11 +268,11 @@ STAGE PLANS:
                           value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: ss_quantity BETWEEN 41 AND 60 (type: boolean)
-                    Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_ext_list_price (type: decimal(7,2))
                       outputColumnNames: ss_ext_list_price
-                      Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_ext_list_price), count(ss_ext_list_price)
                         minReductionHashAggr: 0.99
@@ -287,7 +287,7 @@ STAGE PLANS:
                     Select Operator
                       expressions: ss_net_paid_inc_tax (type: decimal(7,2))
                       outputColumnNames: ss_net_paid_inc_tax
-                      Statistics: Num rows: 16616325265 Data size: 1840645264444 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895317896036 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_net_paid_inc_tax), count(ss_net_paid_inc_tax)
                         minReductionHashAggr: 0.99
@@ -300,7 +300,7 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: decimal(17,2)), _col1 (type: bigint)
                     Select Operator
-                      Statistics: Num rows: 16616325265 Data size: 63470890476 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 65356164452 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         minReductionHashAggr: 0.99
@@ -314,11 +314,11 @@ STAGE PLANS:
                           value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: ss_quantity BETWEEN 21 AND 40 (type: boolean)
-                    Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_ext_list_price (type: decimal(7,2))
                       outputColumnNames: ss_ext_list_price
-                      Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_ext_list_price), count(ss_ext_list_price)
                         minReductionHashAggr: 0.99
@@ -333,7 +333,7 @@ STAGE PLANS:
                     Select Operator
                       expressions: ss_net_paid_inc_tax (type: decimal(7,2))
                       outputColumnNames: ss_net_paid_inc_tax
-                      Statistics: Num rows: 16616325265 Data size: 1840645264444 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895317896036 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_net_paid_inc_tax), count(ss_net_paid_inc_tax)
                         minReductionHashAggr: 0.99
@@ -346,7 +346,7 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: decimal(17,2)), _col1 (type: bigint)
                     Select Operator
-                      Statistics: Num rows: 16616325265 Data size: 63470890476 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 65356164452 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         minReductionHashAggr: 0.99
@@ -360,11 +360,11 @@ STAGE PLANS:
                           value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: ss_quantity BETWEEN 61 AND 80 (type: boolean)
-                    Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_ext_list_price (type: decimal(7,2))
                       outputColumnNames: ss_ext_list_price
-                      Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_ext_list_price), count(ss_ext_list_price)
                         minReductionHashAggr: 0.99
@@ -379,7 +379,7 @@ STAGE PLANS:
                     Select Operator
                       expressions: ss_net_paid_inc_tax (type: decimal(7,2))
                       outputColumnNames: ss_net_paid_inc_tax
-                      Statistics: Num rows: 16616325265 Data size: 1840645264444 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895317896036 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_net_paid_inc_tax), count(ss_net_paid_inc_tax)
                         minReductionHashAggr: 0.99
@@ -392,7 +392,7 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: decimal(17,2)), _col1 (type: bigint)
                     Select Operator
-                      Statistics: Num rows: 16616325265 Data size: 63470890476 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 65356164452 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         minReductionHashAggr: 0.99
@@ -406,11 +406,11 @@ STAGE PLANS:
                           value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: ss_quantity BETWEEN 81 AND 100 (type: boolean)
-                    Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_ext_list_price (type: decimal(7,2))
                       outputColumnNames: ss_ext_list_price
-                      Statistics: Num rows: 16616325265 Data size: 1840672207276 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895345639220 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_ext_list_price), count(ss_ext_list_price)
                         minReductionHashAggr: 0.99
@@ -425,7 +425,7 @@ STAGE PLANS:
                     Select Operator
                       expressions: ss_net_paid_inc_tax (type: decimal(7,2))
                       outputColumnNames: ss_net_paid_inc_tax
-                      Statistics: Num rows: 16616325265 Data size: 1840645264444 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 1895317896036 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(ss_net_paid_inc_tax), count(ss_net_paid_inc_tax)
                         minReductionHashAggr: 0.99
@@ -438,7 +438,7 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: decimal(17,2)), _col1 (type: bigint)
                     Select Operator
-                      Statistics: Num rows: 16616325265 Data size: 63470890476 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 17109879481 Data size: 65356164452 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
                         minReductionHashAggr: 0.99

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query92.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query92.q.out
@@ -67,13 +67,13 @@ STAGE PLANS:
                           minReductionHashAggr: 0.99
                           mode: hash
                           outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 58046732 Data size: 7429981696 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 57694920 Data size: 7384949760 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: bigint)
                             null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: bigint)
-                            Statistics: Num rows: 58046732 Data size: 7429981696 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 57694920 Data size: 7384949760 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: decimal(17,2)), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -177,14 +177,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 51643 Data size: 6610304 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 51330 Data size: 6570240 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: CAST( (_col1 / _col2) AS decimal(11,6)) is not null (type: boolean)
-                  Statistics: Num rows: 51643 Data size: 6610304 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 51330 Data size: 6570240 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: (1.3 * CAST( (_col1 / _col2) AS decimal(11,6))) (type: decimal(14,7)), _col0 (type: bigint)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 51643 Data size: 6197160 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 51330 Data size: 6159600 Basic stats: COMPLETE Column stats: COMPLETE
                     Map Join Operator
                       condition map:
                            Inner Join 0 to 1
@@ -194,10 +194,10 @@ STAGE PLANS:
                       outputColumnNames: _col1, _col2, _col4
                       input vertices:
                         0 Reducer 2
-                      Statistics: Num rows: 51643 Data size: 6197272 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 51330 Data size: 6159712 Basic stats: COMPLETE Column stats: COMPLETE
                       Filter Operator
                         predicate: (_col1 > _col4) (type: boolean)
-                        Statistics: Num rows: 17214 Data size: 2065792 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 17110 Data size: 2053312 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -207,7 +207,7 @@ STAGE PLANS:
                           outputColumnNames: _col1
                           input vertices:
                             1 Map 7
-                          Statistics: Num rows: 17214 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 17110 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(_col1)
                             minReductionHashAggr: 0.99

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query93.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query93.q.out
@@ -20,7 +20,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_returns
                   filterExpr: sr_reason_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_73_container, bigKeyColName:sr_reason_sk, smallTablePos:1, keyRatio:7.477270249392483E-7
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_73_container, bigKeyColName:sr_reason_sk, smallTablePos:1, keyRatio:7.432100865915671E-7
                   Statistics: Num rows: 8634166995 Data size: 238137929652 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: sr_reason_sk is not null (type: boolean)
@@ -131,25 +131,25 @@ STAGE PLANS:
                 outputColumnNames: _col3, _col6, _col8, _col9
                 input vertices:
                   0 Map 1
-                Statistics: Num rows: 1382795827 Data size: 5068243592 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1388898157 Data size: 5092652912 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Select Operator
                   expressions: _col6 (type: bigint), if(_col3 is not null, (CAST( (_col8 - _col3) AS decimal(10,0)) * _col9), (CAST( _col8 AS decimal(10,0)) * _col9)) (type: decimal(18,2))
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1382795827 Data size: 5068243592 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1388898157 Data size: 5092652912 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
                     aggregations: sum(_col1)
                     keys: _col0 (type: bigint)
                     minReductionHashAggr: 0.99
                     mode: hash
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 25134120 Data size: 2815021448 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 25245020 Data size: 2827442248 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: bigint)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: bigint)
-                      Statistics: Num rows: 25134120 Data size: 2815021448 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 25245020 Data size: 2827442248 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: decimal(28,2))
         Reducer 6 
             Execution mode: vectorized, llap
@@ -159,25 +159,25 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1256706 Data size: 140751080 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1262251 Data size: 141372120 Basic stats: COMPLETE Column stats: COMPLETE
                 Top N Key Operator
                   sort order: ++
                   keys: _col1 (type: decimal(28,2)), _col0 (type: bigint)
                   null sort order: zz
-                  Statistics: Num rows: 1256706 Data size: 140751080 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1262251 Data size: 141372120 Basic stats: COMPLETE Column stats: COMPLETE
                   top n: 100
                   Reduce Output Operator
                     key expressions: _col1 (type: decimal(28,2)), _col0 (type: bigint)
                     null sort order: zz
                     sort order: ++
-                    Statistics: Num rows: 1256706 Data size: 140751080 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1262251 Data size: 141372120 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey0 (type: decimal(28,2))
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1256706 Data size: 130697432 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1262251 Data size: 131274112 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 100
                   Statistics: Num rows: 100 Data size: 11208 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query94.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query94.q.out
@@ -122,7 +122,7 @@ STAGE PLANS:
                       Statistics: Num rows: 21594635145 Data size: 345470962208 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: _col0 (type: bigint), _col1 (type: bigint)
-                        minReductionHashAggr: 0.5581621
+                        minReductionHashAggr: 0.5589319
                         mode: hash
                         outputColumnNames: _col0, _col1
                         Statistics: Num rows: 21594635145 Data size: 345470962208 Basic stats: COMPLETE Column stats: COMPLETE
@@ -262,16 +262,16 @@ STAGE PLANS:
                 Group By Operator
                   aggregations: sum(_col5), sum(_col6)
                   keys: _col4 (type: bigint)
-                  minReductionHashAggr: 0.91645867
+                  minReductionHashAggr: 0.9166043
                   mode: hash
                   outputColumnNames: _col0, _col2, _col3
-                  Statistics: Num rows: 2159952 Data size: 501108864 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2156188 Data size: 500235616 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: bigint)
                     null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
-                    Statistics: Num rows: 2159952 Data size: 501108864 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2156188 Data size: 500235616 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: decimal(17,2)), _col3 (type: decimal(17,2))
         Reducer 4 
             Execution mode: vectorized, llap
@@ -281,7 +281,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: partial2
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2159952 Data size: 501108864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2156188 Data size: 500235616 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: count(_col0), sum(_col1), sum(_col2)
                   mode: partial2

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query95.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query95.q.out
@@ -258,15 +258,15 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2
                 input vertices:
                   1 Map 11
-                Statistics: Num rows: 258749294920 Data size: 6209896656240 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 259200876264 Data size: 6220734608496 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Filter Operator
                   predicate: (_col0 <> _col2) (type: boolean)
-                  Statistics: Num rows: 258749294920 Data size: 6209896656240 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 259200876264 Data size: 6220734608496 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col1 (type: bigint)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 258749294920 Data size: 2069994359360 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 259200876264 Data size: 2073607010112 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: _col0 (type: bigint)
                       minReductionHashAggr: 0.99
@@ -291,14 +291,14 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2
                 input vertices:
                   1 Map 14
-                Statistics: Num rows: 25874973741 Data size: 620956158864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 25920131953 Data size: 622039955952 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Reduce Output Operator
                   key expressions: _col1 (type: bigint)
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col1 (type: bigint)
-                  Statistics: Num rows: 25874973741 Data size: 620956158864 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 25920131953 Data size: 622039955952 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col2 (type: bigint)
         Reducer 17 
             Execution mode: vectorized, llap
@@ -312,27 +312,27 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col2, _col3
                 input vertices:
                   1 Map 15
-                Statistics: Num rows: 309959254381 Data size: 7438935683304 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 311042109197 Data size: 7464924198888 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Filter Operator
                   predicate: (_col0 <> _col3) (type: boolean)
-                  Statistics: Num rows: 309959254381 Data size: 7438935683304 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 311042109197 Data size: 7464924198888 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: bigint)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 309959254381 Data size: 2479674035048 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 311042109197 Data size: 2488336873576 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: _col0 (type: bigint)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
-                      Statistics: Num rows: 309959254381 Data size: 2479674035048 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 311042109197 Data size: 2488336873576 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: bigint)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: bigint)
-                        Statistics: Num rows: 309959254381 Data size: 2479674035048 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 311042109197 Data size: 2488336873576 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -383,16 +383,16 @@ STAGE PLANS:
                 Group By Operator
                   aggregations: sum(_col4), sum(_col5)
                   keys: _col3 (type: bigint)
-                  minReductionHashAggr: 0.91645867
+                  minReductionHashAggr: 0.9166043
                   mode: hash
                   outputColumnNames: _col0, _col2, _col3
-                  Statistics: Num rows: 2159952 Data size: 501108864 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2156188 Data size: 500235616 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: bigint)
                     null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
-                    Statistics: Num rows: 2159952 Data size: 501108864 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2156188 Data size: 500235616 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: decimal(17,2)), _col3 (type: decimal(17,2))
         Reducer 4 
             Execution mode: vectorized, llap
@@ -402,7 +402,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: bigint)
                 mode: partial2
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2159952 Data size: 501108864 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2156188 Data size: 500235616 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
                   aggregations: count(_col0), sum(_col1), sum(_col2)
                   mode: partial2

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query97.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query97.q.out
@@ -37,7 +37,7 @@ STAGE PLANS:
                       Statistics: Num rows: 16221796254 Data size: 243989868272 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: _col1 (type: bigint), _col0 (type: bigint)
-                        minReductionHashAggr: 0.7123034
+                        minReductionHashAggr: 0.71317357
                         mode: hash
                         outputColumnNames: _col0, _col1
                         Statistics: Num rows: 16221796254 Data size: 243989868272 Basic stats: COMPLETE Column stats: COMPLETE
@@ -71,7 +71,7 @@ STAGE PLANS:
                       Statistics: Num rows: 8395118768 Data size: 133476173240 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: _col0 (type: bigint), _col1 (type: bigint)
-                        minReductionHashAggr: 0.44997114
+                        minReductionHashAggr: 0.4516346
                         mode: hash
                         outputColumnNames: _col0, _col1
                         Statistics: Num rows: 8395118768 Data size: 133476173240 Basic stats: COMPLETE Column stats: COMPLETE

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregator.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregator.java
@@ -251,7 +251,7 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
     }
 
     // mutate columnStatisticsData to ensure NDV <= the number of integers in the given range.
-    adjustNDV(columnStatisticsData);
+    adjustNDV(columnStatisticsData.getLongStats());
 
     statsObj.setStatsData(columnStatisticsData);
 
@@ -357,22 +357,18 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
     extrapolateLongData.setNumDVs(ndv);
   }
 
-  private void adjustNDV(ColumnStatisticsData columnStatisticsData) {
+  private void adjustNDV(LongColumnStatsData columnStats) {
     // NDV cannot exceed the number of integers within the given range.
-    long numIntInRange = columnStatisticsData.getLongStats().getHighValue()
-        - columnStatisticsData.getLongStats().getLowValue() + 1;
-    if (columnStatisticsData.getLongStats().getNumNulls() > 0) {
-      numIntInRange++;
+    long estimation = columnStats.getHighValue() - columnStats.getLowValue() + 1;
+    if (columnStats.getNumNulls() > 0) {
+      estimation++;
     }
-    if (numIntInRange < columnStatisticsData.getLongStats().getNumDVs()) {
+    if (estimation < columnStats.getNumDVs()) {
       LOG.debug(
           "Adjust the estimated NDV from {} to {} as it exceeds the number of integers "
               + "within the range of colStats: [{}, {}].",
-          columnStatisticsData.getLongStats().getNumDVs(),
-          numIntInRange,
-          columnStatisticsData.getLongStats().getLowValue(),
-          columnStatisticsData.getLongStats().getHighValue());
-      columnStatisticsData.getLongStats().setNumDVs(numIntInRange);
+          columnStats.getNumDVs(), estimation, columnStats.getLowValue(), columnStats.getHighValue());
+      columnStats.setNumDVs(estimation);
     }
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregator.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregator.java
@@ -172,13 +172,7 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
           String partName = csp.getPartName();
           LongColumnStatsData newData = cso.getStatsData().getLongStats();
           if (useDensityFunctionForNDVEstimation) {
-            if (newData.getNumDVs() == 0) {
-              // If NDV is not present, assume that the density is 0.5.
-              densityAvgSum += 0.5;
-            } else {
-              densityAvgSum +=
-                  ((double) (newData.getHighValue() - newData.getLowValue())) / newData.getNumDVs();
-            }
+            densityAvgSum += ((double) (newData.getHighValue() - newData.getLowValue())) / newData.getNumDVs();
           }
           adjustedIndexMap.put(partName, (double) indexMap.get(partName));
           adjustedStatsMap.put(partName, cso.getStatsData());
@@ -207,13 +201,7 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
               csd.setLongStats(aggregateData);
               adjustedStatsMap.put(pseudoPartName.toString(), csd);
               if (useDensityFunctionForNDVEstimation) {
-                if (aggregateData.getNumDVs() == 0) {
-                  // If NDV is not present, assume that the density is 0.5.
-                  densityAvgSum += 0.5;
-                } else {
-                  double range = aggregateData.getHighValue() - aggregateData.getLowValue();
-                  densityAvgSum += range / aggregateData.getNumDVs();
-                }
+                densityAvgSum += ((double) (aggregateData.getHighValue() - aggregateData.getLowValue())) / aggregateData.getNumDVs();
               }
               // reset everything
               pseudoPartName = new StringBuilder();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregator.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregator.java
@@ -242,6 +242,24 @@ public class LongColumnStatsAggregator extends ColumnStatsAggregator implements
     }
 
     statsObj.setStatsData(columnStatisticsData);
+
+    // NDV cannot exceed the number of integers within the given range.
+    long numIntInRange = columnStatisticsData.getLongStats().getHighValue()
+        - columnStatisticsData.getLongStats().getLowValue() + 1;
+    if (columnStatisticsData.getLongStats().getNumNulls() > 0) {
+      numIntInRange++;
+    }
+    if (numIntInRange < columnStatisticsData.getLongStats().getNumDVs()) {
+      LOG.debug(
+          "Adjust the estimated NDV from {} to {} as it exceeds the number of integers "
+              + "within the range of colStats: [{}, {}].",
+          columnStatisticsData.getLongStats().getNumDVs(),
+          numIntInRange,
+          columnStatisticsData.getLongStats().getLowValue(),
+          columnStatisticsData.getLongStats().getHighValue());
+      columnStatisticsData.getLongStats().setNumDVs(numIntInRange);
+    }
+
     return statsObj;
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregatorTest.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/columnstats/aggr/LongColumnStatsAggregatorTest.java
@@ -105,14 +105,14 @@ public class LongColumnStatsAggregatorTest {
 
     aggregator.useDensityFunctionForNDVEstimation = true;
     computedStatsObj = aggregator.aggregate(statsList, partitions, true);
-    expectedStats = new ColStatsBuilder<>(long.class).numNulls(3).numDVs(4)
+    expectedStats = new ColStatsBuilder<>(long.class).numNulls(3).numDVs(3)
         .low(1L).high(2L).hll(1, 2).build();
     assertEqualStatistics(expectedStats, computedStatsObj.getStatsData());
 
     aggregator.useDensityFunctionForNDVEstimation = false;
     aggregator.ndvTuner = 1;
     computedStatsObj = aggregator.aggregate(statsList, partitions, true);
-    expectedStats = new ColStatsBuilder<>(long.class).numNulls(3).numDVs(5)
+    expectedStats = new ColStatsBuilder<>(long.class).numNulls(3).numDVs(3)
         .low(1L).high(2L).hll(1, 2).build();
     assertEqualStatistics(expectedStats, computedStatsObj.getStatsData());
   }
@@ -178,7 +178,7 @@ public class LongColumnStatsAggregatorTest {
 
     aggregator.useDensityFunctionForNDVEstimation = false;
     double[] tunerValues = new double[] { 0, 0.5, 0.75, 1 };
-    long[] expectedDVs = new long[] { 4, 7, 8, 10 };
+    long[] expectedDVs = new long[] { 4, 7, 8, 9 };
     for (int i = 0; i < tunerValues.length; i++) {
       aggregator.ndvTuner = tunerValues[i];
       computedStatsObj = aggregator.aggregate(statsList, partitions, true);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This patch implements a sanity-check in `LongColumnStatsAggregator`. The added check ensures that the estimated NDV is always less than or equal to the maximum number of integers within the estimated range.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If the estimated range of a long type column is `[A, B]`, then the maximum number of distinct values in the column should be `B - A + 1` (assuming no nulls in the column). Therefore, any integer that is larger than `B - A + 1` cannot be the estimated value of NDV.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The patch is tested manually by printing debug messages in bitvector-enabled HMS. Also, I checked that the existing unit tests contains invalid expected outputs.