### PR TITLE
HIVE-28817: Rebuilding a materialized view stored in Iceberg fails when schema has varchar column - ADDENDUM

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -414,7 +414,6 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     }
 
     try {
-      conf.setLong(hive_metastoreConstants.TXN_ID, IcebergAcidUtil.getTxnId());
       commitLock.lock();
       doPreAlterTable(hmsTable, context);
     } catch (Exception e) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.Context.Operation;
 import org.apache.hadoop.hive.ql.Context.RewritePolicy;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -457,7 +456,6 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
 
     for (JobContext jobContext : jobContexts) {
       JobConf conf = jobContext.getJobConf();
-      conf.setLong(hive_metastoreConstants.TXN_ID, IcebergAcidUtil.getTxnId());
       table = Optional.ofNullable(table).orElse(Catalogs.loadTable(conf, catalogProperties));
       branchName = conf.get(InputFormatConfig.OUTPUT_TABLE_SNAPSHOT_REF);
       snapshotId = getSnapshotId(outputTable.table, branchName);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.AggrStats;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
@@ -835,6 +836,9 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    */
   @Override
   public LockType getLockType(WriteEntity writeEntity) {
+    if (TableType.MATERIALIZED_VIEW == writeEntity.getTable().getTableType()) {
+      return LockType.SHARED_READ;
+    }
     if (WriteEntity.WriteType.INSERT_OVERWRITE == writeEntity.getWriteType()) {
       return LockType.EXCL_WRITE;
     }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -836,6 +836,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    */
   @Override
   public LockType getLockType(WriteEntity writeEntity) {
+    // Materialized views stored by Iceberg and the MV metadata is stored in HMS doesn't need write locking because
+    // the locking is done by DbTxnManager.acquireMaterializationRebuildLock()
     if (TableType.MATERIALIZED_VIEW == writeEntity.getTable().getTableType()) {
       return LockType.SHARED_READ;
     }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -28,9 +28,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.PositionDeleteInfo;
-import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
-import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionKey;
@@ -393,17 +391,4 @@ public class IcebergAcidUtil {
     }
   }
 
-  static long getTxnId() {
-    SessionState sessionState = SessionState.get();
-    if (sessionState == null) {
-      return 0L;
-    }
-
-    HiveTxnManager txnManager = sessionState.getTxnMgr();
-    if (txnManager == null) {
-      return 0L;
-    }
-
-    return txnManager.getCurrentTxnId();
-  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -205,7 +205,8 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
       rewrittenAST = ParseUtils.parse(rewrittenInsertStatement, ctx);
       this.ctx.addSubContext(ctx);
 
-      if (!this.ctx.isExplainPlan() && AcidUtils.isTransactionalTable(table)) {
+      if (!this.ctx.isExplainPlan() && (AcidUtils.isTransactionalTable(table) ||
+              table.isNonNative() && table.getStorageHandler().areSnapshotsSupported())) {
         // Acquire lock for the given materialized view. Only one rebuild per materialized view can be triggered at a
         // given time, as otherwise we might produce incorrect results if incremental maintenance is triggered.
         HiveTxnManager txnManager = getTxnMgr();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
* Revert setting the transactionId of an Acid transaction in Iceberg job configurations
* Materialized views stored by Iceberg and the MV metadata is stored in HMS doesn't need a write lock because
   the locking is done by DbTxnManager.acquireMaterializationRebuildLock()
* Acquire materialization rebuild lock when rebuilding an MV stored by Iceberg


### Why are the changes needed?
Avoid deadlock when rebuilding M stored by Iceberg with native base tables

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergLlapLocalCliDriver -Dqfile=mv_iceberg_orc8.q -pl itests/qtest-iceberg -Pitests
```