### PR TITLE
HIVE-29017: Restore ability to prevent metastore metrics startup queries

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -942,6 +942,9 @@ public class MetastoreConf {
     INIT_HOOKS("metastore.init.hooks", "hive.metastore.init.hooks", "",
         "A comma separated list of hooks to be invoked at the beginning of HMSHandler initialization. \n" +
             "An init hook is specified as the name of Java class which extends org.apache.riven.MetaStoreInitListener."),
+    INIT_METADATA_COUNT_ENABLED("metastore.initial.metadata.count.enabled",
+        "hive.metastore.initial.metadata.count.enabled", true,
+        "Enable a metadata count at metastore startup for metrics."),
     INTEGER_JDO_PUSHDOWN("metastore.integral.jdo.pushdown",
         "hive.metastore.integral.jdo.pushdown", false,
         "Allow JDO query pushdown for integral partition columns in metastore. Off by default. This\n" +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -10055,7 +10055,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
   @VisibleForTesting
   void updateMetrics() throws MetaException {
-    if (Metrics.getRegistry() != null) {
+    if (Metrics.getRegistry() != null &&
+        MetastoreConf.getBoolVar(conf, ConfVars.INIT_METADATA_COUNT_ENABLED)) {
       LOG.info("Begin calculating metadata count metrics.");
       Metrics.getOrCreateGauge(MetricsConstants.TOTAL_TABLES).set(getMS().getTableCount());
       Metrics.getOrCreateGauge(MetricsConstants.TOTAL_PARTITIONS).set(getMS().getPartitionCount());


### PR DESCRIPTION
### What changes were proposed in this pull request?

Restore configuration `metastore.initial.metadata.count.enabled` to prevent metastore metrics startup queries

### Why are the changes needed?

For releases as late as Hive 2.3.10, there was support for a `metastore.initial.metadata.count.enabled` configuration property. This could be set to `false` to prevent running queries to determine the counts of existing databases, tables and partitions. In large-scale ephemeral/serverless deployments with many HiveMetaStore processes starting up, this can be a source of unnecessary load spikes on the database. It appears this property was accidentally removed during the Standalone Metastore separation work, specifically in the [HIVE-17307](https://issues.apache.org/jira/browse/HIVE-17307) metrics refactoring.

### Does this PR introduce _any_ user-facing change?

Yes, this restores the ability to control configuration for whether or not to run these metrics queries.

### How was this patch tested?

Manual testing.
