### PR TITLE
HIVE-29051: TestTezTPCDS30TBPerfCliDriver leaks Postgres container causing intermittent failures elsewhere

### DIFF
--- a/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestTezTPCDS30TBPerfCliDriver.java
+++ b/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestTezTPCDS30TBPerfCliDriver.java
@@ -44,27 +44,8 @@ public class TestTezTPCDS30TBPerfCliDriver {
   @ClassRule
   public static TestRule cliClassRule = adapter.buildClassRule();
 
-  /**
-   * Rule for calling only {@link CliAdapter#setUp()} and {@link CliAdapter#tearDown()} before/after running each test.
-   *
-   * At the moment of writing this class the rule is mostly necessary for calling {@link CliAdapter#tearDown()} to avoid
-   * state from one test pass to other (e.g., disabling one test should not disable subsequent ones).
-   * 
-   * {@link CliAdapter#buildTestRule()} cannot not used since it is doing more than necessary for this test case. For
-   * instance, we do not want to create and destroy the metastore after each query.
-   */
   @Rule
-  public TestRule cliTestRule = (statement, description) -> new Statement() {
-    @Override
-    public void evaluate() throws Throwable {
-      adapter.setUp();
-      try {
-        statement.evaluate();
-      } finally {
-        adapter.tearDown();
-      }
-    }
-  };
+  public TestRule cliTestRule = adapter.buildTestRule();
 
   private final String name;
   private final File qfile;

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliAdapter.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliAdapter.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.hive.ql.QTestUtil;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class adapts old vm test-executors to be executed in multiple instances
@@ -37,8 +35,6 @@ public abstract class CliAdapter {
 
   protected final AbstractCliConfig cliConfig;
   protected QTestMetaStoreHandler metaStoreHandler;
-  boolean firstTestNotYetRun = true; // this can protect class/test level logic from each other
-  private static final Logger LOG = LoggerFactory.getLogger(CliAdapter.class);
 
   public CliAdapter(AbstractCliConfig cliConfig) {
     this.cliConfig = cliConfig;
@@ -79,7 +75,6 @@ public abstract class CliAdapter {
             metaStoreHandler.setSystemProperties(); // for QTestUtil pre-initialization
             CliAdapter.this.beforeClass(); // instantiating QTestUtil
 
-            LOG.debug("will initialize metastore database in class rule");
             metaStoreHandler.getRule().before();
             metaStoreHandler.getRule().install();
 
@@ -95,10 +90,7 @@ public abstract class CliAdapter {
               base.evaluate();
             } finally {
               CliAdapter.this.shutdown();
-              if (getQt() != null && firstTestNotYetRun) {
-                LOG.debug("will destroy metastore database in class rule (if not derby)");
-                metaStoreHandler.afterTest(getQt());
-              }
+              metaStoreHandler.getRule().after();
             }
           }
         };
@@ -117,14 +109,6 @@ public abstract class CliAdapter {
         return new Statement() {
           @Override
           public void evaluate() throws Throwable {
-
-            if (getQt() != null && !firstTestNotYetRun) {
-              LOG.debug("will initialize metastore database in test rule");
-              metaStoreHandler.setMetaStoreConfiguration(getQt().getConf());
-              metaStoreHandler.beforeTest();
-            }
-            firstTestNotYetRun = false;
-
             if (getQt() != null && CliAdapter.this.shouldRunCreateScriptBeforeEveryTest()){
               // it's because some drivers still use init scripts, which can create a non-dataset table
               // and get cleant after every test
@@ -136,8 +120,7 @@ public abstract class CliAdapter {
             } finally {
               CliAdapter.this.tearDown();
               if (getQt() != null) {
-                LOG.debug("will destroy metastore database in test rule (if not derby)");
-                metaStoreHandler.afterTest(getQt());
+                metaStoreHandler.truncateDatabase(getQt());
               }
             }
           }

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
@@ -92,7 +92,6 @@ public class CoreCliDriver extends CliAdapter {
   @AfterClass
   public void shutdown() throws Exception {
     qt.shutdown();
-    metaStoreHandler.getRule().after();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestMetaStoreHandler.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestMetaStoreHandler.java
@@ -97,13 +97,7 @@ public class QTestMetaStoreHandler {
     return "sqlserver".equalsIgnoreCase(metastoreType) ? "MSSQL" : metastoreType.toUpperCase();
   }
 
-  public void beforeTest() throws Exception {
-    if (isDerby()) {
-      getRule().before();
-    }
-  }
-
-  public void afterTest(QTestUtil qt) throws Exception {
+  public void truncateDatabase(QTestUtil qt) throws Exception {
 
     // special qtest logic, which doesn't fit quite well into Derby.after()
     if (isDerby()) {


### PR DESCRIPTION
### What changes were proposed in this pull request and why?
1. Move metastore/container destroy logic in buildClassRule of CliAdapter. All database/container lifecyle handling must be in the same place to avoid leaks and inconsistent behavior.
2. Rename QTestMetastoreHandler#afterTest to QTestMetastoreHandler#truncateDatabase to better reflect what is actually doing
3. Perform database truncation (Derby only) only inside buildTestRule. No need to do it also as part of the class rule
4. Handle metastore configuration exclusively in buildClassRule. We need to set the configuration only once before the first test runs and this is exactly what happens if we put it in the class rule.
5. Drop firstTestNotYetRun flag along with related code since there is no longer overlapping logic between test and class rule.
6. Drop now redundant QTestMetastoreHandler#beforeTest method

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Run the following and after each verified (using `docker ps`) that no container is running.
```
mvn test -Dtest=TestTezTPCDS30TBPerfCliDriver -Dqfile=cbo_query1.q,cbo_query2.q 
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dtest.metastore.db=postgres -Dqfile="acid_insert_overwrite_update.q,acid_stats3.q"
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile="acid_insert_overwrite_update.q,acid_stats3.q"
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile_regex=cbo_.* -Dtest.output.overwrite 
```