### PR TITLE
HIVE-28841: Rename hive.metastore.catalog.* to hive.metastore.iceberg.catalog.*

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1829,29 +1829,29 @@ public class MetastoreConf {
             new StringSetValidator("simple", "jwt"),
         "Property-maps servlet authentication method (simple or jwt)."
     ),
-    ICEBERG_CATALOG_SERVLET_FACTORY("hive.metastore.catalog.servlet.factory",
-            "hive.metastore.catalog.servlet.factory",
+    ICEBERG_CATALOG_SERVLET_FACTORY("metastore.iceberg.catalog.servlet.factory",
+            "hive.metastore.iceberg.catalog.servlet.factory",
             "org.apache.iceberg.rest.HMSCatalogFactory",
             "HMS Iceberg Catalog servlet factory class name."
             + "The factory needs to expose a method: "
             + "public static HttpServlet createServlet(Configuration configuration);"
     ),
-    ICEBERG_CATALOG_SERVLET_PATH("hive.metastore.catalog.servlet.path",
-        "hive.metastore.catalog.servlet.path", "iceberg",
+    ICEBERG_CATALOG_SERVLET_PATH("metastore.iceberg.catalog.servlet.path",
+        "hive.metastore.iceberg.catalog.servlet.path", "iceberg",
         "HMS Iceberg Catalog servlet path component of URL endpoint."
     ),
-    ICEBERG_CATALOG_SERVLET_PORT("hive.metastore.catalog.servlet.port",
-        "hive.metastore.catalog.servlet.port", -1,
+    ICEBERG_CATALOG_SERVLET_PORT("metastore.iceberg.catalog.servlet.port",
+        "hive.metastore.iceberg.catalog.servlet.port", -1,
         "HMS Iceberg Catalog servlet server port. Negative value disables the servlet," +
             " 0 will let the system determine the catalog server port," +
             " positive value will be used as-is."
     ),
-    ICEBERG_CATALOG_SERVLET_AUTH("hive.metastore.catalog.servlet.auth",
-        "hive.metastore.catalog.servlet.auth", "jwt", new StringSetValidator("simple", "jwt"),
+    ICEBERG_CATALOG_SERVLET_AUTH("metastore.iceberg.catalog.servlet.auth",
+        "hive.metastore.iceberg.catalog.servlet.auth", "jwt", new StringSetValidator("simple", "jwt"),
         "HMS Iceberg Catalog servlet authentication method (simple or jwt)."
     ),
-    ICEBERG_CATALOG_CACHE_EXPIRY("hive.metastore.catalog.cache.expiry",
-        "hive.metastore.catalog.cache.expiry", 60_000L,
+    ICEBERG_CATALOG_CACHE_EXPIRY("metastore.iceberg.catalog.cache.expiry",
+        "hive.metastore.iceberg.catalog.cache.expiry", 60_000L,
         "HMS Iceberg Catalog cache expiry."
     ),
     HTTPSERVER_THREADPOOL_MIN("hive.metastore.httpserver.threadpool.min",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Relocate the prefix of Iceberg REST Catalog properties.
https://issues.apache.org/jira/browse/HIVE-28841

### Why are the changes needed?

Two reasons.
- The current one is not inconsistent with the constant names, e.g., ICEBERG_CATALOG_SERVLET_FACTORY
- The word "catalog" is too common and might be confusing

### Does this PR introduce _any_ user-facing change?

No. HMS Iceberg catalog has not been released

### Is the change a dependency upgrade?

No

### How was this patch tested?
We have integration tests