### PR TITLE
HIVE-28947: Add ability to specify Compaction options in stats updater of compactor

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -380,11 +380,11 @@ public class TestCompactor extends TestCompactorBase {
 
     //compute stats before compaction
     CompactionInfo ci = new CompactionInfo(dbName, tblName, "bkt=0", CompactionType.MAJOR);
-    statsUpdater.gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
+    statsUpdater.gatherStats(conf, ci, emptyMap(), System.getProperty("user.name"),
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
     ci = new CompactionInfo(dbName, tblName, "bkt=1", CompactionType.MAJOR);
-    statsUpdater.gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
+    statsUpdater.gatherStats(conf, ci, emptyMap(), System.getProperty("user.name"),
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
 
     //Check basic stats are collected
     org.apache.hadoop.hive.ql.metadata.Table hiveTable = Hive.get().getTable(tblName);
@@ -474,8 +474,8 @@ public class TestCompactor extends TestCompactorBase {
 
     //compute stats before compaction
     CompactionInfo ci = new CompactionInfo(dbName, tblName, null, CompactionType.MAJOR);
-    statsUpdater.gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
+    statsUpdater.gatherStats(conf, ci, emptyMap(), System.getProperty("user.name"),
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
 
     //Check basic stats are collected
     Map<String, String> parameters = Hive.get().getTable(tblName).getParameters();

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -66,6 +66,7 @@ import org.mockito.internal.util.reflection.FieldSetter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -74,6 +75,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hive.common.AcidConstants.VISIBILITY_PATTERN;
 import static org.apache.hadoop.hive.ql.TestTxnCommands2.runCleaner;
 import static org.apache.hadoop.hive.ql.TestTxnCommands2.runInitiator;
@@ -379,10 +381,10 @@ public class TestCompactor extends TestCompactorBase {
     //compute stats before compaction
     CompactionInfo ci = new CompactionInfo(dbName, tblName, "bkt=0", CompactionType.MAJOR);
     statsUpdater.gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
     ci = new CompactionInfo(dbName, tblName, "bkt=1", CompactionType.MAJOR);
     statsUpdater.gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
 
     //Check basic stats are collected
     org.apache.hadoop.hive.ql.metadata.Table hiveTable = Hive.get().getTable(tblName);
@@ -473,7 +475,7 @@ public class TestCompactor extends TestCompactorBase {
     //compute stats before compaction
     CompactionInfo ci = new CompactionInfo(dbName, tblName, null, CompactionType.MAJOR);
     statsUpdater.gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
 
     //Check basic stats are collected
     Map<String, String> parameters = Hive.get().getTable(tblName).getParameters();

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -859,8 +859,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     //compute stats before compaction
     CompactionInfo ci = new CompactionInfo(dbName, tblName, null, CompactionType.MAJOR);
-    new StatsUpdater().gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
+    new StatsUpdater().gatherStats(conf, ci, emptyMap(), System.getProperty("user.name"),
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
 
     //Check basic stats are collected
     Map<String, String> parameters = Hive.get().getTable(tblName).getParameters();
@@ -3166,8 +3166,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     //compute stats before compaction
     CompactionInfo ci = new CompactionInfo(dbName, tblName, "bkt=1", compactionType);
-    new StatsUpdater().gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
+    new StatsUpdater().gatherStats(conf, ci, emptyMap(), System.getProperty("user.name"),
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
 
     //Check basic stats are collected
     org.apache.hadoop.hive.ql.metadata.Table hiveTable = Hive.get().getTable(tblName);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -82,6 +82,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.FieldSetter;
 
+import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hive.ql.TxnCommandsBaseForTests.runWorker;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.execSelectAndDumpData;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
@@ -859,7 +860,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //compute stats before compaction
     CompactionInfo ci = new CompactionInfo(dbName, tblName, null, CompactionType.MAJOR);
     new StatsUpdater().gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
 
     //Check basic stats are collected
     Map<String, String> parameters = Hive.get().getTable(tblName).getParameters();
@@ -3166,7 +3167,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //compute stats before compaction
     CompactionInfo ci = new CompactionInfo(dbName, tblName, "bkt=1", compactionType);
     new StatsUpdater().gatherStats(ci, conf, System.getProperty("user.name"),
-            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient);
+            CompactorUtil.getCompactorJobQueueName(conf, ci, table), msClient, emptyMap());
 
     //Check basic stats are collected
     org.apache.hadoop.hive.ql.metadata.Table hiveTable = Hive.get().getTable(tblName);

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorUtil.java
@@ -89,10 +89,15 @@ import static java.lang.String.format;
 import static org.apache.hadoop.hive.metastore.HMSHandler.getMSForConf;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
 
-public class CompactorUtil {
+public final class CompactorUtil {
   private static final Logger LOG = LoggerFactory.getLogger(CompactorUtil.class);
   public static final String COMPACTOR = "compactor";
+  public static final String COMPACTOR_PREFIX = COMPACTOR + ".";
   private static final String COMPACTOR_THRESHOLD_PREFIX = "compactorthreshold.";
+
+  private CompactorUtil() {
+
+  }
 
   /**
    * List of accepted properties for defining the compactor's job queue.
@@ -579,4 +584,20 @@ public class CompactorUtil {
     }
     return poolName;
   }
+
+  /**
+   * Parse tblproperties to override relevant properties of compactor job with specified values.
+   * For example, compactor.mapreuce.map.memory.mb=1024 or compactor.tez.am.view-acls
+   * @param conf the compactor job
+   * @param properties table properties
+   */
+  public static void overrideProps(Configuration conf, Map<String, String> properties) {
+    for (String key : properties.keySet()) {
+      if (key.startsWith(COMPACTOR_PREFIX)) {
+        String mrKey = key.substring(10); // 10 is the length of "compactor." We only keep the rest.
+        conf.set(mrKey, properties.get(key));
+      }
+    }
+  }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorUtil.java
@@ -75,6 +75,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
@@ -84,20 +85,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static org.apache.hadoop.hive.metastore.HMSHandler.getMSForConf;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
 
-public final class CompactorUtil {
+public class CompactorUtil {
   private static final Logger LOG = LoggerFactory.getLogger(CompactorUtil.class);
   public static final String COMPACTOR = "compactor";
   public static final String COMPACTOR_PREFIX = COMPACTOR + ".";
   private static final String COMPACTOR_THRESHOLD_PREFIX = "compactorthreshold.";
 
-  private CompactorUtil() {
-
-  }
 
   /**
    * List of accepted properties for defining the compactor's job queue.
@@ -585,19 +584,19 @@ public final class CompactorUtil {
     return poolName;
   }
 
-  /**
-   * Parse tblproperties to override relevant properties of compactor job with specified values.
-   * For example, compactor.mapreuce.map.memory.mb=1024 or compactor.tez.am.view-acls
-   * @param conf the compactor job
-   * @param properties table properties
-   */
-  public static void overrideProps(Configuration conf, Map<String, String> properties) {
-    for (String key : properties.keySet()) {
-      if (key.startsWith(COMPACTOR_PREFIX)) {
-        String mrKey = key.substring(10); // 10 is the length of "compactor." We only keep the rest.
-        conf.set(mrKey, properties.get(key));
-      }
-    }
+  public static void overrideConfProps(HiveConf conf, CompactionInfo ci, Map<String, String> properties) {
+    overrideConfProps(conf, new StringableMap(ci.properties), properties);
   }
 
+  public static void overrideConfProps(
+          HiveConf conf, Map<String, String> ciProperties, Map<String, String> properties) {
+    Stream.of(properties, ciProperties)
+            .filter(Objects::nonNull)
+            .flatMap(map -> map.entrySet().stream())
+            .filter(entry -> entry.getKey().startsWith(COMPACTOR_PREFIX))
+            .forEach(entry -> {
+              String property = entry.getKey().substring(COMPACTOR_PREFIX.length());
+              conf.set(property, entry.getValue());
+            });
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MRCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MRCompactor.java
@@ -85,8 +85,6 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.hive.ql.txn.compactor.CompactorUtil.overrideProps;
-
 /**
  * Class to do compactions via an MR job.  This has to be in the ql package rather than metastore
  * .compactions package with all of it's relatives because it needs access to the actual input
@@ -111,6 +109,7 @@ public class MRCompactor implements Compactor {
   private static final String DIRS_TO_SEARCH = "hive.compactor.dirs.to.search";
   private static final String TMPDIR = "_tmp";
   private static final String TBLPROPS_PREFIX = "tblprops.";
+  private static final String COMPACTOR_PREFIX = "compactor.";
 
   private JobConf mrJob;  // the MR job for compaction
   private IMetaStoreClient msc;
@@ -167,7 +166,7 @@ public class MRCompactor implements Compactor {
     job.set(TABLE_PROPS, new StringableMap(t.getParameters()).toString());
     job.setInt(NUM_BUCKETS, sd.getNumBuckets());
     job.set(ValidWriteIdList.VALID_WRITEIDS_KEY, writeIds.toString());
-    overrideProps(job, t.getParameters()); // override MR properties from tblproperties if applicable
+    overrideMRProps(job, t.getParameters()); // override MR properties from tblproperties if applicable
     if (ci.properties != null) {
       overrideTblProps(job, t.getParameters(), ci.properties);
     }
@@ -202,7 +201,7 @@ public class MRCompactor implements Compactor {
    */
   private void overrideTblProps(JobConf job, Map<String, String> tblproperties, String properties) {
     StringableMap stringableMap = new StringableMap(properties);
-    overrideProps(job, stringableMap);
+    overrideMRProps(job, stringableMap);
     // mingle existing tblproperties with those specified on the ALTER TABLE command
     for (String key : stringableMap.keySet()) {
       if (key.startsWith(TBLPROPS_PREFIX)) {
@@ -212,6 +211,21 @@ public class MRCompactor implements Compactor {
     }
     // re-set TABLE_PROPS with reloaded tblproperties
     job.set(TABLE_PROPS, new StringableMap(tblproperties).toString());
+  }
+
+  /**
+   * Parse tblproperties to override relevant properties of compactor MR job with specified values.
+   * For example, compactor.mapreuce.map.memory.mb=1024
+   * @param job the compactor MR job
+   * @param properties table properties
+   */
+  private void overrideMRProps(JobConf job, Map<String, String> properties) {
+    for (String key : properties.keySet()) {
+      if (key.startsWith(COMPACTOR_PREFIX)) {
+        String mrKey = key.substring(10); // 10 is the length of "compactor." We only keep the rest.
+        job.set(mrKey, properties.get(key));
+      }
+    }
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -63,7 +63,7 @@ public final class StatsUpdater {
                 throw new IllegalArgumentException("Metastore client is missing");
             }
 
-            HiveConf conf = createConfiguration(hiveConf, compactionQueueName, tableProperties, ci.getProperties());
+            HiveConf conf = setUpDriverSession(hiveConf, compactionQueueName, tableProperties, ci.getProperties());
 
             //e.g. analyze table page_view partition(dt='10/15/2014',country=’US’)
             // compute statistics for columns viewtime
@@ -97,7 +97,7 @@ public final class StatsUpdater {
         }
     }
 
-    HiveConf createConfiguration(
+    HiveConf setUpDriverSession(
             HiveConf sourceConf,
             String compactionQueueName,
             Map<String, String> tableProperties,

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.txn.entities.CompactionInfo;
+import org.apache.hadoop.hive.metastore.utils.StringableMap;
 import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.stats.StatsUtils;
@@ -63,7 +64,8 @@ public final class StatsUpdater {
                 throw new IllegalArgumentException("Metastore client is missing");
             }
 
-            HiveConf conf = setUpDriverSession(hiveConf, compactionQueueName, tableProperties, ci.getProperties());
+            HiveConf conf = setUpDriverSession(
+                    hiveConf, compactionQueueName, tableProperties, new StringableMap(ci.properties));
 
             //e.g. analyze table page_view partition(dt='10/15/2014',country=’US’)
             // compute statistics for columns viewtime

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -56,9 +56,9 @@ public final class StatsUpdater {
      * @param userName The user to run the statistic collection with
      * @param compactionQueueName The name of the compaction queue
      */
-    public void gatherStats(CompactionInfo ci, HiveConf hiveConf,
+    public void gatherStats(HiveConf hiveConf, CompactionInfo ci, Map<String, String> tableProperties,
                             String userName, String compactionQueueName,
-                            IMetaStoreClient msc, Map<String, String> tableProperties) {
+                            IMetaStoreClient msc) {
         try {
             if (msc == null) {
                 throw new IllegalArgumentException("Metastore client is missing");

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.hadoop.hive.ql.txn.compactor.CompactorUtil.overrideProps;
+import static org.apache.hadoop.hive.ql.txn.compactor.CompactorUtil.overrideConfProps;
 
 /**
  *  Updates table/partition statistics.
@@ -110,8 +110,7 @@ public final class StatsUpdater {
         //so that Driver doesn't think it's already in a transaction
         conf.unset(ValidTxnList.VALID_TXNS_KEY);
 
-        overrideProps(conf, tableProperties);
-        overrideProps(conf, ciProperties);
+        overrideConfProps(conf, ciProperties, tableProperties);
 
         if (isNotBlank(compactionQueueName)) {
             conf.set(TezConfiguration.TEZ_QUEUE_NAME, compactionQueueName);

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -286,8 +286,13 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
     }
 
     if (success && compactionService.computeStats()) {
-      statsUpdater.gatherStats(ci, conf, CompactorUtil.runJobAsSelf(ci.runAs) ? ci.runAs : table.getOwner(),
-          CompactorUtil.getCompactorJobQueueName(conf, ci, table), msc, table.getParameters());
+      statsUpdater.gatherStats(
+          conf,
+          ci,
+          table.getParameters(),
+          CompactorUtil.runJobAsSelf(ci.runAs) ? ci.runAs : table.getOwner(),
+          CompactorUtil.getCompactorJobQueueName(conf, ci, table),
+          msc);
     }
     return success;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -287,7 +287,7 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
 
     if (success && compactionService.computeStats()) {
       statsUpdater.gatherStats(ci, conf, CompactorUtil.runJobAsSelf(ci.runAs) ? ci.runAs : table.getOwner(),
-          CompactorUtil.getCompactorJobQueueName(conf, ci, table), msc);
+          CompactorUtil.getCompactorJobQueueName(conf, ci, table), msc, table.getParameters());
     }
     return success;
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestStatsUpdater.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestStatsUpdater.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hive.ql.txn.compactor.CompactorUtil.COMPACTOR_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -59,7 +60,23 @@ public class TestStatsUpdater {
   }
 
   @Test
-  public void testSetUpDriverSessionOverridesExistingCompactorProperties() {
+  public void testSetUpDriverSessionOverridesExistingCompactorPropertiesWithTableProperties() {
+    StatsUpdater statsUpdater = new StatsUpdater();
+
+    HiveConf conf = new HiveConf();
+    conf.set(COMPACTOR_PREFIX + "test.property", "test-value");
+
+    Map<String, String> tableProperties = new HashMap<String, String>() {{
+      put(COMPACTOR_PREFIX + "test.property", "changed-in-table-properties");
+    }};
+
+    HiveConf statsUpdaterConf = statsUpdater.setUpDriverSession(conf, "testQueue", tableProperties, emptyMap());
+
+    assertThat(statsUpdaterConf.get("test.property"), is("changed-in-table-properties"));
+  }
+
+  @Test
+  public void testSetUpDriverSessionOverridesExistingCompactorPropertiesWithPropertiesInCompactionInfo() {
     StatsUpdater statsUpdater = new StatsUpdater();
 
     HiveConf conf = new HiveConf();

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestStatsUpdater.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestStatsUpdater.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.is;
 
 public class TestStatsUpdater {
   @Test
-  public void testCreateConfigurationAddsCompactorPropertiesFromTableProperties() {
+  public void testSetUpDriverSessionAddsCompactorPropertiesFromTableProperties() {
     StatsUpdater statsUpdater = new StatsUpdater();
 
     HiveConf conf = new HiveConf();
@@ -38,13 +38,13 @@ public class TestStatsUpdater {
     }};
 
     Map<String, String> ciProperties = new HashMap<>();
-    HiveConf statsUpdaterConf = statsUpdater.createConfiguration(conf, "testQueue", tableProperties, ciProperties);
+    HiveConf statsUpdaterConf = statsUpdater.setUpDriverSession(conf, "testQueue", tableProperties, ciProperties);
 
     assertThat(statsUpdaterConf.get("test.property"), is("test-value"));
   }
 
   @Test
-  public void testCreateConfigurationAddsCompactorPropertiesFromCompactionInfo() {
+  public void testSetUpDriverSessionAddsCompactorPropertiesFromCompactionInfo() {
     StatsUpdater statsUpdater = new StatsUpdater();
 
     HiveConf conf = new HiveConf();
@@ -53,13 +53,13 @@ public class TestStatsUpdater {
       put(COMPACTOR_PREFIX + "test.property", "test-value");
     }};
 
-    HiveConf statsUpdaterConf = statsUpdater.createConfiguration(conf, "testQueue", tableProperties, ciProperties);
+    HiveConf statsUpdaterConf = statsUpdater.setUpDriverSession(conf, "testQueue", tableProperties, ciProperties);
 
     assertThat(statsUpdaterConf.get("test.property"), is("test-value"));
   }
 
   @Test
-  public void testCreateConfigurationOverridesExistingCompactorProperties() {
+  public void testSetUpDriverSessionOverridesExistingCompactorProperties() {
     StatsUpdater statsUpdater = new StatsUpdater();
 
     HiveConf conf = new HiveConf();
@@ -73,7 +73,7 @@ public class TestStatsUpdater {
       put(COMPACTOR_PREFIX + "test.property", "changed-in-compaction-info");
     }};
 
-    HiveConf statsUpdaterConf = statsUpdater.createConfiguration(conf, "testQueue", tableProperties, ciProperties);
+    HiveConf statsUpdaterConf = statsUpdater.setUpDriverSession(conf, "testQueue", tableProperties, ciProperties);
 
     assertThat(statsUpdaterConf.get("test.property"), is("changed-in-compaction-info"));
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestStatsUpdater.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestStatsUpdater.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.txn.compactor;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.hive.ql.txn.compactor.CompactorUtil.COMPACTOR_PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class TestStatsUpdater {
+  @Test
+  public void testCreateConfigurationAddsCompactorPropertiesFromTableProperties() {
+    StatsUpdater statsUpdater = new StatsUpdater();
+
+    HiveConf conf = new HiveConf();
+    Map<String, String> tableProperties = new HashMap<String, String>() {{
+      put(COMPACTOR_PREFIX + "test.property", "test-value");
+    }};
+
+    Map<String, String> ciProperties = new HashMap<>();
+    HiveConf statsUpdaterConf = statsUpdater.createConfiguration(conf, "testQueue", tableProperties, ciProperties);
+
+    assertThat(statsUpdaterConf.get("test.property"), is("test-value"));
+  }
+
+  @Test
+  public void testCreateConfigurationAddsCompactorPropertiesFromCompactionInfo() {
+    StatsUpdater statsUpdater = new StatsUpdater();
+
+    HiveConf conf = new HiveConf();
+    Map<String, String> tableProperties = new HashMap<>();
+    Map<String, String> ciProperties = new HashMap<String, String>() {{
+      put(COMPACTOR_PREFIX + "test.property", "test-value");
+    }};
+
+    HiveConf statsUpdaterConf = statsUpdater.createConfiguration(conf, "testQueue", tableProperties, ciProperties);
+
+    assertThat(statsUpdaterConf.get("test.property"), is("test-value"));
+  }
+
+  @Test
+  public void testCreateConfigurationOverridesExistingCompactorProperties() {
+    StatsUpdater statsUpdater = new StatsUpdater();
+
+    HiveConf conf = new HiveConf();
+    conf.set(COMPACTOR_PREFIX + "test.property", "test-value");
+
+    Map<String, String> tableProperties = new HashMap<String, String>() {{
+      put(COMPACTOR_PREFIX + "test.property", "changed-in-table-properties");
+    }};
+
+    Map<String, String> ciProperties = new HashMap<String, String>() {{
+      put(COMPACTOR_PREFIX + "test.property", "changed-in-compaction-info");
+    }};
+
+    HiveConf statsUpdaterConf = statsUpdater.createConfiguration(conf, "testQueue", tableProperties, ciProperties);
+
+    assertThat(statsUpdaterConf.get("test.property"), is("changed-in-compaction-info"));
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
@@ -1051,7 +1051,7 @@ public class TestWorker extends CompactorTest {
 
     worker.findNextCompactionAndExecute(true, true);
 
-    Mockito.verify(statsUpdater, Mockito.never()).gatherStats(any(), any(), any(), any(), any());
+    Mockito.verify(statsUpdater, Mockito.never()).gatherStats(any(), any(), any(), any(), any(), any());
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
@@ -30,6 +30,9 @@ import org.apache.hadoop.hive.metastore.utils.StringableMap;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -114,6 +117,14 @@ public class CompactionInfo implements Comparable<CompactionInfo> {
     }
     propertiesMap.put(key, value);
     properties = propertiesMap.toString();
+  }
+
+  public Map<String, String> getProperties() {
+    if (propertiesMap == null) {
+      propertiesMap = new StringableMap(properties);
+    }
+
+    return Collections.unmodifiableMap(propertiesMap);
   }
 
   public String getFullPartitionName() {
@@ -207,7 +218,6 @@ public class CompactionInfo implements Comparable<CompactionInfo> {
     CompactionInfo info = (CompactionInfo) obj;
     return this.compareTo(info) == 0;
   }
-
   /**
    * loads object from a row in Select * from COMPACTION_QUEUE
    * @param rs ResultSet after call to rs.next()
@@ -242,6 +252,7 @@ public class CompactionInfo implements Comparable<CompactionInfo> {
     fullCi.orderByClause = rs.getString(25);
     return fullCi;
   }
+
   static void insertIntoCompletedCompactions(PreparedStatement pStmt, CompactionInfo ci, long endTime) throws SQLException, MetaException {
     pStmt.setLong(1, ci.id);
     pStmt.setString(2, ci.dbname);
@@ -339,7 +350,6 @@ public class CompactionInfo implements Comparable<CompactionInfo> {
     cr.setOrderByClause(ci.orderByClause);
     return cr;
   }
-
   public static OptionalCompactionInfoStruct compactionInfoToOptionalStruct(CompactionInfo ci) {
     CompactionInfoStruct cis = compactionInfoToStruct(ci);
     OptionalCompactionInfoStruct ocis = new OptionalCompactionInfoStruct();
@@ -348,6 +358,7 @@ public class CompactionInfo implements Comparable<CompactionInfo> {
     }
     return ocis;
   }
+
   public static CompactionInfo optionalCompactionInfoStructToInfo(OptionalCompactionInfoStruct ocis) {
     if (ocis.isSetCi()) {
       return compactionStructToInfo(ocis.getCi());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
@@ -119,14 +119,6 @@ public class CompactionInfo implements Comparable<CompactionInfo> {
     properties = propertiesMap.toString();
   }
 
-  public Map<String, String> getProperties() {
-    if (propertiesMap == null) {
-      propertiesMap = new StringableMap(properties);
-    }
-
-    return Collections.unmodifiableMap(propertiesMap);
-  }
-
   public String getFullPartitionName() {
     if (fullPartitionName == null) {
       StringBuilder buf = new StringBuilder();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
@@ -30,9 +30,6 @@ import org.apache.hadoop.hive.metastore.utils.StringableMap;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
 /**


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Copy table properties and properties stored in compaction info to the HiveConf instance of Stats Updater

### Why are the changes needed?
To support passing job configuration properties of compactor to the stats updater job

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest=TestStatsUpdater -pl ql
```