### PR TITLE
HIVE-28826: Beeline fails to connect with spaces in the jdbc url

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -900,6 +900,8 @@ public class BeeLine implements Closeable {
     getOpts().setScriptFile(cl.getOptionValue("f"));
 
     if (url != null) {
+      //remove white spaces in the URL in case there is any, like in "jdbc:oracle:thin:@(DESCRIPTION = (ADDRESS_LIST=..."
+      url = url.replaceAll("\\s+","");
       String hplSqlMode = Utils.parsePropertyFromUrl(url, Constants.MODE);
       if ("HPLSQL".equalsIgnoreCase(hplSqlMode)) {
         getOpts().setDelimiter("/");

--- a/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -132,6 +132,16 @@ public class TestBeelineArgParsing {
   }
 
   @Test
+  public void testSimpleArgsWithSpaceInUrl() throws Exception {
+    TestBeeline bl = new TestBeeline();
+    String args[] = new String[] {"-u", "url with space", "-n", "name",
+            "-p", "password", "-d", "driver", "-a", "authType"};
+    org.junit.Assert.assertEquals(0, bl.initArgs(args));
+    Assert.assertTrue(bl.connectArgs.equals("urlwithspace name password driver"));
+    Assert.assertTrue(bl.getOpts().getAuthType().equals("authType"));
+  }
+
+  @Test
   public void testEmptyHiveConfVariable() throws Exception {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     PrintStream ops = new PrintStream(os);


### PR DESCRIPTION
### What changes were proposed in this pull request?
In some environments we need to customize the javax.jdo.option.ConnectionURL, and typically with Oracle databases the JDBC connection URL might contain spaces, like

jdbc:oracle:thin:@(DESCRIPTION = (ADDRESS_LIST=...

This is not handled by beeline, so hive schema upgrades are failing.

For the Oracle JDBC driver at least, the URL escaping does not work. The proposed solution is to remove the whitespaces from the connection url before passing the url to the Commands.java:
https://github.com/mszurap/hive/blob/2d528556b69c1ec011e83f69d2a2fdcfb78b356e/beeline/src/java/org/apache/hive/beeline/Commands.java#L1521.

Spaces were not respected before in the connection url. However if spaces are needed in the connection URL (like in ";sslTrustStore=/path/to/mydir with spaces/truststore.jks" or "?tez.application.tags=A B") then the URL escaping with "%20" can be still used in those places, those are decoded properly back to spaces.

### Why are the changes needed?
To make the upgades more robust, we should handle these situations.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Added a new beeline test "testSimpleArgsWithSpaceInUrl" to test the functionality that the spaces are now removed from the connection url ("-u" argument only).
The beeline unit tests were successful.