### PR TITLE
HIVE-29068: Drop deprecated compactor.history.retention.attempted property

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3441,13 +3441,6 @@ public class HiveConf extends Configuration {
       new RangeValidator(0, 100), "Determines how many failed compaction records will be " +
       "retained in compaction history for a given table/partition."),
     /**
-     * @deprecated Use MetastoreConf.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE
-     */
-    @Deprecated
-    COMPACTOR_HISTORY_RETENTION_ATTEMPTED("hive.compactor.history.retention.attempted", 2,
-      new RangeValidator(0, 100), "Determines how many attempted compaction records will be " +
-      "retained in compaction history for a given table/partition."),
-    /**
      * @deprecated Use MetastoreConf.ACID_HOUSEKEEPER_SERVICE_INTERVAL
      */
     @Deprecated

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -129,10 +129,6 @@ public class MetastoreConf {
       keyToVars.put(var.hiveName, var);
     }
     Configuration.addDeprecations(new Configuration.DeprecationDelta[] {
-        new Configuration.DeprecationDelta("metastore.compactor.history.retention.attempted",
-            ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE.varname),
-        new Configuration.DeprecationDelta("hive.compactor.history.retention.attempted",
-            ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE.varname),
         new Configuration.DeprecationDelta("datanucleus.plugin.pluginRegistryBundleCheck",
             ConfVars.DATANUCLEUS_PLUGIN_REGISTRY_BUNDLE_CHECK.varname)});
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/CompactorTasks.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/CompactorTasks.java
@@ -99,7 +99,7 @@ public class CompactorTasks implements LeaderElection.LeadershipStateListener {
           MetastoreConf.getIntVar(configuration, MetastoreConf.ConfVars.COMPACTOR_WORKER_THREADS));
       HiveMetaStore.LOG.info("hive.metastore.runworker.in = {}",
           MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.HIVE_METASTORE_RUNWORKER_IN));
-      HiveMetaStore.LOG.info("metastore.compactor.history.retention.attempted = {}",
+      HiveMetaStore.LOG.info("metastore.compactor.history.retention.did.not.initiate = {}",
           MetastoreConf.getIntVar(configuration, MetastoreConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE));
       HiveMetaStore.LOG.info("metastore.compactor.history.retention.failed = {}",
           MetastoreConf.getIntVar(configuration, MetastoreConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED));

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
@@ -313,36 +313,6 @@ public class TestMetastoreConf {
     Assert.assertEquals("false", MetastoreConf.getAsString(conf, ConfVars.BOOLEAN_TEST_ENTRY));
   }
 
-  /**
-   * Verify that a config can be set with a deprecated key/name.
-   */
-  @Test
-  public void testDeprecatedConfigs() throws IOException {
-    // set with deprecated key
-    createConfFile("metastore-site.xml", false, "METASTORE_CONF_DIR", instaMap(
-        "hive.test.str", "hivedefault",
-        "metastore.compactor.history.retention.attempted", "0" // default is 2
-    ));
-    conf = MetastoreConf.newMetastoreConf();
-    Assert.assertEquals(0, MetastoreConf.getIntVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE));
-
-    // set with hive (HiveConf) deprecated key
-    createConfFile("metastore-site.xml", false, "METASTORE_CONF_DIR", instaMap(
-        "hive.test.str", "hivedefault",
-        "hive.compactor.history.retention.attempted", "1" // default is 2
-    ));
-    conf = MetastoreConf.newMetastoreConf();
-    Assert.assertEquals(1, MetastoreConf.getIntVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE));
-
-    // set with normal key
-    createConfFile("metastore-site.xml", false, "METASTORE_CONF_DIR", instaMap(
-        "hive.test.str", "hivedefault",
-        "metastore.compactor.history.retention.did.not.initiate", "3" // default is 2
-    ));
-    conf = MetastoreConf.newMetastoreConf();
-    Assert.assertEquals(3, MetastoreConf.getIntVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE));
-  }
-
   @Test
   public void timeUnits() throws IOException {
     conf = MetastoreConf.newMetastoreConf();


### PR DESCRIPTION
### Why are the changes needed?
The compactor.history.retention.attempted property has been deprecated in 4.0.0-alpha-1 (HIVE-24586).

This ticket drops completely the respective entries from everywhere. 

### Does this PR introduce _any_ user-facing change?
Yes, from now onward, users must use `metastore.compactor.history.retention.did.not.initiate`.

### How was this patch tested?
Existing tests