### PR TITLE
HIVE-28972: HMS performace degradation post HIVE-28909 for alter query

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -407,6 +407,8 @@ public class HiveAlterHandler implements AlterHandler {
               MetastoreConf.getBoolVar(handler.getConf(), MetastoreConf.ConfVars.COLSTATS_RETAIN_ON_COLUMN_REMOVAL);
 
           if (runPartitionMetadataUpdate) {
+            // Don't validate table-level stats for a partitoned table.
+            msdb.alterTable(catName, dbname, name, newt, null);
             if (cascade || retainOnColRemoval) {
               parts = msdb.getPartitions(catName, dbname, name, -1);
               for (Partition part : parts) {
@@ -431,8 +433,6 @@ public class HiveAlterHandler implements AlterHandler {
               TableName tableName = new TableName(catName, dbname, name);
               msdb.deleteAllPartitionColumnStatistics(tableName, writeIdList);
             }
-            // Don't validate table-level stats for a partitoned table.
-            msdb.alterTable(catName, dbname, name, newt, null);
           } else {
             LOG.warn("Alter table not cascaded to partitions.");
             msdb.alterTable(catName, dbname, name, newt, writeIdList);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -409,6 +409,7 @@ public class HiveAlterHandler implements AlterHandler {
           if (runPartitionMetadataUpdate) {
             // Don't validate table-level stats for a partitoned table.
             msdb.alterTable(catName, dbname, name, newt, null);
+
             if (cascade || retainOnColRemoval) {
               parts = msdb.getPartitions(catName, dbname, name, -1);
               for (Partition part : parts) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -5188,7 +5188,7 @@ public class ObjectStore implements RawStore, Configurable {
     catName = normalizeIdentifier(catName);
     name = normalizeIdentifier(name);
     dbname = normalizeIdentifier(dbname);
-    MPartition newp = convertToMPart(newPart, table, false);
+    MPartition newp = convertToMPart(newPart, table, true);
     MColumnDescriptor oldCD = null;
     MStorageDescriptor oldSD = oldp.getSd();
     if (oldSD != null) {
@@ -5248,9 +5248,6 @@ public class ObjectStore implements RawStore, Configurable {
     Partition result = null;
     try {
       openTransaction();
-      if (newPart.isSetWriteId()) {
-        LOG.warn("Alter partitions with write ID called without transaction information");
-      }
       Ref<MColumnDescriptor> oldCd = new Ref<>();
       result = alterPartitionNoTxn(catName, dbname, name, part_vals, newPart, validWriteIds, oldCd);
       removeUnusedColumnDescriptor(oldCd.t);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -2715,7 +2715,7 @@ public class ObjectStore implements RawStore, Configurable {
         throw new MetaException("Partition does not belong to target table "
             + dbName + "." + tblName + ": " + part);
       }
-      MPartition mpart = convertToMPart(part, table, true);
+      MPartition mpart = convertToMPart(part, table);
       mParts.add(mpart);
       int now = (int) (System.currentTimeMillis() / 1000);
       List<MPartitionPrivilege> mPartPrivileges = new ArrayList<>();
@@ -2817,7 +2817,7 @@ public class ObjectStore implements RawStore, Configurable {
         Partition part = iterator.next();
 
         if (isValidPartition(part, partitionKeys, ifNotExists)) {
-          MPartition mpart = convertToMPart(part, table, true);
+          MPartition mpart = convertToMPart(part, table);
           pm.makePersistent(mpart);
           if (tabGrants != null) {
             for (MTablePrivilege tab : tabGrants) {
@@ -3013,10 +3013,9 @@ public class ObjectStore implements RawStore, Configurable {
    * to the same one as the table's storage descriptor.
    * @param part the partition to convert
    * @param mt the parent table object
-   * @param useTableCD whether to try to use the parent table's column descriptor.
    * @return the model partition object, and null if the input partition is null.
    */
-  private MPartition convertToMPart(Partition part, MTable mt, boolean useTableCD)
+  private MPartition convertToMPart(Partition part, MTable mt)
       throws InvalidObjectException, MetaException {
     // NOTE: we don't set writeId in this method. Write ID is only set after validating the
     //       existing write ID against the caller's valid list.
@@ -3032,8 +3031,7 @@ public class ObjectStore implements RawStore, Configurable {
     // use the parent table's, so we do not create a duplicate column descriptor,
     // thereby saving space
     MStorageDescriptor msd;
-    if (useTableCD &&
-        mt.getSd() != null && mt.getSd().getCD() != null &&
+    if (mt.getSd() != null && mt.getSd().getCD() != null &&
         mt.getSd().getCD().getCols() != null &&
         part.getSd() != null &&
         convertToFieldSchemas(mt.getSd().getCD().getCols()).
@@ -5188,7 +5186,7 @@ public class ObjectStore implements RawStore, Configurable {
     catName = normalizeIdentifier(catName);
     name = normalizeIdentifier(name);
     dbname = normalizeIdentifier(dbname);
-    MPartition newp = convertToMPart(newPart, table, true);
+    MPartition newp = convertToMPart(newPart, table);
     MColumnDescriptor oldCD = null;
     MStorageDescriptor oldSD = oldp.getSd();
     if (oldSD != null) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MColumn.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MColumn.java
@@ -62,7 +62,8 @@ public class MColumn {
   public MColumn() {
   }
 
-  public MColumn(String name, String type, String comment) {
+  public MColumn(MColumnDescriptor cd, String name, String type, String comment) {
+    this.cd = cd;
     this.name = name;
     this.type = type;
     this.comment = comment;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MColumnDescriptor.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MColumnDescriptor.java
@@ -16,9 +16,6 @@
  * limitations under the License.
  */
 
-/**
- *
- */
 package org.apache.hadoop.hive.metastore.model;
 
 import javax.jdo.annotations.NotPersistent;
@@ -42,9 +39,8 @@ public class MColumnDescriptor {
 
   public MColumnDescriptor(List<MFieldSchema> cols) {
     fields = cols.stream().map(schema ->
-        new MColumn(schema.getName(), schema.getType(), schema.getComment()))
+        new MColumn(this, schema.getName(), schema.getType(), schema.getComment()))
             .collect(Collectors.toList());
-    fields.forEach(column -> column.setCd(this));
   }
 
   public List<MColumn> getFields() {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MColumnDescriptor.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MColumnDescriptor.java
@@ -44,6 +44,7 @@ public class MColumnDescriptor {
     fields = cols.stream().map(schema ->
         new MColumn(schema.getName(), schema.getType(), schema.getComment()))
             .collect(Collectors.toList());
+    fields.forEach(column -> column.setCd(this));
   }
 
   public List<MColumn> getFields() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
HMS performace degradation post HIVE-28909 for alter table cascade, with this PR the alter query in this Jira runs ~30X faster against the master, and 5X faster without the HIVE-28909 on my local. This also saves the entries stored in back db, before (with or without HIVE-28909) it has 4 million entries in COLUMNS_V2, now it's only about ~800 records.

Why the performance degradation post HIVE-28909?
With HIVE-28909, the column is inserted to the db one by one per partition, before that the partition's columns are added in a batch. With this PR, all the partitions refer to the same MColumnDescriptor the table holds, so no more column is inserted per partition.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
Current unit tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
