### PR TITLE
HIVE-29009: Enable TestHttpSamlAuthentication since JDK-8315422 is fixed in JDK 21.0.5

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/service/auth/saml/TestHttpSamlAuthentication.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/auth/saml/TestHttpSamlAuthentication.java
@@ -79,7 +79,6 @@ import org.testcontainers.utility.DockerImageName;
  * It uses HTMLUnit to simulate the browser interaction (provide user/password) of the
  * end user.
  */
-@org.junit.Ignore("HIVE-29009")
 public class TestHttpSamlAuthentication {
 
   //user credentials. These much match with the authsources.php of the simpleSAMLPHP


### PR DESCRIPTION
### Why are the changes needed?
The CI/JVM hang was caused by [JDK-8315422](https://bugs.openjdk.org/browse/JDK-8315422) but now CI is running on JDK 21.0.7+6-LTS so the problem no longer affects this branch.

Full details can be found under: https://issues.apache.org/jira/browse/HIVE-29009

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
1. Downloaded Zulu JDK 21.0.7+6 that is used in CI and set JAVA_HOME to point to it
2. Cloned https://github.com/zabetak/testcontainers-tls-hang-issue-10454
3. Run `for i in {1..100}; do mvn clean test; done` and confirmed it always pass
4. Setup Docker with TLS locally (using Docker-in-Docker) and run the problematic test 
```
mvn test -Dtest=TestHttpSamlAuthentication.java -Pitests -pl itests/hive-unit
```