### PR TITLE
HIVE-22167: TIMESTAMP - Backwards incompatible change: Hive 4 reads back binary RCFILE timestamps written by Hive 2.x incorrectly

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2256,6 +2256,8 @@ public class HiveConf extends Configuration {
     HIVE_RCFILE_COLUMN_NUMBER_CONF("hive.io.rcfile.column.number.conf", 0, ""),
     HIVE_RCFILE_TOLERATE_CORRUPTIONS("hive.io.rcfile.tolerate.corruptions", false, ""),
     HIVE_RCFILE_RECORD_BUFFER_SIZE("hive.io.rcfile.record.buffer.size", 4194304, ""),   // 4M
+    HIVE_RCFILE_TIMESTAMP_LEGACY_CONVERSION("hive.rcfile.timestamp.legacy.conversion", false,
+            "Whether to convert legacy RCFile timestamps (Hive 2.x format)"),
 
     PARQUET_MEMORY_POOL_RATIO("parquet.memory.pool.ratio", 0.5f,
         "Maximum fraction of heap that can be used by Parquet file writers in one task.\n" +

--- a/serde/src/java/org/apache/hadoop/hive/serde2/columnar/LazyBinaryColumnarStruct.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/columnar/LazyBinaryColumnarStruct.java
@@ -30,8 +30,11 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.Pr
 
 public class LazyBinaryColumnarStruct extends ColumnarStructBase {
 
-  public LazyBinaryColumnarStruct(ObjectInspector oi, List<Integer> notSkippedColumnIDs) {
+  private final boolean legacyConversionEnabled;
+
+  public LazyBinaryColumnarStruct(ObjectInspector oi, List<Integer> notSkippedColumnIDs, boolean legacyConversionEnabled) {
     super(oi, notSkippedColumnIDs);
+    this.legacyConversionEnabled = legacyConversionEnabled;
   }
 
   @Override
@@ -55,6 +58,6 @@ public class LazyBinaryColumnarStruct extends ColumnarStructBase {
 
   @Override
   protected LazyObjectBase createLazyObjectBase(ObjectInspector objectInspector) {
-    return LazyBinaryFactory.createLazyBinaryObject(objectInspector);
+    return LazyBinaryFactory.createLazyBinaryObject(objectInspector, legacyConversionEnabled);
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryFactory.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryFactory.java
@@ -58,7 +58,7 @@ public final class LazyBinaryFactory {
    * Create a lazy binary primitive class given the type name.
    */
   public static LazyBinaryPrimitive<?, ?> createLazyBinaryPrimitiveClass(
-      PrimitiveObjectInspector oi) {
+      PrimitiveObjectInspector oi, boolean legacyConversionEnabled) {
     PrimitiveCategory p = oi.getPrimitiveCategory();
     switch (p) {
     case BOOLEAN:
@@ -86,7 +86,7 @@ public final class LazyBinaryFactory {
     case DATE:
       return new LazyBinaryDate((WritableDateObjectInspector) oi);
     case TIMESTAMP:
-      return new LazyBinaryTimestamp((WritableTimestampObjectInspector) oi);
+      return new LazyBinaryTimestamp((WritableTimestampObjectInspector) oi, legacyConversionEnabled);
     case TIMESTAMPLOCALTZ:
       return new LazyBinaryTimestampLocalTZ((WritableTimestampLocalTZObjectInspector) oi);
     case INTERVAL_YEAR_MONTH:
@@ -106,10 +106,14 @@ public final class LazyBinaryFactory {
    * Create a hierarchical LazyBinaryObject based on the given typeInfo.
    */
   public static LazyBinaryObject createLazyBinaryObject(ObjectInspector oi) {
+    return createLazyBinaryObject(oi, false);
+  }
+
+  public static LazyBinaryObject createLazyBinaryObject(ObjectInspector oi, boolean legacyConversionEnabled) {
     ObjectInspector.Category c = oi.getCategory();
     switch (c) {
     case PRIMITIVE:
-      return createLazyBinaryPrimitiveClass((PrimitiveObjectInspector) oi);
+      return createLazyBinaryPrimitiveClass((PrimitiveObjectInspector) oi, legacyConversionEnabled);
     case MAP:
       return new LazyBinaryMap((LazyBinaryMapObjectInspector) oi);
     case LIST:

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryMap.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryMap.java
@@ -272,8 +272,8 @@ public class LazyBinaryMap extends
       if (keyObjects[index] == null) {
         // Keys are always primitive
         keyObjects[index] = LazyBinaryFactory
-            .createLazyBinaryPrimitiveClass((PrimitiveObjectInspector) ((MapObjectInspector) oi)
-            .getMapKeyObjectInspector());
+            .createLazyBinaryPrimitiveClass((PrimitiveObjectInspector) oi
+            .getMapKeyObjectInspector(), false);
       }
       keyObjects[index].init(bytes, keyStart[index], keyLength[index]);
     }


### PR DESCRIPTION
**MOTIVATION:**
Hive 4 reads RCFile timestamps written by Hive 2 incorrectly. Please see https://issues.apache.org/jira/browse/HIVE-22167 for more details.
 
**SOLUTION:**
A new property has been added to switch between current and legacy interpretation.
```
<property>
  <name>hive.rcfile.timestamp.legacy.conversion</name>
  <value>true</value>
  <description>Whether to convert legacy RCFile timestamps (Hive 2.x format)</description>
</property>
```

**CHECKS:** 
```
hive> set hive.rcfile.timestamp.legacy.conversion;
hive.rcfile.timestamp.legacy.conversion=false --------->> DEFAULT
hive> SELECT * FROM t;
OK
2025-07-01 12:48:15.01295 -------->> Incorrect value

--SET TO TRUE:

hive> set hive.rcfile.timestamp.legacy.conversion=true;
hive> SELECT * FROM t;
OK
2025-07-01 14:48:15.01295 -------->> Correct value
Time taken: 0.222 seconds, Fetched: 1 row(s)
hive>
```