### PR TITLE
HIVE-28817: Rebuilding a materialized view stored in Iceberg fails when schema has varchar column

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.hive;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -33,6 +31,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.LockRequestBuilder;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
 import org.apache.hadoop.hive.metastore.api.LockComponent;
 import org.apache.hadoop.hive.metastore.api.LockLevel;
 import org.apache.hadoop.hive.metastore.api.LockRequest;
@@ -42,12 +42,12 @@ import org.apache.hadoop.hive.metastore.api.LockType;
 import org.apache.hadoop.hive.metastore.api.ShowLocksRequest;
 import org.apache.hadoop.hive.metastore.api.ShowLocksResponse;
 import org.apache.hadoop.hive.metastore.api.ShowLocksResponseElement;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.iceberg.ClientPool;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.iceberg.util.Tasks;
 import org.apache.thrift.TException;
@@ -91,6 +91,7 @@ public class MetastoreLock implements HiveLock {
   private final long lockHeartbeatIntervalTime;
   private final ScheduledExecutorService exitingScheduledExecutorService;
   private final String agentInfo;
+  private final Configuration conf;
 
   private Optional<Long> hmsLockId = Optional.empty();
   private ReentrantLock jvmLock = null;
@@ -102,6 +103,7 @@ public class MetastoreLock implements HiveLock {
     this.fullName = catalogName + "." + databaseName + "." + tableName;
     this.databaseName = databaseName;
     this.tableName = tableName;
+    this.conf = conf;
 
     this.lockAcquireTimeout =
         conf.getLong(HIVE_ACQUIRE_LOCK_TIMEOUT_MS, HIVE_ACQUIRE_LOCK_TIMEOUT_MS_DEFAULT);
@@ -268,21 +270,18 @@ public class MetastoreLock implements HiveLock {
   private LockInfo createLock() throws LockException {
     LockInfo lockInfo = new LockInfo();
 
-    String hostName;
-    try {
-      hostName = InetAddress.getLocalHost().getHostName();
-    } catch (UnknownHostException uhe) {
-      throw new LockException(uhe, "Error generating host name");
-    }
-
     LockComponent lockComponent =
             new LockComponent(LockType.EXCL_WRITE, LockLevel.TABLE, databaseName);
+    lockComponent.setOperationType(DataOperationType.NO_TXN);
     lockComponent.setTablename(tableName);
-    LockRequest lockRequest =
-            new LockRequest(
-                    Lists.newArrayList(lockComponent),
-                    HiveHadoopUtil.currentUser(),
-                    hostName);
+
+    // An open ACID transaction might exist when the SQL statement involves both native and Iceberg tables.
+    // Use it's txn id.
+    LockRequest lockRequest = new LockRequestBuilder(null)
+            .setTransactionId(conf.getLong(hive_metastoreConstants.TXN_ID, 0L))
+            .setUser(HiveHadoopUtil.currentUser())
+            .addLockComponent(lockComponent)
+            .build();
 
     // Only works in Hive 2 or later.
     if (HiveVersion.min(HiveVersion.HIVE_2)) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -414,6 +414,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     }
 
     try {
+      conf.setLong(hive_metastoreConstants.TXN_ID, IcebergAcidUtil.getTxnId());
       commitLock.lock();
       doPreAlterTable(hmsTable, context);
     } catch (Exception e) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.Context.Operation;
 import org.apache.hadoop.hive.ql.Context.RewritePolicy;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -456,6 +457,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
 
     for (JobContext jobContext : jobContexts) {
       JobConf conf = jobContext.getJobConf();
+      conf.setLong(hive_metastoreConstants.TXN_ID, IcebergAcidUtil.getTxnId());
       table = Optional.ofNullable(table).orElse(Catalogs.loadTable(conf, catalogProperties));
       branchName = conf.get(InputFormatConfig.OUTPUT_TABLE_SNAPSHOT_REF);
       snapshotId = getSnapshotId(outputTable.table, branchName);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -23,12 +23,14 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.PositionDeleteInfo;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
+import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionKey;
@@ -389,6 +391,11 @@ public class IcebergAcidUtil {
     public T build() {
       return (T) current;
     }
+  }
+
+  static long getTxnId() {
+    return Optional.ofNullable(SessionState.get())
+            .map(ss -> ss.getTxnMgr().getCurrentTxnId()).orElse(0L);
   }
 
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -23,12 +23,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.PositionDeleteInfo;
+import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.iceberg.ContentFile;
@@ -394,8 +394,16 @@ public class IcebergAcidUtil {
   }
 
   static long getTxnId() {
-    return Optional.ofNullable(SessionState.get())
-            .map(ss -> ss.getTxnMgr().getCurrentTxnId()).orElse(0L);
-  }
+    SessionState sessionState = SessionState.get();
+    if (sessionState == null) {
+      return 0L;
+    }
 
+    HiveTxnManager txnManager = sessionState.getTxnMgr();
+    if (txnManager == null) {
+      return 0L;
+    }
+
+    return txnManager.getCurrentTxnId();
+  }
 }

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc8.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc8.q
@@ -1,18 +1,19 @@
 -- MV source table has varchar column.
+-- SORT_QUERY_RESULTS
 
 set hive.explain.user=false;
 set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 set iceberg.mr.schema.auto.conversion=true;
 
-create external table t1 (a int, b varchar(256)) stored by iceberg stored as orc tblproperties ('format-version'='1');
+create table t1 (a int, b varchar(256)) stored as orc tblproperties ('transactional'='true');
 
-insert into t1 values (1, 'alfred');
+insert into t1 values (1, 'Alfred');
 
 create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
 select b, sum(a) from t1 group by b;
 
-insert into t1 values (4, 'amia');
+insert into t1 values (4, 'Jane');
 
 explain
 alter materialized view mat1 rebuild;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc8.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc8.q
@@ -6,14 +6,14 @@ set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 set iceberg.mr.schema.auto.conversion=true;
 
-create table t1 (a int, b varchar(256)) stored as orc tblproperties ('transactional'='true');
+create table t1 (a int, b varchar(256), c char(100), d int not null) stored as orc tblproperties ('transactional'='true');
 
-insert into t1 values (1, 'Alfred');
+insert into t1 values (1, 'Alfred', 'Alfred', 1);
 
 create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
-select b, sum(a) from t1 group by b;
+select b, c, d, sum(a) from t1 group by b, c, d;
 
-insert into t1 values (4, 'Jane');
+insert into t1 values (4, 'Jane', 'Jane', 4);
 
 explain
 alter materialized view mat1 rebuild;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc8.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc8.q
@@ -1,0 +1,22 @@
+-- MV source table has varchar column.
+
+set hive.explain.user=false;
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set iceberg.mr.schema.auto.conversion=true;
+
+create external table t1 (a int, b varchar(256)) stored by iceberg stored as orc tblproperties ('format-version'='1');
+
+insert into t1 values (1, 'alfred');
+
+create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select b, sum(a) from t1 group by b;
+
+insert into t1 values (4, 'amia');
+
+explain
+alter materialized view mat1 rebuild;
+
+alter materialized view mat1 rebuild;
+
+select * from mat1;

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc8.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc8.q.out
@@ -1,19 +1,21 @@
-PREHOOK: query: create external table t1 (a int, b varchar(256)) stored by iceberg stored as orc tblproperties ('format-version'='1')
+PREHOOK: query: create table t1 (a int, b varchar(256)) stored as orc tblproperties ('transactional'='true')
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@t1
-POSTHOOK: query: create external table t1 (a int, b varchar(256)) stored by iceberg stored as orc tblproperties ('format-version'='1')
+POSTHOOK: query: create table t1 (a int, b varchar(256)) stored as orc tblproperties ('transactional'='true')
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t1
-PREHOOK: query: insert into t1 values (1, 'alfred')
+PREHOOK: query: insert into t1 values (1, 'Alfred')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@t1
-POSTHOOK: query: insert into t1 values (1, 'alfred')
+POSTHOOK: query: insert into t1 values (1, 'Alfred')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
 PREHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
 select b, sum(a) from t1 group by b
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
@@ -29,15 +31,17 @@ POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat1
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: Lineage: mat1._c1 EXPRESSION [(t1)t1.FieldSchema(name:a, type:int, comment:null), ]
-POSTHOOK: Lineage: mat1.b SIMPLE [(t1)t1.FieldSchema(name:b, type:string, comment:null), ]
-PREHOOK: query: insert into t1 values (4, 'amia')
+POSTHOOK: Lineage: mat1.b EXPRESSION [(t1)t1.FieldSchema(name:b, type:varchar(256), comment:null), ]
+PREHOOK: query: insert into t1 values (4, 'Jane')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@t1
-POSTHOOK: query: insert into t1 values (4, 'amia')
+POSTHOOK: query: insert into t1 values (4, 'Jane')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
 PREHOOK: query: explain
 alter materialized view mat1 rebuild
 PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
@@ -77,41 +81,44 @@ STAGE PLANS:
                   alias: default.mat1
                   Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: b (type: string), _c1 (type: bigint), true (type: boolean), PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string)
+                    expressions: CAST( b AS varchar(256)) (type: varchar(256)), _c1 (type: bigint), true (type: boolean), PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 1 Data size: 490 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 740 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      key expressions: _col0 (type: string)
+                      key expressions: _col0 (type: varchar(256))
                       null sort order: z
                       sort order: +
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 1 Data size: 490 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map-reduce partition columns: _col0 (type: varchar(256))
+                      Statistics: Num rows: 1 Data size: 740 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint), _col2 (type: boolean), _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string)
             Execution mode: vectorized
         Map 6 
             Map Operator Tree:
                 TableScan
                   alias: t1
+                  filterExpr: (ROW__ID.writeid > 1L) (type: boolean)
                   Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
-                  Version interval from: 5632151099214777496
-                  Select Operator
-                    expressions: a (type: int), b (type: string)
-                    outputColumnNames: a, b
-                    Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: sum(a)
-                      keys: b (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: bigint)
+                  Filter Operator
+                    predicate: (ROW__ID.writeid > 1L) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: varchar(256))
+                      outputColumnNames: a, b
+                      Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: sum(a)
+                        keys: b (type: varchar(256))
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: varchar(256))
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: varchar(256))
+                          Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
@@ -119,33 +126,33 @@ STAGE PLANS:
                 condition map:
                      Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: string)
-                  1 _col0 (type: string)
+                  0 _col0 (type: varchar(256))
+                  1 _col0 (type: varchar(256))
                 nullSafes: [true]
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
-                Statistics: Num rows: 2 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 838 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: _col2 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 588 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 838 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: string), _col1 (type: bigint)
+                    expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: varchar(256)), _col1 (type: bigint)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       null sort order: 
                       sort order: 
-                      Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: string), _col6 (type: bigint)
+                      Statistics: Num rows: 1 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: varchar(256)), _col6 (type: bigint)
                 Filter Operator
                   predicate: _col2 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 588 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 838 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col8 (type: string), CASE WHEN (_col1 is null) THEN (_col9) WHEN (_col9 is null) THEN (_col1) ELSE ((_col9 + _col1)) END (type: bigint)
+                    expressions: CAST( _col8 AS STRING) (type: string), CASE WHEN (_col1 is null) THEN (_col9) WHEN (_col9 is null) THEN (_col1) ELSE ((_col9 + _col1)) END (type: bigint)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -154,7 +161,7 @@ STAGE PLANS:
                     Select Operator
                       expressions: _col0 (type: string), _col1 (type: bigint)
                       outputColumnNames: b, _c1
-                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: max(length(b)), avg(COALESCE(length(b),0)), count(1), count(b), compute_bit_vector_hll(b), min(_c1), max(_c1), count(_c1), compute_bit_vector_hll(_c1)
                         minReductionHashAggr: 0.4
@@ -168,14 +175,14 @@ STAGE PLANS:
                           value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: binary)
                 Filter Operator
                   predicate: _col2 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 588 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 838 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col8 (type: string), CASE WHEN (_col1 is null) THEN (_col9) WHEN (_col9 is null) THEN (_col1) ELSE ((_col9 + _col1)) END (type: bigint)
+                    expressions: CAST( _col8 AS STRING) (type: string), CASE WHEN (_col1 is null) THEN (_col9) WHEN (_col9 is null) THEN (_col1) ELSE ((_col9 + _col1)) END (type: bigint)
                     outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -184,7 +191,7 @@ STAGE PLANS:
                     Select Operator
                       expressions: _col0 (type: string), _col1 (type: bigint)
                       outputColumnNames: b, _c1
-                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: max(length(b)), avg(COALESCE(length(b),0)), count(1), count(b), compute_bit_vector_hll(b), min(_c1), max(_c1), count(_c1), compute_bit_vector_hll(_c1)
                         minReductionHashAggr: 0.4
@@ -200,12 +207,12 @@ STAGE PLANS:
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: string), VALUE._col6 (type: bigint)
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: varchar(256)), VALUE._col6 (type: bigint)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -254,16 +261,16 @@ STAGE PLANS:
             Reduce Operator Tree:
               Group By Operator
                 aggregations: sum(VALUE._col0)
-                keys: KEY._col0 (type: string)
+                keys: KEY._col0 (type: varchar(256))
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col0 (type: string)
+                  key expressions: _col0 (type: varchar(256))
                   null sort order: z
                   sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  Map-reduce partition columns: _col0 (type: varchar(256))
+                  Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
 
   Stage: Stage-4
@@ -312,5 +319,5 @@ POSTHOOK: query: select * from mat1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-alfred	1
-amia	4
+Alfred	1
+Jane	4

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc8.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc8.q.out
@@ -1,0 +1,316 @@
+PREHOOK: query: create external table t1 (a int, b varchar(256)) stored by iceberg stored as orc tblproperties ('format-version'='1')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create external table t1 (a int, b varchar(256)) stored by iceberg stored as orc tblproperties ('format-version'='1')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1 values (1, 'alfred')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1 values (1, 'alfred')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+PREHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select b, sum(a) from t1 group by b
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select b, sum(a) from t1 group by b
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: Lineage: mat1._c1 EXPRESSION [(t1)t1.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1.b SIMPLE [(t1)t1.FieldSchema(name:b, type:string, comment:null), ]
+PREHOOK: query: insert into t1 values (4, 'amia')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1 values (4, 'amia')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+PREHOOK: query: explain
+alter materialized view mat1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: explain
+alter materialized view mat1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+STAGE DEPENDENCIES:
+  Stage-3 is a root stage
+  Stage-4 depends on stages: Stage-3
+  Stage-0 depends on stages: Stage-4
+  Stage-5 depends on stages: Stage-0
+  Stage-6 depends on stages: Stage-5
+
+STAGE PLANS:
+  Stage: Stage-3
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: default.mat1
+                  Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: b (type: string), _c1 (type: bigint), true (type: boolean), PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Statistics: Num rows: 1 Data size: 490 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: string)
+                      Statistics: Num rows: 1 Data size: 490 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: bigint), _col2 (type: boolean), _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string)
+            Execution mode: vectorized
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                  Version interval from: 5632151099214777496
+                  Select Operator
+                    expressions: a (type: int), b (type: string)
+                    outputColumnNames: a, b
+                    Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: sum(a)
+                      keys: b (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: bigint)
+            Execution mode: vectorized
+        Reducer 2 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Right Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 2 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col2 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 588 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: string), _col1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: string), _col6 (type: bigint)
+                Filter Operator
+                  predicate: _col2 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 588 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col8 (type: string), CASE WHEN (_col1 is null) THEN (_col9) WHEN (_col9 is null) THEN (_col1) ELSE ((_col9 + _col1)) END (type: bigint)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.mat1
+                    Select Operator
+                      expressions: _col0 (type: string), _col1 (type: bigint)
+                      outputColumnNames: b, _c1
+                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: max(length(b)), avg(COALESCE(length(b),0)), count(1), count(b), compute_bit_vector_hll(b), min(_c1), max(_c1), count(_c1), compute_bit_vector_hll(_c1)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                        Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: binary)
+                Filter Operator
+                  predicate: _col2 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 588 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col8 (type: string), CASE WHEN (_col1 is null) THEN (_col9) WHEN (_col9 is null) THEN (_col1) ELSE ((_col9 + _col1)) END (type: bigint)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.mat1
+                    Select Operator
+                      expressions: _col0 (type: string), _col1 (type: bigint)
+                      outputColumnNames: b, _c1
+                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: max(length(b)), avg(COALESCE(length(b),0)), count(1), count(b), compute_bit_vector_hll(b), min(_c1), max(_c1), count(_c1), compute_bit_vector_hll(_c1)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                        Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: binary)
+        Reducer 3 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: string), VALUE._col6 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 486 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                      output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                      serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                      name: default.mat1
+        Reducer 4 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: max(VALUE._col0), avg(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), min(VALUE._col5), max(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 1 Data size: 340 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'STRING' (type: string), UDFToLong(COALESCE(_col0,0)) (type: bigint), COALESCE(_col1,0) (type: double), (_col2 - _col3) (type: bigint), COALESCE(ndv_compute_bit_vector(_col4),0) (type: bigint), _col4 (type: binary), 'LONG' (type: string), _col5 (type: bigint), _col6 (type: bigint), (_col2 - _col7) (type: bigint), COALESCE(ndv_compute_bit_vector(_col8),0) (type: bigint), _col8 (type: binary)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                  Statistics: Num rows: 1 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: max(VALUE._col0), avg(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), min(VALUE._col5), max(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 1 Data size: 340 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'STRING' (type: string), UDFToLong(COALESCE(_col0,0)) (type: bigint), COALESCE(_col1,0) (type: double), (_col2 - _col3) (type: bigint), COALESCE(ndv_compute_bit_vector(_col4),0) (type: bigint), _col4 (type: binary), 'LONG' (type: string), _col5 (type: bigint), _col6 (type: bigint), (_col2 - _col7) (type: bigint), COALESCE(ndv_compute_bit_vector(_col8),0) (type: bigint), _col8 (type: binary)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                  Statistics: Num rows: 1 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 7 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 2 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: bigint)
+
+  Stage: Stage-4
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+              output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+              serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+              name: default.mat1
+
+  Stage: Stage-5
+    Stats Work
+      Basic Stats Work:
+      Column Stats Desc:
+          Columns: b, _c1
+          Column Types: string, bigint
+          Table: default.mat1
+
+  Stage: Stage-6
+    Materialized View Update
+      name: default.mat1
+      update creation metadata: true
+
+PREHOOK: query: alter materialized view mat1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+PREHOOK: query: select * from mat1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mat1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+alfred	1
+amia	4

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc8.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc8.q.out
@@ -1,47 +1,53 @@
-PREHOOK: query: create table t1 (a int, b varchar(256)) stored as orc tblproperties ('transactional'='true')
+PREHOOK: query: create table t1 (a int, b varchar(256), c char(100), d int not null) stored as orc tblproperties ('transactional'='true')
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@t1
-POSTHOOK: query: create table t1 (a int, b varchar(256)) stored as orc tblproperties ('transactional'='true')
+POSTHOOK: query: create table t1 (a int, b varchar(256), c char(100), d int not null) stored as orc tblproperties ('transactional'='true')
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t1
-PREHOOK: query: insert into t1 values (1, 'Alfred')
+PREHOOK: query: insert into t1 values (1, 'Alfred', 'Alfred', 1)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@t1
-POSTHOOK: query: insert into t1 values (1, 'Alfred')
+POSTHOOK: query: insert into t1 values (1, 'Alfred', 'Alfred', 1)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@t1
 POSTHOOK: Lineage: t1.a SCRIPT []
 POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+POSTHOOK: Lineage: t1.d SCRIPT []
 PREHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
-select b, sum(a) from t1 group by b
+select b, c, d, sum(a) from t1 group by b, c, d
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
 PREHOOK: Input: default@t1
 PREHOOK: Output: database:default
 PREHOOK: Output: default@mat1
 PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
-select b, sum(a) from t1 group by b
+select b, c, d, sum(a) from t1 group by b, c, d
 POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat1
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: Lineage: mat1._c1 EXPRESSION [(t1)t1.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1._c3 EXPRESSION [(t1)t1.FieldSchema(name:a, type:int, comment:null), ]
 POSTHOOK: Lineage: mat1.b EXPRESSION [(t1)t1.FieldSchema(name:b, type:varchar(256), comment:null), ]
-PREHOOK: query: insert into t1 values (4, 'Jane')
+POSTHOOK: Lineage: mat1.c EXPRESSION [(t1)t1.FieldSchema(name:c, type:char(100), comment:null), ]
+POSTHOOK: Lineage: mat1.d SIMPLE [(t1)t1.FieldSchema(name:d, type:int, comment:null), ]
+PREHOOK: query: insert into t1 values (4, 'Jane', 'Jane', 4)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@t1
-POSTHOOK: query: insert into t1 values (4, 'Jane')
+POSTHOOK: query: insert into t1 values (4, 'Jane', 'Jane', 4)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@t1
 POSTHOOK: Lineage: t1.a SCRIPT []
 POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+POSTHOOK: Lineage: t1.d SCRIPT []
 PREHOOK: query: explain
 alter materialized view mat1 rebuild
 PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
@@ -79,46 +85,46 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: default.mat1
-                  Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: CAST( b AS varchar(256)) (type: varchar(256)), _c1 (type: bigint), true (type: boolean), PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                    Statistics: Num rows: 1 Data size: 740 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: CAST( b AS varchar(256)) (type: varchar(256)), CAST( c AS CHAR(100)) (type: char(100)), d (type: int), _c3 (type: bigint), true (type: boolean), PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
+                    Statistics: Num rows: 1 Data size: 928 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      key expressions: _col0 (type: varchar(256))
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: varchar(256))
-                      Statistics: Num rows: 1 Data size: 740 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: bigint), _col2 (type: boolean), _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string)
+                      key expressions: _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int)
+                      null sort order: zzz
+                      sort order: +++
+                      Map-reduce partition columns: _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int)
+                      Statistics: Num rows: 1 Data size: 928 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col3 (type: bigint), _col4 (type: boolean), _col5 (type: int), _col6 (type: bigint), _col7 (type: string), _col8 (type: bigint), _col9 (type: string)
             Execution mode: vectorized
         Map 6 
             Map Operator Tree:
                 TableScan
                   alias: t1
                   filterExpr: (ROW__ID.writeid > 1L) (type: boolean)
-                  Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (ROW__ID.writeid > 1L) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: a (type: int), b (type: varchar(256))
-                      outputColumnNames: a, b
-                      Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: a (type: int), b (type: varchar(256)), c (type: char(100)), d (type: int)
+                      outputColumnNames: a, b, c, d
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: sum(a)
-                        keys: b (type: varchar(256))
+                        keys: b (type: varchar(256)), c (type: char(100)), d (type: int)
                         minReductionHashAggr: 0.4
                         mode: hash
-                        outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
-                          key expressions: _col0 (type: varchar(256))
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: varchar(256))
-                          Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col1 (type: bigint)
+                          key expressions: _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int)
+                          null sort order: zzz
+                          sort order: +++
+                          Map-reduce partition columns: _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int)
+                          Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col3 (type: bigint)
             Execution mode: vectorized
         Reducer 2 
             Reduce Operator Tree:
@@ -126,93 +132,93 @@ STAGE PLANS:
                 condition map:
                      Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: varchar(256))
-                  1 _col0 (type: varchar(256))
-                nullSafes: [true]
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
-                Statistics: Num rows: 1 Data size: 838 Basic stats: COMPLETE Column stats: COMPLETE
+                  0 _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int)
+                  1 _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int)
+                nullSafes: [true, true, true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
+                Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col2 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 838 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: varchar(256)), _col1 (type: bigint)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                    Statistics: Num rows: 1 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: _col5 (type: int), _col6 (type: bigint), _col7 (type: string), _col8 (type: bigint), _col9 (type: string), _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int), _col3 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                    Statistics: Num rows: 1 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       null sort order: 
                       sort order: 
-                      Statistics: Num rows: 1 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: varchar(256)), _col6 (type: bigint)
+                      Statistics: Num rows: 1 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col5 (type: varchar(256)), _col6 (type: char(100)), _col7 (type: int), _col8 (type: bigint)
                 Filter Operator
-                  predicate: _col2 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 838 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 (type: boolean)
+                  Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: CAST( _col8 AS STRING) (type: string), CASE WHEN (_col1 is null) THEN (_col9) WHEN (_col9 is null) THEN (_col1) ELSE ((_col9 + _col1)) END (type: bigint)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: CAST( _col10 AS STRING) (type: string), CAST( _col11 AS STRING) (type: string), _col12 (type: int), CASE WHEN (_col3 is null) THEN (_col13) WHEN (_col13 is null) THEN (_col3) ELSE ((_col13 + _col3)) END (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                           serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                           name: default.mat1
                     Select Operator
-                      expressions: _col0 (type: string), _col1 (type: bigint)
-                      outputColumnNames: b, _c1
-                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: bigint)
+                      outputColumnNames: b, c, d, _c3
+                      Statistics: Num rows: 1 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
-                        aggregations: max(length(b)), avg(COALESCE(length(b),0)), count(1), count(b), compute_bit_vector_hll(b), min(_c1), max(_c1), count(_c1), compute_bit_vector_hll(_c1)
+                        aggregations: max(length(b)), avg(COALESCE(length(b),0)), count(1), count(b), compute_bit_vector_hll(b), max(length(c)), avg(COALESCE(length(c),0)), count(c), compute_bit_vector_hll(c), min(d), max(d), count(d), compute_bit_vector_hll(d), min(_c3), max(_c3), count(_c3), compute_bit_vector_hll(_c3)
                         minReductionHashAggr: 0.4
                         mode: hash
-                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                        Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16
+                        Statistics: Num rows: 1 Data size: 800 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           null sort order: 
                           sort order: 
-                          Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: binary)
+                          Statistics: Num rows: 1 Data size: 800 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: struct<count:bigint,sum:double,input:int>), _col7 (type: bigint), _col8 (type: binary), _col9 (type: int), _col10 (type: int), _col11 (type: bigint), _col12 (type: binary), _col13 (type: bigint), _col14 (type: bigint), _col15 (type: bigint), _col16 (type: binary)
                 Filter Operator
-                  predicate: _col2 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 838 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col4 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: CAST( _col8 AS STRING) (type: string), CASE WHEN (_col1 is null) THEN (_col9) WHEN (_col9 is null) THEN (_col1) ELSE ((_col9 + _col1)) END (type: bigint)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: CAST( _col10 AS STRING) (type: string), CAST( _col11 AS STRING) (type: string), _col12 (type: int), CASE WHEN (_col3 is null) THEN (_col13) WHEN (_col13 is null) THEN (_col3) ELSE ((_col13 + _col3)) END (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                           serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                           name: default.mat1
                     Select Operator
-                      expressions: _col0 (type: string), _col1 (type: bigint)
-                      outputColumnNames: b, _c1
-                      Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: bigint)
+                      outputColumnNames: b, c, d, _c3
+                      Statistics: Num rows: 1 Data size: 380 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
-                        aggregations: max(length(b)), avg(COALESCE(length(b),0)), count(1), count(b), compute_bit_vector_hll(b), min(_c1), max(_c1), count(_c1), compute_bit_vector_hll(_c1)
+                        aggregations: max(length(b)), avg(COALESCE(length(b),0)), count(1), count(b), compute_bit_vector_hll(b), max(length(c)), avg(COALESCE(length(c),0)), count(c), compute_bit_vector_hll(c), min(d), max(d), count(d), compute_bit_vector_hll(d), min(_c3), max(_c3), count(_c3), compute_bit_vector_hll(_c3)
                         minReductionHashAggr: 0.4
                         mode: hash
-                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                        Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16
+                        Statistics: Num rows: 1 Data size: 800 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           null sort order: 
                           sort order: 
-                          Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: binary)
+                          Statistics: Num rows: 1 Data size: 800 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: struct<count:bigint,sum:double,input:int>), _col7 (type: bigint), _col8 (type: binary), _col9 (type: int), _col10 (type: int), _col11 (type: bigint), _col12 (type: binary), _col13 (type: bigint), _col14 (type: bigint), _col15 (type: bigint), _col16 (type: binary)
         Reducer 3 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: varchar(256)), VALUE._col6 (type: bigint)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 1 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: string), VALUE._col3 (type: bigint), VALUE._col4 (type: string), VALUE._col5 (type: varchar(256)), VALUE._col6 (type: char(100)), VALUE._col7 (type: int), VALUE._col8 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 1 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
@@ -222,17 +228,17 @@ STAGE PLANS:
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0), avg(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), min(VALUE._col5), max(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8)
+                aggregations: max(VALUE._col0), avg(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), max(VALUE._col5), avg(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8), min(VALUE._col9), max(VALUE._col10), count(VALUE._col11), compute_bit_vector_hll(VALUE._col12), min(VALUE._col13), max(VALUE._col14), count(VALUE._col15), compute_bit_vector_hll(VALUE._col16)
                 mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 1 Data size: 340 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16
+                Statistics: Num rows: 1 Data size: 664 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: 'STRING' (type: string), UDFToLong(COALESCE(_col0,0)) (type: bigint), COALESCE(_col1,0) (type: double), (_col2 - _col3) (type: bigint), COALESCE(ndv_compute_bit_vector(_col4),0) (type: bigint), _col4 (type: binary), 'LONG' (type: string), _col5 (type: bigint), _col6 (type: bigint), (_col2 - _col7) (type: bigint), COALESCE(ndv_compute_bit_vector(_col8),0) (type: bigint), _col8 (type: binary)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                  Statistics: Num rows: 1 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: 'STRING' (type: string), UDFToLong(COALESCE(_col0,0)) (type: bigint), COALESCE(_col1,0) (type: double), (_col2 - _col3) (type: bigint), COALESCE(ndv_compute_bit_vector(_col4),0) (type: bigint), _col4 (type: binary), 'STRING' (type: string), UDFToLong(COALESCE(_col5,0)) (type: bigint), COALESCE(_col6,0) (type: double), (_col2 - _col7) (type: bigint), COALESCE(ndv_compute_bit_vector(_col8),0) (type: bigint), _col8 (type: binary), 'LONG' (type: string), UDFToLong(_col9) (type: bigint), UDFToLong(_col10) (type: bigint), (_col2 - _col11) (type: bigint), COALESCE(ndv_compute_bit_vector(_col12),0) (type: bigint), _col12 (type: binary), 'LONG' (type: string), _col13 (type: bigint), _col14 (type: bigint), (_col2 - _col15) (type: bigint), COALESCE(ndv_compute_bit_vector(_col16),0) (type: bigint), _col16 (type: binary)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23
+                  Statistics: Num rows: 1 Data size: 1060 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 1060 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -241,17 +247,17 @@ STAGE PLANS:
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0), avg(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), min(VALUE._col5), max(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8)
+                aggregations: max(VALUE._col0), avg(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), max(VALUE._col5), avg(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8), min(VALUE._col9), max(VALUE._col10), count(VALUE._col11), compute_bit_vector_hll(VALUE._col12), min(VALUE._col13), max(VALUE._col14), count(VALUE._col15), compute_bit_vector_hll(VALUE._col16)
                 mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 1 Data size: 340 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16
+                Statistics: Num rows: 1 Data size: 664 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: 'STRING' (type: string), UDFToLong(COALESCE(_col0,0)) (type: bigint), COALESCE(_col1,0) (type: double), (_col2 - _col3) (type: bigint), COALESCE(ndv_compute_bit_vector(_col4),0) (type: bigint), _col4 (type: binary), 'LONG' (type: string), _col5 (type: bigint), _col6 (type: bigint), (_col2 - _col7) (type: bigint), COALESCE(ndv_compute_bit_vector(_col8),0) (type: bigint), _col8 (type: binary)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                  Statistics: Num rows: 1 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  expressions: 'STRING' (type: string), UDFToLong(COALESCE(_col0,0)) (type: bigint), COALESCE(_col1,0) (type: double), (_col2 - _col3) (type: bigint), COALESCE(ndv_compute_bit_vector(_col4),0) (type: bigint), _col4 (type: binary), 'STRING' (type: string), UDFToLong(COALESCE(_col5,0)) (type: bigint), COALESCE(_col6,0) (type: double), (_col2 - _col7) (type: bigint), COALESCE(ndv_compute_bit_vector(_col8),0) (type: bigint), _col8 (type: binary), 'LONG' (type: string), UDFToLong(_col9) (type: bigint), UDFToLong(_col10) (type: bigint), (_col2 - _col11) (type: bigint), COALESCE(ndv_compute_bit_vector(_col12),0) (type: bigint), _col12 (type: binary), 'LONG' (type: string), _col13 (type: bigint), _col14 (type: bigint), (_col2 - _col15) (type: bigint), COALESCE(ndv_compute_bit_vector(_col16),0) (type: bigint), _col16 (type: binary)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23
+                  Statistics: Num rows: 1 Data size: 1060 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 1060 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -261,17 +267,17 @@ STAGE PLANS:
             Reduce Operator Tree:
               Group By Operator
                 aggregations: sum(VALUE._col0)
-                keys: KEY._col0 (type: varchar(256))
+                keys: KEY._col0 (type: varchar(256)), KEY._col1 (type: char(100)), KEY._col2 (type: int)
                 mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col0 (type: varchar(256))
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: varchar(256))
-                  Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: bigint)
+                  key expressions: _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int)
+                  null sort order: zzz
+                  sort order: +++
+                  Map-reduce partition columns: _col0 (type: varchar(256)), _col1 (type: char(100)), _col2 (type: int)
+                  Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col3 (type: bigint)
 
   Stage: Stage-4
     Dependency Collection
@@ -290,8 +296,8 @@ STAGE PLANS:
     Stats Work
       Basic Stats Work:
       Column Stats Desc:
-          Columns: b, _c1
-          Column Types: string, bigint
+          Columns: b, c, d, _c3
+          Column Types: string, string, int, bigint
           Table: default.mat1
 
   Stage: Stage-6
@@ -319,5 +325,5 @@ POSTHOOK: query: select * from mat1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-Alfred	1
-Jane	4
+Alfred	Alfred	1	1
+Jane	Jane	4	4

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/NonNativeAcidMaterializedViewASTBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/NonNativeAcidMaterializedViewASTBuilder.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
-import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.ParseDriver;
 
 import java.util.HashSet;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/NonNativeAcidMaterializedViewASTBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/NonNativeAcidMaterializedViewASTBuilder.java
@@ -50,12 +50,7 @@ public class NonNativeAcidMaterializedViewASTBuilder extends MaterializedViewAST
 
     for (int i = 0; i < selectNode.getChildCount(); ++i) {
       ASTNode selectExpr = (ASTNode) selectNode.getChild(i);
-      ASTNode expression = (ASTNode) selectExpr.getChild(0);
-      if (expression.getType() == HiveParser.DOT &&
-          expression.getChildCount() == 2 &&
-          expression.getChild(0).getType() == HiveParser.TOK_TABLE_OR_COL) {
-        selectedColumns.add(expression.getChild(1).getText());
-      }
+      selectedColumns.add(selectExpr.getChild(selectExpr.getChildCount() - 1).getText());
     }
 
     for (FieldSchema fieldSchema : mvTable.getStorageHandler().acidSelectColumns(mvTable, Context.Operation.DELETE)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -93,7 +93,6 @@ import org.apache.hadoop.hive.metastore.api.TxnType;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.txn.entities.CompactionState;
-import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableDesc;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -3042,7 +3042,7 @@ public class AcidUtils {
             compBuilder.setExclWrite();
           }
           compBuilder.setOperationType(DataOperationType.UPDATE);
-        } else if (MetaStoreUtils.isNonNativeTable(t.getTTable())) {
+        } else if (t.isNonNative()) {
           compBuilder.setLock(getLockTypeFromStorageHandler(output, t));
           compBuilder.setOperationType(DataOperationType.UPDATE);
         } else {
@@ -3066,7 +3066,7 @@ public class AcidUtils {
             compBuilder.setOperationType(DataOperationType.UPDATE);
             break;
           }
-        } else if (MetaStoreUtils.isNonNativeTable(t.getTTable())) {
+        } else if (t.isNonNative()) {
           compBuilder.setLock(getLockTypeFromStorageHandler(output, t));
         } else {
           if (conf.getBoolVar(HiveConf.ConfVars.HIVE_TXN_STRICT_LOCKING_MODE)) {
@@ -3094,7 +3094,7 @@ public class AcidUtils {
         assert t != null;
         if (AcidUtils.isTransactionalTable(t) && sharedWrite) {
           compBuilder.setSharedWrite();
-        } else if (MetaStoreUtils.isNonNativeTable(t.getTTable())) {
+        } else if (t.isNonNative()) {
           compBuilder.setLock(getLockTypeFromStorageHandler(output, t));
         } else {
           compBuilder.setExclWrite();
@@ -3125,7 +3125,7 @@ public class AcidUtils {
     final HiveStorageHandler storageHandler = Preconditions.checkNotNull(t.getStorageHandler(),
         "Non-native tables must have an instance of storage handler.");
     LockType lockType = storageHandler.getLockType(output);
-    if (null == lockType) {
+    if (lockType == null) {
       throw new IllegalArgumentException(
               String.format("Lock type for Database.Table [%s.%s] is null", t.getDbName(), t.getTableName()));
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/HiveIncrementalRelMdRowCount.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/HiveIncrementalRelMdRowCount.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.ql.metadata.MaterializedViewMetadata;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveTezModelRelMetadataProvider;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveTableScan;
+import org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveMaterializedViewUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -52,8 +53,7 @@ public class HiveIncrementalRelMdRowCount extends HiveRelMdRowCount {
   }
 
   public static RelMetadataProvider source(RelOptMaterialization materialization) {
-    MaterializedViewMetadata mvMetadata = ((RelOptHiveTable) materialization.tableRel.getTable())
-            .getHiveTableMD().getMVMetadata();
+    MaterializedViewMetadata mvMetadata = HiveMaterializedViewUtils.extractTable(materialization).getMVMetadata();
     Map<String, SourceTable> sourceTableMap = new HashMap<>(mvMetadata.getSourceTables().size());
     for (SourceTable sourceTable : mvMetadata.getSourceTables()) {
       Table table = sourceTable.getTable();


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
In general materialized view table scan plan is just a TableScan operator.
```
HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
```
However in some cases a `Project` is added with cast expressions. For example when the MV schema contains `varchar` typed columns.
```
HiveProject(b=[CAST($0):VARCHAR(256) CHARACTER SET "UTF-16LE"], _c1=[$1])
  HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
```

* Use `HiveMaterializedViewUtils.extractTable` in `HiveIncrementalRelMdRowCount.source` to get the materialized view table object.
* When transforming the Materialized View rebuild AST to a multi insert AST extract all projected expression aliases from plan branch scanning the materialized view. 

### Why are the changes needed?
Materialized view scan plan may contain a project with cast expressions. The project operator doesn't contain the MV table and an exception is thrown when querying it

### Does this PR introduce _any_ user-facing change?
No exception is thrown when rebuilding MVs with `varchar` typed column

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergLlapLocalCliDriver -Dqfile=mv_iceberg_orc8.q -pl itests/qtest-iceberg -Pitests,iceberg
```
