### PR TITLE
HIVE-29087: Add MAX_LIFE_TIME configuration for hikaricp connection pool

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -713,6 +713,7 @@ public class MetastoreConf {
             "Specify the maximum number of connections in the secondary connection pools (objectstore-secondary, objectstore-compactor-secondary).\n" +
                     "Same as datanucleus.connectionPool.maxPoolSize, but for the objectstore-secondary and objectstore-compactor-secondary pools. \n" +
                     "Values smaller than 2 are ignored."),
+    METASTORE_HIKARICP_MAX_LIFE_TIME("hive.hikaricp.max.life.time", "hive.hikaricp.max.life.time", 1500000, "use hikaricp pool max life time,default value is millisecond"),
     CONNECT_URL_HOOK("metastore.ds.connection.url.hook",
         "hive.metastore.ds.connection.url.hook", "",
         "Name of the hook to use for retrieving the JDO connection URL. If empty, the value in javax.jdo.option.ConnectionURL is used"),

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -22,6 +22,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.DatabaseProduct;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.metrics.Metrics;
 import org.apache.hadoop.hive.metastore.utils.StringUtils;
 import org.slf4j.Logger;
@@ -49,6 +50,8 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     String driverUrl = DataSourceProvider.getMetastoreJdbcDriverUrl(hdpConfig);
     String user = DataSourceProvider.getMetastoreJdbcUser(hdpConfig);
     String passwd = DataSourceProvider.getMetastoreJdbcPasswd(hdpConfig);
+    long maxLifeTime = MetastoreConf.getLongVar(hdpConfig,
+            MetastoreConf.ConfVars.METASTORE_HIKARICP_MAX_LIFE_TIME);
 
     Properties properties = replacePrefix(DataSourceProvider.getPrefixedProperties(hdpConfig, HIKARI));
 
@@ -62,6 +65,7 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     config.setJdbcUrl(driverUrl);
     config.setUsername(user);
     config.setPassword(passwd);
+    config.setMaxLifetime(maxLifeTime);
     if (!StringUtils.isEmpty(poolName)) {
       config.setPoolName(poolName);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `MAX_LIFE_TIME` configuration for hikaricp connection pool.

### Why are the changes needed?

fix: [HIVE-29087](https://issues.apache.org/jira/projects/HIVE/issues/HIVE-29087)

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

local test.