### PR TITLE
HIVE-28902: Fix unknown column PARTITION_NAME in aggrStatsUseDB

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -1994,7 +1994,7 @@ class MetaStoreDirectSql {
     // Extrapolation is not needed.
     if (areAllPartsFound) {
       queryText = commonPrefix + " and \"COLUMN_NAME\" in (" + makeParams(colNames.size()) + ")"
-          + " and \"PARTITION_NAME\" in (" + makeParams(partNames.size()) + ")"
+          + " and " + PARTITIONS + ".\"PART_NAME\" in (" + makeParams(partNames.size()) + ")"
           + " and \"ENGINE\" = ? "
           + " group by \"COLUMN_NAME\", \"COLUMN_TYPE\"";
       start = doTrace ? System.nanoTime() : 0;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the sql in direct SQL implement of `aggrStatsUseDB`.


### Why are the changes needed?
https://github.com/apache/hive/pull/4744 remove `PARTITION_NAME` column from `PART_COL_STATS` table, it would throw exception now:
```bash
java.sql.SQLSyntaxErrorException: Unknown column 'PARTITION_NAME' in 'where clause'
```


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Add unit test:
```bash
mvn test -Dtest.groups= -Dtest=org.apache.hadoop.hive.metastore.TestObjectStore#testAggrStatsUseDB -pl :hive-standalone-metastore-server
```
