### PR TITLE
HIVE-24419: Refactor junit database rules to exploit testcontainers

### DIFF
--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -25,7 +25,6 @@
   <name>Hive Integration - Unit Tests</name>
   <properties>
     <hive.path.to.root>../..</hive.path.to.root>
-    <testcontainers.version>1.15.2</testcontainers.version>
     <htmlunit.version>2.70.0</htmlunit.version>
   </properties>
   <dependencies>
@@ -500,7 +499,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -194,6 +194,26 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mariadb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mysql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>oracle-xe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mssqlserver</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <classifier>tests</classifier>

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliAdapter.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliAdapter.java
@@ -72,11 +72,10 @@ public abstract class CliAdapter {
         return new Statement() {
           @Override
           public void evaluate() throws Throwable {
-            metaStoreHandler.setSystemProperties(); // for QTestUtil pre-initialization
-            CliAdapter.this.beforeClass(); // instantiating QTestUtil
-
             metaStoreHandler.getRule().before();
             metaStoreHandler.getRule().install();
+            metaStoreHandler.setSystemProperties(); // for QTestUtil pre-initialization
+            CliAdapter.this.beforeClass(); // instantiating QTestUtil
 
             if (getQt() != null) {
               metaStoreHandler.setMetaStoreConfiguration(getQt().getConf());

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,7 @@
     <tez.version>0.10.5</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
     <tempus-fugit.version>1.1</tempus-fugit.version>
+    <testcontainers.version>1.21.3</testcontainers.version>
     <snappy.version>1.1.10.4</snappy.version>
     <jersey-wadl-doclet.version>4.0.0-M2</jersey-wadl-doclet.version>
     <jaxb-runtime.version>4.0.0-M2</jaxb-runtime.version>
@@ -1454,6 +1455,36 @@
         <artifactId>postgresql</artifactId>
         <version>${postgres.version}</version>
         <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mariadb</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mysql</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>oracle-xe</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mssqlserver</artifactId>
+        <version>${testcontainers.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -574,6 +574,31 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mariadb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mysql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>oracle-xe</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mssqlserver</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- test inter-project -->
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/ITestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/ITestDbTxnManager.java
@@ -21,12 +21,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.DatabaseProduct;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.dbinstall.rules.DatabaseRule;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Derby;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Mariadb;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Mssql;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Mysql;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Oracle;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Postgres;
+import org.apache.hadoop.hive.metastore.dbinstall.rules.MetastoreRuleFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
@@ -48,7 +43,10 @@ public class ITestDbTxnManager extends TestDbTxnManager2 {
     String metastoreType =
         System.getProperty(SYS_PROP_METASTORE_DB) == null ? "derby" : System.getProperty(SYS_PROP_METASTORE_DB)
             .toLowerCase();
-    rule = getDatabaseRule(metastoreType).setVerbose(false);
+    rule = MetastoreRuleFactory.create(metastoreType).setVerbose(false);
+    // Start the docker container and create the hive user
+    rule.before();
+    rule.install();
 
     conf.setVar(HiveConf.ConfVars.METASTORE_DB_TYPE, metastoreType.toUpperCase());
 
@@ -62,30 +60,10 @@ public class ITestDbTxnManager extends TestDbTxnManager2 {
 
     LOG.info("Set metastore connection to url: {}",
         MetastoreConf.getVar(conf, MetastoreConf.ConfVars.CONNECT_URL_KEY));
-    // Start the docker container and create the hive user
-    rule.before();
-    rule.install();
   }
 
   @AfterClass
   public static void tearDownDb() {
     rule.after();
-  }
-
-  private static DatabaseRule getDatabaseRule(String metastoreType) {
-    switch (metastoreType) {
-      case "postgres":
-        return new Postgres();
-      case "oracle":
-        return new Oracle();
-      case "mysql":
-        return new Mysql();
-      case "mariadb":
-        return new Mariadb();
-      case "mssql":
-        return new Mssql();
-      default:
-        return new Derby();
-    }
   }
 }

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -441,6 +441,31 @@
       <version>2.1.8</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mariadb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mysql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>oracle-xe</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mssqlserver</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Derby.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Derby.java
@@ -37,16 +37,6 @@ public class Derby extends DatabaseRule {
   }
 
   @Override
-  public String getDockerImageName() {
-    return null;
-  }
-
-  @Override
-  public String[] getDockerAdditionalArgs() {
-    return null;
-  }
-
-  @Override
   public String getDbType() {
     return "derby";
   }
@@ -77,24 +67,19 @@ public class Derby extends DatabaseRule {
   }
 
   @Override
-  public String getJdbcUrl(String hostAddress) {
+  public String getJdbcUrl() {
 
     return String.format("jdbc:derby:memory:%s;create=true", getDb());
   }
 
   @Override
-  public String getInitialJdbcUrl(String hostAddress) {
+  public String getInitialJdbcUrl() {
     return String.format("jdbc:derby:memory:%s;create=true", getDb());
   }
 
   public String getDb() {
     return MetaStoreServerUtils.JUNIT_DATABASE_PREFIX;
   };
-
-  @Override
-  public boolean isContainerReady(ProcessResults pr) {
-    return true;
-  }
 
   @Override
   public void before() throws Exception {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Mariadb.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Mariadb.java
@@ -18,19 +18,22 @@
 
 package org.apache.hadoop.hive.metastore.dbinstall.rules;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
 
 public class Mariadb extends DatabaseRule {
+  private final MariaDBContainer<?> container = new MariaDBContainer<>(DockerImageName.parse("mariadb:11.4"));
 
   @Override
-  public String getDockerImageName() {
-    return "mariadb:11.4";
+  public void before() throws IOException, InterruptedException {
+    container.start();
   }
 
   @Override
-  public String[] getDockerAdditionalArgs() {
-    return buildArray("-p", "3306:3306", "-e", "MYSQL_ROOT_PASSWORD=" + getDbRootPassword(), "-d");
+  public void after() {
+    container.stop();
   }
 
   @Override
@@ -45,29 +48,22 @@ public class Mariadb extends DatabaseRule {
 
   @Override
   public String getDbRootPassword() {
-    return "its-a-secret";
+    return container.getPassword();
   }
 
   @Override
   public String getJdbcDriver() {
-    return "org.mariadb.jdbc.Driver";
+    return container.getDriverClassName();
   }
 
   @Override
-  public String getJdbcUrl(String hostAddress) {
-    return "jdbc:mariadb://" + hostAddress + ":3306/" + HIVE_DB;
+  public String getJdbcUrl() {
+    return container.withDatabaseName(HIVE_DB).getJdbcUrl();
   }
 
   @Override
-  public String getInitialJdbcUrl(String hostAddress) {
-    return "jdbc:mariadb://" + hostAddress + ":3306/?allowPublicKeyRetrieval=true";
-  }
-
-  @Override
-  public boolean isContainerReady(ProcessResults pr) {
-    Pattern pat = Pattern.compile("ready for connections");
-    Matcher m = pat.matcher(pr.stderr);
-    return m.find() && m.find();
+  public String getInitialJdbcUrl() {
+    return container.withDatabaseName("").getJdbcUrl();
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/MetastoreRuleFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/MetastoreRuleFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.dbinstall.rules;
+
+/**
+ * A factory for creating a Metastore database rule for use in tests.
+ */
+public final class MetastoreRuleFactory {
+  private MetastoreRuleFactory() {
+    throw new IllegalStateException("Factory class should not be instantiated");
+  }
+
+  /**
+   * Creates a new Metastore rule based on the provided database type.
+   *
+   * @param dbType the type of database (e.g., "mysql", "postgres", etc.)
+   * @return a DatabaseRule instance for the specified database type
+   * @throws IllegalArgumentException if the database type is unsupported
+   */
+  public static DatabaseRule create(String dbType) {
+    return switch (dbType.toLowerCase()) {
+      case "mysql" -> new Mysql();
+      case "postgres" -> new Postgres();
+      case "postgres.tpcds" -> new PostgresTPCDS();
+      case "mariadb" -> new Mariadb();
+      case "derby" -> new Derby();
+      case "derby.clean" -> new Derby(true);
+      case "mssql", "sqlserver" -> new Mssql();
+      case "oracle" -> new Oracle();
+      default -> throw new IllegalArgumentException("Unsupported database type: " + dbType);
+    };
+  }
+}

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/PostgresTPCDS.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/PostgresTPCDS.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore.dbinstall.rules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.MetaStoreSchemaInfoFactory;
 import org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,14 +30,14 @@ import java.io.UncheckedIOException;
  * JUnit TestRule for Postgres metastore with TPCDS schema and stat information.
  */
 public class PostgresTPCDS extends Postgres {
-  @Override
-  public String getDockerImageName() {
-    return "zabetak/postgres-tpcds-metastore:1.3";
+  public PostgresTPCDS() {
+    super(DockerImageName.parse("zabetak/postgres-tpcds-metastore:1.3").asCompatibleSubstituteFor("postgres"));
+    container.withUsername("postgres");
   }
 
   @Override
-  public String getJdbcUrl(String hostAddress) {
-    return "jdbc:postgresql://" + hostAddress + ":5432/metastore";
+  public String getJdbcUrl() {
+    return container.withDatabaseName("metastore").getJdbcUrl();
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
@@ -29,10 +29,9 @@ import java.net.URI;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -45,12 +44,7 @@ import org.apache.hadoop.hive.metastore.MetaStoreSchemaInfoFactory;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.dbinstall.rules.DatabaseRule;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Derby;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Mariadb;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Mssql;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Mysql;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Oracle;
-import org.apache.hadoop.hive.metastore.dbinstall.rules.Postgres;
+import org.apache.hadoop.hive.metastore.dbinstall.rules.MetastoreRuleFactory;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -75,20 +69,13 @@ public class TestSchemaToolForMetastore {
   private PrintStream outStream;
   private SchemaToolTaskValidate validator;
 
-  public TestSchemaToolForMetastore(DatabaseRule dbms){
-    this.dbms = dbms;
+  public TestSchemaToolForMetastore(String dbType){
+    this.dbms = MetastoreRuleFactory.create(dbType);
   }
 
   @Parameterized.Parameters(name = "{0}")
-  public static Collection<Object[]> databases() {
-    List<Object[]> dbs = new ArrayList<>();
-    dbs.add(new Object[] { new Derby(true) });
-    dbs.add(new Object[] { new Mysql() });
-    dbs.add(new Object[] { new Oracle() });
-    dbs.add(new Object[] { new Postgres() });
-    dbs.add(new Object[] { new Mariadb() });
-    dbs.add(new Object[] { new Mssql() });
-    return dbs;
+  public static Collection<String> databases() {
+    return Arrays.asList("derby.clean", "mysql", "oracle", "postgres", "mariadb", "mssql");
   }
   
   @Before

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -120,6 +120,7 @@
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
     <spring.version>5.3.39</spring.version>
     <spring.ldap.version>2.4.4</spring.ldap.version>
+    <testcontainers.version>1.21.3</testcontainers.version>
     <!-- Thrift properties -->
     <thrift.home>you-must-set-this-to-run-thrift</thrift.home>
     <thrift.gen.dir>${basedir}/src/gen/thrift</thrift.gen.dir>
@@ -506,6 +507,31 @@
         <artifactId>slf4j-simple</artifactId>
         <version>${slf4j.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mariadb</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mysql</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>oracle-xe</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mssqlserver</artifactId>
+        <version>${testcontainers.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Use testcontainers library to manage the lifecycle of dockerized databases
2. Use the newest version of the library (1.21.3) everywhere

### Why are the changes needed?
1. Reduce maintenance burden since we no longer have to manually craft and fix docker handling logic
2. Stabilize CI and by avoiding common problems as port conflicts, container leaks, etc., which are handled automatically by the library
3.  Enhance OS independence since we no longer call Runtime.exec methods. The underlying docker-java library takes care of using the appropriate APIs (REST, etc.)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
mvn test -Dtest=TestMssql,TestDerby,TestMysql,TestOracle,TestPostgres -Dtest.groups= -Dverbose.schematool
```