### PR TITLE
HIVE-29067 - insert-select-union-all query fails while publishing InsertEvent if source query does not return output

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -3961,7 +3961,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
     }
   }
 
-  private void fireInsertEvent(Table tbl, Map<String, String> partitionSpec, boolean replace, List<FileStatus> newFiles)
+  void fireInsertEvent(Table tbl, Map<String, String> partitionSpec, boolean replace, List<FileStatus> newFiles)
       throws HiveException {
     if (conf.getBoolVar(ConfVars.FIRE_EVENTS_FOR_DML)) {
       LOG.debug("Firing dml insert event");
@@ -3974,11 +3974,10 @@ private void constructOneLBLocationMap(FileStatus fSta,
         FireEventRequestData data = new FireEventRequestData();
         InsertEventRequestData insertData = new InsertEventRequestData();
         insertData.setReplace(replace);
+        insertData.setFilesAdded(new ArrayList());
         data.setInsertData(insertData);
         if (newFiles != null && !newFiles.isEmpty()) {
           addInsertFileInformation(newFiles, fileSystem, insertData);
-        } else {
-          insertData.setFilesAdded(new ArrayList<String>());
         }
         FireEventRequest rqst = new FireEventRequest(true, data);
         rqst.setDbName(tbl.getDbName());

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -1055,6 +1055,17 @@ public class TestHive {
       Path insertedPath = new Path(insertEvent.getFiles().get(i));
       Assert.assertEquals(expectedCheckSums.get(insertedPath.getName()), checkSums.get(i));
     }
+
+    // Fire the InsertEvent with empty folder
+    hiveDb.fireInsertEvent(table, null, false,
+      Lists.newArrayList(new FileStatus(5, true, 1, 64, 100, tablePath)));
+    // Get the last Metastore event
+    InsertEvent insertEvent1 = DummyFireInsertListener.getLastEvent();
+    // Check the event
+    Assert.assertNotNull(insertEvent1);
+    // getFiles should be empty and not null
+    Assert.assertNotNull(insertEvent1.getFiles());
+    Assert.assertTrue(insertEvent1.getFiles().isEmpty());
   }
 
   private String getFileCheckSum(FileSystem fileSystem, Path p) throws Exception {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Bug fix to avoid insert-select-union-all query failure while publishing InsertEvent if source produce empty output

### Why are the changes needed?
Query fails without this fix

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Included testcase in q file
