### PR TITLE
HIVE-28916: Fix unbalannced calls in ObjectStore rollback transaction

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -3247,12 +3247,10 @@ public class ObjectStore implements RawStore, Configurable {
   public Partition getPartitionWithAuth(String catName, String dbName, String tblName,
       List<String> partVals, String user_name, List<String> group_names)
       throws NoSuchObjectException, MetaException, InvalidObjectException {
-    boolean success = false;
     try {
       openTransaction();
       MPartition mpart = getMPartition(catName, dbName, tblName, partVals, null);
       if (mpart == null) {
-        success = commitTransaction();
         throw new NoSuchObjectException("partition values="
             + partVals.toString());
       }
@@ -3267,10 +3265,9 @@ public class ObjectStore implements RawStore, Configurable {
         part.setPrivileges(partAuth);
       }
 
-      success = commitTransaction();
       return part;
     } finally {
-      rollbackAndCleanup(success, null);
+      commitTransaction();
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -3252,7 +3252,7 @@ public class ObjectStore implements RawStore, Configurable {
       openTransaction();
       MPartition mpart = getMPartition(catName, dbName, tblName, partVals, null);
       if (mpart == null) {
-        commitTransaction();
+        success = commitTransaction();
         throw new NoSuchObjectException("partition values="
             + partVals.toString());
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the bug in `ObjectStore#openTransaction` and `ObjectStore#rollbackTransaction`.


### Why are the changes needed?
Currently `rollbackTransaction()` always reset `openTransactionCalls` to 0, but it would cause unbalanced issue in nested transaction calls, for example:
```bash
openTransaction()
  // new function1
  {
    openTransaction()
    commitTransaction() # place1
  }

  // new function2
  {
    openTransaction()
    commitTransaction()
  }
commitTransaction() # place2
```
If the new function1 rollbackTransaction in place1, then it would get unbalanced exception in place2.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add a unit test:
```bash
mvn test -Dtest.groups= -Dtest=org.apache.hadoop.hive.metastore.TestObjectStore#testNestedTransaction -pl :hive-standalone-metastore-server
```
