### PR TITLE
HIVE-28929: TestEmbeddedHiveMetaStore#testAlterTable fails while trying to create managed directory

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetastoreTransformer.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetastoreTransformer.java
@@ -103,8 +103,8 @@ public class TestMetastoreTransformer {
     client.dropTable(dbName, tblName);
     silentDropDatabase(dbName);
 
-    String dbLocation = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE_EXTERNAL) + "/_testDB_table_create_";
-    String mgdLocation = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE) + "/_testDB_table_create_";
+    String dbLocation = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE_EXTERNAL) + "/testAlterTableIsCaseInSensitive";
+    String mgdLocation = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE) + "/testAlterTableIsCaseInSensitive";
     new DatabaseBuilder().setName(dbName).setLocation(dbLocation).setManagedLocation(mgdLocation).create(client, conf);
 
     ArrayList<FieldSchema> invCols = new ArrayList<>(2);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the database path for TestMetastoreTransformer

### Why are the changes needed?
The TestEmbeddedHiveMetaStore test runs fine when it is launched individually, but it fails on some CI runs cause it conflicts with state from TestMetastoreTransformer. The two tests are trying to create a directory for the database at the same path which leads to failures.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
mvn test -Dtest=TestEmbeddedHiveMetaStore,TestMetastoreTransformer -Dtest.groups= -pl standalone-metastore/metastore-server
mvn test -Dtest=TestMetastoreTransformer,TestEmbeddedHiveMetaStore -Dtest.groups= -pl standalone-metastore/metastore-server
```