### PR TITLE
HIVE-29013: [ICEBERG] Data type info is not correct in Error message for tinyint, smallint

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -87,7 +87,7 @@ class HiveSchemaConverter {
           case SHORT:
             Preconditions.checkArgument(autoConvert, "Unsupported Hive type %s, use integer " +
                     "instead or enable automatic type conversion, set 'iceberg.mr.schema.auto.conversion' to true",
-                ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory());
+                typeInfo.toString().toUpperCase());
 
             LOG.debug("Using auto conversion from SHORT/BYTE to INTEGER");
             return Types.IntegerType.get();

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -852,7 +852,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
                                 testTables.propertiesForCreateTableSQL(ImmutableMap.of())))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageStartingWith("Failed to execute Hive query")
-          .hasMessageContaining("Unsupported Hive type");
+          .hasMessageContaining("Unsupported Hive type " + notSupportedType.replaceAll("\\(.*\\)", ""));
     }
   }
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This is to fix the wrong data type logged in the error, when table is created with smallint, tinyint datatypes


### Why are the changes needed?
wrong data type in error message


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Existing tests, and one updated test testCreateTableWithNotSupportedTypes()
