### PR TITLE
HIVE-28868: Print AM hostname on console

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezRuntimeContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezRuntimeContext.java
@@ -18,10 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec.tez;
 
-import java.util.Optional;
-
 import org.apache.hadoop.hive.ql.exec.tez.monitoring.TezJobMonitor;
-import org.apache.tez.client.TezClient;
 import org.apache.tez.common.counters.CounterGroup;
 import org.apache.tez.common.counters.TezCounters;
 
@@ -90,14 +87,6 @@ public class TezRuntimeContext {
 
   public String getAmAddress() {
     return amAddress;
-  }
-
-  /**
-   * Convenience method to retrieve the AM hostname for callers that are not interested in the port.
-   * @return AM hostname
-   */
-  public String getAmHostName() {
-    return Optional.of(amAddress).map(address -> address.split(":")[0]).get();
   }
 
   public TezJobMonitor getMonitor() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezRuntimeContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezRuntimeContext.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hive.ql.exec.tez;
 
+import java.util.Optional;
+
 import org.apache.hadoop.hive.ql.exec.tez.monitoring.TezJobMonitor;
 import org.apache.tez.client.TezClient;
 import org.apache.tez.common.counters.CounterGroup;
@@ -88,6 +90,14 @@ public class TezRuntimeContext {
 
   public String getAmAddress() {
     return amAddress;
+  }
+
+  /**
+   * Convenience method to retrieve the AM hostname for callers that are not interested in the port.
+   * @return AM hostname
+   */
+  public String getAmHostName() {
+    return Optional.of(amAddress).map(address -> address.split(":")[0]).get();
   }
 
   public TezJobMonitor getMonitor() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -268,8 +268,8 @@ public class TezTask extends Task<TezWork> {
         // Log all the info required to find the various logs for this query
         String dagId = this.dagClient.getDagIdentifierString();
         String appId = this.dagClient.getSessionIdentifierString();
-        LOG.info("HS2 Host: [{}], Query ID: [{}], Dag ID: [{}], DAG App ID: [{}]", ServerUtils.hostname(), queryId,
-            dagId, appId);
+        LOG.info("HS2 Host: [{}], Query ID: [{}], Dag ID: [{}], DAG App ID: [{}], DAG App address: [{}]",
+            ServerUtils.hostname(), queryId, dagId, appId, runtimeContext.getAmHostName());
         LogUtils.putToMDC(LogUtils.DAGID_KEY, dagId);
         this.jobID = dagId;
         runtimeContext.setDagId(dagId);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -269,7 +269,7 @@ public class TezTask extends Task<TezWork> {
         String dagId = this.dagClient.getDagIdentifierString();
         String appId = this.dagClient.getSessionIdentifierString();
         LOG.info("HS2 Host: [{}], Query ID: [{}], Dag ID: [{}], DAG App ID: [{}], DAG App address: [{}]",
-            ServerUtils.hostname(), queryId, dagId, appId, runtimeContext.getAmHostName());
+            ServerUtils.hostname(), queryId, dagId, appId, session.getSession().getAmHost());
         LogUtils.putToMDC(LogUtils.DAGID_KEY, dagId);
         this.jobID = dagId;
         runtimeContext.setDagId(dagId);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Print AM hostname on the console.

### Why are the changes needed?
Because on DAG submission, the user ends up seeing an application id, which is hard to track back to a Tez AM / coordinator, making the investigation hard. Imagine a long-running query on a cluster that utilizes 30+ Tez AMs, and in case of e.g. a kubernetes environment, logical hostnames are used, like TezAM1, TezAM2...by knowing only the DAG id and application id, there will always be an extra step to locate the AM, which could be painful if the app id <-> hostname pair is only printed once a few hours (days?) ago, if it logged at all (need to be aware that the application can be alive since "forever").


### Does this PR introduce _any_ user-facing change?
Yes, on DAG submission, not only the AM app id, but the app master's hostname will be printed.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Tested on cluster, check screenshot:
https://issues.apache.org/jira/secure/attachment/13075767/Screenshot%202025-04-02%20at%2014.53.49.png
