### PR TITLE
HIVE-28995: Add a space to debug log in HMSHandler#endFunction

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -854,7 +854,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     if (timerContext != null) {
       long timeTaken = timerContext.stop();
       LOG.debug((getThreadLocalIpAddress() == null ? "" : "source:" + getThreadLocalIpAddress() + " ") +
-          function + "time taken(ns): " + timeTaken);
+          function + " time taken(ns): " + timeTaken);
     }
     Counter counter = Metrics.getOrCreateCounter(MetricsConstants.ACTIVE_CALLS + function);
     if (counter != null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a space to debug log in endFunction.

### Why are the changes needed?
The debug log in endFunction is missing a space, which leads to incorrect format. We should keep the correct format.

```
private void endFunction(String function, MetaStoreEndFunctionContext context) {
    com.codahale.metrics.Timer.Context timerContext = HMSHandlerContext.getTimerContexts().remove(function);
    if (timerContext != null) {
      long timeTaken = timerContext.stop();
      LOG.debug((getThreadLocalIpAddress() == null ? "" : "source:" + getThreadLocalIpAddress() + " ") +
          function + "time taken(ns): " + timeTaken);
    }
   ...
  }
```
The debug log shows before:
```
[DEBUG] 2025-06-06 18:05:09.398 [main] HMSHandler - get_databasetime taken(ns): 45370281
```
After this PR:
```
[DEBUG] 2025-06-06 18:16:15.551 [main] HMSHandler - get_database time taken(ns): 45370281
```
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Just change the debug log format
