### PR TITLE
HIVE-26336: Add a connectTimeout parameter for JDBC

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
@@ -69,6 +69,19 @@ public class HiveAuthUtils {
   }
 
   /**
+   * Create a TSocket for the provided host and port with specified loginTimeout. Thrift maxMessageSize
+   * will default to Thrift library default.
+   * @param host Host to connect to.
+   * @param port Port to connect to.
+   * @param socketTimeout Socket timeout (0 means no timeout).
+   * @param connectTimeout Connection timeout (0 means no timeout).
+   * @return TTransport TSocket for host/port.
+   */
+  public static TTransport getSocketTransport(String host, int port, int socketTimeout, int connectTimeout) throws TTransportException {
+    return getSocketTransport(host, port, socketTimeout, connectTimeout, /* maxMessageSize */ -1);
+  }
+
+  /**
    * Create a TSocket for the provided host and port with specified loginTimeout and maxMessageSize.
    * will default to Thrift library default.
    * @param host Host to connect to.

--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/thrift/TestThriftCliServiceWithInfoMessage.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/thrift/TestThriftCliServiceWithInfoMessage.java
@@ -95,7 +95,7 @@ public class TestThriftCliServiceWithInfoMessage {
 
   @Test
   public void testExecuteReturnWithInfoMessage() throws Exception {
-    TTransport transport = HiveAuthUtils.getSocketTransport(host, cliPort, 0);
+    TTransport transport = HiveAuthUtils.getSocketTransport(host, cliPort, 0, 0);
     try {
       transport.open();
       TCLIService.Iface client = new TCLIService.Client(new TBinaryProtocol(transport));

--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/thrift/TestThriftHttpCLIServiceFeatures.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/thrift/TestThriftHttpCLIServiceFeatures.java
@@ -217,7 +217,7 @@ public class TestThriftHttpCLIServiceFeatures extends AbstractThriftCLITest {
   }
 
   private TTransport getRawBinaryTransport() throws Exception {
-    return HiveAuthUtils.getSocketTransport(host, port, 0);
+    return HiveAuthUtils.getSocketTransport(host, port, 0, 0);
   }
 
   private static TTransport getHttpTransport() throws Exception {

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -1450,7 +1450,7 @@ public class HiveConnection implements java.sql.Connection {
   private int getTimeoutVar(Map<String, String> sessConfMap, String timeoutVar) {
     String timeoutStr = sessConfMap.getOrDefault(timeoutVar, "0");
     try {
-      long timeoutMs = Long.parseLong(timeoutStr);
+      long timeoutMs = Long.parseLong(timeoutStr) * 1000;
       return (int) Math.max(0, Math.min(timeoutMs, Integer.MAX_VALUE));
     } catch (NumberFormatException e) {
       LOG.warn("Failed to parse {} of value '{}'. Using default timeout 0ms",

--- a/jdbc/src/java/org/apache/hive/jdbc/Utils.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/Utils.java
@@ -172,6 +172,7 @@ public class Utils {
     static final String HTTP_COOKIE_PREFIX = "http.cookie.";
     // Create external purge table by default
     static final String CREATE_TABLE_AS_EXTERNAL = "hiveCreateAsExternalLegacy";
+    public static final String CONNECT_TIMEOUT = "connectTimeout";
     public static final String SOCKET_TIMEOUT = "socketTimeout";
     static final String THRIFT_CLIENT_MAX_MESSAGE_SIZE = "thrift.client.max.message.size";
 

--- a/jdbc/src/test/org/apache/hive/jdbc/TestHiveConnection.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestHiveConnection.java
@@ -63,7 +63,7 @@ public class TestHiveConnection {
   @Test
   public void testHiveConnectionParameters() throws SQLException, ZooKeeperHiveClientException {
     JdbcConnectionParams params = Utils.parseURL(
-        "jdbc:hive2://hello.host:10002/default;transportMode=http;httpPath=cliservice;socketTimeout=60;requestTrack=true;");
+        "jdbc:hive2://hello.host:10002/default;transportMode=http;httpPath=cliservice;socketTimeout=60;connectTimeout=10;requestTrack=true;");
 
     Assert.assertEquals("hello.host", params.getHost());
     Assert.assertEquals("default", params.getDbName());
@@ -72,6 +72,7 @@ public class TestHiveConnection {
     Assert.assertEquals("http", params.getSessionVars().get(JdbcConnectionParams.TRANSPORT_MODE));
     Assert.assertEquals("cliservice", params.getSessionVars().get(JdbcConnectionParams.HTTP_PATH));
     Assert.assertEquals("60", params.getSessionVars().get(JdbcConnectionParams.SOCKET_TIMEOUT));
+    Assert.assertEquals("10", params.getSessionVars().get(JdbcConnectionParams.CONNECT_TIMEOUT));
     Assert.assertEquals("true", params.getSessionVars().get(JdbcConnectionParams.JDBC_PARAM_REQUEST_TRACK));
 
     JdbcConnectionParams nonPortParams = Utils.parseURL("jdbc:hive2://hello.host/default");

--- a/service/src/java/org/apache/hive/service/cli/thrift/RetryingThriftCLIServiceClient.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/RetryingThriftCLIServiceClient.java
@@ -314,7 +314,7 @@ public class RetryingThriftCLIServiceClient implements InvocationHandler {
     LOG.info("Connecting to {}:{} using a thrift max message of size: {}",
         host, port, maxThriftMessageSize);
 
-    transport = HiveAuthUtils.getSocketTransport(host, port, 0, maxThriftMessageSize);
+    transport = HiveAuthUtils.getSocketTransport(host, port, 0, 0, maxThriftMessageSize);
     ((TSocket) transport).setTimeout((int) conf.getTimeVar(HiveConf.ConfVars.SERVER_READ_SOCKET_TIMEOUT,
       TimeUnit.SECONDS) * 1000);
     try {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a connectTimeout parameter for JDBC


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, the Hive JDBC driver lacks a dedicated parameter to set the connectTimeout for connection establishment. The driver implicitly uses the socketTimeout value for both the connect phase and subsequent socket operations. This creates ambiguity and limits users' ability to handle connection establishment failures gracefully.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. New JDBC parameter connectTimeout is introduced.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This patch was tested by validate the parsing of JDBC connection parameters in org.apache.hive.jdbc.TestHiveConnection#testHiveConnectionParameters
