### PR TITLE
HIVE-28976 : Enhance Commit message in notification_log  to correctly filter events during incremental replication

### DIFF
--- a/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
+++ b/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
@@ -668,7 +668,7 @@ public class DbNotificationListener extends TransactionalMetaStoreEventListener 
       return;
     }
     CommitTxnMessage msg =
-        MessageBuilder.getInstance().buildCommitTxnMessage(commitTxnEvent.getTxnId());
+        MessageBuilder.getInstance().buildCommitTxnMessage(commitTxnEvent.getTxnId(), commitTxnEvent.getDatabases(), commitTxnEvent.getWriteId());
 
     NotificationEvent event =
         new NotificationEvent(0, now(), EventType.COMMIT_TXN.toString(),
@@ -688,7 +688,7 @@ public class DbNotificationListener extends TransactionalMetaStoreEventListener 
       return;
     }
     AbortTxnMessage msg =
-        MessageBuilder.getInstance().buildAbortTxnMessage(abortTxnEvent.getTxnId(), abortTxnEvent.getDbsUpdated());
+        MessageBuilder.getInstance().buildAbortTxnMessage(abortTxnEvent.getTxnId(), abortTxnEvent.getDbsUpdated(), abortTxnEvent.getWriteId());
     NotificationEvent event =
         new NotificationEvent(0, now(), EventType.ABORT_TXN.toString(),
             msgEncoder.getSerializer().serialize(msg));

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/events/AbortTxnEvent.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/events/AbortTxnEvent.java
@@ -37,13 +37,14 @@ public class AbortTxnEvent extends ListenerEvent {
   private final Long txnId;
   private final TxnType txnType;
   private final List<String> dbsUpdated;
+  private final List<Long> writeId;
 
   public AbortTxnEvent(Long transactionId, IHMSHandler handler) {
-    this(transactionId, null, handler, null);
+    this(transactionId, null, handler, null, null);
   }
 
   public AbortTxnEvent(Long transactionId, TxnType txnType) {
-    this(transactionId, txnType, null, null);
+    this(transactionId, txnType, null, null, null);
   }
 
   /**
@@ -51,15 +52,17 @@ public class AbortTxnEvent extends ListenerEvent {
    * @param txnType type of transaction
    * @param handler handler that is firing the event
    * @param dbsUpdated list of databases that had update events
+   * @param writeId write id for transaction
    */
-  public AbortTxnEvent(Long transactionId, TxnType txnType, IHMSHandler handler, List<String> dbsUpdated) {
+  public AbortTxnEvent(Long transactionId, TxnType txnType, IHMSHandler handler, List<String> dbsUpdated, List<Long> writeId) {
     super(true, handler);
     this.txnId = transactionId;
     this.txnType = txnType;
     this.dbsUpdated = new ArrayList<String>();
     if (dbsUpdated != null) {
-      this.dbsUpdated.addAll(dbsUpdated);;
+      this.dbsUpdated.addAll(dbsUpdated);
     }
+    this.writeId = writeId == null ? new ArrayList<>() : writeId;
   }
 
   /**
@@ -82,5 +85,12 @@ public class AbortTxnEvent extends ListenerEvent {
    */
   public List<String> getDbsUpdated() {
     return dbsUpdated;
+  }
+
+  /**
+   * @return List of write ids which are associated with abort txn
+   */
+  public List<Long> getWriteId() {
+    return writeId;
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/events/CommitTxnEvent.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/events/CommitTxnEvent.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.api.TxnType;
 
+import java.util.List;
+
 /**
  * CommitTxnEvent
  * Event generated for commit transaction operation
@@ -33,24 +35,30 @@ public class CommitTxnEvent extends ListenerEvent {
 
   private final Long txnId;
   private final TxnType txnType;
+  private final List<Long> writeId;
+  private final List<String> databases;
 
   public CommitTxnEvent(Long transactionId, IHMSHandler handler) {
-    this(transactionId, null, handler);
+    this(transactionId, null, handler, null, null);
   }
 
   public CommitTxnEvent(Long transactionId, TxnType txnType) {
-    this(transactionId, txnType, null);
+    this(transactionId, txnType, null, null, null);
   }
 
   /**
    * @param transactionId Unique identification for the transaction just got committed.
    * @param txnType type of transaction
    * @param handler handler that is firing the event
+   * @param databases list of databases for which commit txn event is fired
+   * @param writeId write id for transaction
    */
-  public CommitTxnEvent(Long transactionId, TxnType txnType, IHMSHandler handler) {
+  public CommitTxnEvent(Long transactionId, TxnType txnType, IHMSHandler handler, List<String> databases, List<Long> writeId) {
     super(true, handler);
     this.txnId = transactionId;
     this.txnType = txnType;
+    this.writeId = writeId;
+    this.databases = databases;
   }
 
   /**
@@ -65,5 +73,19 @@ public class CommitTxnEvent extends ListenerEvent {
    */
   public TxnType getTxnType() {
     return txnType;
+  }
+
+    /**
+     * @return List of write ids for which commit txn event is fired
+     */
+  public List<Long> getWriteId() {
+    return writeId;
+  }
+
+    /**
+     * @return List of databases for which commit txn event is fired
+     */
+  public List<String> getDatabases() {
+    return databases;
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/messaging/AbortTxnMessage.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/messaging/AbortTxnMessage.java
@@ -36,4 +36,6 @@ public abstract class AbortTxnMessage extends EventMessage {
   public abstract Long getTxnId();
 
   public abstract List<String> getDbsUpdated();
+
+  public abstract List<Long> getWriteIds();
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/messaging/MessageBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/messaging/MessageBuilder.java
@@ -303,12 +303,12 @@ public class MessageBuilder {
     return new JSONOpenTxnMessage(MS_SERVER_URL, MS_SERVICE_PRINCIPAL, fromTxnId, toTxnId, now());
   }
 
-  public CommitTxnMessage buildCommitTxnMessage(Long txnId) {
-    return new JSONCommitTxnMessage(MS_SERVER_URL, MS_SERVICE_PRINCIPAL, txnId, now());
+  public CommitTxnMessage buildCommitTxnMessage(Long txnId,  List<String> databases,  List<Long> writeIds) {
+    return new JSONCommitTxnMessage(MS_SERVER_URL, MS_SERVICE_PRINCIPAL, txnId, now(), databases, writeIds);
   }
 
-  public AbortTxnMessage buildAbortTxnMessage(Long txnId, List<String> dbsUpdated) {
-    return new JSONAbortTxnMessage(MS_SERVER_URL, MS_SERVICE_PRINCIPAL, txnId, now(), dbsUpdated);
+  public AbortTxnMessage buildAbortTxnMessage(Long txnId, List<String> dbsUpdated, List<Long> writeIds) {
+    return new JSONAbortTxnMessage(MS_SERVER_URL, MS_SERVICE_PRINCIPAL, txnId, now(), dbsUpdated, writeIds);
   }
 
   public AllocWriteIdMessage buildAllocWriteIdMessage(List<TxnToWriteId> txnToWriteIdList,

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/messaging/json/JSONAbortTxnMessage.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/messaging/json/JSONAbortTxnMessage.java
@@ -43,6 +43,8 @@ public class JSONAbortTxnMessage extends AbortTxnMessage {
 
   @JsonProperty
   private List<String> dbsUpdated;
+  @JsonProperty
+  private List<Long> writeIds;
 
   /**
    * Default constructor, needed for Jackson.
@@ -50,12 +52,13 @@ public class JSONAbortTxnMessage extends AbortTxnMessage {
   public JSONAbortTxnMessage() {
   }
 
-  public JSONAbortTxnMessage(String server, String servicePrincipal, Long txnid, Long timestamp, List<String> dbsUpdated) {
+  public JSONAbortTxnMessage(String server, String servicePrincipal, Long txnid, Long timestamp, List<String> dbsUpdated, List<Long> writeIds) {
     this.timestamp = timestamp;
     this.txnid = txnid;
     this.server = server;
     this.servicePrincipal = servicePrincipal;
     this.dbsUpdated = dbsUpdated;
+    this.writeIds = writeIds;
   }
 
   @Override
@@ -86,6 +89,11 @@ public class JSONAbortTxnMessage extends AbortTxnMessage {
   @Override
   public List<String> getDbsUpdated() {
     return dbsUpdated;
+  }
+
+  @Override
+  public List<Long> getWriteIds() {
+    return writeIds;
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/messaging/json/JSONCommitTxnMessage.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/messaging/json/JSONCommitTxnMessage.java
@@ -72,6 +72,12 @@ public class JSONCommitTxnMessage extends CommitTxnMessage {
     this.files = null;
   }
 
+  public JSONCommitTxnMessage(String server, String servicePrincipal, Long txnid, Long timestamp, List<String> databases, List<Long> writeIds) {
+    this(server, servicePrincipal, txnid, timestamp);
+    this.databases = databases;
+    this.writeIds = writeIds;
+  }
+
   @Override
   public Long getTxnId() {
     return txnid;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/TxnWriteDetails.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/TxnWriteDetails.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.txn.entities;
+
+/**
+ * Class to hold transaction id, database name and write id.
+ */
+public class TxnWriteDetails {
+    private final long txnId;
+    private final String dbName;
+    private final long writeId;
+
+    public TxnWriteDetails(long txnId, String dbName, long writeId) {
+        this.txnId = txnId;
+        this.dbName = dbName;
+        this.writeId = writeId;
+    }
+
+    @Override
+    public String toString() {
+        return "TxnToWriteID{" +
+                "txnId=" + txnId +
+                ", dbName='" + dbName + '\'' +
+                ", writeId=" + writeId +
+                '}';
+    }
+
+    public long getTxnId() {
+        return txnId;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public long getWriteId() {
+        return writeId;
+    }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetWriteIdsForTxnIDHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetWriteIdsForTxnIDHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.txn.jdbc.queries;
+
+import org.apache.hadoop.hive.metastore.DatabaseProduct;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.txn.entities.TxnWriteDetails;
+import org.apache.hadoop.hive.metastore.txn.jdbc.QueryHandler;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Returns the databases and writeID updated by txnId.
+ * Queries TXN_TO_WRITE_ID using txnId.
+ */
+public class GetWriteIdsForTxnIDHandler implements QueryHandler<List<TxnWriteDetails>> {
+
+    private final long txnId;
+
+    public GetWriteIdsForTxnIDHandler(long txnId) {
+        this.txnId = txnId;
+    }
+
+    @Override
+    public String getParameterizedQueryString(DatabaseProduct databaseProduct) throws MetaException {
+        return "SELECT DISTINCT \"T2W_DATABASE\", \"T2W_WRITEID\" FROM \"TXN_TO_WRITE_ID\" \"COMMITTED\" WHERE \"T2W_TXNID\" = :txnId";
+    }
+
+    @Override
+    public SqlParameterSource getQueryParameters() {
+        return new MapSqlParameterSource().addValue("txnId", txnId);
+    }
+
+    @Override
+    public List<TxnWriteDetails> extractData(ResultSet rs) throws SQLException, DataAccessException {
+        List<TxnWriteDetails> dbsUpdated = new ArrayList<>();
+        while (rs.next()) {
+            TxnWriteDetails entry = new TxnWriteDetails(txnId, rs.getString(1), rs.getLong(2));
+            dbsUpdated.add(entry);
+        }
+        return dbsUpdated;
+    }
+}
+

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/events/TestAbortTxnEventDbsUpdated.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/events/TestAbortTxnEventDbsUpdated.java
@@ -49,9 +49,10 @@ public class TestAbortTxnEventDbsUpdated {
   @Test
   public void testSerializeDeserialize() {
     List dbsUpdated = Arrays.asList("db1", "db22");
-    AbortTxnEvent event = new AbortTxnEvent(999L, TxnType.DEFAULT, null, dbsUpdated);
+    List writeIds = Arrays.asList(1L, 2L);
+    AbortTxnEvent event = new AbortTxnEvent(999L, TxnType.DEFAULT, null, dbsUpdated, writeIds);
     AbortTxnMessage msg =
-            MessageBuilder.getInstance().buildAbortTxnMessage(event.getTxnId(), event.getDbsUpdated());
+            MessageBuilder.getInstance().buildAbortTxnMessage(event.getTxnId(), event.getDbsUpdated(), event.getWriteId());
     JSONMessageEncoder msgEncoder = new JSONMessageEncoder();
     String json = msgEncoder.getSerializer().serialize(msg);
 
@@ -63,6 +64,12 @@ public class TestAbortTxnEventDbsUpdated {
     Assert.assertTrue(actual.remove("db1"));
     Assert.assertTrue(actual.remove("db22"));
     Assert.assertTrue(actual.isEmpty());
+
+    List actualWriteIds = abortTxnMsg.getWriteIds();
+    Assert.assertTrue(actualWriteIds.remove(1L));
+    Assert.assertTrue(actualWriteIds.remove(2L));
+    Assert.assertTrue(actualWriteIds.isEmpty());
+
     Assert.assertEquals(999L, abortTxnMsg.getTxnId().longValue());
   }
 }

--- a/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/events/TestCommitTxnEventWithDbAndWriteId.java
+++ b/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/events/TestCommitTxnEventWithDbAndWriteId.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.events;
+
+import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
+import org.apache.hadoop.hive.metastore.api.TxnType;
+import org.apache.hadoop.hive.metastore.messaging.CommitTxnMessage;
+import org.apache.hadoop.hive.metastore.messaging.MessageBuilder;
+import org.apache.hadoop.hive.metastore.messaging.json.JSONMessageDeserializer;
+import org.apache.hadoop.hive.metastore.messaging.json.JSONMessageEncoder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Category(MetastoreUnitTest.class)
+public class TestCommitTxnEventWithDbAndWriteId {
+    @Test
+    public void testBackwardsCompatibility() {
+        final String json = "{\"txnid\":12787,\"timestamp\":1654116516,\"server\":\"\",\"servicePrincipal\":\"\"}";
+        JSONMessageDeserializer deserializer = new JSONMessageDeserializer();
+        CommitTxnMessage commitTxnMsg = deserializer.getCommitTxnMessage(json);
+        Assert.assertNull(commitTxnMsg.getDatabases());
+        Assert.assertEquals(12787L, commitTxnMsg.getTxnId().longValue());
+    }
+
+    @Test
+    public void testSerializeDeserialize() {
+        
+        List<String> databases = Arrays.asList("db1", "db22");
+        List<Long> writeIds = Arrays.asList(1L, 2L);
+        CommitTxnEvent event = new CommitTxnEvent(999L, TxnType.DEFAULT, null, databases, writeIds);
+        CommitTxnMessage msg =
+                MessageBuilder.getInstance().buildCommitTxnMessage(event.getTxnId(), event.getDatabases(), event.getWriteId());
+        JSONMessageEncoder msgEncoder = new JSONMessageEncoder();
+        String json = msgEncoder.getSerializer().serialize(msg);
+
+        JSONMessageDeserializer deserializer = new JSONMessageDeserializer();
+        CommitTxnMessage commitTxnMsg = deserializer.getCommitTxnMessage(json);
+        Set<String> expected = new HashSet(databases);
+        Assert.assertEquals(expected.size(), commitTxnMsg.getDatabases().size());
+        List actual = commitTxnMsg.getDatabases();
+        Assert.assertTrue(actual.remove("db1"));
+        Assert.assertTrue(actual.remove("db22"));
+        Assert.assertTrue(actual.isEmpty());
+
+        List actualWriteIds = commitTxnMsg.getWriteIds();
+        Assert.assertTrue(actualWriteIds.remove(1L));
+        Assert.assertTrue(actualWriteIds.remove(2L));
+        Assert.assertTrue(actualWriteIds.isEmpty());
+
+        Assert.assertEquals(999L, commitTxnMsg.getTxnId().longValue());
+    }
+    
+    
+}


### PR DESCRIPTION
Details:
  * Added write ID, database name into commit & abort message
  * Updated filter in CommitTxnHandler to utilise it during replication dump process

Testing:
  * Added test cases
  * Tested on YCloud

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
  * In commit & abort message in notification_log will have additional write IDs and databases details to be used by replication. 
  * During Replication dump, if hive.repl.filter.transactions is true then, it will use these details there are some DDLs which needs new write ID but it does not add an entry into txn_write_notification_log table which was only source of truth earlier to figure out whether that txn was read / write related. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

  * In presence of hive.repl.filter.transactions property, replication will fail on the DR side post 11 days if user runs Truncate operation (or any other which implements DDLDescWithWriteId). Reason being it generates alloc_write_id event in notification_log table. In presence of above filter on source side we want to filter out commit_txn which are associated with read operation or it's not related to database in replication. 
  * To decide this we rely on another historical table txn_write_notification_log, now, in insert and other DML operatioins it does get an entry. But for truncate / DDLDescWithWriteId it doesn't get any entry into that which leads to skipping the commit operation on the source and on the DR side, we open the implicit txn if alloc_write_id event is present and we wait for commit / abort to come from the source
  * This results into txn being open for a long time and then it eventually times out and adds repl_incompatible flag on the database on the DR side
  * So, now there are 2 options to address this issue. Either add an dummy entry into txn_write_notification_log, which may open up some other issue and we will have to keep on monitoring the code change because if hive adds any new command which implements DDLDescWithWriteId then it can break the replication again in future
  * The 2nd option is to enhance the commit message, which we are storing in the notifiation_log and add some additional context, which replication dump can use to figure it out.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
  * No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
  * Added test cases
  * Tested on actual cluster

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
