### PR TITLE
HIVE-28808: Avoid reading event messages in DB-Notification-Cleaner

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -746,6 +746,10 @@ public class MetastoreConf {
         true, "In strict JDO all SQL queries must begin with \"SELECT ...\", and consequently it "
         + "is not possible to execute queries that change data. This DataNucleus property when set to true allows "
         + "insert, update and delete operations from JDO SQL. Default value is true."),
+    DATANUCLEUS_QUERY_JDOQL_ALLOWALL("datanucleus.query.jdoql.allowAll", "datanucleus.query.jdoql.allowAll",
+        true, "In strict JDOQL all queries must begin with \"SELECT ...\", and consequently it "
+        + "is not possible to execute queries that change data. This DataNucleus property when set to true allows "
+        + "insert, update and delete operations from JDOQL. Default value is true."),
 
     // Parameters for configuring SSL encryption to the database store
     // If DBACCESS_USE_SSL is false, then all other DBACCESS_SSL_* properties will be ignored
@@ -2064,6 +2068,7 @@ public class MetastoreConf {
       ConfVars.DATANUCLEUS_TRANSACTION_ISOLATION,
       ConfVars.DATANUCLEUS_USE_LEGACY_VALUE_STRATEGY,
       ConfVars.DATANUCLEUS_QUERY_SQL_ALLOWALL,
+      ConfVars.DATANUCLEUS_QUERY_JDOQL_ALLOWALL,
       ConfVars.DETACH_ALL_ON_COMMIT,
       ConfVars.IDENTIFIER_FACTORY,
       ConfVars.MANAGER_FACTORY_CLASS,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Improves DB-Notification-Cleaner thread to just fetch the eventId/txnId and eventTime of the old events, then delete them based on the id range. This avoids the thread hitting OOM and silently die in cleaning huge events that have a long message body.

Set datanucleus.query.jdoql.allowAll=true to allow using DELETE in JDOQL.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix the DB-Notification-Cleaner hitting OOM and die silently.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested in a downstream build of CDP Hive 3.1.3000.7.3.1.0-160 in an env that have 1134925 old events. Some a pretty big that have a long message body. The DB is PostgreSQL.
Before this fix, HMS is not able to clean the events using the default `hive.metastore.event.db.clean.maxevents` (10000).
After this fix, it works as expected:
```
2025-03-10T10:43:59,651  INFO [DB-Notification-Cleaner] metastore.ObjectStore: Deleted 1134893 NotificationLog events older than epoch:1741488200 in 38667ms
2025-03-10T10:43:59,740  INFO [DB-Notification-Cleaner] metastore.ObjectStore: WriteNotification Cleaned 1072 events with eventTime < 1741488239 in 1 iteration, minimum txnId 187032 (with eventTime 1674098659) and maximum txnId 194134 (with eventTime 1734521765)
```