### PR TITLE
HIVE-29047: Adjust httpclient5 httpcore dependencies in TestHttpServices

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/service/TestHttpServices.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/TestHttpServices.java
@@ -20,11 +20,11 @@ package org.apache.hive.service;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.Header;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.Header;
 import org.apache.hive.jdbc.miniHS2.MiniHS2;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -83,7 +83,7 @@ public class TestHttpServices {
       HttpGet request = new HttpGet(miniHS2);
 
       try (CloseableHttpResponse response = httpClient.execute(request)) {
-        for (Header header : response.getHeaders()) {
+        for (Header header : response.getAllHeaders()) {
           Assert.assertNotEquals("x-powered-by", header.getName().toLowerCase());
           Assert.assertNotEquals("server", header.getName().toLowerCase());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1733,6 +1733,15 @@
                   </bannedImports>
                   <includeTestCode>true</includeTestCode>
                 </restrictImports>
+                <!-- To prevent unintentional usage of HTTP Components 5, e.g., via transitive dependencies -->
+                <restrictImports implementation="de.skuzzle.enforcer.restrictimports.RestrictImports">
+                  <reason>Do not use httpcore5/httpclient5 classes until Hive is not upgraded to httpcore5/httpclient5</reason>
+                  <bannedImports>
+                    <bannedImport>org.apache.hc.client5.**</bannedImport>
+                    <bannedImport>org.apache.hc.core5.**</bannedImport>
+                  </bannedImports>
+                  <includeTestCode>true</includeTestCode>
+                </restrictImports>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adjust httpclient5 httpcore dependencies in TestHttpServices
https://github.com/richardantal/hive/pull/new/HIVE-29047



### Why are the changes needed?
In TestHttpServices we use transitive httpclient5 and httpcore5 dependencies because of
https://github.com/apache/hive/commit/174ac6215a2b70c655d3dcfed3dc0001ecb97b9b
Later It will break in case of 1.26 avatica version




### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
I ran TestHttpServices unit test
