### PR TITLE
HIVE-28813: MSCK/Analyze commands can show a warning in console for Small files.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckOperation.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.hive.ql.ddl.misc.msck;
 import static org.apache.hadoop.hive.metastore.Msck.getProxyClass;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -75,7 +78,18 @@ public class MsckOperation extends DDLOperation<MsckDesc> {
       MsckInfo msckInfo = new MsckInfo(SessionState.get().getCurrentCatalog(), tableName.getDb(), tableName.getTable(),
           desc.getFilterExp(), desc.getResFile(), desc.isRepairPartitions(),
           desc.isAddPartitions(), desc.isDropPartitions(), partitionExpirySeconds);
-      return msck.repair(msckInfo);
+      int result = msck.repair(msckInfo);
+      if (msckInfo.getSmallFilesStats() != null && !msckInfo.getSmallFilesStats().isEmpty()){
+        List<String> logInfo = new ArrayList<>(msckInfo.getSmallFilesStats().size());
+        for (Map.Entry<String, String> me : msckInfo.getSmallFilesStats().entrySet()){
+          String partitionName = me.getKey();
+          String smallFilesStats = me.getValue();
+          logInfo.add("This table/partition average file size is less than Hive average file size.\n " +
+                  "The partition name is " + partitionName + ". " + smallFilesStats);
+        }
+        LOG.info("There are small files exist.\n{}", String.join("\n", logInfo));
+      }
+      return result;
     } catch (MetaException | MetastoreException e) {
       LOG.error("Unable to create msck instance.", e);
       throw e;

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/CheckResult.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/CheckResult.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -36,6 +37,9 @@ public class CheckResult {
   private Set<PartitionResult> partitionsNotInMs = new TreeSet<>();
   private Set<PartitionResult> expiredPartitions = new TreeSet<>();
   private Set<PartitionResult> correctPartitions = new TreeSet<>();
+
+  private Map<String, String> smallFilesStats = new HashMap<>();
+
   private long maxWriteId;
   private long maxTxnId;
 
@@ -113,6 +117,14 @@ public class CheckResult {
 
   public void setCorrectPartitions(final Set<PartitionResult> correctPartitions) {
     this.correctPartitions = correctPartitions;
+  }
+
+  public Map<String, String> getSmallFilesStats() {
+    return this.smallFilesStats;
+  }
+
+  public void setSmallFilesStats(Map<String, String> smallFilesStats) {
+    this.smallFilesStats = smallFilesStats;
   }
 
   public long getMaxWriteId() {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -38,6 +38,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -59,6 +60,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsFilterSpec;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
@@ -348,6 +350,7 @@ public class HiveMetaStoreChecker {
       allPartDirs = partDirs;
     }
 
+    Map<String, String> smallFilesStats = new HashMap<>();
     // check that the partition folders exist on disk
     for (Partition partition : parts) {
       if (partition == null) {
@@ -358,6 +361,28 @@ public class HiveMetaStoreChecker {
       if (partPath == null) {
         continue;
       }
+
+      // check the table/partition if (totalSize / numFiles) is less than avgFileSize
+      Map<String, String> partitionParameters = partition.getParameters();
+      if (partitionParameters != null) {
+        long totalSize = Long.parseLong(partitionParameters.getOrDefault(StatsSetupConst.TOTAL_SIZE, "0"));
+        long numFiles = Long.parseLong(partitionParameters.getOrDefault(StatsSetupConst.NUM_FILES, "0"));
+        if (numFiles != 0) {
+          long avgFileSize = totalSize / numFiles;
+          long HIVE_FILES_AVG_SIZE = conf.getLong("hive.merge.smallfiles.avgsize", 0);
+          if (avgFileSize <= HIVE_FILES_AVG_SIZE) {
+            StringBuilder tmpStatsSb = new StringBuilder();
+            tmpStatsSb.append("totalSize = ").append(totalSize).append(", numFiles = ")
+                    .append(numFiles).append(". ");
+            smallFilesStats.putIfAbsent(Warehouse.makePartName(table.getPartitionKeys(), partition.getValues()), tmpStatsSb.toString());
+            result.setSmallFilesStats(smallFilesStats);
+          }
+        } else {
+          LOG.warn("Partition total number of files is 0.");
+          LOG.debug("Partition total number of files is 0. Table name : {}, Partition values : {}. ", partition.getTableName(), partition.getValues().toString());
+        }
+      }
+
       fs = partPath.getFileSystem(conf);
 
       CheckResult.PartitionResult prFromMetastore = new CheckResult.PartitionResult();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/Msck.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/Msck.java
@@ -143,6 +143,7 @@ public class Msck {
       // accessed through getPartitionNotOnFS
       result = checker.checkMetastore(msckInfo.getCatalogName(), msckInfo.getDbName(), msckInfo.getTableName(),
         msckInfo.getFilterExp(), table);
+      msckInfo.setSmallFilesStats(result.getSmallFilesStats());
       Set<CheckResult.PartitionResult> partsNotInMs = result.getPartitionsNotInMs();
       Set<CheckResult.PartitionResult> partsNotInFs = result.getPartitionsNotOnFs();
       Set<CheckResult.PartitionResult> expiredPartitions = result.getExpiredPartitions();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MsckInfo.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MsckInfo.java
@@ -18,6 +18,9 @@
 package org.apache.hadoop.hive.metastore;
 
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Metadata related to Msck.
  */
@@ -32,6 +35,8 @@ public class MsckInfo {
   private final boolean addPartitions;
   private final boolean dropPartitions;
   private final long partitionExpirySeconds;
+
+  private Map<String, String> smallFilesStats = new HashMap<>();
 
   public MsckInfo(String catalogName, String dbName, String tableName, byte[] filterExp, String resFile,
                   boolean repairPartitions, boolean addPartitions,
@@ -81,5 +86,11 @@ public class MsckInfo {
 
   public long getPartitionExpirySeconds() {
     return partitionExpirySeconds;
+  }
+
+  public Map<String, String> getSmallFilesStats() { return smallFilesStats; }
+
+  public void setSmallFilesStats(Map<String, String> smallFilesStats){
+    this.smallFilesStats = smallFilesStats;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add warning when MSCK/Analyze commands can show a warning in console for table/partition if (totalSize / numFiles) is less than avgFileSize.

### Why are the changes needed?
So the users can know if there are small files.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual tests.
