### PR TITLE
HIVE-28821: Forward CLI Arguments from hive script to hive-config.sh

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -23,7 +23,9 @@ esac
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
 
-. "$bin"/hive-config.sh
+ARGS=("$@")
+. "$bin"/hive-config.sh "$@"
+set -- "${ARGS[@]}"
 
 SERVICE=""
 HELP=""


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pass all arguments of `bin/hive` script to `hive-config.sh` script.


### Why are the changes needed?
Enable to config `HIVE_CONF_DIR` and `HIVE_AUX_JARS_PATH` in script arguments directly.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Test deployment locally.
