### PR TITLE
HIVE-28955: Tests using HiveConfForTest and Tez engine consume large amounts of disk space

### DIFF
--- a/common/src/test/org/apache/hadoop/hive/conf/HiveConfForTest.java
+++ b/common/src/test/org/apache/hadoop/hive/conf/HiveConfForTest.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hive.conf;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,7 +52,8 @@ public class HiveConfForTest extends HiveConf {
     initDataDir(cls);
     LOG.info("Using test data dir (class: {}): {}", cls.getName(), testDataDir);
     // HIVE_USER_INSTALL_DIR is required in DagUtils, let's set one
-    setValue(HiveConf.ConfVars.HIVE_USER_INSTALL_DIR.varname, testDataDir);
+    Path installDir = Paths.get(System.getProperty("test.tmp.dir"), "user_install_dir");
+    setValue(HiveConf.ConfVars.HIVE_USER_INSTALL_DIR.varname, installDir.toString());
     // to avoid the overhead of starting a tez session when creating a new SessionState
     // many unit tests don't need actual tez execution, and this can save a lot of time
     setValue(HiveConf.ConfVars.HIVE_CLI_TEZ_INITIALIZE_SESSION.varname, "false");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use the same hive.user.install.directory for all tests in the same module that make use of HiveConfForTest objects.

### Why are the changes needed?

1. Stabilize CI and reduce failures related to ephemeral storage
2. Avoid disk exhaustion and cryptic errors due to the filesystem running low on space

Having a distinct installation directory for each HiveConfForTest object leads to copying the hive-exec*jar (87MB) multiple times necessitating large amounts of disk space. The hive-exec.jar does not change so there is no reason to keep separate copies and it is just wasting space.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
mvn clean test -Dtest=TestTxnCommands*
```
Manually check and ensure that there are not multiple copies of hive-exec.jar under the target directories.
```
find . -name "*jar"
./target/tmp/user_install_dir/zabetak/.hiveJars/hive-exec-4.1.0-SNAPSHOT-e5846dd8216ed0426374a80f7bc577bf21cb67d8db936e52c6769aa563cea6cf.jar
```