### PR TITLE
HIVE-29033: ORC reader should not assume that TimestampColumnVector is in UTC time zone

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/type/Timestamp.java
+++ b/common/src/java/org/apache/hadoop/hive/common/type/Timestamp.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.common.type;
 
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hive.common.util.SuppressFBWarnings;
 
 import java.time.DateTimeException;
@@ -235,6 +236,11 @@ public class Timestamp implements Comparable<Timestamp> {
     return new Timestamp(LocalDateTime
         .ofInstant(Instant.ofEpochMilli(epochMilli), ZoneOffset.UTC)
         .withNano(nanos));
+  }
+
+  public static Timestamp from(TimestampColumnVector tcv, int row) {
+    return Timestamp.ofEpochSecond(Math.floorDiv(tcv.time[row], 1000L), tcv.nanos[row],
+        tcv.isUTC() ? ZoneOffset.UTC : ZoneId.systemDefault());
   }
 
   public void setNanos(int nanos) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/BatchToRowReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/BatchToRowReader.java
@@ -20,8 +20,11 @@ package org.apache.hadoop.hive.ql.io;
 
 import com.google.common.collect.Lists;
 
+import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.llap.DebugUtils;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 
 import org.slf4j.Logger;
@@ -518,7 +521,8 @@ public abstract class BatchToRowReader<StructType, UnionType>
         result = (TimestampWritableV2) previous;
       }
       TimestampColumnVector tcv = (TimestampColumnVector) vector;
-      result.setInternal(tcv.time[row], tcv.nanos[row]);
+      result.set(Timestamp.ofEpochSecond(Math.floorDiv(tcv.time[row], 1000L), tcv.nanos[row],
+          tcv.isUTC() ? ZoneOffset.UTC : ZoneId.systemDefault()));
       return result;
     } else {
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/BatchToRowReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/BatchToRowReader.java
@@ -23,8 +23,6 @@ import com.google.common.collect.Lists;
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.llap.DebugUtils;
 
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 
 import org.slf4j.Logger;
@@ -520,9 +518,7 @@ public abstract class BatchToRowReader<StructType, UnionType>
       } else {
         result = (TimestampWritableV2) previous;
       }
-      TimestampColumnVector tcv = (TimestampColumnVector) vector;
-      result.set(Timestamp.ofEpochSecond(Math.floorDiv(tcv.time[row], 1000L), tcv.nanos[row],
-          tcv.isUTC() ? ZoneOffset.UTC : ZoneId.systemDefault()));
+      result.set(Timestamp.from((TimestampColumnVector) vector, row));
       return result;
     } else {
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/ReaderImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/ReaderImpl.java
@@ -35,6 +35,10 @@ public class ReaderImpl extends org.apache.orc.impl.ReaderImpl
 
   private final ObjectInspector inspector;
 
+  boolean isUTC() {
+    return useUTCTimestamp;
+  }
+  
   @Override
   public ObjectInspector getObjectInspector() {
     return inspector;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/RecordReaderImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/RecordReaderImpl.java
@@ -18,8 +18,6 @@
 package org.apache.hadoop.hive.ql.io.orc;
 
 import java.io.IOException;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -464,9 +462,7 @@ public class RecordReaderImpl extends org.apache.orc.impl.RecordReaderImpl
       } else {
         result = (TimestampWritableV2) previous;
       }
-      TimestampColumnVector tcv = (TimestampColumnVector) vector;
-      result.set(Timestamp.ofEpochSecond(Math.floorDiv(tcv.time[row], 1000L), tcv.nanos[row],
-          tcv.isUTC() ? ZoneOffset.UTC : ZoneId.systemDefault()));
+      result.set(Timestamp.from((TimestampColumnVector) vector, row));
       return result;
     } else {
       return null;

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/TimestampColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/TimestampColumnVector.java
@@ -40,6 +40,15 @@ import org.apache.hive.common.util.SuppressFBWarnings;
  * using the scratch timestamp, and then perhaps update the column vector row with a result.
  */
 public class TimestampColumnVector extends ColumnVector {
+  private static final ThreadLocal<Boolean> useUTC = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+  public static void setUseUTC(Boolean isUTC) {
+    if (isUTC != null) {
+      useUTC.set(isUTC);
+    } else {
+      useUTC.remove();
+    }
+  }
 
   /*
    * The storage arrays for this column vector corresponds to the storage of a Timestamp:
@@ -85,7 +94,7 @@ public class TimestampColumnVector extends ColumnVector {
 
     scratchWritable = null;     // Allocated by caller.
 
-    isUTC = false;
+    isUTC = useUTC.get();
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
While setting `TimestampWritableV2` result from `TimestampColumnVector` use either UTC or local time zone depending on `TimestampColumnVector.isUTC()` flag.

### Why are the changes needed?
While Hive assumes that `isUTC` is always true, Spark uses local time zone


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Using existing tests in Hive and Spark
