### PR TITLE
HIVE-29043: Ban the Jupiter dependency from hive-unit to prevent unit tests from being skipped

### DIFF
--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -549,6 +549,33 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-banned-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.junit.jupiter:junit-jupiter</exclude>
+                  </excludes>
+                  <searchTransitive>true</searchTransitive>
+                  <message>
+                    Banned jupiter dependency was found!
+                    Only remove this rule if you confirmed that adding jupiter dependency
+                    to the project won't make unit tests silently skipped.
+                  </message>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1664,7 +1664,7 @@
             </configuration>
           </execution>
           <execution>
-            <id>enforce-banned-dependencies-licenses</id>
+            <id>enforce-banned-dependencies</id>
             <goals>
               <goal>enforce</goal>
             </goals>
@@ -1677,17 +1677,6 @@
                   </excludes>
                   <message>A banned license dependency was found!</message>
                 </bannedDependencies>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-banned-dependencies-logging</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
                 <bannedDependencies>
                   <excludes>
                     <!-- Move to SLF4J -->


### PR DESCRIPTION


### What changes were proposed in this pull request?
Ban jupiter dependency.

### Why are the changes needed?
To prevent skipping hive-unit unit tests silently again.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested with adding the problematic dependency, and instead of silently skipping unit test, it failed.
```
mvn install -Pitests -Dtest=TestHttpServices -pl ./itests/hive-unit -nsu

...

[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: org.junit.jupiter:junit-jupiter:jar:5.11.2
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.237 s
[INFO] Finished at: 2025-06-24T14:56:04+02:00
[INFO] ------------------------------------------------------------------------
[INFO] 5 goals, 5 executed
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.4.1:enforce (ban-jupiter) on project hive-it-unit: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
[ERROR]
```
