### PR TITLE
HIVE-29105. Migrate iceberg-catalog Tests to JUnit 5.

### DIFF
--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -34,8 +34,8 @@ import org.apache.iceberg.expressions.BoundSetPredicate;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.UnboundPredicate;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHelpers {
 
@@ -43,29 +43,29 @@ public class TestHelpers {
   }
 
   public static <T> T assertAndUnwrap(Expression expr, Class<T> expected) {
-    Assert.assertTrue("Expression should have expected type: " + expected,
-        expected.isInstance(expr));
+    Assertions.assertTrue(
+       expected.isInstance(expr), "Expression should have expected type: " + expected);
     return expected.cast(expr);
   }
 
   @SuppressWarnings("unchecked")
   public static <T> BoundPredicate<T> assertAndUnwrap(Expression expr) {
-    Assert.assertTrue("Expression should be a bound predicate: " + expr,
-        expr instanceof BoundPredicate);
+    Assertions.assertTrue(
+       expr instanceof BoundPredicate, "Expression should be a bound predicate: " + expr);
     return (BoundPredicate<T>) expr;
   }
 
   @SuppressWarnings("unchecked")
   public static <T> BoundSetPredicate<T> assertAndUnwrapBoundSet(Expression expr) {
-    Assert.assertTrue("Expression should be a bound set predicate: " + expr,
-        expr instanceof BoundSetPredicate);
+    Assertions.assertTrue(
+       expr instanceof BoundSetPredicate, "Expression should be a bound set predicate: " + expr);
     return (BoundSetPredicate<T>) expr;
   }
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundPredicate<T> assertAndUnwrapUnbound(Expression expr) {
-    Assert.assertTrue("Expression should be an unbound predicate: " + expr,
-        expr instanceof UnboundPredicate);
+    Assertions.assertTrue(
+       expr instanceof UnboundPredicate, "Expression should be an unbound predicate: " + expr);
     return (UnboundPredicate<T>) expr;
   }
 
@@ -87,7 +87,7 @@ public class TestHelpers {
   }
 
   public static void assertSameSchemaList(List<Schema> list1, List<Schema> list2) {
-    Assertions.assertThat(list1)
+    assertThat(list1)
         .as("Should have same number of schemas in both lists")
         .hasSameSizeAs(list2);
 
@@ -96,48 +96,50 @@ public class TestHelpers {
             index -> {
               Schema schema1 = list1.get(index);
               Schema schema2 = list2.get(index);
-              Assert.assertEquals(
-                  "Should have matching schema id", schema1.schemaId(), schema2.schemaId());
-              Assert.assertEquals(
-                  "Should have matching schema struct", schema1.asStruct(), schema2.asStruct());
+              Assertions.assertEquals(schema1.schemaId(), schema2.schemaId(),
+                  "Should have matching schema id");
+              Assertions.assertEquals(schema1.asStruct(), schema2.asStruct(),
+                  "Should have matching schema struct");
             });
   }
 
   public static void assertSerializedMetadata(Table expected, Table actual) {
-    Assert.assertEquals("Name must match", expected.name(), actual.name());
-    Assert.assertEquals("Location must match", expected.location(), actual.location());
-    Assert.assertEquals("Props must match", expected.properties(), actual.properties());
-    Assert.assertEquals("Schema must match", expected.schema().asStruct(), actual.schema().asStruct());
-    Assert.assertEquals("Spec must match", expected.spec(), actual.spec());
-    Assert.assertEquals("Sort order must match", expected.sortOrder(), actual.sortOrder());
+    Assertions.assertEquals(expected.name(), actual.name(), "Name must match");
+    Assertions.assertEquals(expected.location(), actual.location(), "Location must match");
+    Assertions.assertEquals(expected.properties(), actual.properties(), "Props must match");
+    Assertions.assertEquals(expected.schema().asStruct(), actual.schema().asStruct(),
+        "Schema must match");
+    Assertions.assertEquals(expected.spec(), actual.spec(), "Spec must match");
+    Assertions.assertEquals(expected.sortOrder(), actual.sortOrder(), "Sort order must match");
   }
 
   public static void assertSerializedAndLoadedMetadata(Table expected, Table actual) {
     assertSerializedMetadata(expected, actual);
-    Assert.assertEquals("Specs must match", expected.specs(), actual.specs());
-    Assert.assertEquals("Sort orders must match", expected.sortOrders(), actual.sortOrders());
-    Assert.assertEquals("Current snapshot must match", expected.currentSnapshot(), actual.currentSnapshot());
-    Assert.assertEquals("Snapshots must match", expected.snapshots(), actual.snapshots());
-    Assert.assertEquals("History must match", expected.history(), actual.history());
+    Assertions.assertEquals(expected.specs(), actual.specs(), "Specs must match");
+    Assertions.assertEquals(expected.sortOrders(), actual.sortOrders(), "Sort orders must match");
+    Assertions.assertEquals(expected.currentSnapshot(), actual.currentSnapshot(),
+        "Current snapshot must match");
+    Assertions.assertEquals(expected.snapshots(), actual.snapshots(), "Snapshots must match");
+    Assertions.assertEquals(expected.history(), actual.history(), "History must match");
   }
 
   public static void assertSameSchemaMap(Map<Integer, Schema> map1, Map<Integer, Schema> map2) {
-    Assertions.assertThat(map1)
+    assertThat(map1)
         .as("Should have same number of schemas in both maps")
         .hasSameSizeAs(map2);
 
     map1.forEach(
         (schemaId, schema1) -> {
           Schema schema2 = map2.get(schemaId);
-          Assert.assertNotNull(
-              String.format("Schema ID %s does not exist in map: %s", schemaId, map2), schema2);
+          Assertions.assertNotNull(
+          schema2, String.format("Schema ID %s does not exist in map: %s", schemaId, map2));
 
-          Assert.assertEquals(
-              "Should have matching schema id", schema1.schemaId(), schema2.schemaId());
-          Assert.assertTrue(
-              String.format(
-                  "Should be the same schema. Schema 1: %s, schema 2: %s", schema1, schema2),
-              schema1.sameSchema(schema2));
+          Assertions.assertEquals(schema1.schemaId(), schema2.schemaId(),
+              "Should have matching schema id");
+          Assertions.assertTrue(
+          
+             schema1.sameSchema(schema2), String.format(
+                  "Should be the same schema. Schema 1: %s, schema 2: %s", schema1, schema2));
         });
   }
 
@@ -150,7 +152,7 @@ public class TestHelpers {
 
     @Override
     public <T> Void predicate(UnboundPredicate<T> pred) {
-      Assert.fail(message + ": Found unbound predicate: " + pred);
+      Assertions.fail(message + ": Found unbound predicate: " + pred);
       return null;
     }
   }

--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestClientPoolImpl.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestClientPoolImpl.java
@@ -30,23 +30,23 @@ import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.thrift.transport.TTransportException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestClientPoolImpl {
 
   HiveClientPool clients;
 
-  @Before
+  @BeforeEach
   public void before() {
     HiveClientPool clientPool = new HiveClientPool(2, new Configuration());
     clients = Mockito.spy(clientPool);
   }
 
-  @After
+  @AfterEach
   public void after() {
     clients.close();
     clients = null;
@@ -84,7 +84,7 @@ public class TestClientPoolImpl {
 
     Mockito.doReturn(databases).when(newClient).getAllDatabases();
     // The return is OK when the reconnect method is called.
-    Assert.assertEquals(databases, clients.run(client -> client.getAllDatabases(), true));
+    Assertions.assertEquals(databases, clients.run(client -> client.getAllDatabases(), true));
 
     // Verify that the method is called.
     Mockito.verify(clients).reconnect(hmsClient);
@@ -104,7 +104,7 @@ public class TestClientPoolImpl {
         new Function("concat", "db1", "classname", "root", PrincipalType.USER, 100, FunctionType.JAVA, null));
     Mockito.doReturn(response).when(newClient).getAllFunctions();
 
-    Assert.assertEquals(response, clients.run(client -> client.getAllFunctions(), true));
+    Assertions.assertEquals(response, clients.run(client -> client.getAllFunctions(), true));
 
     Mockito.verify(clients).reconnect(hmsClient);
     Mockito.verify(clients, Mockito.never()).reconnect(newClient);

--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -65,7 +65,7 @@ import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
 import org.apache.thrift.TException;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -595,7 +595,7 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
     try {
       database = HIVE_METASTORE_EXTENSION.metastoreClient().getDatabase(namespace.level(0));
     } catch (TException e) {
-      Assert.fail();
+      Assertions.fail();
     }
     assertThat(database.getParameters()).containsEntry("owner", "alter_apache");
     assertThat(database.getParameters()).containsEntry("test", "test");
@@ -799,7 +799,7 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
     try {
       database = HIVE_METASTORE_EXTENSION.metastoreClient().getDatabase(namespace.level(0));
     } catch (TException e) {
-      Assert.fail();
+      Assertions.fail();
     }
     assertThat(database.getParameters()).doesNotContainKey("owner");
     assertThat(database.getParameters()).containsEntry("group", "iceberg");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

JIRA: HIVE-29105. Migrate iceberg-catalog Tests to JUnit 5.

### Why are the changes needed?

This PR upgrades the iceberg-catalog module from JUnit 4 to JUnit 5. The migration includes:

Replacing deprecated JUnit 4 annotations (@Test, @Before, @After, etc.) with their JUnit 5 equivalents.
Updating import statements and base test classes to use JUnit Jupiter APIs.
Ensuring compatibility with JUnit Platform, including parameterized tests and assertions.
Removing any legacy rules or runners no longer compatible with JUnit 5.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Junit Test.
