### PR TITLE
HIVE-29048: Increase default pool and queue size of HS2 Background Async Threadpool.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4230,12 +4230,12 @@ public class HiveConf extends Configuration {
         "excessive threads are killed after this time interval."),
 
     // Configuration for async thread pool in SessionManager
-    HIVE_SERVER2_ASYNC_EXEC_THREADS("hive.server2.async.exec.threads", 100,
+    HIVE_SERVER2_ASYNC_EXEC_THREADS("hive.server2.async.exec.threads", 250,
         "Number of threads in the async thread pool for HiveServer2"),
     HIVE_SERVER2_ASYNC_EXEC_SHUTDOWN_TIMEOUT("hive.server2.async.exec.shutdown.timeout", "10s",
         new TimeValidator(TimeUnit.SECONDS),
         "How long HiveServer2 shutdown will wait for async threads to terminate."),
-    HIVE_SERVER2_ASYNC_EXEC_WAIT_QUEUE_SIZE("hive.server2.async.exec.wait.queue.size", 100,
+    HIVE_SERVER2_ASYNC_EXEC_WAIT_QUEUE_SIZE("hive.server2.async.exec.wait.queue.size", 250,
         "Size of the wait queue for async thread pool in HiveServer2.\n" +
         "After hitting this limit, the async thread pool will reject new requests."),
     HIVE_SERVER2_ASYNC_EXEC_KEEPALIVE_TIME("hive.server2.async.exec.keepalive.time", "10s",


### PR DESCRIPTION
HIVE-29048: Increase default pool and queue size of HS2 Background Async Threadpool.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
To increase the default value for the [hive.server2.async.exec.threads](https://github.com/apache/hive/blob/68f8734b3b7db2fdc8bc0c11ad3c37eb2e2a808c/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java#L4233-L4234) and [hive.server2.async.exec.wait.queue.size](https://github.com/apache/hive/blob/68f8734b3b7db2fdc8bc0c11ad3c37eb2e2a808c/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java#L4238-L4240) configuration from **100** to **250**.

Recently most of the customers reported below error on beeline
```
0: jdbc:hive2://localhost> show databases;
Error: The background threadpool cannot accept new task for execution, please retry the operation (state=,code=0)
```

HS2 server logs shows below exception
```
Caused by: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@24363395 rejected from java.util.concurrent.ThreadPoolExecutor@54ef7045[Running, pool size = 100, active threads = 100, queued tasks = 100, completed tasks = 682504]
at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063) ~[?:1.8.0_342]
at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830) ~[?:1.8.0_342]
at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379) ~[?:1.8.0_342]
at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112) ~[?:1.8.0_342]
at org.apache.hive.service.cli.session.SessionManager.submitBackgroundOperation(SessionManager.java:760) ~[hive-service-3.1.3]
at org.apache.hive.service.cli.session.HiveSessionImpl.submitBackgroundOperation(HiveSessionImpl.java:598) ~[hive-service-3.1.3]
at org.apache.hive.service.cli.operation.SQLOperation.runInternal(SQLOperation.java:279) ~[hive-service-3.1.3]
... 50 more
```
So here for most of the customers load, the default value 100 is not sufficient so their queries are getting rejected. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The changes required to handle most of the customer's cluster basic load.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
NA
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
