### PR TITLE
HIVE-29066: PARTITION_NAME_WHITELIST_PATTERN is not honouring session level configuration

### DIFF
--- a/common/src/java/org/apache/hive/common/util/HiveStringUtils.java
+++ b/common/src/java/org/apache/hive/common/util/HiveStringUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hive.common.util;
 
+import com.google.common.base.Splitter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.InetAddress;
@@ -38,8 +39,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
-
-import com.google.common.base.Splitter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
 import org.apache.commons.lang3.text.translate.EntityArrays;
@@ -1080,19 +1079,17 @@ public class HiveStringUtils {
     return false;
   }
 
-  public static String getPartitionValWithInvalidCharacter(List<String> partVals,
-      Pattern partitionValidationPattern) {
-    if (partitionValidationPattern == null) {
-      return null;
+  public static String getPartitionValWithInvalidCharacter(
+      List<String> partVals, Pattern partitionValidationPattern) {
+    String result = null;
+    if (partitionValidationPattern != null) {
+      result =
+          partVals.stream()
+              .filter(partVal -> !partitionValidationPattern.matcher(partVal).matches())
+              .findFirst()
+              .orElse(null);
     }
-  
-    for (String partVal : partVals) {
-      if (!partitionValidationPattern.matcher(partVal).matches()) {
-        return partVal;
-      }
-    }
-  
-    return null;
+    return result;
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/DynamicPartitionCtx.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/DynamicPartitionCtx.java
@@ -91,7 +91,7 @@ public class DynamicPartitionCtx implements Serializable {
     this.spPath = null;
     String confVal;
     try {
-      confVal = Hive.get().getMetaConf(ConfVars.PARTITION_NAME_WHITELIST_PATTERN.getHiveName());
+      confVal = Hive.get().getMetaConf(ConfVars.PARTITION_NAME_WHITELIST_PATTERN.getVarname());
     } catch (HiveException e) {
       throw new SemanticException(e);
     }
@@ -126,7 +126,7 @@ public class DynamicPartitionCtx implements Serializable {
     }
     String confVal;
     try {
-      confVal = Hive.get().getMetaConf(ConfVars.PARTITION_NAME_WHITELIST_PATTERN.getHiveName());
+      confVal = Hive.get().getMetaConf(ConfVars.PARTITION_NAME_WHITELIST_PATTERN.getVarname());
     } catch (HiveException e) {
       throw new SemanticException(e);
     }

--- a/ql/src/test/queries/clientnegative/dynamic_partitions_with_whitelist.q
+++ b/ql/src/test/queries/clientnegative/dynamic_partitions_with_whitelist.q
@@ -2,7 +2,6 @@
 set hive.strict.checks.bucketing=false;
 
 set hive.mapred.mode=nonstrict;
-SET hive.metastore.partition.name.whitelist.pattern=[^9]*;
 set hive.exec.failure.hooks=org.apache.hadoop.hive.ql.hooks.VerifyTableDirectoryIsEmptyHook;
 
 set hive.exec.dynamic.partition=true;
@@ -17,4 +16,5 @@ load data local inpath '../../data/files/bmj/000000_0' INTO TABLE source_table p
 -- If the directory is not empty the hook will throw an error, instead the error should come from the metastore
 -- This shows that no dynamic partitions were created and left behind or had directories created
 
+SET metaconf:metastore.partition.name.whitelist.pattern=[^9]*;
 insert overwrite table dest_table partition (ds, hr) select key, hr, ds, value from source_table where ds='2008-04-08' and value='val_129' order by value asc;

--- a/ql/src/test/queries/clientnegative/session_partition_with_whitelist.q
+++ b/ql/src/test/queries/clientnegative/session_partition_with_whitelist.q
@@ -1,0 +1,9 @@
+set metaconf:metastore.partition.name.whitelist.pattern;
+
+create table t1 (id int) partitioned by (pcol string);
+alter table t1 add partition (pCol='2025-06-09');
+
+set metaconf:metastore.partition.name.whitelist.pattern=[^9]*;
+alter table t1 add partition (pCol='2025-06-19');
+show partitions t1;
+

--- a/ql/src/test/results/clientnegative/add_partition_with_whitelist.q.out
+++ b/ql/src/test/results/clientnegative/add_partition_with_whitelist.q.out
@@ -15,4 +15,4 @@ POSTHOOK: Input: default@part_whitelist_test
 PREHOOK: query: ALTER TABLE part_whitelist_test ADD PARTITION (ds='1,2,3,4')
 PREHOOK: type: ALTERTABLE_ADDPARTS
 PREHOOK: Output: default@part_whitelist_test
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Partition value '1,2,3,4' contains a character not matched by whitelist pattern '[\\x20-\\x7E&&[^,]]*'.  (configure with metastore.partition.name.whitelist.pattern))
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Partition value '1,2,3,4' contains a character not matched by whitelist pattern '[\\x20-\\x7E&&[^,]]*'. Configure with metastore.partition.name.whitelist.pattern)

--- a/ql/src/test/results/clientnegative/alter_partition_with_whitelist.q.out
+++ b/ql/src/test/results/clientnegative/alter_partition_with_whitelist.q.out
@@ -23,4 +23,4 @@ PREHOOK: query: ALTER TABLE part_whitelist_test PARTITION (ds='1') rename to par
 PREHOOK: type: ALTERTABLE_RENAMEPART
 PREHOOK: Input: default@part_whitelist_test
 PREHOOK: Output: default@part_whitelist_test@ds=1
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. Unable to rename partition. Partition value '1,2,3' contains a character not matched by whitelist pattern '[\\x20-\\x7E&&[^,]]*'.  (configure with metastore.partition.name.whitelist.pattern)
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. Unable to rename partition. Partition value '1,2,3' contains a character not matched by whitelist pattern '[\\x20-\\x7E&&[^,]]*'. Configure with metastore.partition.name.whitelist.pattern

--- a/ql/src/test/results/clientnegative/dynamic_partitions_with_whitelist.q.out
+++ b/ql/src/test/results/clientnegative/dynamic_partitions_with_whitelist.q.out
@@ -33,13 +33,13 @@ Vertex failed, vertexName=Map 1, vertexId=vertex_#ID#, diagnostics=[Task failed,
 #### A masked pattern was here ####
 Caused by: java.lang.RuntimeException: Hive Runtime Error while closing operators
 #### A masked pattern was here ####
-Caused by: org.apache.hadoop.hive.ql.metadata.HiveFatalException: Partition value 'val_129' contains a character not matched by whitelist pattern '[^9]*'.  (configure with hive.metastore.partition.name.whitelist.pattern)
+Caused by: org.apache.hadoop.hive.ql.metadata.HiveFatalException: Partition value 'val_129' contains a character not matched by whitelist pattern '[^9]*'. Configure with metastore.partition.name.whitelist.pattern
 #### A masked pattern was here ####
 ], TaskAttempt 1 failed, info=[Error: Error while running task ( failure ) : attempt_#ID#:java.lang.RuntimeException: java.lang.RuntimeException: Hive Runtime Error while closing operators
 #### A masked pattern was here ####
 Caused by: java.lang.RuntimeException: Hive Runtime Error while closing operators
 #### A masked pattern was here ####
-Caused by: org.apache.hadoop.hive.ql.metadata.HiveFatalException: Partition value 'val_129' contains a character not matched by whitelist pattern '[^9]*'.  (configure with hive.metastore.partition.name.whitelist.pattern)
+Caused by: org.apache.hadoop.hive.ql.metadata.HiveFatalException: Partition value 'val_129' contains a character not matched by whitelist pattern '[^9]*'. Configure with metastore.partition.name.whitelist.pattern
 #### A masked pattern was here ####
 ]], Vertex did not succeed due to OWN_TASK_FAILURE, failedTasks:1 killedTasks:0, Vertex vertex_#ID# [Map 1] killed/failed due to:OWN_TASK_FAILURE]
 [Masked Vertex killed due to OTHER_VERTEX_FAILURE]
@@ -48,12 +48,12 @@ FAILED: Execution Error, return code 2 from org.apache.hadoop.hive.ql.exec.tez.T
 #### A masked pattern was here ####
 Caused by: java.lang.RuntimeException: Hive Runtime Error while closing operators
 #### A masked pattern was here ####
-Caused by: org.apache.hadoop.hive.ql.metadata.HiveFatalException: Partition value 'val_129' contains a character not matched by whitelist pattern '[^9]*'.  (configure with hive.metastore.partition.name.whitelist.pattern)
+Caused by: org.apache.hadoop.hive.ql.metadata.HiveFatalException: Partition value 'val_129' contains a character not matched by whitelist pattern '[^9]*'. Configure with metastore.partition.name.whitelist.pattern
 #### A masked pattern was here ####
 ], TaskAttempt 1 failed, info=[Error: Error while running task ( failure ) : attempt_#ID#:java.lang.RuntimeException: java.lang.RuntimeException: Hive Runtime Error while closing operators
 #### A masked pattern was here ####
 Caused by: java.lang.RuntimeException: Hive Runtime Error while closing operators
 #### A masked pattern was here ####
-Caused by: org.apache.hadoop.hive.ql.metadata.HiveFatalException: Partition value 'val_129' contains a character not matched by whitelist pattern '[^9]*'.  (configure with hive.metastore.partition.name.whitelist.pattern)
+Caused by: org.apache.hadoop.hive.ql.metadata.HiveFatalException: Partition value 'val_129' contains a character not matched by whitelist pattern '[^9]*'. Configure with metastore.partition.name.whitelist.pattern
 #### A masked pattern was here ####
 ]], Vertex did not succeed due to OWN_TASK_FAILURE, failedTasks:1 killedTasks:0, Vertex vertex_#ID# [Map 1] killed/failed due to:OWN_TASK_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE]DAG did not succeed due to VERTEX_FAILURE. failedVertices:1 killedVertices:1

--- a/ql/src/test/results/clientnegative/session_partition_with_whitelist.q.out
+++ b/ql/src/test/results/clientnegative/session_partition_with_whitelist.q.out
@@ -1,0 +1,20 @@
+metaconf:metastore.partition.name.whitelist.pattern=
+PREHOOK: query: create table t1 (id int) partitioned by (pcol string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (id int) partitioned by (pcol string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: alter table t1 add partition (pCol='2025-06-09')
+PREHOOK: type: ALTERTABLE_ADDPARTS
+PREHOOK: Output: default@t1
+POSTHOOK: query: alter table t1 add partition (pCol='2025-06-09')
+POSTHOOK: type: ALTERTABLE_ADDPARTS
+POSTHOOK: Output: default@t1
+POSTHOOK: Output: default@t1@pcol=2025-06-09
+PREHOOK: query: alter table t1 add partition (pCol='2025-06-19')
+PREHOOK: type: ALTERTABLE_ADDPARTS
+PREHOOK: Output: default@t1
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Partition value '2025-06-19' contains a character not matched by whitelist pattern '[^9]*'. Configure with metastore.partition.name.whitelist.pattern)

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -296,7 +296,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   private MetaStoreFilterHook filterHook;
   private boolean isServerFilterEnabled = false;
 
-  private Pattern partitionValidationPattern;
   private final boolean isInTest;
 
   @Override
@@ -366,11 +365,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     endFunctionListeners = MetaStoreServerUtils.getMetaStoreListeners(
         MetaStoreEndFunctionListener.class, conf, MetastoreConf.getVar(conf, ConfVars.END_FUNCTION_LISTENERS));
 
-    String partitionValidationRegex =
-        MetastoreConf.getVar(conf, ConfVars.PARTITION_NAME_WHITELIST_PATTERN);
-    if (partitionValidationRegex != null && !partitionValidationRegex.isEmpty()) {
-      partitionValidationPattern = Pattern.compile(partitionValidationRegex);
-    }
+
 
     expressionProxy = PartFilterExprUtil.createExpressionProxy(conf);
     fileMetadataManager = new FileMetadataManager(this.getMS(), conf);
@@ -467,13 +462,13 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
   @Override
   public Configuration getConf() {
-    Configuration conf = HMSHandlerContext.getConfiguration()
-        .orElseGet(() -> {
-          Configuration configuration = new Configuration(this.conf);
-          HMSHandlerContext.setConfiguration(configuration);
-          return configuration;
-        });
-    return conf;
+    return HMSHandlerContext.getConfiguration()
+        .orElseGet(
+            () -> {
+              Configuration configuration = new Configuration(this.conf);
+              HMSHandlerContext.setConfiguration(configuration);
+              return configuration;
+            });
   }
 
   @Override
@@ -4044,7 +4039,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       part.setTableName(tableName);
       part.setValues(part_vals);
 
-      MetaStoreServerUtils.validatePartitionNameCharacters(part_vals, partitionValidationPattern);
+      MetaStoreServerUtils.validatePartitionNameCharacters(part_vals, getConf());
 
       tbl = ms.getTable(part.getCatName(), part.getDbName(), part.getTableName(), null);
       if (tbl == null) {
@@ -4457,8 +4452,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   private void validatePartition(final Partition part, final String catName,
                                     final String tblName, final String dbName, final Set<PartValEqWrapperLite> partsToAdd)
       throws MetaException, TException {
-    MetaStoreServerUtils.validatePartitionNameCharacters(part.getValues(),
-        partitionValidationPattern);
+    MetaStoreServerUtils.validatePartitionNameCharacters(part.getValues(), getConf());
     if (part.getDbName() == null || part.getTableName() == null) {
       throw new MetaException("The database and table name must be set in the partition.");
     }
@@ -6007,8 +6001,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
       firePreEvent(new PreAlterPartitionEvent(db_name, tbl_name, table, part_vals, new_part, this));
       if (part_vals != null && !part_vals.isEmpty()) {
-        MetaStoreServerUtils.validatePartitionNameCharacters(new_part.getValues(),
-            partitionValidationPattern);
+        MetaStoreServerUtils.validatePartitionNameCharacters(new_part.getValues(), getConf());
       }
 
       oldPart = alterHandler.alterPartition(getMS(), wh, catName, db_name, tbl_name,
@@ -8645,18 +8638,17 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   }
 
   @Override
-  public boolean partition_name_has_valid_characters(List<String> part_vals,
-                                                     boolean throw_exception) throws TException {
+  public boolean partition_name_has_valid_characters(
+      List<String> part_vals, boolean throw_exception) throws TException {
     startFunction("partition_name_has_valid_characters");
     boolean ret;
     Exception ex = null;
     try {
       if (throw_exception) {
-        MetaStoreServerUtils.validatePartitionNameCharacters(part_vals, partitionValidationPattern);
+        MetaStoreServerUtils.validatePartitionNameCharacters(part_vals, getConf());
         ret = true;
       } else {
-        ret = MetaStoreServerUtils.partitionNameHasValidCharacters(part_vals,
-            partitionValidationPattern);
+        ret = MetaStoreServerUtils.partitionNameHasValidCharacters(part_vals, getConf());
       }
     } catch (Exception e) {
       ex = e;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -343,7 +343,6 @@ public class ObjectStore implements RawStore, Configurable {
   private volatile int openTrasactionCalls = 0;
   private Transaction currentTransaction = null;
   private TXN_STATUS transactionStatus = TXN_STATUS.NO_STATE;
-  private Pattern partitionValidationPattern;
   private Counter directSqlErrors;
   private boolean areTxnStatsSupported = false;
   private PropertyStore propertyStore;
@@ -384,15 +383,7 @@ public class ObjectStore implements RawStore, Configurable {
     transactionStatus = TXN_STATUS.NO_STATE;
 
     initialize();
-
-    String partitionValidationRegex =
-        MetastoreConf.getVar(this.conf, ConfVars.PARTITION_NAME_WHITELIST_PATTERN);
-    if (partitionValidationRegex != null && !partitionValidationRegex.isEmpty()) {
-      partitionValidationPattern = Pattern.compile(partitionValidationRegex);
-    } else {
-      partitionValidationPattern = null;
-    }
-
+    
     // Note, if metrics have not been initialized this will return null, which means we aren't
     // using metrics.  Thus we should always check whether this is non-null before using.
     MetricRegistry registry = Metrics.getRegistry();
@@ -2773,8 +2764,7 @@ public class ObjectStore implements RawStore, Configurable {
 
   private boolean isValidPartition(
       Partition part, List<FieldSchema> partitionKeys, boolean ifNotExists) throws MetaException {
-    MetaStoreServerUtils.validatePartitionNameCharacters(part.getValues(),
-        partitionValidationPattern);
+    MetaStoreServerUtils.validatePartitionNameCharacters(part.getValues(), conf);
     boolean doesExist = doesPartitionExist(part.getCatName(),
         part.getDbName(), part.getTableName(), partitionKeys, part.getValues());
     if (doesExist && !ifNotExists) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-29066](https://issues.apache.org/jira/browse/HIVE-29066), Ensure that the partitionValidationPattern is picked from the metaconf instead of HMSHandler Object.


### Why are the changes needed?
To honour, modified session level metaconf.


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
q file is attached.
