### PR TITLE
HIVE-29002: Upgrade parquet to 1.15.2 to be in sync with iceberg 1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.8</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
-    <parquet.version>1.15.1</parquet.version>
+    <parquet.version>1.15.2</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
     <protobuf.version>3.25.5</protobuf.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-29002](https://issues.apache.org/jira/browse/HIVE-29002). 
Changelog b/w parquet 1.15.1 to 1.15.2 are present [here](https://github.com/apache/parquet-java/compare/apache-parquet-1.15.1...apache-parquet-1.15.2). The code changes are predominantly on parquet-avro on which hive doesn't have direct dependency, so it should be just pom changes.


### Why are the changes needed?
To be in sync with iceberg 1.9.1 parquet version


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Will see CI output
