### PR TITLE
HIVE-28857. Fix logging for invalid partition path

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -680,9 +680,10 @@ public class Warehouse {
     return partSpec;
   }
 
-  public static boolean makeSpecFromName(Map<String, String> partSpec, Path currPath,
+  public static boolean makeSpecFromName(Map<String, String> partSpec, Path path,
       Set<String> requiredKeys) {
     List<String[]> kvs = new ArrayList<>();
+    Path currPath = path;
     do {
       String component = currPath.getName();
       Matcher m = pat.matcher(component);
@@ -706,7 +707,7 @@ public class Warehouse {
       partSpec.put(key, kvs.get(i - 1)[1]);
     }
     if (requiredKeys == null || requiredKeys.isEmpty()) return true;
-    LOG.warn("Cannot create partition spec from " + currPath + "; missing keys " + requiredKeys);
+    LOG.warn("Cannot create partition spec from {}; missing keys {}", path, requiredKeys);
     return false;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix logging for invalid partition path.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The currently referenced `currPath` is modified before logging, which makes the warning logs meaningless.

```
LOG.warn("Cannot create partition spec from " + currPath + "; missing keys " + requiredKeys);
```

```
21:15:43.814 pool-1-thread-1-ScalaTest-running-InsertSuite WARN warehouse: Cannot create partition spec from file:/; missing keys [b]
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Minor, the user could see the invalid partition path from logs after this change.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Example of logs for invalid partition path.
```
10:58:14.949 pool-1-thread-1-ScalaTest-running-InsertSuite WARN warehouse: Cannot create partition spec from file:/Users/chengpan/Projects/ne-spark-3.3/target/tmp/warehouse-7c577ad7-5270-430c-b93e-44f8a369aa0f/hive_table/.hive-staging_hive_2025-03-31_19-58-14_723_1019344668587200213-1/-ext-10000/c=15; missing keys [b]
```