### PR TITLE
HIVE-28924: Drop hive.optimize.join.disjunctive.transitive.predicates.pushdown and related logic

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2585,10 +2585,6 @@ public class HiveConf extends Configuration {
         "If this config is true only pushed down filters remain in the operator tree, \n" +
         "and the original filter is removed. If this config is false, the original filter \n" +
         "is also left in the operator tree at the original place."),
-    HIVE_JOIN_DISJ_TRANSITIVE_PREDICATES_PUSHDOWN("hive.optimize.join.disjunctive.transitive.predicates.pushdown",
-        false, "Whether to transitively infer disjunctive predicates across joins. \n"
-        + "Disjunctive predicates are hard to simplify and pushing them down might lead to infinite rule matching "
-        + "causing stackoverflow and OOM errors"),
     HIVE_POINT_LOOKUP_OPTIMIZER("hive.optimize.point.lookup", true,
          "Whether to transform OR clauses in Filter operators into IN clauses"),
     HIVE_POINT_LOOKUP_OPTIMIZER_MIN("hive.optimize.point.lookup.min", 2,

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1795,7 +1795,6 @@ public class CalcitePlanner extends SemanticAnalyzer {
       // corelated sub query.
       final int maxCNFNodeCount = conf.getIntVar(HiveConf.ConfVars.HIVE_CBO_CNF_NODES_LIMIT);
       final int minNumORClauses = conf.getIntVar(HiveConf.ConfVars.HIVE_POINT_LOOKUP_OPTIMIZER_MIN);
-      final boolean allowDisjunctivePredicates = conf.getBoolVar(ConfVars.HIVE_JOIN_DISJ_TRANSITIVE_PREDICATES_PUSHDOWN);
 
       final HepProgramBuilder program = new HepProgramBuilder();
 
@@ -1899,9 +1898,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
       rules.add(HiveJoinAddNotNullRule.INSTANCE_JOIN);
       rules.add(HiveJoinAddNotNullRule.INSTANCE_SEMIJOIN);
       rules.add(HiveJoinAddNotNullRule.INSTANCE_ANTIJOIN);
-      rules.add(new HiveJoinPushTransitivePredicatesRule(HiveJoin.class, allowDisjunctivePredicates));
-      rules.add(new HiveJoinPushTransitivePredicatesRule(HiveSemiJoin.class, allowDisjunctivePredicates));
-      rules.add(new HiveJoinPushTransitivePredicatesRule(HiveAntiJoin.class, allowDisjunctivePredicates));
+      rules.add(new HiveJoinPushTransitivePredicatesRule(HiveJoin.class));
+      rules.add(new HiveJoinPushTransitivePredicatesRule(HiveSemiJoin.class));
+      rules.add(new HiveJoinPushTransitivePredicatesRule(HiveAntiJoin.class));
       rules.add(HiveSortMergeRule.INSTANCE);
       rules.add(HiveSortPullUpConstantsRule.SORT_LIMIT_INSTANCE);
       rules.add(HiveSortPullUpConstantsRule.SORT_EXCHANGE_INSTANCE);

--- a/ql/src/test/queries/clientpositive/cbo_join_transitive_pred_loop_1.q
+++ b/ql/src/test/queries/clientpositive/cbo_join_transitive_pred_loop_1.q
@@ -1,4 +1,3 @@
-set hive.optimize.join.disjunctive.transitive.predicates.pushdown=false;
 set hive.test.currenttimestamp=2025-04-02 10:05:03;
 
 CREATE TABLE test1 (act_nbr string);

--- a/ql/src/test/queries/clientpositive/cbo_join_transitive_pred_loop_2.q
+++ b/ql/src/test/queries/clientpositive/cbo_join_transitive_pred_loop_2.q
@@ -1,5 +1,3 @@
-set hive.optimize.join.disjunctive.transitive.predicates.pushdown=false;
-
 CREATE EXTERNAL TABLE table2 (
   tenant_id int
 ) PARTITIONED BY (date_key int)

--- a/ql/src/test/queries/clientpositive/cbo_join_transitive_pred_loop_3.q
+++ b/ql/src/test/queries/clientpositive/cbo_join_transitive_pred_loop_3.q
@@ -1,5 +1,3 @@
-set hive.optimize.join.disjunctive.transitive.predicates.pushdown=false;
-
 CREATE TABLE tableA (
   bd_id      bigint,
   quota_type string

--- a/ql/src/test/queries/clientpositive/cbo_join_transitive_pred_loop_4.q
+++ b/ql/src/test/queries/clientpositive/cbo_join_transitive_pred_loop_4.q
@@ -1,5 +1,3 @@
-set hive.optimize.join.disjunctive.transitive.predicates.pushdown=false;
-
 CREATE TABLE tableA (
   bd_id      bigint,
   quota_type string


### PR DESCRIPTION
### Why are the changes needed?
1. Remove code that is not actively used by existing tests.
2. Drop redundant config property that is not released yet.

### Does this PR introduce _any_ user-facing change?
No, cause anyways the disjunctive predicate pushdown currently happens irrespective the value of the property.

### How was this patch tested?
```
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile_regex="cbo_join_transitive_pred.*"
mvn test -Dtest=TestTezTPCDS30TBPerfCliDriver -Dtest.output.overwrite
```