### PR TITLE
HIVE-28903: Skip deleting archived path when drop partition/table

### DIFF
--- a/ql/src/test/queries/clientpositive/archive_drop.q
+++ b/ql/src/test/queries/clientpositive/archive_drop.q
@@ -1,0 +1,24 @@
+set hive.mapred.mode=nonstrict;
+set hive.archive.enabled = true;
+
+create database test_db;
+
+create table test_db.test_tbl (id int, name string) partitioned by (dt date, hr string);
+
+insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='11') select 1, 'tom';
+insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='12') select 2, 'jerry';
+insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='13') select 3, 'spike';
+
+show partitions test_db.test_tbl;
+
+alter table test_db.test_tbl archive partition (dt='2025-04-01');
+
+show partitions test_db.test_tbl;
+
+alter table test_db.test_tbl drop partition (dt='2025-04-01',hr='12');
+
+show partitions test_db.test_tbl;
+
+select * from test_db.test_tbl;
+
+drop table test_db.test_tbl;

--- a/ql/src/test/queries/clientpositive/archive_drop.q
+++ b/ql/src/test/queries/clientpositive/archive_drop.q
@@ -12,10 +12,14 @@ insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='13') sel
 show partitions test_db.test_tbl;
 
 alter table test_db.test_tbl archive partition (dt='2025-04-01');
+dfs -ls ${hiveconf:hive.metastore.warehouse.dir}/test_db.db/test_tbl/dt=2025-04-01/;
+dfs -ls ${hiveconf:hive.metastore.warehouse.dir}/test_db.db/test_tbl/dt=2025-04-01/data.har/;
 
 show partitions test_db.test_tbl;
 
 alter table test_db.test_tbl drop partition (dt='2025-04-01',hr='12');
+dfs -ls ${hiveconf:hive.metastore.warehouse.dir}/test_db.db/test_tbl/dt=2025-04-01/;
+dfs -ls ${hiveconf:hive.metastore.warehouse.dir}/test_db.db/test_tbl/dt=2025-04-01/data.har/;
 
 show partitions test_db.test_tbl;
 

--- a/ql/src/test/results/clientpositive/llap/archive_drop.q.out
+++ b/ql/src/test/results/clientpositive/llap/archive_drop.q.out
@@ -63,6 +63,10 @@ POSTHOOK: Input: test_db@test_tbl
 POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=11
 POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=12
 POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=13
+Found 1 items
+#### A masked pattern was here ####
+Found 4 items
+#### A masked pattern was here ####
 PREHOOK: query: show partitions test_db.test_tbl
 PREHOOK: type: SHOWPARTITIONS
 PREHOOK: Input: test_db@test_tbl
@@ -80,6 +84,10 @@ POSTHOOK: query: alter table test_db.test_tbl drop partition (dt='2025-04-01',hr
 POSTHOOK: type: ALTERTABLE_DROPPARTS
 POSTHOOK: Input: test_db@test_tbl
 POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=12
+Found 1 items
+#### A masked pattern was here ####
+Found 4 items
+#### A masked pattern was here ####
 PREHOOK: query: show partitions test_db.test_tbl
 PREHOOK: type: SHOWPARTITIONS
 PREHOOK: Input: test_db@test_tbl

--- a/ql/src/test/results/clientpositive/llap/archive_drop.q.out
+++ b/ql/src/test/results/clientpositive/llap/archive_drop.q.out
@@ -1,0 +1,114 @@
+PREHOOK: query: create database test_db
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Output: database:test_db
+POSTHOOK: query: create database test_db
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Output: database:test_db
+PREHOOK: query: create table test_db.test_tbl (id int, name string) partitioned by (dt date, hr string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:test_db
+PREHOOK: Output: test_db@test_tbl
+POSTHOOK: query: create table test_db.test_tbl (id int, name string) partitioned by (dt date, hr string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:test_db
+POSTHOOK: Output: test_db@test_tbl
+PREHOOK: query: insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='11') select 1, 'tom'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=11
+POSTHOOK: query: insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='11') select 1, 'tom'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=11
+POSTHOOK: Lineage: test_tbl PARTITION(dt=2025-04-01,hr=11).id SIMPLE []
+POSTHOOK: Lineage: test_tbl PARTITION(dt=2025-04-01,hr=11).name SIMPLE []
+PREHOOK: query: insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='12') select 2, 'jerry'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=12
+POSTHOOK: query: insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='12') select 2, 'jerry'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=12
+POSTHOOK: Lineage: test_tbl PARTITION(dt=2025-04-01,hr=12).id SIMPLE []
+POSTHOOK: Lineage: test_tbl PARTITION(dt=2025-04-01,hr=12).name SIMPLE []
+PREHOOK: query: insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='13') select 3, 'spike'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=13
+POSTHOOK: query: insert overwrite table test_db.test_tbl partition (dt='2025-04-01', hr='13') select 3, 'spike'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=13
+POSTHOOK: Lineage: test_tbl PARTITION(dt=2025-04-01,hr=13).id SIMPLE []
+POSTHOOK: Lineage: test_tbl PARTITION(dt=2025-04-01,hr=13).name SIMPLE []
+PREHOOK: query: show partitions test_db.test_tbl
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: test_db@test_tbl
+POSTHOOK: query: show partitions test_db.test_tbl
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: test_db@test_tbl
+dt=2025-04-01/hr=11
+dt=2025-04-01/hr=12
+dt=2025-04-01/hr=13
+PREHOOK: query: alter table test_db.test_tbl archive partition (dt='2025-04-01')
+PREHOOK: type: ALTERTABLE_ARCHIVE
+PREHOOK: Input: test_db@test_tbl
+PREHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=11
+PREHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=12
+PREHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=13
+POSTHOOK: query: alter table test_db.test_tbl archive partition (dt='2025-04-01')
+POSTHOOK: type: ALTERTABLE_ARCHIVE
+POSTHOOK: Input: test_db@test_tbl
+POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=11
+POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=12
+POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=13
+PREHOOK: query: show partitions test_db.test_tbl
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: test_db@test_tbl
+POSTHOOK: query: show partitions test_db.test_tbl
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: test_db@test_tbl
+dt=2025-04-01/hr=11
+dt=2025-04-01/hr=12
+dt=2025-04-01/hr=13
+PREHOOK: query: alter table test_db.test_tbl drop partition (dt='2025-04-01',hr='12')
+PREHOOK: type: ALTERTABLE_DROPPARTS
+PREHOOK: Input: test_db@test_tbl
+PREHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=12
+POSTHOOK: query: alter table test_db.test_tbl drop partition (dt='2025-04-01',hr='12')
+POSTHOOK: type: ALTERTABLE_DROPPARTS
+POSTHOOK: Input: test_db@test_tbl
+POSTHOOK: Output: test_db@test_tbl@dt=2025-04-01/hr=12
+PREHOOK: query: show partitions test_db.test_tbl
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: test_db@test_tbl
+POSTHOOK: query: show partitions test_db.test_tbl
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: test_db@test_tbl
+dt=2025-04-01/hr=11
+dt=2025-04-01/hr=13
+PREHOOK: query: select * from test_db.test_tbl
+PREHOOK: type: QUERY
+PREHOOK: Input: test_db@test_tbl
+PREHOOK: Input: test_db@test_tbl@dt=2025-04-01/hr=11
+PREHOOK: Input: test_db@test_tbl@dt=2025-04-01/hr=13
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_db.test_tbl
+POSTHOOK: type: QUERY
+POSTHOOK: Input: test_db@test_tbl
+POSTHOOK: Input: test_db@test_tbl@dt=2025-04-01/hr=11
+POSTHOOK: Input: test_db@test_tbl@dt=2025-04-01/hr=13
+#### A masked pattern was here ####
+1	tom	2025-04-01	11
+3	spike	2025-04-01	13
+PREHOOK: query: drop table test_db.test_tbl
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: test_db@test_tbl
+PREHOOK: Output: database:test_db
+PREHOOK: Output: test_db@test_tbl
+POSTHOOK: query: drop table test_db.test_tbl
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: test_db@test_tbl
+POSTHOOK: Output: database:test_db
+POSTHOOK: Output: test_db@test_tbl

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.HarFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.hive.metastore.ReplChangeManager.RecycleType;
@@ -467,6 +468,10 @@ public class Warehouse {
       }
     }
     FileSystem fs = getFs(f);
+    if (fs instanceof HarFileSystem) {
+      LOG.warn("Har path {} is not supported to delete, skipping it.", f);
+      return true;
+    }
     return fsHandler.deleteDir(fs, f, recursive, ifPurge, conf);
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -3179,7 +3179,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         wh.deleteDir(path, true, ifPurge, shouldEnableCm);
       }
     } catch (Exception e) {
-      LOG.error("Failed to delete directory: " + path, e);
+      LOG.error("Failed to delete directory: {}", path, e);
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -3179,8 +3179,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         wh.deleteDir(path, true, ifPurge, shouldEnableCm);
       }
     } catch (Exception e) {
-      LOG.error("Failed to delete directory: " + path +
-          " " + e.getMessage());
+      LOG.error("Failed to delete directory: " + path, e);
     }
   }
 
@@ -5134,14 +5133,15 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         throw new NoSuchObjectException("Partition doesn't exist. " + part_vals);
       }
       isArchived = MetaStoreUtils.isArchived(part);
-      if (tableDataShouldBeDeleted && isArchived) {
-        archiveParentDir = MetaStoreUtils.getOriginalLocation(part);
-        verifyIsWritablePath(archiveParentDir);
-      }
-
-      if (tableDataShouldBeDeleted && (part.getSd() != null) && (part.getSd().getLocation() != null)) {
-        partPath = new Path(part.getSd().getLocation());
-        verifyIsWritablePath(partPath);
+      if (tableDataShouldBeDeleted) {
+        if (isArchived) {
+          // Archived partition is only able to delete original location.
+          archiveParentDir = MetaStoreUtils.getOriginalLocation(part);
+          verifyIsWritablePath(archiveParentDir);
+        } else if ((part.getSd() != null) && (part.getSd().getLocation() != null)) {
+          partPath = new Path(part.getSd().getLocation());
+          verifyIsWritablePath(partPath);
+        }
       }
 
       String partName = Warehouse.makePartName(tbl.getPartitionKeys(), part_vals);
@@ -5381,15 +5381,17 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         if (colNames != null) {
           partNames.add(FileUtils.makePartName(colNames, part.getValues()));
         }
-        if (tableDataShouldBeDeleted && MetaStoreUtils.isArchived(part)) {
-          Path archiveParentDir = MetaStoreUtils.getOriginalLocation(part);
-          verifyIsWritablePath(archiveParentDir);
-          archToDelete.add(archiveParentDir);
-        }
-        if (tableDataShouldBeDeleted && (part.getSd() != null) && (part.getSd().getLocation() != null)) {
-          Path partPath = new Path(part.getSd().getLocation());
-          verifyIsWritablePath(partPath);
-          dirsToDelete.add(new PathAndDepth(partPath, part.getValues().size()));
+        if (tableDataShouldBeDeleted) {
+          if (MetaStoreUtils.isArchived(part)) {
+            // Archived partition is only able to delete original location.
+            Path archiveParentDir = MetaStoreUtils.getOriginalLocation(part);
+            verifyIsWritablePath(archiveParentDir);
+            archToDelete.add(archiveParentDir);
+          } else if ((part.getSd() != null) && (part.getSd().getLocation() != null)) {
+            Path partPath = new Path(part.getSd().getLocation());
+            verifyIsWritablePath(partPath);
+            dirsToDelete.add(new PathAndDepth(partPath, part.getValues().size()));
+          }
         }
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When drop archived partition/table, only the original path of partition should be considered as a deletion candidate

### Why are the changes needed?
Hadoop archived path is not supported to be deleted, in current implement the drop_partition/table calls would drop metadata successfully but throw exception when deleting the archived paths.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
- Add a qtest
```bash
mvn test -pl itests/qtest -Pitests -Dtest=org.apache.hadoop.hive.cli.TestMiniLlapLocalCliDriver -Dqfile=archive_drop.q
```
- Test locally by sql:
```sql
-- create a table
create table tbl (id int) partitioned by (dt date, region string);

SET hive.execution.engine=mr;
insert overwrite table tbl partition (dt='2025-01-01', region='us') select 1;
insert overwrite table tbl partition (dt='2025-01-01', region='sg') select 2;

-- change to managed table
ALTER TABLE tbl SET TBLPROPERTIES ('EXTERNAL'='FALSE');

-- archive partitions
SET hive.archive.enabled=true;
ALTER TABLE tbl ARCHIVE PARTITION (dt='2025-01-01');

-- drop partition
alter table tbl drop partition (dt='2025-01-01', region='us');

-- drop table
drop table tbl;
```
