### PR TITLE
HIVE-28983: Log HS2 and HMS PID and update hive-env.sh template

### DIFF
--- a/conf/hive-env.sh.template
+++ b/conf/hive-env.sh.template
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,31 +20,6 @@
 # to control the execution of Hive. It should be used by admins to configure
 # the Hive installation (so that users do not have to set environment variables
 # or set command line parameters to get correct behavior).
-#
-# The hive service being invoked (CLI etc.) is available via the environment
-# variable SERVICE
-
-
-# Hive Client memory usage can be an issue if a large number of clients
-# are running at the same time. The flags below have been useful in 
-# reducing memory usage:
-#
-# if [ "$SERVICE" = "cli" ]; then
-#   if [ -z "$DEBUG" ]; then
-#     export HADOOP_OPTS="$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:+UseParNewGC -XX:-UseGCOverheadLimit"
-#   else
-#     export HADOOP_OPTS="$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:-UseGCOverheadLimit"
-#   fi
-# fi
-
-# The heap size of the jvm stared by hive shell script can be controlled via:
-#
-# export HADOOP_HEAPSIZE=1024
-#
-# Larger heap size may be required when running queries over large number of files or partitions. 
-# By default hive shell scripts use a heap size of 256 (MB).  Larger heap size would also be 
-# appropriate for hive server.
-
 
 # Set HADOOP_HOME to point to a specific hadoop install directory
 # HADOOP_HOME=${bin}/../../hadoop
@@ -52,3 +29,45 @@
 
 # Folder containing extra libraries required for hive compilation/execution can be controlled by:
 # export HIVE_AUX_JARS_PATH=
+
+# HIVE Log Directory can be controlled by and ensure it exists on the filesystem:
+# export HIVE_LOG_DIR=
+
+# The hive service being invoked (beeline etc.) is available via the environment
+# variable SERVICE
+
+# Hive Client memory usage can be an issue if a large number of clients
+# are running at the same time. The flags below have been useful in
+# reducing memory usage:
+
+# if [ "$SERVICE" = "beeline" ]; then
+#   if [ -z "$DEBUG" ]; then
+#     export HADOOP_OPTS="$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:+G1GC -XX:-UseGCOverheadLimit"
+#   else
+#     export HADOOP_OPTS="$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:-UseGCOverheadLimit"
+#   fi
+# fi
+
+# The heap size of the jvm stared by hive shell script can be controlled via:
+#
+# export HADOOP_HEAPSIZE=1024
+#
+# Larger heap size may be required when running queries over large number of files or partitions.
+# By default hive shell scripts use a heap size of 256 (MB).  Larger heap size would also be
+# appropriate for hive server.
+
+# if [ "$SERVICE" = "metastore" ]; then
+#   export HADOOP_HEAPSIZE=1024
+#   export HADOOP_OPTS="$HADOOP_OPTS -Dhive.log.dir=$HIVE_LOG_DIR -Dhive.log.file=hive$SERVICE.log \
+#     -Dlog4j.configurationFile=$HIVE_CONF_DIR/hive-log4j2.properties -XX:+UseG1GC \
+#     -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$HIVE_LOG_DIR \
+#     -Xlog:gc*=info:file=$HIVE_LOG_DIR/gc-${SERVICE}-%p-%t.log:time,uptime,level,tags:filecount=5,filesize=16M"
+# fi
+#
+# if [ "$SERVICE" = "hiveserver2" ]; then
+#   export HADOOP_HEAPSIZE=1024
+#   export HADOOP_OPTS="$HADOOP_OPTS -Dhive.log.dir=$HIVE_LOG_DIR \
+#     -Dhive.log.file=$SERVICE.log -Dlog4j.configurationFile=$HIVE_CONF_DIR/hive-log4j2.properties \
+#     -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$HIVE_LOG_DIR \
+#     -Xlog:gc*=info:file=$HIVE_LOG_DIR/gc-${SERVICE}-%p-%t.log:time,uptime,level,tags:filecount=5,filesize=16M"
+# fi

--- a/conf/hive-env.sh.template
+++ b/conf/hive-env.sh.template
@@ -30,7 +30,7 @@
 # Folder containing extra libraries required for hive compilation/execution can be controlled by:
 # export HIVE_AUX_JARS_PATH=
 
-# HIVE Log Directory can be controlled by and ensure it exists on the filesystem:
+# HIVE Log Directory can be controlled by the following and ensure it exists on the filesystem:
 # export HIVE_LOG_DIR=
 
 # The hive service being invoked (beeline etc.) is available via the environment
@@ -42,9 +42,9 @@
 
 # if [ "$SERVICE" = "beeline" ]; then
 #   if [ -z "$DEBUG" ]; then
-#     export HADOOP_OPTS="$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:+G1GC -XX:-UseGCOverheadLimit"
+#     export HADOOP_OPTS="$HADOOP_OPTS -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:+UseG1GC -XX:-UseGCOverheadLimit"
 #   else
-#     export HADOOP_OPTS="$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:-UseGCOverheadLimit"
+#     export HADOOP_OPTS="$HADOOP_OPTS -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:-UseGCOverheadLimit"
 #   fi
 # fi
 

--- a/conf/hive-env.sh.template
+++ b/conf/hive-env.sh.template
@@ -42,9 +42,9 @@
 
 # if [ "$SERVICE" = "beeline" ]; then
 #   if [ -z "$DEBUG" ]; then
-#     export HADOOP_OPTS="$HADOOP_OPTS -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:+UseG1GC -XX:-UseGCOverheadLimit"
+#     export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:+UseG1GC -XX:-UseGCOverheadLimit"
 #   else
-#     export HADOOP_OPTS="$HADOOP_OPTS -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:-UseGCOverheadLimit"
+#     export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:-UseGCOverheadLimit"
 #   fi
 # fi
 
@@ -58,7 +58,7 @@
 
 # if [ "$SERVICE" = "metastore" ]; then
 #   export HADOOP_HEAPSIZE=1024
-#   export HADOOP_OPTS="$HADOOP_OPTS -Dhive.log.dir=$HIVE_LOG_DIR -Dhive.log.file=hive$SERVICE.log \
+#   export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Dhive.log.dir=$HIVE_LOG_DIR -Dhive.log.file=hive$SERVICE.log \
 #     -Dlog4j.configurationFile=$HIVE_CONF_DIR/hive-log4j2.properties -XX:+UseG1GC \
 #     -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$HIVE_LOG_DIR \
 #     -Xlog:gc*=info:file=$HIVE_LOG_DIR/gc-${SERVICE}-%p-%t.log:time,uptime,level,tags:filecount=5,filesize=16M"
@@ -66,7 +66,7 @@
 #
 # if [ "$SERVICE" = "hiveserver2" ]; then
 #   export HADOOP_HEAPSIZE=1024
-#   export HADOOP_OPTS="$HADOOP_OPTS -Dhive.log.dir=$HIVE_LOG_DIR \
+#   export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Dhive.log.dir=$HIVE_LOG_DIR \
 #     -Dhive.log.file=$SERVICE.log -Dlog4j.configurationFile=$HIVE_CONF_DIR/hive-log4j2.properties \
 #     -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$HIVE_LOG_DIR \
 #     -Xlog:gc*=info:file=$HIVE_LOG_DIR/gc-${SERVICE}-%p-%t.log:time,uptime,level,tags:filecount=5,filesize=16M"

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -1206,7 +1206,8 @@ public class HiveServer2 extends CompositeService {
   private static void startHiveServer2() throws Throwable {
     long attempts = 0, maxAttempts = 1;
     while (true) {
-      LOG.info("Starting HiveServer2");
+      long pid = ProcessHandle.current().pid();
+      LOG.info("Starting HiveServer2. PID is: {}", pid);
       HiveConf hiveConf = new HiveConf();
       maxAttempts = hiveConf.getLongVar(HiveConf.ConfVars.HIVE_SERVER2_MAX_START_ATTEMPTS);
       long retrySleepIntervalMs = hiveConf

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -1206,8 +1206,7 @@ public class HiveServer2 extends CompositeService {
   private static void startHiveServer2() throws Throwable {
     long attempts = 0, maxAttempts = 1;
     while (true) {
-      long pid = ProcessHandle.current().pid();
-      LOG.info("Starting HiveServer2. PID is: {}", pid);
+      LOG.info("Starting HiveServer2. PID is: {}", ProcessHandle.current().pid());
       HiveConf hiveConf = new HiveConf();
       maxAttempts = hiveConf.getLongVar(HiveConf.ConfVars.HIVE_SERVER2_MAX_START_ATTEMPTS);
       long retrySleepIntervalMs = hiveConf

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -263,12 +263,10 @@ public class HiveMetaStore extends ThriftHiveMetastore {
 
     try {
       String msg =
-          "Starting hive metastore on port "
-              + cli.getPort()
-              + ". PID is "
-              + ProcessHandle.current().pid();
+          "Starting hive metastore on port %d. PID is %d"
+              .formatted(cli.getPort(), ProcessHandle.current().pid());
       LOG.info(msg);
-      if (cli.isVerbose()) {
+      if (isCliVerbose) {
         System.err.println(msg);
       }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -262,7 +262,8 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     startupShutdownMessage(HiveMetaStore.class, args, LOG);
 
     try {
-      String msg = "Starting hive metastore on port " + cli.getPort();
+      long pid = ProcessHandle.current().pid();
+      String msg = "Starting hive metastore on port " + cli.getPort() + ". PID is " + pid;
       LOG.info(msg);
       if (cli.isVerbose()) {
         System.err.println(msg);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -262,8 +262,11 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     startupShutdownMessage(HiveMetaStore.class, args, LOG);
 
     try {
-      long pid = ProcessHandle.current().pid();
-      String msg = "Starting hive metastore on port " + cli.getPort() + ". PID is " + pid;
+      String msg =
+          "Starting hive metastore on port "
+              + cli.getPort()
+              + ". PID is "
+              + ProcessHandle.current().pid();
       LOG.info(msg);
       if (cli.isVerbose()) {
         System.err.println(msg);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Log the HS2 and HMS PID in their respective logs and give sample hms and hs2 HADOOP_OPTS in hive-env.sh.template.

### Why are the changes needed?
During debugging prod issue, I saw the need for this.
1. If HMS/HS2 is crashing periodically then the heapdump will have the name in default format i.e. `java_pid14784.hprof`, it becomes difficult to identify whether it belongs to HMS or HS2 without loading it in any analyzer tool.
2. To get the gc logs for a particular HS2 or HMS crash requires extraction of timestamp from logs using text manipulation commands etc.

### Does this PR introduce _any_ user-facing change?
Yes, in HS2 and HMS logs PID will be logged

### How was this patch tested?
On local setup