### PR TITLE
HIVE-29032: Enhance qt:database option to expose connection properties in qfiles

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
@@ -248,7 +248,7 @@ public class QTestUtil {
     dispatcher.register("timezone", new QTestTimezoneHandler());
     dispatcher.register("authorizer", new QTestAuthorizerHandler());
     dispatcher.register("disabled", new QTestDisabledHandler());
-    dispatcher.register("database", new QTestDatabaseHandler());
+    dispatcher.register("database", new QTestDatabaseHandler(scriptsDir));
     dispatcher.register("queryhistory", new QTestQueryHistoryHandler());
 
     this.initScript = scriptsDir + File.separator + testArgs.getInitScript();

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/MSSQLServer.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/MSSQLServer.java
@@ -31,7 +31,7 @@ public class MSSQLServer extends AbstractExternalDB {
 
   @Override
   public String getJdbcUrl() {
-    return "jdbc:sqlserver://" + getContainerHostAddress() + ":1433";
+    return "jdbc:sqlserver://" + getContainerHostAddress() + ":" + getPort();
   }
 
   @Override
@@ -46,7 +46,13 @@ public class MSSQLServer extends AbstractExternalDB {
 
   @Override
   public String[] getDockerAdditionalArgs() {
-    return new String[] { "-p", "1433:1433", "-e", "ACCEPT_EULA=Y", "-e", "SA_PASSWORD=" + getRootPassword(), "-d" };
+    return new String[] { "-p", getPort() + ":1433", "-e", "ACCEPT_EULA=Y", "-e", "SA_PASSWORD=" + getRootPassword(),
+        "-d" };
+  }
+
+  @Override
+  protected int getPort() {
+    return 1433;
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/MariaDB.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/MariaDB.java
@@ -29,17 +29,22 @@ public class MariaDB extends AbstractExternalDB {
 
   @Override
   public String getJdbcUrl() {
-    return "jdbc:mariadb://" + getContainerHostAddress() + ":3309/" + dbName;
+    return "jdbc:mariadb://" + getContainerHostAddress() + ":" + getPort() + "/" + dbName;
   }
   
   public String getJdbcDriver() {
     return "org.mariadb.jdbc.Driver";
   }
 
+  @Override
+  protected int getPort() {
+    return 3309;
+  }
+
   public String getDockerImageName() { return "mariadb:11.4"; }
 
   public String[] getDockerAdditionalArgs() {
-    return new String[] {"-p", "3309:3306",
+    return new String[] { "-p", getPort() + ":3306",
         "-e", "MARIADB_ROOT_PASSWORD=" + getRootPassword(),
         "-e", "MARIADB_DATABASE=" + dbName,
         "-d"

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/MySQLExternalDB.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/MySQLExternalDB.java
@@ -35,17 +35,22 @@ public class MySQLExternalDB extends AbstractExternalDB {
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:mysql://" + getContainerHostAddress() + ":3306/" + dbName;
+        return "jdbc:mysql://" + getContainerHostAddress() + ":" + getPort() + "/" + dbName;
     }
 
     public String getJdbcDriver() {
         return "com.mysql.jdbc.Driver";
     }
 
+    @Override
+    protected int getPort() {
+        return 3306;
+    }
+
     public String getDockerImageName() { return "mysql:8.4.3"; }
 
     public String[] getDockerAdditionalArgs() {
-        return new String[] {"-p", "3306:3306",
+        return new String[] { "-p", getPort() + ":3306",
                           "-e", "MYSQL_ROOT_PASSWORD=" + getRootPassword(),
                           "-e", "MYSQL_DATABASE=" + dbName,
                           "-d"

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/Oracle.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/Oracle.java
@@ -30,12 +30,17 @@ public class Oracle extends AbstractExternalDB {
 
   @Override
   public String getJdbcUrl() {
-    return "jdbc:oracle:thin:@//" + getContainerHostAddress() + ":1521/xe";
+    return "jdbc:oracle:thin:@//" + getContainerHostAddress() + ":" + getPort() + "/xe";
   }
 
   @Override
   public String getJdbcDriver() {
     return "oracle.jdbc.OracleDriver";
+  }
+
+  @Override
+  protected int getPort() {
+    return 1521;
   }
 
   @Override
@@ -45,7 +50,7 @@ public class Oracle extends AbstractExternalDB {
 
   @Override
   protected String[] getDockerAdditionalArgs() {
-    return new String[] { "-p", "1521:1521", "-d", "-e", "ORACLE_PASSWORD=" + getRootPassword() };
+    return new String[] { "-p", getPort() + ":1521", "-d", "-e", "ORACLE_PASSWORD=" + getRootPassword() };
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/PostgresExternalDB.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/PostgresExternalDB.java
@@ -27,11 +27,16 @@ public class PostgresExternalDB extends AbstractExternalDB {
     }
 
     public String getJdbcUrl() {
-        return "jdbc:postgresql://" + getContainerHostAddress() + ":5432/" + dbName;
+        return "jdbc:postgresql://" + getContainerHostAddress() + ":" + getPort() + "/" + dbName;
     }
 
     public String getJdbcDriver() {
         return "org.postgresql.Driver";
+    }
+
+    @Override
+    protected int getPort() {
+        return 5432;
     }
 
     public String getDockerImageName() {
@@ -39,7 +44,7 @@ public class PostgresExternalDB extends AbstractExternalDB {
     }
 
     public String[] getDockerAdditionalArgs() {
-        return new String[] {"-p", "5432:5432",
+        return new String[] { "-p", getPort() + ":5432",
             "-e", "POSTGRES_PASSWORD=" + getRootPassword(),
             "-e", "POSTGRES_USER=" + getRootUser(),
             "-e", "POSTGRES_DB=" + dbName,

--- a/ql/src/test/queries/clientpositive/cbo_jdbc_joincost.q
+++ b/ql/src/test/queries/clientpositive/cbo_jdbc_joincost.q
@@ -1,4 +1,4 @@
---!qt:database:mysql:q_test_author_book_tables.sql
+--!qt:database:mysql:qdb:q_test_author_book_tables.sql
 CREATE EXTERNAL TABLE author
 (
     id int,
@@ -9,9 +9,9 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
-    "hive.sql.dbcp.username" = "root",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "author"
     );
 
@@ -25,9 +25,9 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
-    "hive.sql.dbcp.username" = "root",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "book"
     );
 

--- a/ql/src/test/queries/clientpositive/dataconnector_mysql.q
+++ b/ql/src/test/queries/clientpositive/dataconnector_mysql.q
@@ -1,18 +1,18 @@
---!qt:database:mysql:q_test_country_state_city_tables.sql
+--!qt:database:mysql:qdb:q_test_country_state_city_tables.sql
 -- CREATE with comment
 CREATE CONNECTOR mysql_qtest
 TYPE 'mysql'
-URL 'jdbc:mysql://localhost:3306/qtestDB'
+URL '${system:hive.test.database.qdb.jdbc.url}'
 COMMENT 'test connector'
 WITH DCPROPERTIES (
-"hive.sql.dbcp.username"="root",
-"hive.sql.dbcp.password"="qtestpassword",
+"hive.sql.dbcp.username"="${system:hive.test.database.qdb.jdbc.username}",
+"hive.sql.dbcp.password"="${system:hive.test.database.qdb.jdbc.password}",
 "hive.connector.autoReconnect"="true",
 "hive.connector.maxReconnects"="3",
 "hive.connector.connectTimeout"="10000");
 SHOW CONNECTORS;
 
-CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB");
+CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qdb");
 SHOW DATABASES;
 USE db_mysql;
 SHOW TABLES;

--- a/ql/src/test/queries/clientpositive/jdbc_filter_expand_row_operator.q
+++ b/ql/src/test/queries/clientpositive/jdbc_filter_expand_row_operator.q
@@ -1,13 +1,13 @@
---! qt:database:postgres:q_test_book_table.sql
+--! qt:database:postgres:qdb:q_test_book_table.sql
 
 CREATE EXTERNAL TABLE book (id int, title varchar(100), author int)
 STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-    "hive.sql.dbcp.username" = "qtestuser",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "book");
 
 explain cbo

--- a/ql/src/test/queries/clientpositive/jdbc_partition_table_pruned_pcolumn.q
+++ b/ql/src/test/queries/clientpositive/jdbc_partition_table_pruned_pcolumn.q
@@ -1,4 +1,4 @@
---!qt:database:postgres:q_test_book_table.sql
+--!qt:database:postgres:qdb:q_test_book_table.sql
 
 CREATE EXTERNAL TABLE book
 (
@@ -11,9 +11,9 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-    "hive.sql.dbcp.username" = "qtestuser",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "book",
     "hive.sql.partitionColumn" = "author",
     "hive.sql.numPartitions" = "2"

--- a/ql/src/test/queries/clientpositive/jdbc_project_pushdown.q
+++ b/ql/src/test/queries/clientpositive/jdbc_project_pushdown.q
@@ -1,4 +1,4 @@
---!qt:database:postgres:q_test_author_book_tables.sql
+--!qt:database:postgres:qdb:q_test_author_book_tables.sql
 
 CREATE EXTERNAL TABLE book
 (
@@ -11,9 +11,9 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-    "hive.sql.dbcp.username" = "qtestuser",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "book"
 );
 
@@ -26,9 +26,9 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-    "hive.sql.dbcp.username" = "qtestuser",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "author"
 );
 

--- a/ql/src/test/queries/clientpositive/jdbc_table_dml_postgres.q
+++ b/ql/src/test/queries/clientpositive/jdbc_table_dml_postgres.q
@@ -1,13 +1,13 @@
---! qt:database:postgres:q_test_country_table.sql
+--! qt:database:postgres:qdb:q_test_country_table.sql
 
 CREATE EXTERNAL TABLE country (id int, name varchar(20))
 STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-    "hive.sql.dbcp.username" = "qtestuser",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "country");
 
 SELECT * FROM country ORDER BY id;

--- a/ql/src/test/queries/clientpositive/jdbc_table_limit_postgres.q
+++ b/ql/src/test/queries/clientpositive/jdbc_table_limit_postgres.q
@@ -1,13 +1,13 @@
---! qt:database:postgres:q_test_country_table.sql
+--! qt:database:postgres:qdb:q_test_country_table.sql
 
 CREATE EXTERNAL TABLE country (id int, name varchar(20))
 STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-    "hive.sql.dbcp.username" = "qtestuser",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "country");
 
 EXPLAIN CBO SELECT * FROM country ORDER BY id LIMIT 2;

--- a/ql/src/test/queries/clientpositive/jdbc_table_with_schema_mariadb.q
+++ b/ql/src/test/queries/clientpositive/jdbc_table_with_schema_mariadb.q
@@ -1,4 +1,4 @@
---! qt:database:mariadb:q_test_country_table_with_schema.mariadb.sql
+--! qt:database:mariadb:qdb:q_test_country_table_with_schema.mariadb.sql
 
 -- In MariaDB (and MySQL) CREATE SCHEMA is a synonym to CREATE DATABASE so the use of hive.sql.schema is not required.
 -- A MariaDB table can be uniquely identified by including the database/schema name in the JDBC URL and specifying the
@@ -18,9 +18,9 @@ CREATE EXTERNAL TABLE country_0 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "MYSQL",
         "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
-        "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/bob",
-        "hive.sql.dbcp.username" = "root",
-        "hive.sql.dbcp.password" = "qtestpassword",
+        "hive.sql.jdbc.url" = "jdbc:mariadb://${system:hive.test.database.qdb.host}:${system:hive.test.database.qdb.port}/bob",
+        "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+        "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
         "hive.sql.table" = "country");
 
 EXPLAIN CBO SELECT COUNT(*) FROM country_0;
@@ -33,9 +33,9 @@ CREATE EXTERNAL TABLE country_1 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "MYSQL",
         "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
-        "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/bob",
-        "hive.sql.dbcp.username" = "root",
-        "hive.sql.dbcp.password" = "qtestpassword",
+        "hive.sql.jdbc.url" = "jdbc:mariadb://${system:hive.test.database.qdb.host}:${system:hive.test.database.qdb.port}/bob",
+        "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+        "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
         "hive.sql.schema" = "bob",
         "hive.sql.table" = "country");
 
@@ -47,9 +47,9 @@ CREATE EXTERNAL TABLE country_2 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "MYSQL",
         "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
-        "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/alice",
-        "hive.sql.dbcp.username" = "root",
-        "hive.sql.dbcp.password" = "qtestpassword",
+        "hive.sql.jdbc.url" = "jdbc:mariadb://${system:hive.test.database.qdb.host}:${system:hive.test.database.qdb.port}/alice",
+        "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+        "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
         "hive.sql.table" = "country");
 
 EXPLAIN CBO SELECT COUNT(*) FROM country_2;
@@ -62,9 +62,9 @@ CREATE EXTERNAL TABLE country_3 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "MYSQL",
         "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
-        "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/bob",
-        "hive.sql.dbcp.username" = "root",
-        "hive.sql.dbcp.password" = "qtestpassword",
+        "hive.sql.jdbc.url" = "jdbc:mariadb://${system:hive.test.database.qdb.host}:${system:hive.test.database.qdb.port}/bob",
+        "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+        "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
         "hive.sql.schema" = "alice",
         "hive.sql.table" = "country");
 

--- a/ql/src/test/queries/clientpositive/jdbc_table_with_schema_mssql.q
+++ b/ql/src/test/queries/clientpositive/jdbc_table_with_schema_mssql.q
@@ -1,4 +1,4 @@
---! qt:database:mssql:q_test_country_table_with_schema.mssql.sql
+--! qt:database:mssql:qdb:q_test_country_table_with_schema.mssql.sql
 -- Microsoft SQL server allows multiple schemas per database so to disambiguate between tables in different schemas it
 -- is necessary to set the hive.sql.schema property properly.
 
@@ -11,9 +11,9 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MSSQL",
     "hive.sql.jdbc.driver" = "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-    "hive.sql.jdbc.url" = "jdbc:sqlserver://localhost:1433;DatabaseName=world;",
-    "hive.sql.dbcp.username" = "sa",
-    "hive.sql.dbcp.password" = "Its-a-s3cret",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url};DatabaseName=world;",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.schema" = "bob",
     "hive.sql.table" = "country");
 
@@ -25,9 +25,9 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MSSQL",
     "hive.sql.jdbc.driver" = "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-    "hive.sql.jdbc.url" = "jdbc:sqlserver://localhost:1433;DatabaseName=world;",
-    "hive.sql.dbcp.username" = "sa",
-    "hive.sql.dbcp.password" = "Its-a-s3cret",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url};DatabaseName=world;",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.schema" = "alice",
     "hive.sql.table" = "country");
 
@@ -45,7 +45,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MSSQL",
     "hive.sql.jdbc.driver" = "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-    "hive.sql.jdbc.url" = "jdbc:sqlserver://localhost:1433;DatabaseName=world;",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url};DatabaseName=world;",
     "hive.sql.dbcp.username" = "greg",
     "hive.sql.dbcp.password" = "GregPass123!$",
     "hive.sql.table" = "country");

--- a/ql/src/test/queries/clientpositive/jdbc_table_with_schema_oracle.q
+++ b/ql/src/test/queries/clientpositive/jdbc_table_with_schema_oracle.q
@@ -1,4 +1,4 @@
---! qt:database:oracle:q_test_country_table_with_schema.oracle.sql
+--! qt:database:oracle:qdb:q_test_country_table_with_schema.oracle.sql
 -- Oracle does not allow explicitly the creation of different namespaces/schemas in the same database. This can be
 -- achieved by creating different users where each user is associated with a schema having the same name.
 
@@ -12,7 +12,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "ORACLE",
     "hive.sql.jdbc.driver" = "oracle.jdbc.OracleDriver",
-    "hive.sql.jdbc.url" = "jdbc:oracle:thin:@//localhost:1521/XEPDB1",
+    "hive.sql.jdbc.url" = "jdbc:oracle:thin:@//${system:hive.test.database.qdb.host}:${system:hive.test.database.qdb.port}/XEPDB1",
     "hive.sql.dbcp.username" = "bob",
     "hive.sql.dbcp.password" = "bobpass",
     "hive.sql.schema" = "BOB",
@@ -28,7 +28,7 @@ CREATE EXTERNAL TABLE country_1 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "ORACLE",
         "hive.sql.jdbc.driver" = "oracle.jdbc.OracleDriver",
-        "hive.sql.jdbc.url" = "jdbc:oracle:thin:@//localhost:1521/XEPDB1",
+        "hive.sql.jdbc.url" = "jdbc:oracle:thin:@//${system:hive.test.database.qdb.host}:${system:hive.test.database.qdb.port}/XEPDB1",
         "hive.sql.dbcp.username" = "bob",
         "hive.sql.dbcp.password" = "bobpass",
         "hive.sql.table" = "COUNTRY"
@@ -43,7 +43,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "ORACLE",
     "hive.sql.jdbc.driver" = "oracle.jdbc.OracleDriver",
-    "hive.sql.jdbc.url" = "jdbc:oracle:thin:@//localhost:1521/XEPDB1",
+    "hive.sql.jdbc.url" = "jdbc:oracle:thin:@//${system:hive.test.database.qdb.host}:${system:hive.test.database.qdb.port}/XEPDB1",
     "hive.sql.dbcp.username" = "bob",
     "hive.sql.dbcp.password" = "bobpass",
     "hive.sql.schema" = "ALICE",

--- a/ql/src/test/queries/clientpositive/jdbc_table_with_schema_postgres.q
+++ b/ql/src/test/queries/clientpositive/jdbc_table_with_schema_postgres.q
@@ -1,4 +1,4 @@
---! qt:database:postgres:q_test_country_table_with_schema.postgres.sql
+--! qt:database:postgres:qdb:q_test_country_table_with_schema.postgres.sql
 -- Postgres allows multiple schemas per database so to disambiguate between tables in different schemas it
 -- is necessary to set the hive.sql.schema property properly.
 
@@ -11,9 +11,9 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-    "hive.sql.dbcp.username" = "qtestuser",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.schema" = "bob",
     "hive.sql.table" = "country");
 
@@ -25,9 +25,9 @@ CREATE EXTERNAL TABLE country_1 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-        "hive.sql.dbcp.username" = "qtestuser",
-        "hive.sql.dbcp.password" = "qtestpassword",
+        "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+        "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+        "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
         "hive.sql.schema" = "alice",
         "hive.sql.table" = "country");
 
@@ -45,7 +45,7 @@ CREATE EXTERNAL TABLE country_2 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+        "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
         "hive.sql.dbcp.username" = "greg",
         "hive.sql.dbcp.password" = "GregPass123!$",
         "hive.sql.table" = "country");

--- a/ql/src/test/queries/clientpositive/qt_database_mariadb.q
+++ b/ql/src/test/queries/clientpositive/qt_database_mariadb.q
@@ -1,4 +1,4 @@
---!qt:database:mariadb:q_test_country_table.sql
+--!qt:database:mariadb:qdb:q_test_country_table.sql
 CREATE EXTERNAL TABLE country
 (
     id int,
@@ -8,9 +8,9 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL", 
     "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/qtestDB",
-    "hive.sql.dbcp.username" = "root",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "country"
     );
 -- hive.sql.database.type above is not MARIADB cause at the moment it doesn't exist in org.apache.hive.storage.jdbc.conf.DatabaseType

--- a/ql/src/test/queries/clientpositive/qt_database_mssql.q
+++ b/ql/src/test/queries/clientpositive/qt_database_mssql.q
@@ -1,4 +1,4 @@
---!qt:database:mssql:q_test_country_table.sql
+--!qt:database:mssql:qdb:q_test_country_table.sql
 CREATE EXTERNAL TABLE country
 (
     id int,
@@ -8,9 +8,9 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MSSQL", 
     "hive.sql.jdbc.driver" = "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-    "hive.sql.jdbc.url" = "jdbc:sqlserver://localhost:1433",
-    "hive.sql.dbcp.username" = "sa",
-    "hive.sql.dbcp.password" = "Its-a-s3cret",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "country"
     );
 SELECT * FROM country;

--- a/ql/src/test/queries/clientpositive/qt_database_mysql.q
+++ b/ql/src/test/queries/clientpositive/qt_database_mysql.q
@@ -1,4 +1,4 @@
---!qt:database:mysql:q_test_country_table.sql
+--!qt:database:mysql:qdb:q_test_country_table.sql
 CREATE EXTERNAL TABLE country
 (
     id int,
@@ -8,9 +8,9 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
-    "hive.sql.dbcp.username" = "root",
-    "hive.sql.dbcp.password" = "qtestpassword",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+    "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+    "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
     "hive.sql.table" = "country"
     );
 SELECT * FROM country;

--- a/ql/src/test/queries/clientpositive/qt_database_oracle.q
+++ b/ql/src/test/queries/clientpositive/qt_database_oracle.q
@@ -1,4 +1,4 @@
---!qt:database:oracle:q_test_country_table.sql
+--!qt:database:oracle:qdb:q_test_country_table.sql
 CREATE EXTERNAL TABLE country
 (
     id int,
@@ -8,7 +8,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "ORACLE", 
     "hive.sql.jdbc.driver" = "oracle.jdbc.OracleDriver",
-    "hive.sql.jdbc.url" = "jdbc:oracle:thin:@//localhost:1521/xe",
+    "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
     "hive.sql.dbcp.username" = "SYS as SYSDBA",
     "hive.sql.dbcp.password" = "oracle",
     "hive.sql.table" = "COUNTRY"

--- a/ql/src/test/queries/clientpositive/qt_database_postgres.q
+++ b/ql/src/test/queries/clientpositive/qt_database_postgres.q
@@ -1,4 +1,4 @@
---!qt:database:postgres:q_test_country_table.sql
+--!qt:database:postgres:qdb:q_test_country_table.sql
 CREATE EXTERNAL TABLE country
 (
     id int,
@@ -8,9 +8,9 @@ CREATE EXTERNAL TABLE country
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
-        "hive.sql.dbcp.username" = "qtestuser",
-        "hive.sql.dbcp.password" = "qtestpassword",
+        "hive.sql.jdbc.url" = "${system:hive.test.database.qdb.jdbc.url}",
+        "hive.sql.dbcp.username" = "${system:hive.test.database.qdb.jdbc.username}",
+        "hive.sql.dbcp.password" = "${system:hive.test.database.qdb.jdbc.password}",
         "hive.sql.table" = "country"
         );
 SELECT * FROM country;

--- a/ql/src/test/results/clientpositive/llap/cbo_jdbc_joincost.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_jdbc_joincost.q.out
@@ -8,7 +8,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qdb",
     "hive.sql.dbcp.username" = "root",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "author"
@@ -26,7 +26,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qdb",
     "hive.sql.dbcp.username" = "root",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "author"
@@ -44,7 +44,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qdb",
     "hive.sql.dbcp.username" = "root",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "book"
@@ -62,7 +62,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qdb",
     "hive.sql.dbcp.username" = "root",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "book"

--- a/ql/src/test/results/clientpositive/llap/dataconnector_mysql.q.out
+++ b/ql/src/test/results/clientpositive/llap/dataconnector_mysql.q.out
@@ -1,6 +1,6 @@
 PREHOOK: query: CREATE CONNECTOR mysql_qtest
 TYPE 'mysql'
-URL 'jdbc:mysql://localhost:3306/qtestDB'
+URL 'jdbc:mysql://localhost:3306/qdb'
 COMMENT 'test connector'
 WITH DCPROPERTIES (
 "hive.sql.dbcp.username"="root",
@@ -12,7 +12,7 @@ PREHOOK: type: CREATEDATACONNECTOR
 PREHOOK: Output: connector:mysql_qtest
 POSTHOOK: query: CREATE CONNECTOR mysql_qtest
 TYPE 'mysql'
-URL 'jdbc:mysql://localhost:3306/qtestDB'
+URL 'jdbc:mysql://localhost:3306/qdb'
 COMMENT 'test connector'
 WITH DCPROPERTIES (
 "hive.sql.dbcp.username"="root",
@@ -27,11 +27,11 @@ PREHOOK: type: SHOWDATACONNECTORS
 POSTHOOK: query: SHOW CONNECTORS
 POSTHOOK: type: SHOWDATACONNECTORS
 mysql_qtest
-PREHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB")
+PREHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qdb")
 PREHOOK: type: CREATEDATABASE
 PREHOOK: Input: connector:mysql_qtest
 PREHOOK: Output: database:db_mysql
-POSTHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB")
+POSTHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qdb")
 POSTHOOK: type: CREATEDATABASE
 POSTHOOK: Input: connector:mysql_qtest
 POSTHOOK: Output: database:db_mysql
@@ -75,8 +75,8 @@ TBLPROPERTIES (
   'hive.sql.dbcp.password'='qtestpassword', 
   'hive.sql.dbcp.username'='root', 
   'hive.sql.jdbc.driver'='com.mysql.jdbc.Driver', 
-  'hive.sql.jdbc.url'='jdbc:mysql://localhost:3306/qtestDB', 
-  'hive.sql.schema'='qtestDB', 
+  'hive.sql.jdbc.url'='jdbc:mysql://localhost:3306/qdb', 
+  'hive.sql.schema'='qdb', 
   'hive.sql.table'='country')
 PREHOOK: query: SELECT * FROM country
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/jdbc_filter_expand_row_operator.q.out
+++ b/ql/src/test/results/clientpositive/llap/jdbc_filter_expand_row_operator.q.out
@@ -3,7 +3,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "book")
@@ -15,7 +15,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "book")

--- a/ql/src/test/results/clientpositive/llap/jdbc_partition_table_pruned_pcolumn.q.out
+++ b/ql/src/test/results/clientpositive/llap/jdbc_partition_table_pruned_pcolumn.q.out
@@ -9,7 +9,7 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "book",
@@ -30,7 +30,7 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "book",

--- a/ql/src/test/results/clientpositive/llap/jdbc_project_pushdown.q.out
+++ b/ql/src/test/results/clientpositive/llap/jdbc_project_pushdown.q.out
@@ -9,7 +9,7 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "book"
@@ -28,7 +28,7 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "book"
@@ -45,7 +45,7 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "author"
@@ -62,7 +62,7 @@ STORED BY
 TBLPROPERTIES (                                    
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "author"

--- a/ql/src/test/results/clientpositive/llap/jdbc_table_dml_postgres.q.out
+++ b/ql/src/test/results/clientpositive/llap/jdbc_table_dml_postgres.q.out
@@ -3,7 +3,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "country")
@@ -15,7 +15,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "country")

--- a/ql/src/test/results/clientpositive/llap/jdbc_table_limit_postgres.q.out
+++ b/ql/src/test/results/clientpositive/llap/jdbc_table_limit_postgres.q.out
@@ -3,7 +3,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "country")
@@ -15,7 +15,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "country")

--- a/ql/src/test/results/clientpositive/llap/jdbc_table_with_schema_postgres.q.out
+++ b/ql/src/test/results/clientpositive/llap/jdbc_table_with_schema_postgres.q.out
@@ -3,7 +3,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.schema" = "bob",
@@ -16,7 +16,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "POSTGRES",
     "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
     "hive.sql.dbcp.username" = "qtestuser",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.schema" = "bob",
@@ -51,7 +51,7 @@ PREHOOK: query: CREATE EXTERNAL TABLE country_1 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
         "hive.sql.dbcp.username" = "qtestuser",
         "hive.sql.dbcp.password" = "qtestpassword",
         "hive.sql.schema" = "alice",
@@ -64,7 +64,7 @@ POSTHOOK: query: CREATE EXTERNAL TABLE country_1 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
         "hive.sql.dbcp.username" = "qtestuser",
         "hive.sql.dbcp.password" = "qtestpassword",
         "hive.sql.schema" = "alice",
@@ -120,7 +120,7 @@ PREHOOK: query: CREATE EXTERNAL TABLE country_2 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
         "hive.sql.dbcp.username" = "greg",
         "hive.sql.dbcp.password" = "GregPass123!$",
         "hive.sql.table" = "country")
@@ -132,7 +132,7 @@ POSTHOOK: query: CREATE EXTERNAL TABLE country_2 (id int, name varchar(20))
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
         "hive.sql.dbcp.username" = "greg",
         "hive.sql.dbcp.password" = "GregPass123!$",
         "hive.sql.table" = "country")

--- a/ql/src/test/results/clientpositive/llap/qt_database_mariadb.q.out
+++ b/ql/src/test/results/clientpositive/llap/qt_database_mariadb.q.out
@@ -7,7 +7,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL", 
     "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/qdb",
     "hive.sql.dbcp.username" = "root",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "country"
@@ -24,7 +24,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL", 
     "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/qdb",
     "hive.sql.dbcp.username" = "root",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "country"

--- a/ql/src/test/results/clientpositive/llap/qt_database_mysql.q.out
+++ b/ql/src/test/results/clientpositive/llap/qt_database_mysql.q.out
@@ -7,7 +7,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qdb",
     "hive.sql.dbcp.username" = "root",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "country"
@@ -24,7 +24,7 @@ STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (
     "hive.sql.database.type" = "MYSQL",
     "hive.sql.jdbc.driver" = "com.mysql.jdbc.Driver",
-    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qtestDB",
+    "hive.sql.jdbc.url" = "jdbc:mysql://localhost:3306/qdb",
     "hive.sql.dbcp.username" = "root",
     "hive.sql.dbcp.password" = "qtestpassword",
     "hive.sql.table" = "country"

--- a/ql/src/test/results/clientpositive/llap/qt_database_postgres.q.out
+++ b/ql/src/test/results/clientpositive/llap/qt_database_postgres.q.out
@@ -7,7 +7,7 @@ PREHOOK: query: CREATE EXTERNAL TABLE country
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
         "hive.sql.dbcp.username" = "qtestuser",
         "hive.sql.dbcp.password" = "qtestpassword",
         "hive.sql.table" = "country"
@@ -24,7 +24,7 @@ POSTHOOK: query: CREATE EXTERNAL TABLE country
     TBLPROPERTIES (
         "hive.sql.database.type" = "POSTGRES",
         "hive.sql.jdbc.driver" = "org.postgresql.Driver",
-        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qtestDB",
+        "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/qdb",
         "hive.sql.dbcp.username" = "qtestuser",
         "hive.sql.dbcp.password" = "qtestpassword",
         "hive.sql.table" = "country"


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Allow to define name/id for each database used via the qt:database directive
2. Expose database connection properties via system properties and manage them during the life-cycle of the database

### Why are the changes needed?
1. Facilitate writing of qtests for the JDBC storage handler
3. Avoid harcoding connection properties in qfiles
4. Opens up the stage for supporting multiple databases of the same kind in qtests

### Does this PR introduce _any_ user-facing change?
No, it only affects the test infrastructure.

### How was this patch tested?
```
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=cbo_jdbc_joincost.q,dataconnector_mysql.q,jdbc_filter_expand_row_operator.q,jdbc_partition_table_pruned_pcolumn.q,jdbc_project_pushdown.q,jdbc_table_dml_postgres.q,jdbc_table_limit_postgres.q,jdbc_table_with_schema_mariadb.q,jdbc_table_with_schema_mssql.q,jdbc_table_with_schema_oracle.q,jdbc_table_with_schema_postgres.q,qt_database_mssql.q,qt_database_mysql.q,qt_database_postgres.q -Dtest.output.overwrite
```