### PR TITLE
HIVE-28899: Make 'get_table_meta' query case-sensitive to use index

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -1921,10 +1921,10 @@ public class ObjectStore implements RawStore, Configurable {
       List<String> parameterVals = new ArrayList<>();
       appendSimpleCondition(filterBuilder, "database.catalogName", new String[] {catName}, parameterVals);
       if (dbNames != null && !dbNames.equals("*")) {
-        appendPatternCondition(filterBuilder, "database.name", dbNames, parameterVals);
+        appendPatternConditionCaseSensitive(filterBuilder, "database.name", dbNames, parameterVals);
       }
       if (tableNames != null && !tableNames.equals("*")) {
-        appendPatternCondition(filterBuilder, "tableName", tableNames, parameterVals);
+        appendPatternConditionCaseSensitive(filterBuilder, "tableName", tableNames, parameterVals);
       }
       if (tableTypes != null && !tableTypes.isEmpty()) {
         appendSimpleCondition(filterBuilder, "tableType", tableTypes.toArray(new String[0]), parameterVals);
@@ -1984,6 +1984,17 @@ public class ObjectStore implements RawStore, Configurable {
 
   private StringBuilder appendCondition(StringBuilder builder,
       String fieldName, String[] elements, boolean pattern, List<String> parameters) {
+    return appendCondition(builder, fieldName, elements, pattern, parameters, false);
+  }
+
+  private StringBuilder appendPatternConditionCaseSensitive(StringBuilder builder,
+      String fieldName, String elements, List<String> parameters) {
+    elements = normalizeIdentifier(elements);
+    return appendCondition(builder, fieldName, elements.split("\\|"), true, parameters, true);
+  }
+
+  private StringBuilder appendCondition(StringBuilder builder,
+      String fieldName, String[] elements, boolean pattern, List<String> parameters, boolean caseSensitive) {
     if (builder.length() > 0) {
       builder.append(" && ");
     }
@@ -1991,7 +2002,10 @@ public class ObjectStore implements RawStore, Configurable {
     int length = builder.length();
     for (String element : elements) {
       if (pattern) {
-        element = "(?i)" + element.replaceAll("\\*", ".*");
+        element = element.replaceAll("\\*", ".*");
+        if (!caseSensitive) {
+          element = "(?i)" + element;
+        }
       }
       parameters.add(element);
       if (builder.length() > length) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This PR proposes to optimize the SQL query generated by the `get_table_meta` API in Hive Metastore by removing the use of the LOWER() function.
- before
``` diff
# JDOQL
SELECT FROM org.apache.hadoop.hive.metastore.model.MTable 
+ WHERE (database.catalogName == hive ) && (database.name.matches((?i)db_name) )
```
- after
``` diff
# JDOQL
SELECT FROM org.apache.hadoop.hive.metastore.model.MTable
+ WHERE (database.catalogName == hive ) && (database.name.matches(db_name) )
```

### Why are the changes needed?
In production environments with a large number of tables, we observed that the SQL query generated by `get_table_meta` caused full scans on the TBLS table, resulting in high CPU usage on the Metastore's MySQL backend.
https://issues.apache.org/jira/projects/HIVE/issues/HIVE-28899?filter=allopenissues


### Does this PR introduce _any_ user-facing change?
No. Since both database names and table names are already stored in lowercase in the Metastore DB, this change should not have any impact on users.
This change is only applied to get_table_meta to minimize risk. Other commands were left unchanged as we are not yet certain about potential side effects in those paths.

### How was this patch tested?
- Verified the generated SQL via logging.
- Manually tested the change in a local Hive Metastore instance with MySQL 5.7 and a large dataset.
- Observed a significant drop in CPU usage during repeated get_table_meta requests.
  - https://issues.apache.org/jira/projects/HIVE/issues/HIVE-28899?filter=allopenissues