### PR TITLE
HIVE-29081: CI fails intermittently cause some runs exceed ephemeral storage limits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,8 +135,8 @@ def hdbPodTemplate(closure) {
         resourceLimitCpu: '8000m',
         resourceRequestMemory: '6400Mi',
         resourceLimitMemory: '12000Mi',
-        resourceRequestEphemeralStorage: '10Gi',
-        resourceLimitEphemeralStorage: '20Gi',
+        resourceRequestEphemeralStorage: '15Gi',
+        resourceLimitEphemeralStorage: '30Gi',
         envVars: [
             envVar(key: 'DOCKER_HOST', value: 'tcp://localhost:2376'),
             envVar(key: 'DOCKER_TLS_VERIFY', value: '1'),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Increase request and limit based on the disk usage stats gathered in a recent run.

### Why are the changes needed?
Stabilize CI and avoid pod eviction.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
1. Check CI finishes without pod eviction failures.
2. Monitor requests and limits in Google Cloud Console