### PR TITLE
HIVE-29001: Remove duplicate mockito dependency in hive-common pom causing maven warnings

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -255,12 +255,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-29001](https://issues.apache.org/jira/browse/HIVE-29001), duplicate dependency of mockito throwing maven warning during build


### Why are the changes needed?
To have a clean maven build output :-)


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Will see CI output