### PR TITLE
HIVE-29038: Make catalog servlet parameters generic

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1853,26 +1853,26 @@ public class MetastoreConf {
             new StringSetValidator("simple", "jwt"),
         "Property-maps servlet authentication method (simple or jwt)."
     ),
-    ICEBERG_CATALOG_SERVLET_FACTORY("metastore.iceberg.catalog.servlet.factory",
-            "hive.metastore.iceberg.catalog.servlet.factory",
-            "org.apache.iceberg.rest.HMSCatalogFactory",
-            "HMS Iceberg Catalog servlet factory class name."
+    CATALOG_SERVLET_FACTORY("metastore.catalog.servlet.factory",
+        "hive.metastore.catalog.servlet.factory",
+        "org.apache.iceberg.rest.HMSCatalogFactory",
+        "HMS Catalog servlet factory class name. The default serves Iceberg REST API."
             + "The factory needs to expose a method: "
             + "public static HttpServlet createServlet(Configuration configuration);"
+    ),
+    CATALOG_SERVLET_PORT("metastore.catalog.servlet.port",
+        "hive.metastore.catalog.servlet.port", -1,
+        "HMS Catalog servlet server port. Negative value disables the servlet," +
+            " 0 will let the system determine the catalog server port," +
+            " positive value will be used as-is."
+    ),
+    CATALOG_SERVLET_AUTH("metastore.catalog.servlet.auth",
+        "hive.metastore.catalog.servlet.auth", "jwt", new StringSetValidator("none", "simple", "jwt"),
+        "HMS Catalog servlet authentication method (none, simple, or jwt)."
     ),
     ICEBERG_CATALOG_SERVLET_PATH("metastore.iceberg.catalog.servlet.path",
         "hive.metastore.iceberg.catalog.servlet.path", "iceberg",
         "HMS Iceberg Catalog servlet path component of URL endpoint."
-    ),
-    ICEBERG_CATALOG_SERVLET_PORT("metastore.iceberg.catalog.servlet.port",
-        "hive.metastore.iceberg.catalog.servlet.port", -1,
-        "HMS Iceberg Catalog servlet server port. Negative value disables the servlet," +
-            " 0 will let the system determine the catalog server port," +
-            " positive value will be used as-is."
-    ),
-    ICEBERG_CATALOG_SERVLET_AUTH("metastore.iceberg.catalog.servlet.auth",
-        "hive.metastore.iceberg.catalog.servlet.auth", "jwt", new StringSetValidator("none", "simple", "jwt"),
-        "HMS Iceberg Catalog servlet authentication method (none, simple, or jwt)."
     ),
     ICEBERG_CATALOG_CACHE_EXPIRY("metastore.iceberg.catalog.cache.expiry",
         "hive.metastore.iceberg.catalog.cache.expiry", -1,

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -48,7 +48,7 @@ public class HMSCatalogFactory {
    * @param conf the configuration
    */
   private HMSCatalogFactory(Configuration conf) {
-    port = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.ICEBERG_CATALOG_SERVLET_PORT);
+    port = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.CATALOG_SERVLET_PORT);
     path = MetastoreConf.getVar(conf, MetastoreConf.ConfVars.ICEBERG_CATALOG_SERVLET_PATH);
     this.configuration = conf;
   }
@@ -99,7 +99,7 @@ public class HMSCatalogFactory {
    * @return the servlet
    */
   private HttpServlet createServlet(Catalog catalog) {
-    String authType = MetastoreConf.getVar(configuration, ConfVars.ICEBERG_CATALOG_SERVLET_AUTH);
+    String authType = MetastoreConf.getVar(configuration, ConfVars.CATALOG_SERVLET_AUTH);
     ServletSecurity security = new ServletSecurity(AuthType.fromString(authType), configuration);
     return security.proxy(new HMSCatalogServlet(new HMSCatalogAdapter(catalog)));
   }
@@ -117,7 +117,7 @@ public class HMSCatalogFactory {
   
   /**
    * Factory method to describe Iceberg servlet.
-   * <p>This method name is found through configuration as {@link MetastoreConf.ConfVars#ICEBERG_CATALOG_SERVLET_FACTORY}
+   * <p>This method name is found through configuration as {@link MetastoreConf.ConfVars#CATALOG_SERVLET_FACTORY}
    * and looked up through reflection to start from HMS.</p>
    *
    * @param configuration the configuration

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/extension/HiveRESTCatalogServerExtension.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/extension/HiveRESTCatalogServerExtension.java
@@ -44,10 +44,10 @@ public class HiveRESTCatalogServerExtension implements BeforeAllCallback, Before
 
   private HiveRESTCatalogServerExtension(AuthType authType) {
     this.conf = MetastoreConf.newMetastoreConf();
-    MetastoreConf.setVar(conf, ConfVars.ICEBERG_CATALOG_SERVLET_AUTH, authType.name());
+    MetastoreConf.setVar(conf, ConfVars.CATALOG_SERVLET_AUTH, authType.name());
     if (authType == AuthType.JWT) {
       jwksServer = new JwksServer();
-      MetastoreConf.setVar(conf, ConfVars.ICEBERG_CATALOG_SERVLET_AUTH, "jwt");
+      MetastoreConf.setVar(conf, ConfVars.CATALOG_SERVLET_AUTH, "jwt");
       MetastoreConf.setVar(conf, ConfVars.THRIFT_METASTORE_AUTHENTICATION_JWT_JWKS_URL,
           String.format("http://localhost:%d/jwks", jwksServer.getPort()));
     } else {

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/extension/RESTCatalogServer.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/extension/RESTCatalogServer.java
@@ -38,7 +38,7 @@ public class RESTCatalogServer {
   private int restPort = -1;
 
   private static int createMetastoreServerWithRESTCatalog(int restPort, Configuration conf) throws Exception {
-    MetastoreConf.setLongVar(conf, MetastoreConf.ConfVars.ICEBERG_CATALOG_SERVLET_PORT, restPort);
+    MetastoreConf.setLongVar(conf, MetastoreConf.ConfVars.CATALOG_SERVLET_PORT, restPort);
     return MetaStoreTestUtils.startMetaStoreWithRetry(HadoopThriftAuthBridge.getBridge(), conf,
         true, false, false, false);
   }

--- a/standalone-metastore/metastore-server/src/docker/conf/metastore-site.xml
+++ b/standalone-metastore/metastore-server/src/docker/conf/metastore-site.xml
@@ -33,11 +33,11 @@
         <value>false</value>
     </property>
     <property>
-        <name>hive.metastore.iceberg.catalog.servlet.port</name>
+        <name>metastore.catalog.servlet.port</name>
         <value>9001</value>
     </property>
     <property>
-        <name>hive.metastore.iceberg.catalog.servlet.auth</name>
+        <name>metastore.catalog.servlet.auth</name>
         <value>none</value>
     </property>
 </configuration>

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -722,7 +722,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     // optionally create and start the property and Iceberg REST server
     ServletServerBuilder builder = new ServletServerBuilder(conf);
     ServletServerBuilder.Descriptor properties = builder.addServlet(PropertyServlet.createServlet(conf));
-    builder.addServlet(createIcebergServlet(conf));
+    builder.addServlet(createCatalogServlet(conf));
     servletServer = builder.start(LOG);
     if (servletServer != null && properties != null) {
       propertyServletPort = properties.getPort();
@@ -733,21 +733,21 @@ public class HiveMetaStore extends ThriftHiveMetastore {
   }
   
   /**
-   * Creates the Iceberg REST catalog servlet descriptor.
+   * Creates the HMS catalog servlet descriptor.
    * @param configuration the configuration
    * @return the servlet descriptor (can be null)
    */
-  static ServletServerBuilder.Descriptor createIcebergServlet(Configuration configuration) {
+  static ServletServerBuilder.Descriptor createCatalogServlet(Configuration configuration) {
     try {
-      String className = MetastoreConf.getVar(configuration, ConfVars.ICEBERG_CATALOG_SERVLET_FACTORY);
+      String className = MetastoreConf.getVar(configuration, ConfVars.CATALOG_SERVLET_FACTORY);
       Class<?> iceClazz = Class.forName(className);
       Method iceStart = iceClazz.getMethod("createServlet", Configuration.class);
       return (ServletServerBuilder.Descriptor) iceStart.invoke(null, configuration);
     } catch (ClassNotFoundException xnf) {
-      LOG.warn("Unable to start Iceberg REST Catalog server, missing jar?", xnf);
+      LOG.warn("Unable to start the Catalog server, missing jar?", xnf);
       return null;
     } catch (Exception e) {
-      LOG.error("Unable to start Iceberg REST Catalog server", e);
+      LOG.error("Unable to start the Catalog server", e);
       return null;
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Change the parameter names for Iceberg REST API.

### Why are the changes needed?

We discussed the possibility of adding new catalogs, such as HMS v2 or Unity Catalog. We concluded that we would like to consolidate common properties, especially auth methods.

https://issues.apache.org/jira/browse/HIVE-29038

This PR will not change the following endpoints. As they have already been shipped as of 4.0.0, we can't silently change the params.

- HMS over HTTP
- Properties API

### Does this PR introduce _any_ user-facing change?

No. Iceberg REST API has not been released yet.

### How was this patch tested?

I locally built the docker image and tested it with Trino.