### PR TITLE
HIVE-28653: Jetty version disclosure in Hive

### DIFF
--- a/common/src/java/org/apache/hive/http/HttpServer.java
+++ b/common/src/java/org/apache/hive/http/HttpServer.java
@@ -652,6 +652,8 @@ public class HttpServer {
 
     final HttpConfiguration conf = new HttpConfiguration();
     conf.setRequestHeaderSize(1024*64);
+    conf.setSendServerVersion(false);
+    conf.setSendXPoweredBy(false);
     final HttpConnectionFactory http = new HttpConnectionFactory(conf);
 
     if (!b.useSSL) {

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/Main.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/Main.java
@@ -282,6 +282,8 @@ public class Main {
     ServerConnector connector;
     final HttpConfiguration httpConf = new HttpConfiguration();
     httpConf.setRequestHeaderSize(1024 * 64);
+    httpConf.setSendServerVersion(false);
+    httpConf.setSendXPoweredBy(false);
     final HttpConnectionFactory http = new HttpConnectionFactory(httpConf);
 
     if (conf.getBoolean(AppConfig.USE_SSL, false)) {

--- a/itests/hive-unit/src/test/java/org/apache/hive/service/TestHttpServices.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/TestHttpServices.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.service;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.Header;
+import org.apache.hive.jdbc.miniHS2.MiniHS2;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class TestHttpServices {
+
+  private static MiniHS2 miniHS2 = null;
+
+  @BeforeClass
+  public static void startServices() throws Exception {
+    HiveConf hiveConf = new HiveConf();
+    hiveConf.set(MetastoreConf.ConfVars.THRIFT_TRANSPORT_MODE.toString(), "http"); // HS2 -> HMS thrift on http
+
+    miniHS2 = new MiniHS2.Builder()
+            .withConf(hiveConf)
+            .withHTTPTransport() // Cli service -> HS2 thrift on http
+            .withRemoteMetastore()
+            .build();
+
+    miniHS2.start(new HashMap<>());
+  }
+
+  @AfterClass
+  public static void stopServices() {
+    if (miniHS2 != null && miniHS2.isStarted()) {
+      miniHS2.stop();
+    }
+  }
+
+  @Test
+  public void testWebUIResponseDoesNotContainServerVersionAndXPoweredBy() throws Exception {
+    testHttpServiceDoesNotContainServerVersionAndXPoweredBy(
+            "http://" + miniHS2.getHost() + ":" + miniHS2.getWebPort());
+  }
+
+  @Test
+  public void testCliServiceResponseDoesNotContainServerVersionAndXPoweredBy() throws Exception {
+    testHttpServiceDoesNotContainServerVersionAndXPoweredBy(
+            "http://" + miniHS2.getHost() + ":" + miniHS2.getWebPort() + "/cliservice");
+  }
+
+  @Test
+  public void testHMSServiceResponseDoesNotContainServerVersionAndXPoweredBy() throws Exception {
+    testHttpServiceDoesNotContainServerVersionAndXPoweredBy(
+            "http://" + miniHS2.getHost() + ":" + miniHS2.getWebPort() + "/" +
+            MetastoreConf.ConfVars.METASTORE_CLIENT_THRIFT_HTTP_PATH.getDefaultVal());
+  }
+
+  private void testHttpServiceDoesNotContainServerVersionAndXPoweredBy(String miniHS2) throws IOException {
+    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+      HttpGet request = new HttpGet(miniHS2);
+
+      try (CloseableHttpResponse response = httpClient.execute(request)) {
+        for (Header header : response.getHeaders()) {
+          Assert.assertNotEquals("x-powered-by", header.getName().toLowerCase());
+          Assert.assertNotEquals("server", header.getName().toLowerCase());
+        }
+      }
+    }
+  }
+}

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
@@ -123,6 +123,8 @@ public class ThriftHttpCLIService extends ThriftCLIService {
           hiveConf.getIntVar(ConfVars.HIVE_SERVER2_THRIFT_HTTP_RESPONSE_HEADER_SIZE);
       conf.setRequestHeaderSize(requestHeaderSize);
       conf.setResponseHeaderSize(responseHeaderSize);
+      conf.setSendServerVersion(false);
+      conf.setSendXPoweredBy(false);
       final HttpConnectionFactory http = new HttpConnectionFactory(conf) {
         public Connection newConnection(Connector connector, EndPoint endPoint) {
           Connection connection = super.newConnection(connector, endPoint);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -395,6 +395,8 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         MetastoreConf.getIntVar(conf, ConfVars.METASTORE_THRIFT_HTTP_REQUEST_HEADER_SIZE));
     httpServerConf.setResponseHeaderSize(
         MetastoreConf.getIntVar(conf, ConfVars.METASTORE_THRIFT_HTTP_RESPONSE_HEADER_SIZE));
+    httpServerConf.setSendServerVersion(false);
+    httpServerConf.setSendXPoweredBy(false);
 
     final HttpConnectionFactory http = new HttpConnectionFactory(httpServerConf);
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Disable send server version and `x-powered-by` properties when configuring Jetty.

### Why are the changes needed?
Exposing the Jetty version in the header is considered a security issue.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
1. Manually:
Set `hive.in.test` to `false` in `/data/conf/tez/hive-site.xml` temporary and run
```
mvn test -Dtest=StartMiniHS2Cluster -DminiHS2.clusterType=Tez -DminiHS2.run=true -DminiHS2.usePortsFromConf=true -DminiHS2.conf="target/testconf/tez/hive-site.xml" -Dpackaging.minimizeJar=false -T 1C -DskipShade -Dremoteresources.skip=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -pl itests/hive-unit -Pitests
```
then open a browser and go to the page: 
```
localhost:10002
```
and inspect the Http response headers using the browsers inspect function. It should not contain properties `Server` and `x-powered-by`

2. Automated end-to-end test

```
mvn test -Dtest=TestHttpServices -pl itests/hive-unit -Pitests
```
