### PR TITLE
HIVE-29009: Intermittent CI timeouts while running tests - disable TestHttpSamlAuthentication

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/service/auth/saml/TestHttpSamlAuthentication.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/auth/saml/TestHttpSamlAuthentication.java
@@ -79,6 +79,7 @@ import org.testcontainers.utility.DockerImageName;
  * It uses HTMLUnit to simulate the browser interaction (provide user/password) of the
  * end user.
  */
+@org.junit.Ignore("HIVE-29009")
 public class TestHttpSamlAuthentication {
 
   //user credentials. These much match with the authsources.php of the simpleSAMLPHP


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disabled TestHttpSamlAuthentication temporarily.


### Why are the changes needed?
It hangs and blocks precommit.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Precommit passed.
