### PR TITLE
HIVE-28802: NPE in MiniHS2 with miniHS2.clusterType=LOCALFS_ONLY

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
@@ -77,7 +77,6 @@ public class TestReExecuteKilledTezAMQueryPlugin {
     dataFileDir = conf.get("test.data.files").replace('\\', '/').replace("c:", "");
     Map<String, String> confOverlay = new HashMap<String, String>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
 
     Connection conDefault = getConnection(miniHS2.getJdbcURL(),
     System.getProperty("user.name"), "bar");

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/AbstractJdbcTriggersTest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/AbstractJdbcTriggersTest.java
@@ -89,7 +89,6 @@ public abstract class AbstractJdbcTriggersTest {
 
     Map<String, String> confOverlay = new HashMap<>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
   }
 
   @Before

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/AbstractTestJdbcGenericUDTFGetSplits.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/AbstractTestJdbcGenericUDTFGetSplits.java
@@ -84,7 +84,6 @@ public abstract class AbstractTestJdbcGenericUDTFGetSplits {
 
     Map<String, String> confOverlay = new HashMap<>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
   }
 
   @AfterClass

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/BaseJdbcWithMiniLlap.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/BaseJdbcWithMiniLlap.java
@@ -91,7 +91,6 @@ public abstract class BaseJdbcWithMiniLlap {
     over10KFilePath = new Path(dataFileDir, "over10k");
     Map<String, String> confOverlay = new HashMap<String, String>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
     return miniHS2;
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestKillQueryWithAuthorizationDisabled.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestKillQueryWithAuthorizationDisabled.java
@@ -112,7 +112,6 @@ public class TestKillQueryWithAuthorizationDisabled {
     miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.LLAP);
     Map<String, String> confOverlay = new HashMap<String, String>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
 
     Connection conDefault =
         BaseJdbcWithMiniLlap.getConnection(miniHS2.getJdbcURL(), System.getProperty("user.name"), "bar");

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestTriggersMoveWorkloadManager.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestTriggersMoveWorkloadManager.java
@@ -92,7 +92,6 @@ public class TestTriggersMoveWorkloadManager extends AbstractJdbcTriggersTest {
 
     Map<String, String> confOverlay = new HashMap<>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
   }
 
   @Test(timeout = 60000)

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestTriggersWorkloadManager.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestTriggersWorkloadManager.java
@@ -86,7 +86,6 @@ public class TestTriggersWorkloadManager extends TestTriggersTezSessionPoolManag
 
     Map<String, String> confOverlay = new HashMap<>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
   }
 
   @Override

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestWMMetricsWithTrigger.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestWMMetricsWithTrigger.java
@@ -106,7 +106,6 @@ public class TestWMMetricsWithTrigger {
     miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.LLAP);
     Map<String, String> confOverlay = new HashMap<>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
 
     Connection conDefault =
         BaseJdbcWithMiniLlap.getConnection(miniHS2.getJdbcURL(), System.getProperty("user.name"), "bar");

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/StartMiniHS2Cluster.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/StartMiniHS2Cluster.java
@@ -22,7 +22,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/StartMiniHS2Cluster.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/StartMiniHS2Cluster.java
@@ -81,7 +81,6 @@ public class StartMiniHS2Cluster {
         .withRemoteMetastore(isMetastoreRemote).withQueryHistory(queryHistory).build();
     Map<String, String> confOverlay = new HashMap<String, String>();
     miniHS2.start(confOverlay);
-    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
 
     System.out.println("JDBC URL available at " + miniHS2.getJdbcURL());
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removed an mkdir from MiniHS2 initialization.


### Why are the changes needed?
I didn't find why it was needed (introduced in the original MiniHS2 patch), and the whole thing works without it (but caused an NPE in LOCALFS_ONLY mode.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Worked with LLAP/TEZ/LOCALFS_ONLY, ran a simple query that needs tez session (I was assuming that the staging dir hack I removed was needed for tez apps):
```
CREATE TABLE test_part(id int) PARTITIONED BY(dt string) STORED AS ORC;
INSERT INTO test_part VALUES (1, '1'),(2, '2');
```

locafs_only
```
mvn clean install -Dtest=StartMiniHS2Cluster -DminiHS2.conf="target/testconf/llap/hive-site.xml"  -DminiHS2.run=true -DminiHS2.usePortsFromConf=true -pl itests/hive-unit -Pitests -DminiHS2.clusterType=LOCALFS_ONLY
```

llap
```
mvn clean install -Dtest=StartMiniHS2Cluster -DminiHS2.conf="target/testconf/llap/hive-site.xml"  -DminiHS2.run=true -DminiHS2.usePortsFromConf=true -pl itests/hive-unit -Pitests -DminiHS2.clusterType=LLAP
```

tez
```
mvn clean install -Dtest=StartMiniHS2Cluster -DminiHS2.run=true -DminiHS2.usePortsFromConf=true -pl itests/hive-unit -Pitests -DminiHS2.clusterType=TEZ
```

sanity-checked itests/hive-unit/target/tmp/log/hive.log but haven't found any suspicious exceptions