### PR TITLE
HIVE-28643: Fix "Error getting slot value" for Java 12 and above

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -560,21 +560,13 @@ public final class ObjectInspectorUtils {
    * Get all the declared non-static fields of Class c.
    */
   public static Field[] getDeclaredNonStaticFields(Class<?> c) {
-    Field[] f = c.getDeclaredFields();
-    ArrayList<Field> af = new ArrayList<Field>();
-    if (slot != null) {
+    Field[] f = Arrays.stream(c.getDeclaredFields())
+        .filter(field -> !Modifier.isStatic(field.getModifiers()))
+        .toArray(Field[]::new);
+    if (f.length > 1 && slot != null) {
       Arrays.sort(f, Comparator.comparingInt(slot::get));
     }
-    for (int i = 0; i < f.length; ++i) {
-      if (!Modifier.isStatic(f[i].getModifiers())) {
-        af.add(f[i]);
-      }
-    }
-    Field[] r = new Field[af.size()];
-    for (int i = 0; i < af.size(); ++i) {
-      r[i] = af.get(i);
-    }
-    return r;
+    return f;
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `getDeclaredFields0` to try getting `slot` `Field` if `getDeclaredField` fails. Fallback to the old non deterministic behavior if `slot` field is not accessible.

### Why are the changes needed?
Java 12 and above filters out private fields of the `Field` class causing "Error getting slot value".

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Verified manually that the error is gone on Java 17. Using existing test for the rest.
