### PR TITLE
HIVE-29010: Correct assignment of metastore object count metrics

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -10057,9 +10057,9 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   void updateMetrics() throws MetaException {
     if (Metrics.getRegistry() != null) {
       LOG.info("Begin calculating metadata count metrics.");
-      Metrics.getOrCreateGauge(MetricsConstants.TOTAL_DATABASES).set(getMS().getTableCount());
-      Metrics.getOrCreateGauge(MetricsConstants.TOTAL_TABLES).set(getMS().getPartitionCount());
-      Metrics.getOrCreateGauge(MetricsConstants.TOTAL_PARTITIONS).set(getMS().getDatabaseCount());
+      Metrics.getOrCreateGauge(MetricsConstants.TOTAL_TABLES).set(getMS().getTableCount());
+      Metrics.getOrCreateGauge(MetricsConstants.TOTAL_PARTITIONS).set(getMS().getPartitionCount());
+      Metrics.getOrCreateGauge(MetricsConstants.TOTAL_DATABASES).set(getMS().getDatabaseCount());
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct assignment of metastore object count metrics.

### Why are the changes needed?

[HIVE-26701](https://issues.apache.org/jira/browse/HIVE-26701) enhanced metrics for connection pools. It also included some refactoring of existing metrics code in `HMSHandler`. It appears that this change accidentally swapped some metric names, so that `total_count_dbs` counts tables, `total_count_tables` counts partitions and `total_count_partitions` counts databases.

### Does this PR introduce _any_ user-facing change?

Yes, previous mismatched total metrics will now show correctly.

### How was this patch tested?

Manual testing.
