### PR TITLE
HIVE-28855: VectorGroupByOperator should use getGroupByMemoryUsage() instead of getMemoryThreshold().

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorGroupByOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorGroupByOperator.java
@@ -155,7 +155,7 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
 
   private transient long maxMemory;
 
-  private float memoryThreshold;
+  private float hashTableMemoryPercentage;
 
   private boolean isLlap = false;
 
@@ -626,20 +626,20 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
 
       MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
       maxMemory = isLlap ? getConf().getMaxMemoryAvailable() : memoryMXBean.getHeapMemoryUsage().getMax();
-      memoryThreshold = conf.getMemoryThreshold();
+      hashTableMemoryPercentage = conf.getGroupByMemoryUsage();
       // Tests may leave this unitialized, so better set it to 1
-      if (memoryThreshold == 0.0f) {
-        memoryThreshold = 1.0f;
+      if (hashTableMemoryPercentage == 0.0f) {
+        hashTableMemoryPercentage = 1.0f;
       }
 
-      maxHashTblMemory = (int)(maxMemory * memoryThreshold);
+      maxHashTblMemory = (int)(maxMemory * hashTableMemoryPercentage);
 
       if (LOG.isDebugEnabled()) {
         LOG.debug("GBY memory limits - isLlap: {} maxMemory: {} ({} * {}) fixSize:{} (key:{} agg:{})",
           isLlap,
           LlapUtil.humanReadableByteCount(maxHashTblMemory),
           LlapUtil.humanReadableByteCount(maxMemory),
-          memoryThreshold,
+          hashTableMemoryPercentage,
           fixedHashEntrySize,
           keyWrappersBatch.getKeysFixedSize(),
           aggregationBatchInfo.getAggregatorsFixedSize());


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Modify VectorGroupByOperator to use getGroupByMemoryUsage() instead of getMemoryThreshold().

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Both `GroupByOperator` and `VectorGroupByOperator` flush the HashTable when:
(1) The process’s memory usage becomes too high.
(2) The estimated HashTable size exceeds its computed limit (`maxHashTblMemory` in both classes).

For (1), `GroupByOperator` compares memory usage against `hive.map.aggr.hash.force.flush.memory.threshold``, while `VectorGroupByOperator` monitors GC canary.
For (2), both operators compute `maxHashTblMemory` and compare it with the estimated HashTable size. However, they use different configurations: `GroupByOperator` relies on `hive.map.aggr.hash.percentmemory`, while `VectorGroupByOperator` incorrectly uses `hive.map.aggr.hash.force.flush.memory.threshold`.

Since `GroupByOperator` already uses `THRESHOLD` for condition (1), `VectorGroupByOperator` should use `PERCENT` for condition (2) to maintain consistency.
 
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
If a user manages GroupBy's HashTable size using `hive.map.aggr.hash.force.flush.memory.threshold`, one should adjust the configuration file accordingly.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This patch does not include a test since it only corrects a configuration misinterpretation.