### PR TITLE
[DRAFT] HIVE-29066: PARTITION_NAME_WHITELIST_PATTERN is not honouring session level metaconf

### DIFF
--- a/ql/src/test/queries/clientnegative/session_partition_with_whitelist.q
+++ b/ql/src/test/queries/clientnegative/session_partition_with_whitelist.q
@@ -1,0 +1,9 @@
+set metaconf:metastore.partition.name.whitelist.pattern;
+
+create table t1 (id int) partitioned by (pcol string);
+alter table t1 add partition (pCol='2025-06-09');
+
+set metaconf:metastore.partition.name.whitelist.pattern=[^9]*;
+alter table t1 add partition (pCol='2025-06-19');
+show partitions t1;
+

--- a/ql/src/test/results/clientnegative/session_partition_with_whitelist.q.out
+++ b/ql/src/test/results/clientnegative/session_partition_with_whitelist.q.out
@@ -1,0 +1,20 @@
+metaconf:metastore.partition.name.whitelist.pattern=
+PREHOOK: query: create table t1 (id int) partitioned by (pcol string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (id int) partitioned by (pcol string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: alter table t1 add partition (pCol='2025-06-09')
+PREHOOK: type: ALTERTABLE_ADDPARTS
+PREHOOK: Output: default@t1
+POSTHOOK: query: alter table t1 add partition (pCol='2025-06-09')
+POSTHOOK: type: ALTERTABLE_ADDPARTS
+POSTHOOK: Output: default@t1
+POSTHOOK: Output: default@t1@pcol=2025-06-09
+PREHOOK: query: alter table t1 add partition (pCol='2025-06-19')
+PREHOOK: type: ALTERTABLE_ADDPARTS
+PREHOOK: Output: default@t1
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Partition value '2025-06-19' contains a character not matched by whitelist pattern '[^9]*'.  (configure with metastore.partition.name.whitelist.pattern))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-29066](https://issues.apache.org/jira/browse/HIVE-29066), Ensure that the partitionValidationPattern is picked from the metaconf instead of HMSHandler Object.


### Why are the changes needed?
To honour, modified session level metaconf.


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
q file is attached.
