### PR TITLE
HIVE-29022: Schematool fails while initializing hive schema.

### DIFF
--- a/standalone-metastore/metastore-server/src/main/scripts/ext/schemaTool.sh
+++ b/standalone-metastore/metastore-server/src/main/scripts/ext/schemaTool.sh
@@ -16,6 +16,8 @@
 THISSERVICE=schemaTool
 export SERVICE_LIST="${SERVICE_LIST}${THISSERVICE} "
 
+export HADOOP_CLIENT_OPTS=" --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED  --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED $HADOOP_CLIENT_OPTS "
+
 schemaTool() {
   METASTORE_OPTS=''
   CLASS=org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add JDK-17 related exports to make schematool work

### Why are the changes needed?

To make schematool work


### Does this PR introduce _any_ user-facing change?

Yes, you can init Hive schema via schematool

### How was this patch tested?

Locally