### PR TITLE
Fix flaky test in TestLazyBinaryColumnarSerDe by using LinkedHashMap

### DIFF
--- a/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
+import java.util.LinkedHashMap;
 
 import org.junit.Assert;
 import junit.framework.TestCase;
@@ -165,7 +166,7 @@ public class TestLazyBinaryColumnarSerDe {
     outerStruct.mByte  = 101;
     outerStruct.mShort = 2002;
     outerStruct.mInt = 3003;
-    outerStruct.mLong = 4004l;
+    outerStruct.mLong = ddd;
     outerStruct.mFloat = 5005.01f;
     outerStruct.mDouble = 6006.001d;
     outerStruct.mString = "";
@@ -234,7 +235,7 @@ public class TestLazyBinaryColumnarSerDe {
     outerStruct.mArray = new ArrayList<InnerStruct>(2);
     outerStruct.mArray.add(is1);
     outerStruct.mArray.add(is2);
-    outerStruct.mMap = new HashMap<String, InnerStruct>();
+    outerStruct.mMap = new LinkedHashMap<String, InnerStruct>(); //fixed line
     outerStruct.mMap.put(null, new InnerStruct(13, 14l));
     outerStruct.mMap.put(new String("fifteen"), null);
     outerStruct.mStruct = new InnerStruct(null, null);

--- a/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java
@@ -166,7 +166,7 @@ public class TestLazyBinaryColumnarSerDe {
     outerStruct.mByte  = 101;
     outerStruct.mShort = 2002;
     outerStruct.mInt = 3003;
-    outerStruct.mLong = ddd;
+    outerStruct.mLong = 40041;
     outerStruct.mFloat = 5005.01f;
     outerStruct.mDouble = 6006.001d;
     outerStruct.mString = "";


### PR DESCRIPTION
…nerNulls()

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

This pull request fixes a flaky test in TestLazyBinaryColumnarSerDe.java. The test was using a HashMap to store values, which does not guarantee iteration order. This nondeterministic order caused the test to sometimes fail when the output order changed. The fix replaces HashMap with LinkedHashMap to ensure a consistent iteration order and deterministic test results.


### Why are the changes needed?

The test fails nondeterministically because HashMap does not guarantee iteration order. This means the serialized output can vary between runs, leading to intermittent assertion failures. Using LinkedHashMap ensures the order is preserved, making the test reliable.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The test was run multiple times using the NonDex plugin to randomize internal order.

Before the fix, the test failed intermittently, as shown in the attached failing-test.log. After the fix, the test passed consistently across multiple runs, as shown in the attached passing-test.log.

Reproduction steps:

1. Run the test with NonDex:

mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe#testSerDeInnerNulls -DnondexRuns=10

2. Observe that before the fix, the test fails intermittently but after the fix, it always passes.



