### PR TITLE
HIVE-29012: NPE in ExplainTask when protologging posthook is enabled

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveHookEventProtoPartialBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveHookEventProtoPartialBuilder.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.ExplainTask;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
 import org.apache.hadoop.hive.ql.hooks.HiveProtoLoggingHook.OtherInfoType;
@@ -80,7 +81,7 @@ public class HiveHookEventProtoPartialBuilder {
   }
 
   private JSONObject getExplainJSON(ExplainWork explainWork) throws Exception {
-    ExplainTask explain = (ExplainTask) TaskFactory.get(explainWork, null);
+    ExplainTask explain = (ExplainTask) TaskFactory.get(explainWork, new HiveConf());
     return explain.getJSONPlan(null, explainWork, stageIdRearrange);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-29012](https://issues.apache.org/jira/browse/HIVE-29012) for the stacktrace. 


### Why are the changes needed?
When protologging hook is enabled, it stores the query plan for a query as well. The conf object in ExplainTask is null for the "Hive Hook Proto Log Writer" thread.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Will see CI output + local single node setup/cluster testing