### PR TITLE
HIVE-28900: Make the objectstore-secondary connection pool size configurable

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -700,11 +700,10 @@ public class MetastoreConf {
             "configured with embedded metastore. To get optimal performance, set config to meet the following condition\n"+
             "(2 * pool_size * metastore_instances + 2 * pool_size * HS2_instances_with_embedded_metastore) = \n" +
             "(2 * physical_core_count + hard_disk_count)."),
-    CONNECTION_POOLING_MAX_SECONDARY_CONNECTIONS("datanucleus.connectionPool.maxSecondaryPoolSize",
-            "datanucleus.connectionPool.maxSecondaryPoolSize", 2,
-            "Specify the maximum number of connections in the objectstore-secondary connection pool.\n" +
-                    "Same as datanucleus.connectionPool.maxPoolSize, but for the objectstore-secondary pool. \n" +
-                    "Note that this is not a valid datanucleus configuration, this is used only in Hive.\n" +
+    CONNECTION_POOLING_MAX_SECONDARY_CONNECTIONS("datanucleus.connectionPool.secondary.maxPoolSize",
+            "datanucleus.connectionPool.secondary.maxPoolSize", 2,
+            "Specify the maximum number of connections in the secondary connection pools (objectstore-secondary, objectstore-compactor-secondary).\n" +
+                    "Same as datanucleus.connectionPool.maxPoolSize, but for the objectstore-secondary and objectstore-compactor-secondary pools. \n" +
                     "Values smaller than 2 are ignored."),
     CONNECT_URL_HOOK("metastore.ds.connection.url.hook",
         "hive.metastore.ds.connection.url.hook", "",

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -700,6 +700,12 @@ public class MetastoreConf {
             "configured with embedded metastore. To get optimal performance, set config to meet the following condition\n"+
             "(2 * pool_size * metastore_instances + 2 * pool_size * HS2_instances_with_embedded_metastore) = \n" +
             "(2 * physical_core_count + hard_disk_count)."),
+    CONNECTION_POOLING_MAX_SECONDARY_CONNECTIONS("datanucleus.connectionPool.maxSecondaryPoolSize",
+            "datanucleus.connectionPool.maxSecondaryPoolSize", 2,
+            "Specify the maximum number of connections in the objectstore-secondary connection pool.\n" +
+                    "Same as datanucleus.connectionPool.maxPoolSize, but for the objectstore-secondary pool. \n" +
+                    "Note that this is not a valid datanucleus configuration, this is used only in Hive.\n" +
+                    "Values smaller than 2 are ignored."),
     CONNECT_URL_HOOK("metastore.ds.connection.url.hook",
         "hive.metastore.ds.connection.url.hook", "",
         "Name of the hook to use for retrieving the JDO connection URL. If empty, the value in javax.jdo.option.ConnectionURL is used"),

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PersistenceManagerProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PersistenceManagerProvider.java
@@ -314,10 +314,9 @@ public class PersistenceManagerProvider {
         ds = (maxPoolSize > 0) ? dsp.create(conf, maxPoolSize) : dsp.create(conf);
         databaseProduct = DatabaseProduct.determineDatabaseProduct(ds, conf);
         // The secondary connection factory is used for schema generation, and for value generation operations.
-        // We should use a different pool for the secondary connection factory to avoid resource starvation.
+        // We use a different pool for the secondary connection factory to avoid resource starvation.
         // DataNucleus uses locks for schema generation and value generation, under normal circumstances 2 connections
-        // should be sufficient. However, as found in HIVE-28839 in certain situations connection starvation may happen,
-        // so we need to make this configurable until a final fix is not available.
+        // should be sufficient.
         configurator.resetName(sourceName + "-secondary");
         int maxSecondaryPoolSize = Math.max(2, MetastoreConf.getIntVar(conf, ConfVars.CONNECTION_POOLING_MAX_SECONDARY_CONNECTIONS));
         ds2 = dsp.create(conf, maxSecondaryPoolSize);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
@@ -100,7 +100,7 @@ public class TestDataSourceProviderFactory {
   }
 
   @Test
-  public void testHikariCpMaxPoolSize() throws SQLException {
+  public void testHikariCpMaxPoolSize() {
     MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
     PersistenceManagerProvider.updatePmfProperties(conf);
     PersistenceManagerFactory pmf =

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
@@ -100,6 +100,18 @@ public class TestDataSourceProviderFactory {
   }
 
   @Test
+  public void testHikariCpMaxPoolSize() throws SQLException {
+    MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
+    PersistenceManagerProvider.updatePmfProperties(conf);
+    PersistenceManagerFactory pmf =
+            PersistenceManagerProvider.getPersistenceManager().getPersistenceManagerFactory();
+    HikariDataSource hikariDs = (HikariDataSource) pmf.getConnectionFactory();
+    HikariDataSource hikariDs2 = (HikariDataSource) pmf.getConnectionFactory2();
+    Assert.assertEquals(hikariDs.getMaximumPoolSize(), MetastoreConf.getIntVar(conf, ConfVars.CONNECTION_POOLING_MAX_CONNECTIONS));
+    Assert.assertEquals(hikariDs2.getMaximumPoolSize(), MetastoreConf.getIntVar(conf, ConfVars.CONNECTION_POOLING_MAX_SECONDARY_CONNECTIONS));
+  }
+
+  @Test
   public void testCreateHikariCpDataSource() throws SQLException {
 
     MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);


### PR DESCRIPTION
### What changes were proposed in this pull request?

The secondary connection factory is used for schema generation, and for value generation operations. Under normal circumstances 2 connections should be sufficient, and currently it is hardcoded to that value. We have found in [HIVE-28839](https://issues.apache.org/jira/browse/HIVE-28839) that connection starvation may still happen. (in that case due to a datanucleus bug)
We should make the "objectstore-secondary" pool size configurable. This is needed at least until a final fix is not available for [HIVE-28839](https://issues.apache.org/jira/browse/HIVE-28839), but probably it is good to have on the long run if we hit other edge cases.

### Why are the changes needed?
The "objectstore-secondary" pool size is currently hardcoded to 2.
The "datanucleus.connectionPool.maxPoolSize" controls the "objectstore" poolsize, I propose we introduce a new configuration as "datanucleus.connectionPool.secondary.maxPoolSize" to control the number of connections in the "objectstore-secondary" and "objectstore-compactor-secondary" pools.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
As I see there are no automated tests for the pool handling, so I made a manual test:
- Set the "datanucleus.connectionPool.secondary.maxPoolSize" new config item in the HMS hive-site.xml, and observed the new size is now is logged out:
`2025-04-11T13:09:25,881  INFO [main] datasource.HikariCPDataSourceProvider: Creating Hikari connection pool for the MetaStore, maxPoolSize: 4, name: objectstore-secondary`
- Observed that the number of database connections increased on my MySQL side ("show processlist" output)
- Note that this changes the "objectstore-compactor-secondary" pool size also from 2 to the new size.
- Added a new testcase TestDataSourceProviderFactory#testHikariCpMaxPoolSize, it tests the max pool sizes with HikariCP.