### PR TITLE
HIVE-28847: Import of eclipse-styles.xml fails in IntelliJ IDEA 2024.3.4

### DIFF
--- a/dev-support/eclipse-styles.xml
+++ b/dev-support/eclipse-styles.xml
@@ -30,7 +30,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
@@ -40,7 +40,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set the problematic alignment options to the value 16, which in Eclipse is mapped to: 
Line wrapping policy: Wrap where necessary
Indentation policy: Default indentation

### Why are the changes needed?
To allow the code-style to work in recent versions of IntelliJ and Eclipse.

### Does this PR introduce _any_ user-facing change?
No, it only affects developpers and mostly those working in IntelliJ.

### Is the change a dependency upgrade?
No

### How was this patch tested?
Manual import of the new and old style in Eclipse 2025-03 (4.35.0) and IntelliJ IDEA 2024.3.4