### PR TITLE
HIVE-28897: Set logging level to warn for missing proto.base-directory when running schematool

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/schematool/HiveSchemaTool.java
+++ b/beeline/src/java/org/apache/hive/beeline/schematool/HiveSchemaTool.java
@@ -135,11 +135,11 @@ public class HiveSchemaTool extends MetastoreSchemaTool {
     Map<String, String> replacements = new HashMap<>();
 
     if (isEmpty(hiveProtoBaseDir)) {
-      LOG.error("Hive conf variable hive.hook.proto.base-directory is not set for creating protologging tables");
+      LOG.warn("Hive conf variable hive.hook.proto.base-directory is not set for creating protologging tables");
       hiveProtoLoggingEnabled = false;
     }
     if (isEmpty(tezProtoBaseDir)) {
-      LOG.error("Tez conf variable tez.history.logging.proto-base-dir is not set for creating protologging tables");
+      LOG.warn("Tez conf variable tez.history.logging.proto-base-dir is not set for creating protologging tables");
       tezProtoLoggingEnabled = false;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-28897](https://issues.apache.org/jira/browse/HIVE-28897), for the details


### Why are the changes needed?
To prevent ERROR logs in schematool if `hive.hook.proto.base-directory` and `tez.history.logging.proto-base-dir` is not set, which could be misleading


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO


### How was this patch tested?
On local single node cluster.
