### PR TITLE
HIVE-22810: Add drop scheduled query IF EXISTS support

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
@@ -498,6 +498,7 @@ public enum ErrorMsg {
   ALTER_TABLE_COMPACTION_NON_PARTITIONED_COLUMN_NOT_ALLOWED(10443, "Filter expression can contain only partition columns."),
   CATALOG_ALREADY_EXISTS(10444, "Catalog {0} already exists", true),
   CATALOG_NOT_EXISTS(10445, "Catalog {0} does not exists:", true),
+  INVALID_SCHEDULED_QUERY(10446, "Scheduled query {0} does not exist", true),
 
   //========================== 20000 range starts here ========================//
 

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -1745,9 +1745,10 @@ createScheduledQueryStatement
 dropScheduledQueryStatement
 @init { pushMsg("drop scheduled query statement", state); }
 @after { popMsg(state); }
-    : KW_DROP KW_SCHEDULED KW_QUERY name=identifier
+    : KW_DROP KW_SCHEDULED KW_QUERY ifExists? name=identifier
     -> ^(TOK_DROP_SCHEDULED_QUERY
             $name
+            ifExists?
         )
     ;
 

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDriver.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDriver.java
@@ -333,6 +333,7 @@ public class TestParseDriver {
   @Test
   public void testParseDropScheduledQuery() throws Exception {
     parseDriver.parse("drop scheduled query asd");
+    parseDriver.parse("drop scheduled query if exists asd");
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ScheduledQueryAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ScheduledQueryAnalyzer.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hive.metastore.api.ScheduledQuery._Fields;
 import org.apache.hadoop.hive.metastore.api.ScheduledQueryKey;
 import org.apache.hadoop.hive.metastore.api.ScheduledQueryMaintenanceRequestType;
 import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
@@ -74,7 +75,19 @@ public class ScheduledQueryAnalyzer extends BaseSemanticAnalyzer {
     ScheduledQueryMaintenanceWork work;
     ScheduledQueryMaintenanceRequestType type = translateAstType(ast.getToken().getType());
     ScheduledQuery parsedSchq = interpretAstNode(ast);
+    boolean throwException = true;
+    if (type == ScheduledQueryMaintenanceRequestType.DROP) {
+      boolean ifExists = ast.getFirstChildWithType(HiveParser.TOK_IFEXISTS) != null;
+      throwException = !ifExists && !HiveConf.getBoolVar(conf, ConfVars.DROP_IGNORES_NON_EXISTENT);
+    }
     ScheduledQuery schq = fillScheduledQuery(type, parsedSchq);
+    if (schq == null) {
+      if (throwException) {
+        throw new SemanticException(ErrorMsg.INVALID_SCHEDULED_QUERY, parsedSchq.getScheduleKey().getScheduleName());
+      } else {
+        return;
+      }
+    }
     checkAuthorization(type, schq);
     LOG.info("scheduled query operation: " + type + " " + schq);
     try {
@@ -102,7 +115,8 @@ public class ScheduledQueryAnalyzer extends BaseSemanticAnalyzer {
         schqStored.setNextExecutionIsSet(false);
         return composeOverlayObject(schqChanges, schqStored);
       } catch (TException e) {
-        throw new SemanticException("unable to get Scheduled query" + e);
+        LOG.error("Unable to find Scheduled query: " + schqChanges.getScheduleKey().getScheduleName(), e);
+        return null;
       }
     }
   }
@@ -198,6 +212,8 @@ public class ScheduledQueryAnalyzer extends BaseSemanticAnalyzer {
     case HiveParser.TOK_EXECUTE:
       int now = (int) (System.currentTimeMillis() / 1000);
       schq.setNextExecution(now);
+      return;
+    case HiveParser.TOK_IFEXISTS:
       return;
     default:
       throw new SemanticException("Unexpected token: " + node.getType());

--- a/ql/src/test/org/apache/hadoop/hive/ql/schq/TestScheduledQueryStatements.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/schq/TestScheduledQueryStatements.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hive.metastore.model.MScheduledQuery;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.parse.ParseException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.ql.scheduled.ScheduledQueryExecutionService;
 import org.apache.hadoop.hive.ql.session.SessionState;
@@ -201,6 +203,70 @@ public class TestScheduledQueryStatements {
       assertThat(sq.get().getNextExecution(), Matchers.greaterThan((int) (System.currentTimeMillis() / 1000)));
     }
 
+  }
+
+  @Test
+  public void testDrop() throws ParseException, Exception {
+    IDriver driver = createDriver();
+
+    driver.run("set role admin");
+    driver.run("set hive.exec.drop.ignorenonexistent=false");
+    driver.run("create scheduled query drop1 cron '0 0 7 * * ? *' as select 1 from tu");
+    driver.run("drop scheduled query drop1");
+
+    try (CloseableObjectStore os = new CloseableObjectStore(env_setup.getTestCtx().hiveConf)) {
+      Optional<MScheduledQuery> sq = os.getMScheduledQuery(new ScheduledQueryKey("drop1", "hive"));
+      assertFalse(sq.isPresent());
+    }
+  }
+
+  @Test
+  public void testDropIfExists() throws ParseException, Exception {
+    IDriver driver = createDriver();
+
+    driver.run("set role admin");
+    driver.run("set hive.exec.drop.ignorenonexistent=false");
+    driver.run("create scheduled query drop2 cron '0 0 7 * * ? *' as select 1 from tu");
+    driver.run("drop scheduled query if exists drop2");
+
+    try (CloseableObjectStore os = new CloseableObjectStore(env_setup.getTestCtx().hiveConf)) {
+      Optional<MScheduledQuery> sq = os.getMScheduledQuery(new ScheduledQueryKey("drop2", "hive"));
+      assertFalse(sq.isPresent());
+    }
+  }
+
+  @Test
+  public void testDropWithoutCreate() throws ParseException, Exception, SemanticException {
+    IDriver driver = createDriver();
+    driver.run("set role admin");
+    driver.run("set hive.exec.drop.ignorenonexistent=false");
+    driver.run("drop scheduled query drop3");
+  }
+
+  @Test
+  public void testDropWithoutCreateWithIgnoreNonExistent() throws ParseException, Exception {
+    IDriver driver = createDriver();
+    driver.run("set role admin");
+    driver.run("set hive.exec.drop.ignorenonexistent=true");
+    driver.run("drop scheduled query drop4");
+
+    try (CloseableObjectStore os = new CloseableObjectStore(env_setup.getTestCtx().hiveConf)) {
+      Optional<MScheduledQuery> sq = os.getMScheduledQuery(new ScheduledQueryKey("drop4", "hive"));
+      assertFalse(sq.isPresent());
+    }
+  }
+
+  @Test
+  public void testDropIfExistsWithoutCreate() throws ParseException, Exception {
+    IDriver driver = createDriver();
+    driver.run("set role admin");
+    driver.run("set hive.exec.drop.ignorenonexistent=false");
+    driver.run("drop scheduled query if exists drop5");
+
+    try (CloseableObjectStore os = new CloseableObjectStore(env_setup.getTestCtx().hiveConf)) {
+      Optional<MScheduledQuery> sq = os.getMScheduledQuery(new ScheduledQueryKey("drop5", "hive"));
+      assertFalse(sq.isPresent());
+    }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
The changes proposed adds support for IF EXISTS while dropping a Scheduled Query
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
User wants a safety net while dropping a scheduled query and not straightaway get a NoSuchQueryObjectException
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Now, user can add IF EXISTS while dropping Scheduled Query which would not throw an Exception when the Scheduled Query does not exist
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
I tested it on my local machine
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
