### PR TITLE
HIVE-28971: DirectSql for msck repair is failing because of wrong casting

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlInsertPart.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlInsertPart.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.jdo.PersistenceManager;
+import javax.jdo.identity.LongIdentity;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -42,7 +43,6 @@ import org.apache.hadoop.hive.metastore.model.MStorageDescriptor;
 import org.apache.hadoop.hive.metastore.model.MStringList;
 import org.datanucleus.ExecutionContext;
 import org.datanucleus.api.jdo.JDOPersistenceManager;
-import org.datanucleus.identity.DatastoreId;
 import org.datanucleus.metadata.AbstractClassMetaData;
 import org.datanucleus.metadata.IdentityType;
 
@@ -754,7 +754,7 @@ class DirectSqlInsertPart {
       serdeIdToSerDeInfo.put(serDeId, sd.getSerDeInfo());
 
       Long cdId;
-      DatastoreId storeId = (DatastoreId) pm.getObjectId(sd.getCD());
+      LongIdentity storeId = (LongIdentity) pm.getObjectId(sd.getCD());
       if (storeId == null) {
         cdId = getDataStoreId(MColumnDescriptor.class);
         cdIdToColumnDescriptor.put(cdId, sd.getCD());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Please check [HIVE-28971](https://issues.apache.org/jira/browse/HIVE-28971), for more details.
ERROR Message:
```
2025-05-26 23:07:36,111 WARN metastore.ObjectStore: Falling back to ORM path due to direct SQL failure (this is not an error): class javax.jdo.identity.LongIdentity cannot be cast to class org.datanucleus.identity.DatastoreId (javax.jdo.identity.LongIdentity and org.datanucleus.identity.DatastoreId are in unnamed module of loader 'app') at org.apache.hadoop.hive.metastore.DirectSqlInsertPart.addPartitions(DirectSqlInsertPart.java:758) at org.apache.hadoop.hive.metastore.MetaStoreDirectSql.addPartitions(MetaStoreDirectSql.java:516) at org.apache.hadoop.hive.metastore.ObjectStore$7.getSqlResult(ObjectStore.java:2747)
```

### Why are the changes needed?
To leverage directSql for _msck repair_ command


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
On local cluster (single node)