### PR TITLE
HIVE-28854: Speed up Docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ kafka-handler/src/test/gen
 /.recommenders/
 dependency-reduced-pom.xml
 **/.mvn/.develocity*
+packaging/cache

--- a/packaging/src/docker/build.sh
+++ b/packaging/src/docker/build.sh
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-set -x
+set -eux
 HIVE_VERSION=
 HADOOP_VERSION=
 TEZ_VERSION=
@@ -64,45 +64,62 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-SOURCE_DIR=${SOURCE_DIR:-"../../.."}
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+SOURCE_DIR=${SOURCE_DIR:-"$SCRIPT_DIR/../../.."}
 repo=${REPO:-apache}
 WORK_DIR="$(mktemp -d)"
+CACHE_DIR="$SCRIPT_DIR/../../cache"
+mkdir -p "$CACHE_DIR"
 HADOOP_VERSION=${HADOOP_VERSION:-$(mvn -f "$SOURCE_DIR/pom.xml" -q help:evaluate -Dexpression=hadoop.version -DforceStdout)}
 TEZ_VERSION=${TEZ_VERSION:-$(mvn -f "$SOURCE_DIR/pom.xml" -q help:evaluate -Dexpression=tez.version -DforceStdout)}
 
-HADOOP_URL=${HADOOP_URL:-"https://archive.apache.org/dist/hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz"}
-echo "Downloading Hadoop from $HADOOP_URL..."
-if ! curl --fail -L "$HADOOP_URL" -o "$WORK_DIR/hadoop-$HADOOP_VERSION.tar.gz"; then
-  echo "Fail to download Hadoop, exiting...."
-  exit 1
+HADOOP_FILE_NAME="hadoop-$HADOOP_VERSION.tar.gz"
+HADOOP_URL=${HADOOP_URL:-"https://archive.apache.org/dist/hadoop/core/hadoop-$HADOOP_VERSION/$HADOOP_FILE_NAME"}
+if [ ! -f "$CACHE_DIR/$HADOOP_FILE_NAME" ]; then
+  echo "Downloading Hadoop from $HADOOP_URL..."
+  if ! curl --fail -L "$HADOOP_URL" -o "$CACHE_DIR/$HADOOP_FILE_NAME.tmp"; then
+    echo "Fail to download Hadoop, exiting...."
+    exit 1
+  fi
+  mv "$CACHE_DIR/$HADOOP_FILE_NAME.tmp" "$CACHE_DIR/$HADOOP_FILE_NAME"
 fi
 
-TEZ_URL=${TEZ_URL:-"https://archive.apache.org/dist/tez/$TEZ_VERSION/apache-tez-$TEZ_VERSION-bin.tar.gz"}
-echo "Downloading Tez from $TEZ_URL..."
-if ! curl --fail -L "$TEZ_URL" -o "$WORK_DIR/apache-tez-$TEZ_VERSION-bin.tar.gz"; then
-  echo "Failed to download Tez, exiting..."
-  exit 1
+TEZ_FILE_NAME="apache-tez-$TEZ_VERSION-bin.tar.gz"
+TEZ_URL=${TEZ_URL:-"https://archive.apache.org/dist/tez/$TEZ_VERSION/$TEZ_FILE_NAME"}
+if [ ! -f "$CACHE_DIR/$TEZ_FILE_NAME" ]; then
+  echo "Downloading Tez from $TEZ_URL..."
+  if ! curl --fail -L "$TEZ_URL" -o "$CACHE_DIR/$TEZ_FILE_NAME.tmp"; then
+    echo "Failed to download Tez, exiting..."
+    exit 1
+  fi
+  mv "$CACHE_DIR/$TEZ_FILE_NAME.tmp" "$CACHE_DIR/$TEZ_FILE_NAME"
 fi
 
 if [ -n "$HIVE_VERSION" ]; then
-  HIVE_URL=${HIVE_URL:-"https://archive.apache.org/dist/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz"}
-  echo "Downloading Hive from $HIVE_URL..."
-  if ! curl --fail -L "$HIVE_URL" -o "$WORK_DIR/apache-hive-$HIVE_VERSION-bin.tar.gz"; then
-    echo "Failed to download Hive, exiting..."
-    exit 1
-  fi
-  hive_package="$WORK_DIR/apache-hive-$HIVE_VERSION-bin.tar.gz"
-else
-    HIVE_VERSION=$(mvn -f "$SOURCE_DIR/pom.xml" -q help:evaluate -Dexpression=project.version -DforceStdout)
-    HIVE_TAR="$SOURCE_DIR/packaging/target/apache-hive-$HIVE_VERSION-bin.tar.gz"
-    if  ls $HIVE_TAR || mvn -f $SOURCE_DIR/pom.xml clean package -DskipTests -Pdist; then
-      cp "$HIVE_TAR" "$WORK_DIR/"
-    else
-      echo "Failed to compile Hive Project, exiting..."
+  HIVE_FILE_NAME="apache-hive-$HIVE_VERSION-bin.tar.gz"
+  if [ ! -f "$CACHE_DIR/$HIVE_FILE_NAME" ]; then
+    HIVE_URL=${HIVE_URL:-"https://archive.apache.org/dist/hive/hive-$HIVE_VERSION/$HIVE_FILE_NAME"}
+    echo "Downloading Hive from $HIVE_URL..."
+    if ! curl --fail -L "$HIVE_URL" -o "$CACHE_DIR/$HIVE_FILE_NAME.tmp"; then
+      echo "Failed to download Hive, exiting..."
       exit 1
     fi
+    mv "$CACHE_DIR/$HIVE_FILE_NAME.tmp" "$CACHE_DIR/$HIVE_FILE_NAME"
+  fi
+  cp "$CACHE_DIR/$HIVE_FILE_NAME" "$WORK_DIR"
+else
+  HIVE_VERSION=$(mvn -f "$SOURCE_DIR/pom.xml" -q help:evaluate -Dexpression=project.version -DforceStdout)
+  HIVE_TAR="$SOURCE_DIR/packaging/target/apache-hive-$HIVE_VERSION-bin.tar.gz"
+  if  ls $HIVE_TAR || mvn -f $SOURCE_DIR/pom.xml clean package -DskipTests -Pdist; then
+    cp "$HIVE_TAR" "$WORK_DIR/"
+  else
+    echo "Failed to compile Hive Project, exiting..."
+    exit 1
+  fi
 fi
 
+cp "$CACHE_DIR/hadoop-$HADOOP_VERSION.tar.gz" "$WORK_DIR/"
+cp "$CACHE_DIR/apache-tez-$TEZ_VERSION-bin.tar.gz" "$WORK_DIR/"
 cp -R "$SOURCE_DIR/packaging/src/docker/conf" "$WORK_DIR/"
 cp -R "$SOURCE_DIR/packaging/src/docker/entrypoint.sh" "$WORK_DIR/"
 cp    "$SOURCE_DIR/packaging/src/docker/Dockerfile" "$WORK_DIR/"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Cache stable Hadoop, Tez, and Hive artifacts. We might have a better approach.
https://issues.apache.org/jira/browse/HIVE-28854

### Why are the changes needed?

The current implementation downloads them every time. Downloading Hadoop is costly.

### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

I ran locally `./build.sh` and `./build.sh -hive 4.0.1`.