### PR TITLE
HIVE-27424: Display dependency:tree in GitHub actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,13 +37,6 @@ If possible, please also clarify if this is a user-facing change compared to the
 If no, write 'No'.
 -->
 
-### Is the change a dependency upgrade?
-<!--
-If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
-If no, write 'No'.
--->
-
-
 ### How was this patch tested?
 <!--
 If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,5 @@ jobs:
       - name: 'Build project'
         run: |
           mvn clean install -DskipTests -Pitests
+      - name: 'Dependency tree'
+        run: mvn dependency:tree -Pitests


### PR DESCRIPTION
### Why are the changes needed?
1. Avoid forcing contributors to upload the dependency tree, which can also be wrong or obsolete. 
2. Avoid having to check and fill an extra field on every submitted PR.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Inspect output of the macOs (JDK 8) action and verify that dependency tree is shown in the logs.