### PR TITLE
HIVE-28969: Use shallow clone with limited depth to reduce .git directory size

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ jobWrappers {
             $class: 'GitSCM',
             branches: scm.branches,
             doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
-            extensions: scm.extensions,
+            extensions: [ cloneOption(honorRefspec: true, depth: 50, noTags: true, shallow: true) ],
             userRemoteConfigs: scm.userRemoteConfigs + [[
               name: 'origin',
               refspec: scm.userRemoteConfigs[0].refspec+ " +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/target",


### PR DESCRIPTION
### Why are the changes needed?
1. Reduce the disk space occupied by the .git directory in CI
2. Speed up checkout times

### Does this PR introduce _any_ user-facing change?
Pull-requests are now limited to 50 commits (value of depth parameter). When the number of commits exceeds this number the CI run will abort since it will not be able to merge the PR branch with master. Affected PRs can either temporarily increase the value of the depth parameter or squash some commits together.

### How was this patch tested?
Manually inspect output of `du` command in pipeline logs