### PR TITLE
HIVE-28836: Hive SessionState Resource directories persists if SessionState is not started

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCreateUdfFile.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCreateUdfFile.java
@@ -115,7 +115,7 @@ class AsyncTaskCreateUdfFile implements Callable<Void> {
       }
     }
     for (URI srcUri : srcUris) {
-      List<URI> localUris = resourceDownloader.downloadExternal(srcUri, null, false);
+      List<URI> localUris = resourceDownloader.downloadExternal(srcUri, null);
       for(URI dst : localUris) {
         LOG.warn("Downloaded " + dst + " from " + srcUri);
       }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/FunctionLocalizer.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/FunctionLocalizer.java
@@ -289,7 +289,7 @@ public class FunctionLocalizer implements GenericUDFBridge.UdfWhitelistChecker {
       return;
     }
     rcr = new RefCountedResource();
-    List<URI> localUris = resourceDownloader.downloadExternal(srcUri, fqfn, false);
+    List<URI> localUris = resourceDownloader.downloadExternal(srcUri, fqfn);
     if (localUris == null || localUris.isEmpty()) {
       LOG.error("Cannot download " + srcUri + " for " + fqfn);
       return;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -4157,7 +4157,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     String progName = getScriptProgName(cmd);
 
     if (!ResourceDownloader.isFileUri(progName)) {
-      String filePath = ss.add_resource(ResourceType.FILE, progName, true);
+      String filePath = ss.add_resource(ResourceType.FILE, progName);
       Path p = new Path(filePath);
       String fileName = p.getName();
       String scriptArgs = getScriptArgs(cmd);

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -1605,29 +1605,16 @@ public class SessionState implements ISessionAuthState{
     return null;
   }
 
-
-
-  public String add_resource(ResourceType t, String value) throws RuntimeException {
-    return add_resource(t, value, false);
-  }
-
-  public String add_resource(ResourceType t, String value, boolean convertToUnix)
+  public String add_resource(ResourceType t, String value)
       throws RuntimeException {
-    List<String> added = add_resources(t, Arrays.asList(value), convertToUnix);
+    List<String> added = add_resources(t, Arrays.asList(value));
     if (added == null || added.isEmpty()) {
       return null;
     }
     return added.get(0);
   }
 
-  public List<String> add_resources(ResourceType t, Collection<String> values)
-      throws RuntimeException {
-    // By default don't convert to unix
-    return add_resources(t, values, false);
-  }
-
-  public List<String> add_resources(ResourceType t, Collection<String> values, boolean convertToUnix)
-      throws RuntimeException {
+  public List<String> add_resources(ResourceType t, Collection<String> values) throws RuntimeException {
     Set<String> resourceSet = resourceMaps.getResourceSet(t);
     Map<String, Set<String>> resourcePathMap = resourceMaps.getResourcePathMap(t);
     Map<String, Set<String>> reverseResourcePathMap = resourceMaps.getReverseResourcePathMap(t);
@@ -1637,7 +1624,7 @@ public class SessionState implements ISessionAuthState{
         String key;
 
         //get the local path of downloaded jars.
-        List<URI> downloadedURLs = resolveAndDownload(t, value, convertToUnix);
+        List<URI> downloadedURLs = resolveAndDownload(t, value);
 
         if (ResourceDownloader.isIvyUri(value)) {
           // get the key to store in map
@@ -1670,10 +1657,7 @@ public class SessionState implements ISessionAuthState{
     } catch (RuntimeException e) {
       getConsole().printError(e.getMessage(), "\n" + org.apache.hadoop.util.StringUtils.stringifyException(e));
       throw e;
-    } catch (URISyntaxException e) {
-      getConsole().printError(e.getMessage());
-      throw new RuntimeException(e);
-    } catch (IOException e) {
+    } catch (URISyntaxException | IOException e) {
       getConsole().printError(e.getMessage());
       throw new RuntimeException(e);
     }
@@ -1683,9 +1667,9 @@ public class SessionState implements ISessionAuthState{
   }
 
   @VisibleForTesting
-  protected List<URI> resolveAndDownload(ResourceType resourceType, String value, boolean convertToUnix)
+  protected List<URI> resolveAndDownload(ResourceType resourceType, String value)
       throws URISyntaxException, IOException {
-    List<URI> uris = resourceDownloader.resolveAndDownload(value, convertToUnix);
+    List<URI> uris = resourceDownloader.resolveAndDownload(value);
     if (ResourceDownloader.isHdfsUri(value)) {
       assert uris.size() == 1 : "There should only be one URI localized-resource.";
       resourceMaps.getLocalHdfsLocationMap(resourceType).put(uris.get(0).toString(), value);

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/ResourceDownloader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/ResourceDownloader.java
@@ -44,7 +44,6 @@ public class ResourceDownloader {
     this.dependencyResolver = new DependencyResolver();
     this.conf = conf;
     this.resourceDir = new File(resourceDirPath);
-    ensureDirectory(resourceDir);
   }
 
   /**
@@ -71,30 +70,29 @@ public class ResourceDownloader {
     }
   }
 
-  public List<URI> resolveAndDownload(String source, boolean convertToUnix)
+  public List<URI> resolveAndDownload(String source)
       throws URISyntaxException, IOException {
-    return resolveAndDownloadInternal(createURI(source), null, convertToUnix, true);
+    return resolveAndDownloadInternal(createURI(source), null, true);
   }
 
-  public List<URI> downloadExternal(URI source, String subDir, boolean convertToUnix)
+  public List<URI> downloadExternal(URI source, String subDir)
       throws URISyntaxException, IOException {
-    return resolveAndDownloadInternal(source, subDir, convertToUnix, false);
+    return resolveAndDownloadInternal(source, subDir, false);
   }
 
   private List<URI> resolveAndDownloadInternal(URI source, String subDir,
-      boolean convertToUnix, boolean isLocalAllowed) throws URISyntaxException, IOException {
+      boolean isLocalAllowed) throws URISyntaxException, IOException {
     switch (getURLType(source)) {
     case FILE: return isLocalAllowed ? Collections.singletonList(source) : null;
     case IVY: return dependencyResolver.downloadDependencies(source);
     case HDFS:
     case OTHER:
-      return Collections.singletonList(createURI(downloadResource(source, subDir, convertToUnix)));
+      return Collections.singletonList(createURI(downloadResource(source, subDir)));
     default: throw new AssertionError(getURLType(source));
     }
   }
 
-  private String downloadResource(URI srcUri, String subDir, boolean convertToUnix)
-      throws IOException, URISyntaxException {
+  private String downloadResource(URI srcUri, String subDir) throws IOException {
     LOG.debug("Converting to local {}", srcUri);
     File destinationDir = (subDir == null) ? resourceDir : new File(resourceDir, subDir);
     ensureDirectory(destinationDir);

--- a/ql/src/test/org/apache/hadoop/hive/ql/session/TestAddResource.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/session/TestAddResource.java
@@ -111,7 +111,7 @@ public class TestAddResource {
     list.add(createURI(TEST_JAR_DIR + "testjar5.jar"));
 
     //return all the dependency urls
-    Mockito.when(ss.resolveAndDownload(t, query, false)).thenReturn(list);
+    Mockito.when(ss.resolveAndDownload(t, query)).thenReturn(list);
     addList.add(query);
     ss.add_resources(t, addList);
     Set<String> dependencies = ss.list_resource(t, null);
@@ -147,7 +147,7 @@ public class TestAddResource {
 
     Collections.sort(list);
 
-    Mockito.when(ss.resolveAndDownload(t, query, false)).thenReturn(list);
+    Mockito.when(ss.resolveAndDownload(t, query)).thenReturn(list);
     for (int i = 0; i < 10; i++) {
       addList.add(query);
     }
@@ -183,8 +183,8 @@ public class TestAddResource {
     list2.add(createURI(TEST_JAR_DIR + "testjar3.jar"));
     list2.add(createURI(TEST_JAR_DIR + "testjar4.jar"));
 
-    Mockito.when(ss.resolveAndDownload(t, query1, false)).thenReturn(list1);
-    Mockito.when(ss.resolveAndDownload(t, query2, false)).thenReturn(list2);
+    Mockito.when(ss.resolveAndDownload(t, query1)).thenReturn(list1);
+    Mockito.when(ss.resolveAndDownload(t, query2)).thenReturn(list2);
     addList.add(query1);
     addList.add(query2);
     ss.add_resources(t, addList);
@@ -234,8 +234,8 @@ public class TestAddResource {
     Collections.sort(list1);
     Collections.sort(list2);
 
-    Mockito.when(ss.resolveAndDownload(t, query1, false)).thenReturn(list1);
-    Mockito.when(ss.resolveAndDownload(t, query2, false)).thenReturn(list2);
+    Mockito.when(ss.resolveAndDownload(t, query1)).thenReturn(list1);
+    Mockito.when(ss.resolveAndDownload(t, query2)).thenReturn(list2);
     addList.add(query1);
     addList.add(query2);
     ss.add_resources(t, addList);
@@ -293,9 +293,9 @@ public class TestAddResource {
     Collections.sort(list2);
     Collections.sort(list3);
 
-    Mockito.when(ss.resolveAndDownload(t, query1, false)).thenReturn(list1);
-    Mockito.when(ss.resolveAndDownload(t, query2, false)).thenReturn(list2);
-    Mockito.when(ss.resolveAndDownload(t, query3, false)).thenReturn(list3);
+    Mockito.when(ss.resolveAndDownload(t, query1)).thenReturn(list1);
+    Mockito.when(ss.resolveAndDownload(t, query2)).thenReturn(list2);
+    Mockito.when(ss.resolveAndDownload(t, query3)).thenReturn(list3);
     addList.add(query1);
     addList.add(query2);
     addList.add(query3);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removed creating resource directories on initialising session state. org.apache.hadoop.hive.ql.util.ResourceDownloader#downloadResource will ensure creating directories when needed.

### Why are the changes needed?
Previously, resource directories were created outside of SessionState.start, leading to inconsistencies and leftover directories when the session state was not properly closed. This issue was particularly noticeable with Spark SQL, as it resulted in the accumulation of unused session resource directories, consuming disk space and potentially affecting performance. 

Check [SPARK-51571](https://issues.apache.org/jira/browse/SPARK-51571) for reference

Fixing this issue in Hive itself ensures consistent behaviour across all engines that use SessionState, including Spark, making it a more robust and centralized solution.

### Does this PR introduce _any_ user-facing change?
no

### Is the change a dependency upgrade?

no

### How was this patch tested?
tested in cluster and existing testcases