### PR TITLE
HIVE-28954: CI fails intermittently due to ephemeral-storage exhaustion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,6 +136,8 @@ def hdbPodTemplate(closure) {
         resourceLimitCpu: '8000m',
         resourceRequestMemory: '6400Mi',
         resourceLimitMemory: '12000Mi',
+        resourceRequestEphemeralStorage: '10Gi',
+        resourceLimitEphemeralStorage: '20Gi',
         envVars: [
             envVar(key: 'DOCKER_HOST', value: 'tcp://localhost:2376'),
             envVar(key: 'DOCKER_TLS_VERIFY', value: '1'),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce ephemeral storage request and limit for HDB container based on current usage and cluster capacity.

### Why are the changes needed?
Based on recent runs the HDB container, which executes the tests, consumes 10Gi to 15Gi of ephemeral storage. To ensure that pods are scheduled correctly to the GKE nodes that have the necessary capacity we should add an explicit resource request.

Moreover, to avoid malfunctioning PRs/pods affect the overall health of the cluster we set the resource limit to 20Gi that is reasonably high to permit precommits to run fine and can also guard against accidental changes that may cause disk spikes.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Monitor requests/limits through the GKE console.