### PR TITLE
HIVE-28163: Upgrade apache directory server to 2.0.0-M24

### DIFF
--- a/itests/hive-minikdc/pom.xml
+++ b/itests/hive-minikdc/pom.xml
@@ -45,6 +45,10 @@
           <groupId>dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <antlr.version>3.5.2</antlr.version>
     <!-- Make sure to sync it with standalone-metastore/pom.xml -->
     <antlr4.version>4.9.3</antlr4.version>
-    <apache-directory-server.version>1.5.7</apache-directory-server.version>
+    <apache-directory-server.version>2.0.0-M24</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
     <arrow.version>16.0.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -348,6 +348,10 @@
           <groupId>dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -61,7 +61,7 @@
     <maven.surefire.plugin.version>3.5.1</maven.surefire.plugin.version>
     <!-- Dependency versions -->
     <antlr.version>4.9.3</antlr.version>
-    <apache-directory-server.version>1.5.7</apache-directory-server.version>
+    <apache-directory-server.version>2.0.0-M24</apache-directory-server.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
@@ -453,6 +453,10 @@
           <exclusion>
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Please refer to [HIVE-28163](https://issues.apache.org/jira/browse/HIVE-28163) and stale PR: https://github.com/apache/hive/pull/5171


### Why are the changes needed?
When running with jdk17, there were failure in service module regarding apache directory server.
```
mvn test -Dtest='org.apache.hive.service.auth.TestLdapAtnProviderWithMiniDS#testGroupFilterPositive' -pl service
```

### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
YES. Here's the dependency tree:  [dependency-tree.txt](https://github.com/user-attachments/files/19565085/dependency-tree.txt)


### How was this patch tested?
In cluster