### PR TITLE
HIVE-28968: In CI use dedicated project-local .m2 directory for storing maven artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,11 +93,12 @@ set -x
 export USER="`whoami`"
 export MAVEN_OPTS="-Xmx2g"
 export -n HIVE_CONF_DIR
-cp $SETTINGS .git/settings.xml
-OPTS=" -s $PWD/.git/settings.xml -B -Dtest.groups= "
+mkdir -p .m2/repository
+cp $SETTINGS .m2/settings.xml
+OPTS=" -s $PWD/.m2/settings.xml -B -Dtest.groups= "
 OPTS+=" -Pitests,qsplits,dist,errorProne"
 OPTS+=" -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugin.surefire.SurefirePlugin=INFO"
-OPTS+=" -Dmaven.repo.local=$PWD/.git/m2"
+OPTS+=" -Dmaven.repo.local=$PWD/.m2/repository"
 git config extra.mavenOpts "$OPTS"
 OPTS=" $M_OPTS -Dmaven.test.failure.ignore "
 if [ -s inclusions.txt ]; then OPTS+=" -Dsurefire.includesFile=$PWD/inclusions.txt";fi

--- a/pom.xml
+++ b/pom.xml
@@ -1848,6 +1848,7 @@
         </executions>
         <configuration>
           <excludes>
+            <exclude>.m2/**</exclude>
             <eclude>.gitattributes</eclude>
             <exclude>*.patch</exclude>
             <exclude>**/pull_request_template.md</exclude>


### PR DESCRIPTION
### Why are the changes needed?
Previously the maven artifacts were stored under .git/.m2 directory. In terms of functionality the exact location (.git/.m2 vs .m2) does not matter. However, putting the artifacts under the .git folder can lead into confusion and false conclusions for people not very familiar with the specificities of the CI.

For instance, someone who is not gonna look into detail on what is present under the .git directory may think that the .git data for the project are huge. Using commands such as `du -h --max-depth=1`, which is also used in some places by the CI, can endorse such false impressions.

Moreover, the .m2 directory is a more common place for storing the maven artifacts in CI/CD pipelines.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
* Ensure tests run fine
* Inspect CI logs especially those related to `du -h --max-depth=1` command