### PR TITLE
HIVE-29021: Update implementation for HMSHandler#get_databases

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -1888,16 +1888,13 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     List<String> ret = null;
     Exception ex = null;
     try {
-      GetDatabaseObjectsRequest req = new GetDatabaseObjectsRequest();
-      req.setCatalogName(parsedDbNamed[CAT_NAME]);
-      if (parsedDbNamed[DB_NAME] != null) {
-        req.setPattern(parsedDbNamed[DB_NAME]);
+      if (parsedDbNamed[DB_NAME] == null) {
+        ret = getMS().getAllDatabases(parsedDbNamed[CAT_NAME]);
+        ret = FilterUtils.filterDbNamesIfEnabled(isServerFilterEnabled, filterHook, ret);
+      } else {
+        ret = getMS().getDatabases(parsedDbNamed[CAT_NAME], parsedDbNamed[DB_NAME]);
+        ret = FilterUtils.filterDbNamesIfEnabled(isServerFilterEnabled, filterHook, ret);
       }
-
-      GetDatabaseObjectsResponse response = get_databases_req(req);
-      ret = response.getDatabases().stream()
-          .map(Database::getName)
-          .collect(Collectors.toList());
     } catch (Exception e) {
       ex = e;
       throw newMetaException(e);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update implementation for HMSHandler#get_databases


### Why are the changes needed?
[HIVE-28921](https://github.com/apache/hive/pull/5782) modified the HMSHandler#get_databases and re-implemented it using get_databases_req.

Here does not need to use getMS().getDatabaseObjects to get databases and then extract the name, just get the name directly using getMS().getDatabases.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Use the existing unit tests.
