### PR TITLE
HIVE-28998: Support Iceberg REST Catalog without authentication

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1868,8 +1868,8 @@ public class MetastoreConf {
             " positive value will be used as-is."
     ),
     ICEBERG_CATALOG_SERVLET_AUTH("metastore.iceberg.catalog.servlet.auth",
-        "hive.metastore.iceberg.catalog.servlet.auth", "jwt", new StringSetValidator("simple", "jwt"),
-        "HMS Iceberg Catalog servlet authentication method (simple or jwt)."
+        "hive.metastore.iceberg.catalog.servlet.auth", "jwt", new StringSetValidator("none", "simple", "jwt"),
+        "HMS Iceberg Catalog servlet authentication method (none, simple, or jwt)."
     ),
     ICEBERG_CATALOG_CACHE_EXPIRY("metastore.iceberg.catalog.cache.expiry",
         "hive.metastore.iceberg.catalog.cache.expiry", -1,

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -23,6 +23,7 @@ import java.util.TreeMap;
 import javax.servlet.http.HttpServlet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.ServletSecurity;
+import org.apache.hadoop.hive.metastore.ServletSecurity.AuthType;
 import org.apache.hadoop.hive.metastore.ServletServerBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
@@ -99,7 +100,7 @@ public class HMSCatalogFactory {
    */
   private HttpServlet createServlet(Catalog catalog) {
     String authType = MetastoreConf.getVar(configuration, ConfVars.ICEBERG_CATALOG_SERVLET_AUTH);
-    ServletSecurity security = new ServletSecurity(authType, configuration);
+    ServletSecurity security = new ServletSecurity(AuthType.fromString(authType), configuration);
     return security.proxy(new HMSCatalogServlet(new HMSCatalogAdapter(catalog)));
   }
 

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogJwtAuth.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogJwtAuth.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class TestRESTCatalogJwtAuth extends BaseRESTCatalogTests {
   @RegisterExtension
   private static final HiveRESTCatalogServerExtension REST_CATALOG_EXTENSION =
-      new HiveRESTCatalogServerExtension(AuthType.JWT);
+      HiveRESTCatalogServerExtension.builder(AuthType.JWT).build();
 
   @Override
   protected Map<String, String> getDefaultClientConfiguration() throws Exception {

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogJwtAuth.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogJwtAuth.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.rest;
 
 import java.util.Map;
+import org.apache.hadoop.hive.metastore.ServletSecurity.AuthType;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.rest.extension.HiveRESTCatalogServerExtension;
@@ -32,8 +33,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @Category(MetastoreCheckinTest.class)
 class TestRESTCatalogJwtAuth extends BaseRESTCatalogTests {
   @RegisterExtension
-  private static final HiveRESTCatalogServerExtension REST_CATALOG_EXTENSION = HiveRESTCatalogServerExtension.builder()
-      .jwt().build();
+  private static final HiveRESTCatalogServerExtension REST_CATALOG_EXTENSION =
+      new HiveRESTCatalogServerExtension(AuthType.JWT);
 
   @Override
   protected Map<String, String> getDefaultClientConfiguration() throws Exception {

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogNoneAuth.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogNoneAuth.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class TestRESTCatalogNoneAuth extends BaseRESTCatalogTests {
   @RegisterExtension
   private static final HiveRESTCatalogServerExtension REST_CATALOG_EXTENSION =
-      new HiveRESTCatalogServerExtension(AuthType.NONE);
+      HiveRESTCatalogServerExtension.builder(AuthType.NONE).build();
 
   @Override
   protected Map<String, String> getDefaultClientConfiguration() {

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogNoneAuth.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogNoneAuth.java
@@ -22,35 +22,20 @@ package org.apache.iceberg.rest;
 import java.util.Map;
 import org.apache.hadoop.hive.metastore.ServletSecurity.AuthType;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
-import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.rest.extension.HiveRESTCatalogServerExtension;
 import org.junit.experimental.categories.Category;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @Category(MetastoreCheckinTest.class)
-class TestRESTCatalogSimpleAuth extends BaseRESTCatalogTests {
+class TestRESTCatalogNoneAuth extends BaseRESTCatalogTests {
   @RegisterExtension
   private static final HiveRESTCatalogServerExtension REST_CATALOG_EXTENSION =
-      new HiveRESTCatalogServerExtension(AuthType.SIMPLE);
+      new HiveRESTCatalogServerExtension(AuthType.NONE);
 
   @Override
   protected Map<String, String> getDefaultClientConfiguration() {
     return Map.of(
-        "uri", REST_CATALOG_EXTENSION.getRestEndpoint(),
-        "header.x-actor-username", "USER_1"
-    );
-  }
-
-  @Test
-  void testWithoutUserName() {
-    Map<String, String> properties = Map.of(
         "uri", REST_CATALOG_EXTENSION.getRestEndpoint()
     );
-    NotAuthorizedException error = Assertions.assertThrows(NotAuthorizedException.class,
-        () -> RCKUtils.initCatalogClient(properties));
-    Assertions.assertEquals("Not authorized: Authentication error: User header x-actor-username missing in request",
-        error.getMessage());
   }
 }

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogSimpleAuth.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestRESTCatalogSimpleAuth.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class TestRESTCatalogSimpleAuth extends BaseRESTCatalogTests {
   @RegisterExtension
   private static final HiveRESTCatalogServerExtension REST_CATALOG_EXTENSION =
-      new HiveRESTCatalogServerExtension(AuthType.SIMPLE);
+      HiveRESTCatalogServerExtension.builder(AuthType.SIMPLE).build();
 
   @Override
   protected Map<String, String> getDefaultClientConfiguration() {

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/extension/HiveRESTCatalogServerExtension.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/extension/HiveRESTCatalogServerExtension.java
@@ -42,7 +42,7 @@ public class HiveRESTCatalogServerExtension implements BeforeAllCallback, Before
   private final JwksServer jwksServer;
   private final RESTCatalogServer restCatalogServer;
 
-  public HiveRESTCatalogServerExtension(AuthType authType) {
+  private HiveRESTCatalogServerExtension(AuthType authType) {
     this.conf = MetastoreConf.newMetastoreConf();
     MetastoreConf.setVar(conf, ConfVars.ICEBERG_CATALOG_SERVLET_AUTH, authType.name());
     if (authType == AuthType.JWT) {
@@ -94,5 +94,21 @@ public class HiveRESTCatalogServerExtension implements BeforeAllCallback, Before
 
   public String getRestEndpoint() {
     return restCatalogServer.getRestEndpoint();
+  }
+
+  public static class Builder {
+    private final AuthType authType;
+
+    private Builder(AuthType authType) {
+      this.authType = authType;
+    }
+
+    public HiveRESTCatalogServerExtension build() {
+      return new HiveRESTCatalogServerExtension(authType);
+    }
+  }
+
+  public static Builder builder(AuthType authType) {
+    return new Builder(authType);
   }
 }

--- a/standalone-metastore/metastore-server/src/docker/conf/metastore-site.xml
+++ b/standalone-metastore/metastore-server/src/docker/conf/metastore-site.xml
@@ -38,6 +38,6 @@
     </property>
     <property>
         <name>hive.metastore.iceberg.catalog.servlet.auth</name>
-        <value>simple</value>
+        <value>none</value>
     </property>
 </configuration>

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -24,6 +24,7 @@ import java.util.concurrent.SynchronousQueue;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.ZKDeRegisterWatcher;
 import org.apache.hadoop.hive.common.ZooKeeperHiveHelper;
+import org.apache.hadoop.hive.metastore.ServletSecurity.AuthType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
@@ -420,7 +421,8 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     processor = new ThriftHiveMetastore.Processor<>(handler);
     LOG.info("Starting DB backed MetaStore Server with generic processor");
     boolean jwt = MetastoreConf.getVar(conf, ConfVars.THRIFT_METASTORE_AUTHENTICATION).equalsIgnoreCase("jwt");
-    ServletSecurity security = new ServletSecurity(conf, jwt);
+    AuthType authType = jwt ? AuthType.JWT : AuthType.SIMPLE;
+    ServletSecurity security = new ServletSecurity(authType, conf);
     Servlet thriftHttpServlet = security.proxy(new TServlet(processor, protocolFactory));
 
     boolean directSqlEnabled = MetastoreConf.getBoolVar(conf, ConfVars.TRY_DIRECT_SQL);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PropertyServlet.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PropertyServlet.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.ServletSecurity.AuthType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
@@ -314,7 +315,7 @@ public class PropertyServlet extends HttpServlet {
       String path = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_PATH);
       if (port >= 0 && path != null && !path.isEmpty()) {
         String authType = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.PROPERTIES_SERVLET_AUTH);
-        ServletSecurity security = new ServletSecurity(authType, configuration);
+        ServletSecurity security = new ServletSecurity(AuthType.fromString(authType), configuration);
         HttpServlet servlet = security.proxy(new PropertyServlet(configuration));
         return new ServletServerBuilder.Descriptor(port, path, servlet);
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This PR would add a new authentication mode, NONE, to the Iceberg REST Catalog API. The currently supported SIMPLE and JWT are not central authentication. It is inherited from another Hive servlet. It appears that NONE and OAuth2 are widely used.

### Why are the changes needed?
To acquire test users.

### Does this PR introduce _any_ user-facing change?
No. The feature has not been shipped.

### How was this patch tested?
Unit and integration tests
