### PR TITLE
HIVE-28881: Ambiguous column reference is not detected in GROUP BY query.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -3800,26 +3800,21 @@ public class CalcitePlanner extends SemanticAnalyzer {
         groupByOutputRowResolver.setIsExprResolver(true);
 
         if (hasGrpByAstExprs) {
-          try {
-            groupByInputRowResolver.setCheckForAmbiguity(true);
-            // 4. Construct GB Keys (ExprNode)
-            for (int i = 0; i < groupByNodes.size(); ++i) {
-              ASTNode groupByNode = groupByNodes.get(i);
-              Map<ASTNode, RexNode> astToRexNodeMap = genAllRexNode(
-                      groupByNode, groupByInputRowResolver, cluster.getRexBuilder());
-              RexNode groupByExpression = astToRexNodeMap.get(groupByNode);
-              if (groupByExpression == null) {
-                throw new CalciteSemanticException("Invalid Column Reference: " + groupByNode.dump(),
-                        UnsupportedFeature.Invalid_column_reference);
-              }
-
-              addToGBExpr(groupByOutputRowResolver, groupByInputRowResolver, groupByNode,
-                      groupByExpression, groupByExpressions, outputColumnNames);
+          groupByInputRowResolver.setCheckForAmbiguity(true);
+          // 4. Construct GB Keys (ExprNode)
+          for (ASTNode groupByNode : groupByNodes) {
+            Map<ASTNode, RexNode> astToRexNodeMap = genAllRexNode(
+                    groupByNode, groupByInputRowResolver, cluster.getRexBuilder());
+            RexNode groupByExpression = astToRexNodeMap.get(groupByNode);
+            if (groupByExpression == null) {
+              throw new CalciteSemanticException("Invalid Column Reference: " + groupByNode.dump(),
+                      UnsupportedFeature.Invalid_column_reference);
             }
+
+            addToGBExpr(groupByOutputRowResolver, groupByInputRowResolver, groupByNode,
+                    groupByExpression, groupByExpressions, outputColumnNames);
           }
-          finally {
-            groupByInputRowResolver.setCheckForAmbiguity(false);
-          }
+          groupByInputRowResolver.setCheckForAmbiguity(false);
         }
 
         // 5. GroupingSets, Cube, Rollup

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -3800,19 +3800,25 @@ public class CalcitePlanner extends SemanticAnalyzer {
         groupByOutputRowResolver.setIsExprResolver(true);
 
         if (hasGrpByAstExprs) {
-          // 4. Construct GB Keys (ExprNode)
-          for (int i = 0; i < groupByNodes.size(); ++i) {
-            ASTNode groupByNode = groupByNodes.get(i);
-            Map<ASTNode, RexNode> astToRexNodeMap = genAllRexNode(
-                groupByNode, groupByInputRowResolver, cluster.getRexBuilder());
-            RexNode groupByExpression = astToRexNodeMap.get(groupByNode);
-            if (groupByExpression == null) {
-              throw new CalciteSemanticException("Invalid Column Reference: " + groupByNode.dump(),
-                  UnsupportedFeature.Invalid_column_reference);
-            }
+          try {
+            groupByInputRowResolver.setCheckForAmbiguity(true);
+            // 4. Construct GB Keys (ExprNode)
+            for (int i = 0; i < groupByNodes.size(); ++i) {
+              ASTNode groupByNode = groupByNodes.get(i);
+              Map<ASTNode, RexNode> astToRexNodeMap = genAllRexNode(
+                      groupByNode, groupByInputRowResolver, cluster.getRexBuilder());
+              RexNode groupByExpression = astToRexNodeMap.get(groupByNode);
+              if (groupByExpression == null) {
+                throw new CalciteSemanticException("Invalid Column Reference: " + groupByNode.dump(),
+                        UnsupportedFeature.Invalid_column_reference);
+              }
 
-            addToGBExpr(groupByOutputRowResolver, groupByInputRowResolver, groupByNode,
-                groupByExpression, groupByExpressions, outputColumnNames);
+              addToGBExpr(groupByOutputRowResolver, groupByInputRowResolver, groupByNode,
+                      groupByExpression, groupByExpressions, outputColumnNames);
+            }
+          }
+          finally {
+            groupByInputRowResolver.setCheckForAmbiguity(false);
           }
         }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -3804,15 +3804,15 @@ public class CalcitePlanner extends SemanticAnalyzer {
           // 4. Construct GB Keys (ExprNode)
           for (ASTNode groupByNode : groupByNodes) {
             Map<ASTNode, RexNode> astToRexNodeMap = genAllRexNode(
-                    groupByNode, groupByInputRowResolver, cluster.getRexBuilder());
+                groupByNode, groupByInputRowResolver, cluster.getRexBuilder());
             RexNode groupByExpression = astToRexNodeMap.get(groupByNode);
             if (groupByExpression == null) {
               throw new CalciteSemanticException("Invalid Column Reference: " + groupByNode.dump(),
-                      UnsupportedFeature.Invalid_column_reference);
+                  UnsupportedFeature.Invalid_column_reference);
             }
 
             addToGBExpr(groupByOutputRowResolver, groupByInputRowResolver, groupByNode,
-                    groupByExpression, groupByExpressions, outputColumnNames);
+                groupByExpression, groupByExpressions, outputColumnNames);
           }
           groupByInputRowResolver.setCheckForAmbiguity(false);
         }

--- a/ql/src/test/queries/clientnegative/cbo_ambiguous_colref_in_gby.q
+++ b/ql/src/test/queries/clientnegative/cbo_ambiguous_colref_in_gby.q
@@ -1,0 +1,7 @@
+create table t1 (a int);
+
+explain cbo
+select s.a from
+  (select a, a from t1) s
+group by s.a
+;

--- a/ql/src/test/results/clientnegative/cbo_ambiguous_colref_in_gby.q.out
+++ b/ql/src/test/results/clientnegative/cbo_ambiguous_colref_in_gby.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table t1 (a int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (a int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+FAILED: SemanticException Ambiguous column reference: s.a


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Check for ambiguity when building expressions of group by keys.

### Why are the changes needed?
Ambiguous column references are not detected.

### Does this PR introduce _any_ user-facing change?
Yes, exception is thrown when ambiguous column references are found in group by key expressions.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestNegativeLlapLocalCliDriver -Dqfile=cbo_ambiguous_colref_in_gby.q -pl itests/qtest -Pitests
```