### PR TITLE
HIVE-27944: When HIVE-LLAP reads the ICEBERG table, a deadlock may occur.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/SplitGrouper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/SplitGrouper.java
@@ -29,11 +29,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.common.collect.Maps;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.BucketizedHiveInputFormat;
-import org.apache.hadoop.mapred.InputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -66,15 +65,10 @@ import com.google.common.collect.Multimap;
  * also enforces restrictions around schema, file format and bucketing.
  */
 public class SplitGrouper {
-
   private static final Logger LOG = LoggerFactory.getLogger(SplitGrouper.class);
 
-  // TODO This needs to be looked at. Map of Map to Map... Made concurrent for now since split generation
-  // can happen in parallel.
-  private static final Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> cache =
-      new ConcurrentHashMap<>();
-
   private final TezMapredSplitsGrouper tezGrouper = new TezMapredSplitsGrouper();
+  private final Map<Path, Path> cache = Maps.newHashMap();
 
   /**
    * group splits for each bucket separately - while evenly filling all the
@@ -91,7 +85,7 @@ public class SplitGrouper {
 
     // allocate map bucket id to grouped splits
     Multimap<Integer, InputSplit> bucketGroupedSplitMultimap =
-        ArrayListMultimap.<Integer, InputSplit> create();
+        ArrayListMultimap.create();
 
     // use the tez grouper to combine splits once per bucket
     for (int bucketId : bucketSplitMultimap.keySet()) {
@@ -137,9 +131,8 @@ public class SplitGrouper {
         String [] locations = split.getLocations();
         if (locations != null && locations.length > 0) {
           // Worthwhile only if more than 1 split, consistentGroupingEnabled and is a FileSplit
-          if (consistentLocations && locations.length > 1 && split instanceof FileSplit) {
+          if (consistentLocations && locations.length > 1 && split instanceof FileSplit fileSplit) {
             Arrays.sort(locations);
-            FileSplit fileSplit = (FileSplit) split;
             Path path = fileSplit.getPath();
             long startLocation = fileSplit.getStart();
             int hashCode = Objects.hash(path, startLocation);
@@ -153,8 +146,8 @@ public class SplitGrouper {
             locationHints.add(TaskLocationHint.createTaskLocationHint(locationSet, null));
           } else {
             locationHints.add(TaskLocationHint
-                .createTaskLocationHint(new LinkedHashSet<String>(Arrays.asList(split
-                    .getLocations())), null));
+                .createTaskLocationHint(new LinkedHashSet<>(Arrays.asList(split
+                  .getLocations())), null));
           }
         } else {
           locationHints.add(TaskLocationHint.createTaskLocationHint(null, null));
@@ -189,16 +182,15 @@ public class SplitGrouper {
     boolean isMinorCompaction = true;
     MapWork mapWork = populateMapWork(jobConf, inputName);
     // ArrayListMultimap is important here to retain the ordering for the splits.
-    Multimap<Integer, InputSplit> schemaGroupedSplitMultiMap = ArrayListMultimap.<Integer, InputSplit> create();
+    Multimap<Integer, InputSplit> schemaGroupedSplitMultiMap = ArrayListMultimap.create();
     if (HiveConf.getVar(jobConf, HiveConf.ConfVars.SPLIT_GROUPING_MODE).equalsIgnoreCase("compactor")) {
       List<Path> paths = Utilities.getInputPathsTez(jobConf, mapWork);
       for (Path path : paths) {
         List<String> aliases = mapWork.getPathToAliases().get(path);
         if ((aliases != null) && (aliases.size() == 1)) {
-          Operator<? extends OperatorDesc> op = mapWork.getAliasToWork().get(aliases.get(0));
-          if ((op != null) && (op instanceof TableScanOperator)) {
-            TableScanOperator tableScan = (TableScanOperator) op;
-            PartitionDesc partitionDesc = mapWork.getAliasToPartnInfo().get(aliases.get(0));
+          Operator<? extends OperatorDesc> op = mapWork.getAliasToWork().get(aliases.getFirst());
+          if (op instanceof TableScanOperator tableScan) {
+            PartitionDesc partitionDesc = mapWork.getAliasToPartnInfo().get(aliases.getFirst());
             isMinorCompaction &= AcidUtils.isCompactionTable(partitionDesc.getTableDesc().getProperties());
             if (!tableScan.getConf().isTranscationalTable() && !isMinorCompaction) {
               String splitPath = getFirstSplitPath(splits);
@@ -260,7 +252,7 @@ public class SplitGrouper {
   Multimap<Integer, InputSplit> getCompactorSplitGroups(InputSplit[] rawSplits, Configuration conf,
       boolean isMinorCompaction) {
     // Note: For our case, this multimap will essentially contain one value (one TezGroupedSplit) per key 
-    Multimap<Integer, InputSplit> bucketSplitMultiMap = ArrayListMultimap.<Integer, InputSplit> create();
+    Multimap<Integer, InputSplit> bucketSplitMultiMap = ArrayListMultimap.create();
     HiveInputFormat.HiveInputSplit[] splits = new HiveInputFormat.HiveInputSplit[rawSplits.length];
     int i = 0;
     for (InputSplit is : rawSplits) {
@@ -345,10 +337,10 @@ public class SplitGrouper {
                                                     Map<Integer, Collection<InputSplit>> bucketSplitMap) {
 
     // mapping of bucket id to size of all splits in bucket in bytes
-    Map<Integer, Long> bucketSizeMap = new HashMap<Integer, Long>();
+    Map<Integer, Long> bucketSizeMap = new HashMap<>();
 
     // mapping of bucket id to number of required tasks to run
-    Map<Integer, Integer> bucketTaskMap = new HashMap<Integer, Integer>();
+    Map<Integer, Integer> bucketTaskMap = new HashMap<>();
 
     // TODO HIVE-12255. Make use of SplitSizeEstimator.
     // The actual task computation needs to be looked at as well.
@@ -362,12 +354,11 @@ public class SplitGrouper {
         // the case of SMB join. So in this case, we can do an early exit by not doing the
         // calculation for bucketSizeMap. Each bucket will assume it can fill availableSlots * waves
         // (preset to 0.5) for SMB join.
-        if (!(s instanceof FileSplit)) {
+        if (!(s instanceof FileSplit fsplit)) {
           bucketTaskMap.put(bucketId, (int) (availableSlots * waves));
           earlyExit = true;
           continue;
         }
-        FileSplit fsplit = (FileSplit) s;
         size += fsplit.getLength();
         totalSize += fsplit.getLength();
       }
@@ -413,7 +404,7 @@ public class SplitGrouper {
   }
 
   private boolean schemaEvolved(InputSplit s, InputSplit prevSplit, boolean groupAcrossFiles,
-                                       MapWork work) throws IOException {
+                                     MapWork work) throws IOException {
     boolean retval = false;
     Path path = ((FileSplit) s).getPath();
     PartitionDesc pd = HiveFileFormatUtils.getFromPathRecursively(
@@ -434,7 +425,6 @@ public class SplitGrouper {
       previousDeserializerClass = prevPD.getDeserializerClassName();
       previousInputFormatClass = prevPD.getInputFileFormatClass();
     }
-
     if ((currentInputFormatClass != previousInputFormatClass)
         || (!currentDeserializerClass.equals(previousDeserializerClass))) {
       retval = true;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveRecordReader.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.lib.CombineFileSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * CombineHiveRecordReader.
@@ -51,7 +53,7 @@ import org.apache.hadoop.mapred.lib.CombineFileSplit;
  */
 public class CombineHiveRecordReader<K extends WritableComparable, V extends Writable>
     extends HiveContextAwareRecordReader<K, V> {
-  private org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(CombineHiveRecordReader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CombineHiveRecordReader.class);
 
   private Map<Path, PartitionDesc> pathToPartInfo;
 
@@ -104,17 +106,16 @@ public class CombineHiveRecordReader<K extends WritableComparable, V extends Wri
 
     //If current split is from the same file as preceding split and the preceding split has footerbuffer,
     //the current split should use the preceding split's footerbuffer in order to skip footer correctly.
-    if (preReader != null && preReader instanceof CombineHiveRecordReader
-        && ((CombineHiveRecordReader)preReader).getFooterBuffer() != null) {
+    if (preReader instanceof CombineHiveRecordReader
+        && ((CombineHiveRecordReader) preReader).getFooterBuffer() != null) {
       if (partition != 0 && hsplit.getPaths()[partition -1].equals(hsplit.getPaths()[partition]))
         this.setFooterBuffer(((CombineHiveRecordReader)preReader).getFooterBuffer());
     }
-
   }
 
   private PartitionDesc extractSinglePartSpec(CombineHiveInputSplit hsplit) throws IOException {
     PartitionDesc part = null;
-    Map<Map<Path,PartitionDesc>, Map<Path,PartitionDesc>> cache = new HashMap<>();
+    Map<Path, Path> cache = new HashMap<>();
     for (Path path : hsplit.getPaths()) {
       PartitionDesc otherPart = HiveFileFormatUtils.getFromPathRecursively(
           pathToPartInfo, path, cache);
@@ -147,12 +148,12 @@ public class CombineHiveRecordReader<K extends WritableComparable, V extends Wri
 
   @Override
   public K createKey() {
-    return (K) recordReader.createKey();
+    return recordReader.createKey();
   }
 
   @Override
   public V createValue() {
-    return (V) recordReader.createValue();
+    return recordReader.createValue();
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/IOPrepareCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/IOPrepareCache.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.plan.PartitionDesc;
 
 /**
  * IOPrepareCache is used to cache pre-query io-related objects.
@@ -31,7 +30,8 @@ import org.apache.hadoop.hive.ql.plan.PartitionDesc;
  */
 public class IOPrepareCache {
   
-  private static ThreadLocal<IOPrepareCache> threadLocalIOPrepareCache = new ThreadLocal<IOPrepareCache>();
+  private static final ThreadLocal<IOPrepareCache> threadLocalIOPrepareCache =
+      new ThreadLocal<>();
   
   public static IOPrepareCache get() {
     IOPrepareCache cache = IOPrepareCache.threadLocalIOPrepareCache.get();
@@ -39,32 +39,25 @@ public class IOPrepareCache {
       threadLocalIOPrepareCache.set(new IOPrepareCache());
       cache = IOPrepareCache.threadLocalIOPrepareCache.get();
     }
-
     return cache;
   }
   
-  public void clear() {
-    if(partitionDescMap != null) {
-      partitionDescMap.clear();      
-    }
-  }
+  private Map<Path, Path> partitionDescMap;
   
-  private Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> partitionDescMap;
-  
-  public Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> allocatePartitionDescMap() {
+  public Map<Path, Path> allocatePartitionDescMap() {
     if (partitionDescMap == null) {
       partitionDescMap = new HashMap<>();
     }
     return partitionDescMap;
   }
 
-  public Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> getPartitionDescMap() {
+  public Map<Path, Path> getPartitionDescMap() {
     return partitionDescMap;
   }
 
-  public void setPartitionDescMap(
-      Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> partitionDescMap) {
-    this.partitionDescMap = partitionDescMap;
-  } 
-
+  public void clear() {
+    if (partitionDescMap != null) {
+      partitionDescMap.clear();
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Modified the modifier of the cache property in the SplitGroup class to make it non-static.

JIRA: https://issues.apache.org/jira/browse/HIVE-27944


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Since the Properties object implement HashTable interface, all the methods of the HashTable interface are synchronised.
In a multi-threaded environment, a deadlock will occur when propA.equals(propB) and propB.equals(propA) occur at the same time.
The problem can be solved with minimal modification by changing SplitGroup.cache to a non-static property.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
