### PR TITLE
HIVE-29065: Fix Dockerfile warnings - FromAsCasing and InvalidDefault…

### DIFF
--- a/.github/workflows/docker-GA-images.yml
+++ b/.github/workflows/docker-GA-images.yml
@@ -85,7 +85,7 @@ jobs:
             HIVE_VERSION=${{ env.HIVE_VERSION }}
             HADOOP_VERSION=${{ env.HADOOP_VERSION }}
             TEZ_VERSION=${{ env.TEZ_VERSION }}
-            BUILD_ENV=archive
+            BUILD_ENV=release
 
       - name: Build and push Standalone Metastore Image to docker hub
         uses: docker/build-push-action@v4
@@ -99,7 +99,7 @@ jobs:
             |
             HIVE_VERSION=${{ env.HIVE_VERSION }}
             HADOOP_VERSION=${{ env.HADOOP_VERSION }}
-            BUILD_ENV=archive      
+            BUILD_ENV=release      
 
   buildFromSource:
     if: github.event_name == 'create' && github.event.ref_type == 'tag' && startsWith(github.event.ref, 'rel/')
@@ -159,7 +159,7 @@ jobs:
             HIVE_VERSION=${{ env.HIVE_VERSION }}
             HADOOP_VERSION=${{ env.HADOOP_VERSION }}
             TEZ_VERSION=${{ env.TEZ_VERSION }}
-            BUILD_ENV=buildarchive
+            BUILD_ENV=hybrid
 
       - name: Check for hive-standalone-metastore tar.gz
         run: ls ./standalone-metastore/packaging/target/
@@ -183,4 +183,4 @@ jobs:
             |
             HIVE_VERSION=${{ env.HIVE_VERSION }}
             HADOOP_VERSION=${{ env.HADOOP_VERSION }}
-            BUILD_ENV=buildarchive
+            BUILD_ENV=hybrid

--- a/packaging/src/docker/Dockerfile
+++ b/packaging/src/docker/Dockerfile
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG BUILD_ENV
+ARG BUILD_ENV=local
 
-FROM ubuntu as unarchive
+FROM ubuntu AS local
 ONBUILD COPY hadoop-*.tar.gz /opt
 ONBUILD COPY apache-hive-*-bin.tar.gz /opt
 ONBUILD COPY apache-tez-*-bin.tar.gz /opt
 
-FROM ubuntu as archive
+FROM ubuntu AS release
 ARG HADOOP_VERSION
 ARG HIVE_VERSION
 ARG TEZ_VERSION
@@ -33,7 +33,7 @@ ONBUILD RUN mv /apache-tez-$TEZ_VERSION-bin.tar.gz /opt && \
  mv hadoop-$HADOOP_VERSION.tar.gz /opt && \
  mv apache-hive-$HIVE_VERSION-bin.tar.gz /opt
 
-FROM ubuntu as buildarchive
+FROM ubuntu AS hybrid
 ARG HADOOP_VERSION
 ARG HIVE_VERSION
 ARG TEZ_VERSION
@@ -44,7 +44,7 @@ ONBUILD COPY ./apache-hive-$HIVE_VERSION-bin.tar.gz /opt
 ONBUILD RUN mv /apache-tez-$TEZ_VERSION-bin.tar.gz /opt && \
  mv hadoop-$HADOOP_VERSION.tar.gz /opt
 
-FROM ${BUILD_ENV} as env
+FROM ${BUILD_ENV} AS env
 RUN echo ${BUILD_ENV}
 ARG HADOOP_VERSION
 ARG HIVE_VERSION

--- a/packaging/src/docker/build.sh
+++ b/packaging/src/docker/build.sh
@@ -127,7 +127,6 @@ docker build \
         "$WORK_DIR" \
         -f "$WORK_DIR/Dockerfile" \
         -t "$repo/hive:$HIVE_VERSION" \
-        --build-arg "BUILD_ENV=unarchive" \
         --build-arg "HIVE_VERSION=$HIVE_VERSION" \
         --build-arg "HADOOP_VERSION=$HADOOP_VERSION" \
         --build-arg "TEZ_VERSION=$TEZ_VERSION" \

--- a/standalone-metastore/packaging/src/docker/Dockerfile
+++ b/standalone-metastore/packaging/src/docker/Dockerfile
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG BUILD_ENV
+ARG BUILD_ENV=local
 
-FROM ubuntu as unarchive
+FROM ubuntu AS local
 ONBUILD COPY hadoop-*.tar.gz /opt
 ONBUILD COPY hive-standalone-metastore-*-bin.tar.gz /opt
 
-FROM ubuntu as archive
+FROM ubuntu AS release
 ARG HADOOP_VERSION
 ARG HIVE_VERSION
 ONBUILD RUN apt-get update && apt-get -y install wget
@@ -29,7 +29,7 @@ ONBUILD RUN wget https://archive.apache.org/dist/hadoop/core/hadoop-$HADOOP_VERS
 ONBUILD RUN mv hadoop-$HADOOP_VERSION.tar.gz /opt && \
  mv hive-standalone-metastore-$HIVE_VERSION-bin.tar.gz /opt
 
-FROM ubuntu as buildarchive
+FROM ubuntu AS hybrid
 ARG HADOOP_VERSION
 ARG HIVE_VERSION
 ONBUILD RUN apt-get update && apt-get -y install wget
@@ -37,7 +37,7 @@ ONBUILD RUN wget https://archive.apache.org/dist/hadoop/core/hadoop-$HADOOP_VERS
 ONBUILD COPY ./hive-standalone-metastore-$HIVE_VERSION-bin.tar.gz /opt
 ONBUILD RUN mv hadoop-$HADOOP_VERSION.tar.gz /opt
 
-FROM ${BUILD_ENV} as env
+FROM ${BUILD_ENV} AS env
 RUN echo ${BUILD_ENV}
 ARG HADOOP_VERSION
 ARG HIVE_VERSION

--- a/standalone-metastore/packaging/src/docker/build.sh
+++ b/standalone-metastore/packaging/src/docker/build.sh
@@ -107,7 +107,6 @@ docker build \
         "$WORK_DIR" \
         -f "$WORK_DIR/Dockerfile" \
         -t "$repo/hive:standalone-metastore-$HIVE_VERSION" \
-        --build-arg "BUILD_ENV=unarchive" \
         --build-arg "HIVE_VERSION=$HIVE_VERSION" \
         --build-arg "HADOOP_VERSION=$HADOOP_VERSION" \
 


### PR DESCRIPTION
…ArgInFrom

### What changes were proposed in this pull request?
In the Dockerfile
- Match the case for all keywords (UPPER CASE). 
- Default value for BUILD_ENV argument.  "FROM" determines the base image for the build and arg BUILD_ENV is used here. If it is empty/invalid , the image will not be created. So docker lint checks for this issue. To avoid it, a default value needs to set. 

### Why are the changes needed?
To remove the warnings thrown during docker build.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Create the docker image using build script for both hive and hms image.
./build.sh
