### PR TITLE
HIVE-28790: ACID deletes are failing with ArrayIndexOutOfBoundsExcept…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -501,7 +501,9 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
 
       if (this.finalPaths[writerOffset] == null) {
         if (conf.isDirectInsert()) {
-          this.outPathsCommitted = Arrays.copyOf(outPathsCommitted, writerOffset + 1);
+          if (outPathsCommitted.length <= writerOffset) {
+            this.outPathsCommitted = Arrays.copyOf(outPathsCommitted, writerOffset + 1);
+          }
           this.finalPaths[writerOffset] = buildTmpPath();
           this.outPaths[writerOffset] = buildTmpPath();
         } else {

--- a/ql/src/test/queries/clientpositive/acid_direct_update_delete.q
+++ b/ql/src/test/queries/clientpositive/acid_direct_update_delete.q
@@ -18,4 +18,13 @@ DELETE FROM test_update_bucketed WHERE id IN ('2', '11', '10');
 UPDATE test_update_bucketed SET value='New value2' WHERE id IN ('2','18', '19');
 SELECT * FROM test_update_bucketed;
 
+CREATE TABLE test_delete(id int) STORED AS ORC TBLPROPERTIES('transactional'='true');
+
+INSERT INTO test_delete SELECT id FROM test_update_bucketed WHERE id != 3 and id <=9;
+INSERT INTO test_delete SELECT id FROM test_update_bucketed WHERE id > 9;
+
+DELETE FROM test_delete WHERE id in (5, 13);
+SELECT * FROM test_delete;
+
 DROP TABLE IF EXISTS test_update_bucketed;
+DROP TABLE IF EXISTS test_delete;

--- a/ql/src/test/results/clientpositive/llap/acid_direct_update_delete.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_direct_update_delete.q.out
@@ -136,6 +136,59 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 7	seven
 8	eight
 9	nine
+PREHOOK: query: CREATE TABLE test_delete(id int) STORED AS ORC TBLPROPERTIES('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_delete
+POSTHOOK: query: CREATE TABLE test_delete(id int) STORED AS ORC TBLPROPERTIES('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_delete
+PREHOOK: query: INSERT INTO test_delete SELECT id FROM test_update_bucketed WHERE id != 3 and id <=9
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_update_bucketed
+PREHOOK: Output: default@test_delete
+POSTHOOK: query: INSERT INTO test_delete SELECT id FROM test_update_bucketed WHERE id != 3 and id <=9
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_update_bucketed
+POSTHOOK: Output: default@test_delete
+POSTHOOK: Lineage: test_delete.id EXPRESSION [(test_update_bucketed)test_update_bucketed.FieldSchema(name:id, type:string, comment:null), ]
+PREHOOK: query: INSERT INTO test_delete SELECT id FROM test_update_bucketed WHERE id > 9
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_update_bucketed
+PREHOOK: Output: default@test_delete
+POSTHOOK: query: INSERT INTO test_delete SELECT id FROM test_update_bucketed WHERE id > 9
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_update_bucketed
+POSTHOOK: Output: default@test_delete
+POSTHOOK: Lineage: test_delete.id EXPRESSION [(test_update_bucketed)test_update_bucketed.FieldSchema(name:id, type:string, comment:null), ]
+PREHOOK: query: DELETE FROM test_delete WHERE id in (5, 13)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_delete
+PREHOOK: Output: default@test_delete
+POSTHOOK: query: DELETE FROM test_delete WHERE id in (5, 13)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_delete
+POSTHOOK: Output: default@test_delete
+PREHOOK: query: SELECT * FROM test_delete
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_delete
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT * FROM test_delete
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_delete
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1
+14
+16
+17
+18
+19
+20
+6
+7
+8
+9
 PREHOOK: query: DROP TABLE IF EXISTS test_update_bucketed
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@test_update_bucketed
@@ -146,3 +199,13 @@ POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@test_update_bucketed
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@test_update_bucketed
+PREHOOK: query: DROP TABLE IF EXISTS test_delete
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_delete
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_delete
+POSTHOOK: query: DROP TABLE IF EXISTS test_delete
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_delete
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_delete


### PR DESCRIPTION
…ion when direct insert is enabled

### What changes were proposed in this pull request?
If the length of outPathsCommitted array is shorter than the writeroffset, then extend the outPathsCommitted array to the length of writeroffset + 1

### Why are the changes needed?
The problem is in the FileSinkOperator.createDynamicBucket method:
Acid deletes will fail with ArrayIndexOutOfBoundException when closing the writes, because the size of the array is not compared with the writerOffsetbecause and there is a possibility that the outPathsCommitted array is shorter than the updaters array.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
qtest
