### PR TITLE
HIVE-28859: Upgrade commons-logging to 1.3.5 to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
     <commons-exec.version>1.1</commons-exec.version>
     <commons-io.version>2.14.0</commons-io.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
+    <commons-logging.version>1.3.5</commons-logging.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <commons-text.version>1.10.0</commons-text.version>
@@ -333,6 +334,11 @@
         <groupId>com.thoughtworks.paranamer</groupId>
         <artifactId>paranamer</artifactId>
         <version>${paranamer.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>${commons-logging.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -63,7 +63,7 @@
     <antlr.version>4.9.3</antlr.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
-    <commons-logging.version>1.1.3</commons-logging.version>
+    <commons-logging.version>1.3.5</commons-logging.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <datasketches.version>1.2.0</datasketches.version>
     <datanucleus-api-jdo.version>5.2.8</datanucleus-api-jdo.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -28,7 +28,6 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <commons-logging.version>1.3.5</commons-logging.version>
     <guava.version>22.0</guava.version>
     <hadoop.version>3.4.1</hadoop.version>
     <junit.version>4.13.2</junit.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <commons-logging.version>1.1.3</commons-logging.version>
+    <commons-logging.version>1.3.5</commons-logging.version>
     <guava.version>22.0</guava.version>
     <hadoop.version>3.4.1</hadoop.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrading commons-logging to 1.3.5


### Why are the changes needed?
To fix multiple CVEs


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes
[dpn_2.txt](https://github.com/user-attachments/files/19552812/dpn_2.txt)


### How was this patch tested?
Built hive locally with this patch and ran some manual queries
