### PR TITLE
HIVE-29060: HivePreparedStatements failed with regex column specification

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HivePreparedStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HivePreparedStatement.java
@@ -141,6 +141,7 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
   private List<String> splitSqlStatement(String sql) {
     List<String> parts = new ArrayList<>();
     int apCount = 0;
+    int backTicksCount = 0;
     int off = 0;
     boolean skip = false;
 
@@ -157,8 +158,11 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
       case '\\':
         skip = true;
         break;
+      case '`':
+        backTicksCount++;
+        break;
       case '?':
-        if ((apCount & 1) == 0) {
+        if ((apCount & 1) == 0 && (backTicksCount & 1) == 0) {
           parts.add(sql.substring(off,i));
           off=i+1;
         }

--- a/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
@@ -211,4 +211,17 @@ public class TestHivePreparedStatement {
     assertEquals("select * from table where value='\\'anyValue\\' or 1=1'",
         argument.getValue().getStatement());
   }
+
+  @Test
+  public void testColumnRegex() throws Exception {
+    String sql = "select `(col)?.` from x where a=?";
+    HivePreparedStatement ps = new HivePreparedStatement(connection, client, sessHandle, sql);
+    ps.setString(1, "asd");
+    ps.execute();
+
+    ArgumentCaptor<TExecuteStatementReq> argument =
+            ArgumentCaptor.forClass(TExecuteStatementReq.class);
+    verify(client).ExecuteStatement(argument.capture());
+    assertEquals("select `(col)?.` from x where a='asd'", argument.getValue().getStatement());
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Currently, regex column specification which includes ( ? ) fails with Hive Prepared Statements. The changes proposed fixes the issue
For eg:- Consider the query  ```select `(id)?.` from tb1 where a=?``` , when the user sets the 1st and the only parameter in the Hive Prepared Query to a value say 'asd', the expected behaviour was the query formed should be ```select `(id)?.` from tb1 where a='asd'``` and using the regex, return matching columns but the query fails saying ```parameter #2 is unset``` . The reason this happens is because Hive Prepared Statement injects the provided parameter into  ( ? ) of the column regex considering it as a parameter which is ideally not.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
So that column regex specification can work with Hive Prepared Statements
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Now the user will be able to query using Hive Prepared Statements along with regex column specification.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
Tested it on my local machine and added a test which was run pre and post changes to verify the fix.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
