### PR TITLE
HIVE-29107: Drop avatica version management and use of shaded jars

### DIFF
--- a/itests/hive-blobstore/pom.xml
+++ b/itests/hive-blobstore/pom.xml
@@ -289,10 +289,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-client</artifactId>
       <scope>test</scope>

--- a/itests/qtest-druid/pom.xml
+++ b/itests/qtest-druid/pom.xml
@@ -30,7 +30,6 @@
   <!-- dependencies are always listed in sorted order by groupId, artifactId -->
   <properties>
     <hive.path.to.root>../..</hive.path.to.root>
-    <druid.avatica.version>1.15.0</druid.avatica.version>
     <druid.curator.version>4.0.0</druid.curator.version>
     <druid.jersey.version>1.19.3</druid.jersey.version>
     <druid.jetty.version>9.4.57.v20241219</druid.jetty.version>
@@ -162,26 +161,6 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
       <version>${druid.curator.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica</artifactId>
-      <version>${avatica.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica-core</artifactId>
-      <version>${avatica.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica-metrics</artifactId>
-      <version>${avatica.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica-server</artifactId>
-      <version>${avatica.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
     <!-- Make sure to sync it with standalone-metastore/pom.xml -->
     <antlr4.version>4.9.3</antlr4.version>
     <apache-directory-server.version>2.0.0-M24</apache-directory-server.version>
-    <avatica.version>1.23.0</avatica.version>
     <avro.version>1.12.0</avro.version>
     <bcprov-jdk18on.version>1.78</bcprov-jdk18on.version>
     <calcite.version>1.33.0</calcite.version>
@@ -545,26 +544,6 @@
         <groupId>org.apache.accumulo</groupId>
         <artifactId>accumulo-trace</artifactId>
         <version>${accumulo.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.calcite.avatica</groupId>
-        <artifactId>avatica</artifactId>
-        <version>${avatica.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.calcite.avatica</groupId>
-        <artifactId>avatica-core</artifactId>
-        <version>${avatica.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.calcite.avatica</groupId>
-        <artifactId>avatica-metrics</artifactId>
-        <version>${avatica.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.calcite.avatica</groupId>
-        <artifactId>avatica-server</artifactId>
-        <version>${avatica.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -481,10 +481,6 @@
           <groupId>org.yaml</groupId>
           <artifactId>snakeyaml</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.apache.calcite.avatica</groupId>
-          <artifactId>avatica-core</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -492,41 +488,8 @@
       <artifactId>calcite-druid</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.calcite.avatica</groupId>
-          <artifactId>avatica-core</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.yaml</groupId>
           <artifactId>snakeyaml</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.calcite.avatica</groupId>
-          <artifactId>avatica-core</artifactId>
-        </exclusion>
-        <!-- hsqldb interferes with the use of derby as the default db
-          in hive's use of datanucleus.
-        -->
-        <exclusion>
-          <groupId>org.hsqldb</groupId>
-          <artifactId>hsqldb</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1102,7 +1065,7 @@
                   <include>com.zaxxer:HikariCP</include>
                   <include>org.apache.datasketches:*</include>
                   <include>org.apache.calcite:*</include>
-                  <include>org.apache.calcite.avatica:avatica</include>
+                  <include>org.apache.calcite.avatica:*</include>
                   <include>com.esri.geometry:esri-geometry-api</include>
                   <include>org.roaringbitmap:RoaringBitmap</include>
                   <include>com.github.luben:zstd-jni</include>
@@ -1111,15 +1074,6 @@
                 </includes>
               </artifactSet>
               <filters>
-                <filter>
-                  <artifact>org.apache.calcite.avatica:avatica</artifact>
-                  <excludes>
-                    <!-- Exclude Avatica bundled SLF4J, because Hive manages its own SLF4J version. -->
-                    <exclude>org/slf4j/**</exclude>
-                    <exclude>META-INF/maven/org.slf4j/**</exclude>
-                    <exclude>META-INF/licenses/slf4j*/**</exclude>
-                  </excludes>
-                </filter>
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>


### PR DESCRIPTION
### Why are the changes needed?
Avatica is tightly connected with Calcite so it doesn't make sense to manage it separately Moreover, there is no need to use the shaded avatica artifact since the latter pulls in tons of things that Hive doesn't need.

### Does this PR introduce _any_ user-facing change?
No product facing changes for Hive users.

However, due to the removal of the shaded avatica jar some classes will not be part hive-exec so maven projects that depend on hive-exec may run into `ClassNotFoundException` issues if they depend implicitly on code bundled in avatica.

### How was this patch tested?
1. Existing tests
2. Build the hive binaries using mvn clean install -DskipTests -Pdist
3. Deployed to local cluster in pseudo-distributed mode and run a bunch of queries