### PR TITLE
HIVE-28618: TestGenericUDTFGetSQLSchema to run on Tez

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
@@ -556,8 +556,9 @@ public final class ParseUtils {
       throws SemanticException, ParseException {
     final Context ctx = new Context(conf);
     ctx.setIsLoadingMaterializedView(true);
+    final QueryState qs = new QueryState.Builder().withHiveConf(conf).build();
     final ASTNode ast = parse(viewQuery, ctx);
-    final CalcitePlanner analyzer = getAnalyzer(conf, ctx);
+    final BaseSemanticAnalyzer analyzer = SemanticAnalyzerFactory.get(qs, ast);
     analyzer.analyze(ast, ctx);
     return analyzer.getResultSchema();
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDTFGetSQLSchema.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDTFGetSQLSchema.java
@@ -87,9 +87,6 @@ public class TestGenericUDTFGetSQLSchema {
 
   @Test
   public void testWithDDL() throws Exception {
-    // Set the execution engine to mr to avoid the NPE exception in stats flow
-    // TODO: HIVE-28618: TestGenericUDTFGetSQLSchema to run on Tez
-    conf.set("hive.execution.engine", "mr");
     invokeUDTFAndTest("show tables", new String[]{});
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Let `TestGenericUDTFGetSQLSchema.testWithDDL` on Tez.
https://issues.apache.org/jira/browse/HIVE-28618

On Tez, we see the NPE when we run [StatsRulesProcFactory](https://github.com/apache/hive/blob/be59bd0b445096e431c18bbfa0d682c78ba18b76/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java#L177), which is triggered by [TezCompiler](https://github.com/apache/hive/blob/be59bd0b445096e431c18bbfa0d682c78ba18b76/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java#L202). `SHOW TABLES` is a DDL that doesn't scan a regular table. So, some attributes are missing.

On MapReduce, [StatsRulesProcFactory is not enabled unless isExplainSkipExecution is enabled](https://github.com/apache/hive/blob/be59bd0b445096e431c18bbfa0d682c78ba18b76/ql/src/java/org/apache/hadoop/hive/ql/optimizer/Optimizer.java#L214-L217). As far as I tested it, it is skipped when we pass `SHOW TABLES` to the UDF. I've not detailed the intention as MR is already deprecated.

This change will let the UDF choose a correct SemanticAnalyzer based on the statement. I think this change is safe as long as I see the usage of `ParseUtils. parseQueryAndGetSchema`.
- [GenericUDTFGetSQLSchema](https://github.com/apache/hive/blob/be59bd0b445096e431c18bbfa0d682c78ba18b76/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSQLSchema.java#L70)
- [GenericUDTFGetSplits](https://github.com/apache/hive/blob/be59bd0b445096e431c18bbfa0d682c78ba18b76/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSplits.java#L289-L295)

### Why are the changes needed?

To discontinue Hive on MR.

### Does this PR introduce _any_ user-facing change?

The behavior of GenericUDTFGetSQLSchema will be consistent with MapReduce.

### How was this patch tested?

Updated the unit test
