### PR TITLE
HIVE-28973: Metastore service in Docker fails to start unless --verbose is explicitly set

### DIFF
--- a/packaging/src/docker/entrypoint.sh
+++ b/packaging/src/docker/entrypoint.sh
@@ -22,14 +22,18 @@ set -x
 : "${DB_DRIVER:=derby}"
 
 SKIP_SCHEMA_INIT="${IS_RESUME:-false}"
-[[ $VERBOSE = "true" ]] && VERBOSE_MODE="--verbose" || VERBOSE_MODE=""
+[[ $VERBOSE = "true" ]] && VERBOSE_MODE="--verbose"
 
 function initialize_hive {
   COMMAND="-initOrUpgradeSchema"
   if [ "$(echo "$HIVE_VER" | cut -d '.' -f1)" -lt "4" ]; then
      COMMAND="-${SCHEMA_COMMAND:-initSchema}"
   fi
-  "$HIVE_HOME/bin/schematool" -dbType "$DB_DRIVER" "$COMMAND" "$VERBOSE_MODE"
+  if [[ -n "$VERBOSE_MODE" ]]; then
+    "$HIVE_HOME/bin/schematool" -dbType "$DB_DRIVER" "$COMMAND" "$VERBOSE_MODE"
+  else
+    "$HIVE_HOME/bin/schematool" -dbType "$DB_DRIVER" "$COMMAND"
+  fi
   if [ $? -eq 0 ]; then
     echo "Initialized Hive Metastore Server schema successfully.."
   else
@@ -57,5 +61,9 @@ if [ "${SERVICE_NAME}" == "hiveserver2" ]; then
   exec "$HIVE_HOME/bin/hive" --skiphadoopversion --skiphbasecp --service "$SERVICE_NAME"
 elif [ "${SERVICE_NAME}" == "metastore" ]; then
   export METASTORE_PORT=${METASTORE_PORT:-9083}
-  exec "$HIVE_HOME/bin/hive" --skiphadoopversion --skiphbasecp "$VERBOSE_MODE" --service "$SERVICE_NAME"
+  if [[ -n "$VERBOSE_MODE" ]]; then
+    exec "$HIVE_HOME/bin/hive" --skiphadoopversion --skiphbasecp "$VERBOSE_MODE" --service "$SERVICE_NAME"
+  else
+    exec "$HIVE_HOME/bin/hive" --skiphadoopversion --skiphbasecp --service "$SERVICE_NAME"
+  fi
 fi


### PR DESCRIPTION
…se is explicitly set

### What changes were proposed in this pull request?
This commit avoids appending the --verbose flag when it's not explicitly set, preventing invalid arguments from being passed during metastore startup.

### Why are the changes needed?
When VERBOSE is not set, an empty string argument ("") is passed to the startup command, which causes a parsing error. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
**Docker commands:**
**Without Verbose:**
docker run -d -p 9083:9083 --env SERVICE_NAME=metastore --name metastore-standalone apache/hive:${HIVE_VERSION}
**With Verbose:**
docker run -d -p 9083:9083 --env SERVICE_NAME=metastore --env VERBOSE="true" --name metastore-standalone apache/hive:${HIVE_VERSION}
