### PR TITLE
[WIP] HIVE-29053: _REPLACE_WITH directory are created when running qtest using sysdb

### DIFF
--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -500,6 +500,9 @@ public class CliDriver {
     StringBuilder qsb = new StringBuilder();
 
     while ((line = r.readLine()) != null) {
+      // Skipping the proto tables location.
+      if (line.startsWith("LOCATION '_REPLACE_WITH_")) continue;
+
       // Skipping through comments
       if (! line.startsWith("--")) {
         qsb.append(line + "\n");


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HIVE-29053](https://issues.apache.org/jira/browse/HIVE-29053), Skip the LOCATION field for proto tables when running qtests.


### Why are the changes needed?
Running the qtest containing `--! qt:sysdb`, causes creation of following dir in itests/qtest directory.
```
_REPLACE_WITH_APP_DATA_LOCATION_
_REPLACE_WITH_DAG_DATA_LOCATION_
_REPLACE_WITH_DAG_META_LOCATION_
_REPLACE_WITH_QUERY_DATA_LOCATION_
```

It better to have the proto tables share same location as other sys tables for testing/debugging purposes. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran the following command with and without the PR and observed the directory creation in `itests/qtest` directory
```
mvn clean test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=query_history.q -Drat.skip -pl itests/qtest -Pitests
mvn clean test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=sysdb.q -Drat.skip -pl itests/qtest -Pitests
```