### PR TITLE
HIVE-28840: HMS Iceberg Catalog doesn't respect ICEBERG_CATALOG_SERVLET_AUTH

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1844,7 +1844,7 @@ public class MetastoreConf {
             " positive value will be used as-is."
     ),
     ICEBERG_CATALOG_SERVLET_AUTH("hive.metastore.catalog.servlet.auth",
-        "hive.metastore.catalog.servlet.auth", "jwt",
+        "hive.metastore.catalog.servlet.auth", "jwt", new StringSetValidator("simple", "jwt"),
         "HMS Iceberg Catalog servlet authentication method (simple or jwt)."
     ),
     ICEBERG_CATALOG_CACHE_EXPIRY("hive.metastore.catalog.cache.expiry",

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -118,8 +118,8 @@ public class HMSCatalogFactory {
    * @return the servlet
    */
   protected HttpServlet createServlet(Catalog catalog) {
-    String auth = MetastoreConf.getVar(configuration, ConfVars.ICEBERG_CATALOG_SERVLET_AUTH);
-    ServletSecurity security = new ServletSecurity(configuration, "jwt".equalsIgnoreCase(auth));
+    String authType = MetastoreConf.getVar(configuration, ConfVars.ICEBERG_CATALOG_SERVLET_AUTH);
+    ServletSecurity security = new ServletSecurity(authType, configuration);
     return security.proxy(new HMSCatalogServlet(new HMSCatalogAdapter(catalog)));
   }
 

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.ServletSecurity;
 import org.apache.hadoop.hive.metastore.ServletServerBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.slf4j.Logger;
@@ -117,7 +118,8 @@ public class HMSCatalogFactory {
    * @return the servlet
    */
   protected HttpServlet createServlet(Catalog catalog) {
-    ServletSecurity security = new ServletSecurity(configuration);
+    String auth = MetastoreConf.getVar(configuration, ConfVars.ICEBERG_CATALOG_SERVLET_AUTH);
+    ServletSecurity security = new ServletSecurity(configuration, "jwt".equalsIgnoreCase(auth));
     return security.proxy(new HMSCatalogServlet(new HMSCatalogAdapter(catalog)));
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PropertyServlet.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PropertyServlet.java
@@ -313,8 +313,8 @@ public class PropertyServlet extends HttpServlet {
       int port = MetastoreConf.getIntVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_PORT);
       String path = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_PATH);
       if (port >= 0 && path != null && !path.isEmpty()) {
-        String auth = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_AUTH);
-        ServletSecurity security = new ServletSecurity(configuration, "jwt".equalsIgnoreCase(auth));
+        String authType = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_AUTH);
+        ServletSecurity security = new ServletSecurity(authType, configuration);
         HttpServlet servlet = security.proxy(new PropertyServlet(configuration));
         return new ServletServerBuilder.Descriptor(port, path, servlet);
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PropertyServlet.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PropertyServlet.java
@@ -313,7 +313,8 @@ public class PropertyServlet extends HttpServlet {
       int port = MetastoreConf.getIntVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_PORT);
       String path = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_PATH);
       if (port >= 0 && path != null && !path.isEmpty()) {
-        ServletSecurity security = new ServletSecurity(configuration);
+        String auth = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_AUTH);
+        ServletSecurity security = new ServletSecurity(configuration, "jwt".equalsIgnoreCase(auth));
         HttpServlet servlet = security.proxy(new PropertyServlet(configuration));
         return new ServletServerBuilder.Descriptor(port, path, servlet);
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ServletSecurity.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ServletSecurity.java
@@ -85,10 +85,20 @@ public class ServletSecurity {
   private final Configuration conf;
   private JWTValidator jwtValidator = null;
 
+  public ServletSecurity(String authType, Configuration conf) {
+    this.conf = conf;
+    this.isSecurityEnabled = UserGroupInformation.isSecurityEnabled();
+    this.jwtAuthEnabled = isAuthJwt(authType);
+  }
+
   public ServletSecurity(Configuration conf, boolean jwt) {
     this.conf = conf;
     this.isSecurityEnabled = UserGroupInformation.isSecurityEnabled();
     this.jwtAuthEnabled = jwt;
+  }
+
+  private static boolean isAuthJwt(String authType) {
+    return "jwt".equalsIgnoreCase(authType);
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ServletSecurity.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ServletSecurity.java
@@ -86,9 +86,7 @@ public class ServletSecurity {
   private JWTValidator jwtValidator = null;
 
   public ServletSecurity(String authType, Configuration conf) {
-    this.conf = conf;
-    this.isSecurityEnabled = UserGroupInformation.isSecurityEnabled();
-    this.jwtAuthEnabled = isAuthJwt(authType);
+    this(conf, isAuthJwt(authType));
   }
 
   public ServletSecurity(Configuration conf, boolean jwt) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ServletSecurity.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ServletSecurity.java
@@ -85,19 +85,10 @@ public class ServletSecurity {
   private final Configuration conf;
   private JWTValidator jwtValidator = null;
 
-  public ServletSecurity(Configuration conf) {
-    this(conf, isAuthJwt(conf));
-  }
-
   public ServletSecurity(Configuration conf, boolean jwt) {
     this.conf = conf;
     this.isSecurityEnabled = UserGroupInformation.isSecurityEnabled();
     this.jwtAuthEnabled = jwt;
-  }
-
-  public static boolean isAuthJwt(Configuration configuration) {
-    String auth = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_AUTH);
-    return "jwt".equalsIgnoreCase(auth);
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Let HMSCatalog, the Iceberg REST catalog on HMS, respect the parameter.

### Why are the changes needed?

We can't configure the auth mode of the catalog API

### Does this PR introduce _any_ user-facing change?

No. This feature has not been released yet

### Is the change a dependency upgrade?

No

### How was this patch tested?

I ran the server on my local machine