### PR TITLE
HIVE-28851: HiveIcebergMetaHook acquires an HMS lock, regardless of the config and operations

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3121,7 +3121,7 @@ public class HiveConf extends Configuration {
     TXN_MERGE_INSERT_X_LOCK("hive.txn.xlock.mergeinsert", false,
         "Ensures MERGE INSERT operations acquire EXCLUSIVE / EXCL_WRITE lock for transactional tables.\n" +
         "If enabled, prevents duplicates when MERGE statements are executed in parallel transactions."),
-    TXN_WRITE_X_LOCK("hive.txn.xlock.write", true,
+    TXN_WRITE_X_LOCK("hive.txn.xlock.write", false,
         "Manages concurrency levels for ACID resources. Provides better level of query parallelism by enabling " +
         "shared writes and write-write conflict resolution at the commit step." +
         "- If true - exclusive writes are used:\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3130,7 +3130,7 @@ public class HiveConf extends Configuration {
         "  - INSERT acquires SHARED_READ locks\n" +
         "- If false - shared writes, transaction is aborted in case of conflicting changes:\n" +
         "  - INSERT OVERWRITE acquires EXCL_WRITE locks\n" +
-        "  - INSERT/UPDATE/DELETE acquire SHARED_READ locks"),
+        "  - INSERT/UPDATE/DELETE acquire SHARED_WRITE locks"),
     HIVE_TXN_STATS_ENABLED("hive.txn.stats.enabled", true,
         "Whether Hive supports transactional stats (accurate stats for transactional tables)"),
     HIVE_TXN_ACID_DIR_CACHE_DURATION("hive.txn.acid.dir.cache.duration",

--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveLock.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveLock.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg.hive;
 
-interface HiveLock {
+public interface HiveLock {
   void lock() throws LockException;
 
   void ensureActive() throws LockException;

--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableBiMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -476,6 +477,10 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
         ConfigProperties.ENGINE_HIVE_ENABLED, true);
   }
 
+  private static boolean hiveLockEnabled(TableMetadata metadata, Configuration conf) {
+    return hiveLockEnabled(metadata != null ? metadata.properties() : null, conf);
+  }
+
   /**
    * Returns if the hive locking should be enabled on the table, or not.
    *
@@ -489,14 +494,14 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
    *       TableProperties#HIVE_LOCK_ENABLED_DEFAULT}
    * </ol>
    *
-   * @param metadata Table metadata to use
+   * @param properties Table properties to use
    * @param conf The hive configuration to use
    * @return if the hive engine related values should be enabled or not
    */
-  private static boolean hiveLockEnabled(TableMetadata metadata, Configuration conf) {
-    if (metadata != null && metadata.properties().get(TableProperties.HIVE_LOCK_ENABLED) != null) {
+  public static boolean hiveLockEnabled(Map<String, String> properties, Configuration conf) {
+    if (properties != null && properties.containsKey(TableProperties.HIVE_LOCK_ENABLED)) {
       // We know that the property is set, so default value will not be used,
-      return metadata.propertyAsBoolean(TableProperties.HIVE_LOCK_ENABLED, false);
+      return PropertyUtil.propertyAsBoolean(properties, TableProperties.HIVE_LOCK_ENABLED, false);
     }
 
     return conf.getBoolean(

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -437,7 +437,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
 
   private static boolean hiveLockEnabled(org.apache.hadoop.hive.metastore.api.Table hmsTable, Configuration conf) {
     if (SessionStateUtil.getQueryState(conf).map(QueryState::getHiveOperation)
-        .filter(opType -> HiveOperation.ANALYZE_TABLE == opType)
+        .filter(opType -> HiveOperation.QUERY == opType)
         .isPresent()) {
       return false;
     }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStatistics.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStatistics.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -146,6 +147,25 @@ public class TestHiveIcebergStatistics extends HiveIcebergStorageHandlerWithEngi
 
     checkColStat(identifier.name(), "customer_id", true);
     checkColStatMinMaxValue(identifier.name(), "customer_id", 0, 2);
+  }
+
+  @Test
+  public void testStatsWithPessimisticLockInsertWhenHiveLockEnabled() {
+    Assume.assumeTrue(testTableType == TestTables.TestTableType.HIVE_CATALOG);
+    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+
+    shell.setHiveSessionValue(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER.varname, true);
+    shell.setHiveSessionValue(HiveConf.ConfVars.HIVE_TXN_EXT_LOCKING_ENABLED.varname, true);
+    testTables.createTable(shell, identifier.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        PartitionSpec.unpartitioned(), fileFormat, ImmutableList.of(), formatVersion,
+        ImmutableMap.of(TableProperties.HIVE_LOCK_ENABLED, "true"));
+
+    String insert = testTables.getInsertQuery(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, identifier, false);
+    AssertHelpers.assertThrows(
+        "Should throw RuntimeException when Hive locking is on with 'engine.hive.lock-enabled=true'",
+        RuntimeException.class,
+        () -> shell.executeStatement(insert)
+    );
   }
 
   @Test

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStatistics.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStatistics.java
@@ -132,6 +132,7 @@ public class TestHiveIcebergStatistics extends HiveIcebergStorageHandlerWithEngi
 
   @Test
   public void testStatsWithPessimisticLockInsert() {
+    Assume.assumeTrue(testTableType == TestTables.TestTableType.HIVE_CATALOG);
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.setHiveSessionValue(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER.varname, true);
@@ -139,11 +140,6 @@ public class TestHiveIcebergStatistics extends HiveIcebergStorageHandlerWithEngi
     testTables.createTable(shell, identifier.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
         PartitionSpec.unpartitioned(), fileFormat, ImmutableList.of(), 1,
         ImmutableMap.of(TableProperties.HIVE_LOCK_ENABLED, "false"));
-
-    if (testTableType != TestTables.TestTableType.HIVE_CATALOG) {
-      // If the location is set and we have to gather stats, then we have to update the table stats now
-      shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS FOR COLUMNS");
-    }
 
     String insert = testTables.getInsertQuery(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, identifier, false);
     shell.executeStatement(insert);

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStatistics.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStatistics.java
@@ -138,7 +138,7 @@ public class TestHiveIcebergStatistics extends HiveIcebergStorageHandlerWithEngi
     shell.setHiveSessionValue(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER.varname, true);
     shell.setHiveSessionValue(HiveConf.ConfVars.HIVE_TXN_EXT_LOCKING_ENABLED.varname, true);
     testTables.createTable(shell, identifier.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        PartitionSpec.unpartitioned(), fileFormat, ImmutableList.of(), 1,
+        PartitionSpec.unpartitioned(), fileFormat, ImmutableList.of(), formatVersion,
         ImmutableMap.of(TableProperties.HIVE_LOCK_ENABLED, "false"));
 
     String insert = testTables.getInsertQuery(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, identifier, false);

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStatistics.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStatistics.java
@@ -26,7 +26,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -53,20 +52,14 @@ public class TestHiveIcebergStatistics extends HiveIcebergStorageHandlerWithEngi
   @Parameterized.Parameter(4)
   public String statsSource;
 
-  @Parameterized.Parameter(5)
-  public boolean isLockEnabled;
-
-  @Parameterized.Parameters(name = "fileFormat={0}, catalog={1}, isVectorized={2}, " +
-      "formatVersion={3}, statsSource={4}, isLockEnabled={5}")
+  @Parameterized.Parameters(name = "fileFormat={0}, catalog={1}, isVectorized={2}, formatVersion={3}, statsSource={4}")
   public static Collection<Object[]> parameters() {
     Collection<Object[]> baseParams = HiveIcebergStorageHandlerWithEngineBase.parameters();
 
     Collection<Object[]> testParams = Lists.newArrayList();
     for (String statsSource : new String[]{"iceberg", "metastore"}) {
-      for (boolean isLockEnabled : new boolean[]{true, false}) {
-        for (Object[] params : baseParams) {
-          testParams.add(ArrayUtils.addAll(params, new Object[]{statsSource, isLockEnabled}));
-        }
+      for (Object[] params : baseParams) {
+        testParams.add(ArrayUtils.add(params, statsSource));
       }
     }
     return testParams;
@@ -146,21 +139,13 @@ public class TestHiveIcebergStatistics extends HiveIcebergStorageHandlerWithEngi
     shell.setHiveSessionValue(HiveConf.ConfVars.HIVE_TXN_EXT_LOCKING_ENABLED.varname, true);
     testTables.createTable(shell, identifier.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
         PartitionSpec.unpartitioned(), fileFormat, ImmutableList.of(), formatVersion,
-        ImmutableMap.of(TableProperties.HIVE_LOCK_ENABLED, String.valueOf(isLockEnabled)));
+        ImmutableMap.of(TableProperties.HIVE_LOCK_ENABLED, "false"));
 
     String insert = testTables.getInsertQuery(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, identifier, false);
+    shell.executeStatement(insert);
 
-    if (!isLockEnabled) {
-      shell.executeStatement(insert);
-      checkColStat(identifier.name(), "customer_id", true);
-      checkColStatMinMaxValue(identifier.name(), "customer_id", 0, 2);
-    } else {
-      AssertHelpers.assertThrows(
-          "Should throw RuntimeException when Hive locking is on with 'engine.hive.lock-enabled=true'",
-          RuntimeException.class,
-          () -> shell.executeStatement(insert)
-      );
-    }
+    checkColStat(identifier.name(), "customer_id", true);
+    checkColStatMinMaxValue(identifier.name(), "customer_id", 0, 2);
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -404,6 +404,7 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
       throws Exception, MetaException, TException, NoSuchObjectException {
     hiveConf.setBoolean("hive.stats.autogather", true);
     hiveConf.setBoolean("hive.stats.column.autogather", true);
+    hiveConf.setBoolean("hive.txn.xlock.write", true);
     // Need to close the thread local Hive object so that configuration change is reflected to HMS.
     Hive.closeCurrent();
     runStatementOnDriver("drop table if exists " + tableName);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
HiveIcebergMetaHook acquires the HMS lock only when necessary, depending on the operationType and the config(`engine.hive.lock-enabled`).


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Stat tasks fail during insert queries on Iceberg tables.
How to reproduce:
```
set hive.support.concurrency=true;
set hive.txn.ext.locking.enabled=true;
set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
set hive.stats.autogather=true;

create table ice_t (i int) stored by iceberg tblproperties ('engine.hive.lock-enabled'='false');

insert into ice_t values (1);
```
StatsTask Fail:
```
2025-03-27T12:54:00,304 INFO [Thread-108] stats.BasicStatsTask: [Warning] could not update stats.Failed with exception Unable to alter table. org.apache.iceberg.hive.LockException: Timed out after 182005 ms waiting for lock on default.ice_t
 ```
HIVE_LOCKS Table:
```
+----------------+---------+----------+---------------+--------------+-----+---------------------+
| HL_LOCK_EXT_ID | HL_DB   | HL_TABLE | HL_LOCK_STATE | HL_LOCK_TYPE | ... | HL_BLOCKEDBY_EXT_ID |
+----------------+---------+----------+---------------+--------------+-----+---------------------+
|            110 | default | ice_t    | a             | w            | ... |                NULL |
|            111 | default | ice_t    | w             | x            | ... |                 110 |
+----------------+---------+----------+---------------+--------------+-----+---------------------+
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
The Stat tasks of the Iceberg table will succeed


### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test added
