### PR TITLE
HIVE-28937: Static analysis issues fixed in shell scripts

### DIFF
--- a/packaging/src/docker/build.sh
+++ b/packaging/src/docker/build.sh
@@ -110,7 +110,7 @@ if [ -n "$HIVE_VERSION" ]; then
 else
   HIVE_VERSION=$(mvn -f "$SOURCE_DIR/pom.xml" -q help:evaluate -Dexpression=project.version -DforceStdout)
   HIVE_TAR="$SOURCE_DIR/packaging/target/apache-hive-$HIVE_VERSION-bin.tar.gz"
-  if  ls $HIVE_TAR || mvn -f $SOURCE_DIR/pom.xml clean package -DskipTests -Pdist; then
+  if  ls "$HIVE_TAR" || mvn -f "$SOURCE_DIR/pom.xml" clean package -DskipTests -Pdist; then
     cp "$HIVE_TAR" "$WORK_DIR/"
   else
     echo "Failed to compile Hive Project, exiting..."

--- a/packaging/src/docker/entrypoint.sh
+++ b/packaging/src/docker/entrypoint.sh
@@ -19,7 +19,7 @@
 
 set -x
 
-: ${DB_DRIVER:=derby}
+: "${DB_DRIVER:=derby}"
 
 SKIP_SCHEMA_INIT="${IS_RESUME:-false}"
 [[ $VERBOSE = "true" ]] && VERBOSE_MODE="--verbose" || VERBOSE_MODE=""
@@ -29,7 +29,7 @@ function initialize_hive {
   if [ "$(echo "$HIVE_VER" | cut -d '.' -f1)" -lt "4" ]; then
      COMMAND="-${SCHEMA_COMMAND:-initSchema}"
   fi
-  $HIVE_HOME/bin/schematool -dbType $DB_DRIVER $COMMAND $VERBOSE_MODE
+  "$HIVE_HOME/bin/schematool" -dbType "$DB_DRIVER" "$COMMAND" "$VERBOSE_MODE"
   if [ $? -eq 0 ]; then
     echo "Initialized Hive Metastore Server schema successfully.."
   else
@@ -53,9 +53,9 @@ if [[ "${SKIP_SCHEMA_INIT}" == "false" ]]; then
 fi
 
 if [ "${SERVICE_NAME}" == "hiveserver2" ]; then
-  export HADOOP_CLASSPATH=$TEZ_HOME/*:$TEZ_HOME/lib/*:$HADOOP_CLASSPATH
-  exec $HIVE_HOME/bin/hive --skiphadoopversion --skiphbasecp --service $SERVICE_NAME
+  export HADOOP_CLASSPATH="$TEZ_HOME/*:$TEZ_HOME/lib/*:$HADOOP_CLASSPATH"
+  exec "$HIVE_HOME/bin/hive" --skiphadoopversion --skiphbasecp --service "$SERVICE_NAME"
 elif [ "${SERVICE_NAME}" == "metastore" ]; then
   export METASTORE_PORT=${METASTORE_PORT:-9083}
-  exec $HIVE_HOME/bin/hive --skiphadoopversion --skiphbasecp $VERBOSE_MODE --service $SERVICE_NAME
+  exec "$HIVE_HOME/bin/hive" --skiphadoopversion --skiphbasecp "$VERBOSE_MODE" --service "$SERVICE_NAME"
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request addresses several static analysis issues identified in the shell scripts located in the `packaging` folder. The issues were detected using ShellCheck and include:

1. **SC2086**: Double quote to prevent globbing and word splitting. Link to [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086)
2. **SC2125**: Brace expansion is not supported in POSIX sh. Link to [SC2125](https://github.com/koalaman/shellcheck/wiki/SC2125)
3. **SC2223**: This default assignment may cause problems when concatenating strings. Link to [SC2223](https://github.com/koalaman/shellcheck/wiki/SC2223)

### Why are the changes needed?

These changes are necessary to ensure that the shell scripts in the `packaging` folder adhere to best practices and avoid potential issues related to globbing, word splitting, brace expansion, and string concatenation. Addressing these issues will improve the reliability and maintainability of the scripts.

### Does this PR introduce _any_ user-facing change?

No, this PR does not introduce any user-facing changes. It solely focuses on improving the internal shell scripts.

### How was this patch tested?

The patch was tested by running ShellCheck on the modified shell scripts to ensure that the identified issues were resolved. Additionally, the scripts were manually tested to verify that they function correctly after the changes.