### PR TITLE
HIVE-28736:Remove DFS_URI authorization for CREATE_TABLE event with n…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/events/CreateTableEvent.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/events/CreateTableEvent.java
@@ -68,7 +68,7 @@ public class CreateTableEvent extends HiveMetaStoreAuthorizableEvent {
     PreCreateTableEvent       event = (PreCreateTableEvent) preEventContext;
     Table                     table = event.getTable();
     Database               database = event.getDatabase();
-    String                    uri   = getSdLocation(table.getSd());
+    String                      uri = getSdLocation(table.getSd());
 
     if (StringUtils.isEmpty(uri)) {
       return ret;
@@ -97,7 +97,7 @@ public class CreateTableEvent extends HiveMetaStoreAuthorizableEvent {
     PreCreateTableEvent       event = (PreCreateTableEvent) preEventContext;
     Table                     table = event.getTable();
     Database               database = event.getDatabase();
-    String                    uri   = getSdLocation(table.getSd());
+    String                      uri = getSdLocation(table.getSd());
 
     ret.add(getHivePrivilegeObject(database));
     ret.add(getHivePrivilegeObject(table));

--- a/ql/src/test/queries/clientpositive/auth_create_ext_table_1.q
+++ b/ql/src/test/queries/clientpositive/auth_create_ext_table_1.q
@@ -9,7 +9,17 @@ set hive.metastore.pre.event.listeners=org.apache.hadoop.hive.ql.security.author
 set hive.security.authorization.manager=org.apache.hadoop.hive.ql.security.authorization.plugin.fallback.FallbackHiveAuthorizerFactory;
 
 -- Attempt to Create external table without having write permissions on table dir should not result in error
-CREATE EXTERNAL TABLE t1(i int) location '${system:test.tmp.dir}/a_ext_create_tab1';
+CREATE EXTERNAL TABLE t1(i int) location '${system:test.tmp.dir}/t1';
 Select * from t1;
 
-CREATE EXTERNAL TABLE LikeExternalTable LIKE t1 location '${system:test.tmp.dir}/a_ext_create_tab2';
+CREATE EXTERNAL TABLE LikeExternalTable LIKE t1 location '${system:test.warehouse.dir}/LikeExternalTable';
+
+-- Skip authorization if location is not specified
+CREATE DATABASE IF NOT EXISTS test_db COMMENT 'Hive test database';
+use test_db;
+
+--Skip DFS_URI auth for table under default DB location
+CREATE EXTERNAL TABLE t1(i int) location '${system:test.warehouse.dir}/test_db.db/t1';;
+CREATE TABLE t2(i int, name String) stored as ORC;
+CREATE TABLE t3(i int, name String) stored as ORC location '${system:test.warehouse.dir}/test_db.db/t3';
+

--- a/ql/src/test/results/clientpositive/auth_create_ext_table_1.q.out
+++ b/ql/src/test/results/clientpositive/auth_create_ext_table_1.q.out
@@ -1,0 +1,67 @@
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: Select * from t1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: Select * from t1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:default
+PREHOOK: Output: default@LikeExternalTable
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@LikeExternalTable
+PREHOOK: query: CREATE DATABASE IF NOT EXISTS test_db COMMENT 'Hive test database'
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Output: database:test_db
+POSTHOOK: query: CREATE DATABASE IF NOT EXISTS test_db COMMENT 'Hive test database'
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Output: database:test_db
+PREHOOK: query: use test_db
+PREHOOK: type: SWITCHDATABASE
+PREHOOK: Input: database:test_db
+POSTHOOK: query: use test_db
+POSTHOOK: type: SWITCHDATABASE
+POSTHOOK: Input: database:test_db
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:test_db
+PREHOOK: Output: test_db@t1
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:test_db
+POSTHOOK: Output: test_db@t1
+PREHOOK: query: CREATE TABLE t2(i int, name String) stored as ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:test_db
+PREHOOK: Output: test_db@t2
+POSTHOOK: query: CREATE TABLE t2(i int, name String) stored as ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:test_db
+POSTHOOK: Output: test_db@t2
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:test_db
+PREHOOK: Output: test_db@t3
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:test_db
+POSTHOOK: Output: test_db@t3


### PR DESCRIPTION
…o explicit LOCATION

### What changes were proposed in this pull request?

This update ensures that DFS_URI authorization is triggered only when necessary during the CREATE TABLE command. Specifically:

For managed table creation, DFS_URI authorization is skipped if the location is under the default managed DB location.
For external table creation, DFS_URI authorization is skipped if the table location is under the default external DB location.



### Why are the changes needed?
This prevents unnecessary DFS_URI authorization for tables created within default DB locations, and adding extra policies in Ranger for query execution from external clients like Spark.


### Does this PR introduce _any_ user-facing change?

Yes, After this change, users will no longer need the DFS_URI policy for tables that are created in the default managed DB location (for managed tables) or the default external DB location (for external tables).


### Is the change a dependency upgrade?
No


### How was this patch tested?
Changes were verified by running the CREATE table command from Spark sql.
