### PR TITLE
HIVE-28934: PlanUtils.configureJobPropertiesForStorageHandler should use hive session configuration.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.hive.ql.io.HiveSequenceFileInputFormat;
 import org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileOutputFormat;
-import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
@@ -934,7 +933,7 @@ public final class PlanUtils {
     try {
       HiveStorageHandler storageHandler =
         HiveUtils.getStorageHandler(
-          Hive.get().getConf(),
+          SessionState.getSessionConf(),
           tableDesc.getProperties().getProperty(
             org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE));
       if (storageHandler != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.plan;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_LOCATION;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 import static org.apache.hive.common.util.HiveStringUtils.quoteComments;
 
@@ -931,11 +932,9 @@ public final class PlanUtils {
     }
 
     try {
-      HiveStorageHandler storageHandler =
-        HiveUtils.getStorageHandler(
-          SessionState.getSessionConf(),
-          tableDesc.getProperties().getProperty(
-            org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE));
+      HiveConf hiveConf = SessionState.getSessionConf();
+      String className = tableDesc.getProperties().getProperty(META_TABLE_STORAGE);
+      HiveStorageHandler storageHandler = HiveUtils.getStorageHandler(hiveConf, className);
       if (storageHandler != null) {
         Map<String, String> jobProperties = new LinkedHashMap<String, String>();
         Map<String, String> jobSecrets = new LinkedHashMap<String, String>();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use session configuration to create `storageHandler` in `PlanUtils.configureJobPropertiesForStorageHandler()` instead of instantiating `Hive` and using it to get configuration.

### Why are the changes needed?
Creating new instance of `Hive` is a heavy weight operation and it does not give correct HiveConf anyway.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests
