### PR TITLE
HIVE-29064: Drop usage of repository.apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,16 +248,6 @@
       </releases>
     </repository>
     <repository>
-      <id>repository-release</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <!-- shibboleth doesn't publish artifacts on maven central
         See https://wiki.shibboleth.net/confluence/display/DEV/Use+of+Maven+Central -->
       <id>shibboleth</id>


### PR DESCRIPTION
### Why are the changes needed?
The repository.apache.org is not a general-purpose maven repository so we shouldn't use it to fetch artifacts from there. Unnecessary usage puts stress on the Apache infrastructure and can lead into IP bans and CI failures. See for more info: https://infra.apache.org/abc/#BL018

In general, the less we rely on non-standard remote repositories the better in many aspects for devs, CI, and consumers that depend on us.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Built the project successfully using a clean local maven repository.
```
mvn clean install -DskipTests -Pitests -Dmaven.repo.local=/tmp/m2/hive
```
