### PR TITLE
HIVE-29085: CREATE EXTERNAL TABLE fails for JDBC tables when both hiv…

### DIFF
--- a/ql/src/test/queries/clientnegative/create_external_table_ambiguous_jdbc_table_properties.q
+++ b/ql/src/test/queries/clientnegative/create_external_table_ambiguous_jdbc_table_properties.q
@@ -1,0 +1,15 @@
+CREATE EXTERNAL TABLE test_external_table_postgres
+(
+    id INT,
+    name STRING
+)
+STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+TBLPROPERTIES (
+    "hive.sql.database.type" = "POSTGRES",
+    "hive.sql.jdbc.driver" = "org.postgresql.Driver",
+    "hive.sql.jdbc.url" = "jdbc:postgresql://localhost:5432/test",
+    "hive.sql.dbcp.username" = "hiveuser",
+    "hive.sql.dbcp.password" = "password",
+    "hive.sql.table" = "test",
+    "hive.sql.query" = "select id, name from test"
+);

--- a/ql/src/test/results/clientnegative/create_external_table_ambiguous_jdbc_table_properties.q.out
+++ b/ql/src/test/results/clientnegative/create_external_table_ambiguous_jdbc_table_properties.q.out
@@ -1,0 +1,1 @@
+FAILED: SemanticException Cannot specify both hive.sql.query and hive.sql.table for JDBC tables.


### PR DESCRIPTION
…e.sql.table and hive.sql.query are set

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added a check in SemanticAnalyzer to not allow table creation for external JDBC tables when both `hive.sql.query` and `hive.sql.table` are set.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Setting both these properties together is ambiguous. Also we essentially get an NPE when both of them are set, as shown in https://issues.apache.org/jira/browse/HIVE-29085

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
```
mvn test -pl itests/qtest -Pitests -Dtest=TestNegativeLlapCliDriver -Dtest.output.overwrite=true -Dqfile="create_external_table_ambiguous_jdbc_table_properties.q"
mvn test -Dtest=org.apache.hadoop.hive.ql.parse.TestSemanticAnalyzer#testValidateNonAmbiguousJDBCTableProperties
```