### PR TITLE
HIVE-28667: Error initializing field trimmer instance when starting HS2

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/RelFieldTrimmer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/RelFieldTrimmer.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hive.ql.optimizer.calcite.rules;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.apache.calcite.adapter.jdbc.JdbcConvention;
-import org.apache.calcite.adapter.jdbc.JdbcRel;
 import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcAggregate;
 import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcAggregateRule;
 import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcFilter;
@@ -28,6 +27,7 @@ import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcJoin;
 import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcJoinRule;
 import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcProject;
 import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcProjectRule;
+import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcSort;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptUtil;
@@ -361,17 +361,6 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
     return result(rel,
         Mappings.createIdentity(rel.getRowType().getFieldCount()));
   }
-
-  public TrimResult trimFields(
-      JdbcRel rel,
-      ImmutableBitSet fieldsUsed,
-      Set<RelDataTypeField> extraFields) {
-    // We don't know how to trim this kind of relational expression, so give
-    // it back intact.
-    Util.discard(fieldsUsed);
-    return result(rel,
-        Mappings.createIdentity(rel.getRowType().getFieldCount()));
-  }
   
   public TrimResult trimFields(
       HiveJdbcConverter converter,
@@ -585,6 +574,13 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
     // return fields that the consumer didn't ask for, because the filter
     // needs them for its condition.
     return result(relBuilder.build(), inputMapping);
+  }
+
+  public TrimResult trimFields(
+      JdbcSort rel,
+      ImmutableBitSet fieldsUsed,
+      Set<RelDataTypeField> extraFields) {
+    return result(rel, Mappings.createIdentity(rel.getRowType().getFieldCount()));
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -420,7 +420,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
   /**
    * This is the list of operators that are specifically used in Hive.
    */
-  private static final List<Class<? extends RelNode>> HIVE_REL_NODE_CLASSES =
+  public static final List<Class<? extends RelNode>> HIVE_REL_NODE_CLASSES =
       ImmutableList.of(
           RelNode.class,
           AbstractRelNode.class,

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/TestHiveRelFieldTrimmer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/TestHiveRelFieldTrimmer.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.optimizer.calcite.rules;
+
+import org.apache.hadoop.hive.ql.parse.CalcitePlanner;
+import org.junit.Test;
+
+public class TestHiveRelFieldTrimmer {
+
+  @Test
+  public void testRegisterDefaultClassesNoException() throws Throwable {
+    HiveRelFieldTrimmer trimmer = new HiveRelFieldTrimmer(false);
+    trimmer.register(CalcitePlanner.HIVE_REL_NODE_CLASSES);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Change `trimFields(JdbcRel)` to `trimFields(JdbcSort)` to break the ambiguity and avoid the error. 
2. Make `CalcitePlanner#HIVE_REL_NODE_CLASSES` public mainly to facilitate testing. In fact, it makes sense to expose this information somewhere so why not in CalcitePlanner.

### Why are the changes needed?
Avoid the ambiguity exception during HS2 startup. For more details see commit message or HIVE-28667.

### Does this PR introduce _any_ user-facing change?
No. There is no change in behavior since anyways the trimmer cannot be called with a JdbcSort operator.

### How was this patch tested?
```
mvn test -Dtest=TestHiveRelFieldTrimmer -pl ql
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile_regex=".*jdbc.*" -pl itests/qtest -Pitests
```