### PR TITLE
HIVE-28222: Ambiguous table alias exception for queries with self joins

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelShuttle.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelShuttle.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveJoin;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveProject;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveSortLimit;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveTableScan;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.jdbc.HiveJdbcConverter;
 
 /**
  * Visitor that has methods for the common logical relational expressions.
@@ -39,6 +40,7 @@ public interface HiveRelShuttle extends RelShuttle {
     RelNode visit(HiveAggregate aggregate);
     RelNode visit(HiveSortLimit hiveSortLimit);
     RelNode visit(HiveTableScan scan);
+    RelNode visit(HiveJdbcConverter conv);
 }
 
 // End RelShuttle.java

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelShuttleImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelShuttleImpl.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveJoin;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveProject;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveSortLimit;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveTableScan;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.jdbc.HiveJdbcConverter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -170,6 +171,11 @@ public class HiveRelShuttleImpl implements HiveRelShuttle {
     @Override
     public RelNode visit(HiveTableScan scan) {
         return scan;
+    }
+
+    @Override
+    public RelNode visit(HiveJdbcConverter conv) {
+        return visitChild(conv, 0, conv.getInput());
     }
 }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/jdbc/HiveJdbcConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/jdbc/HiveJdbcConverter.java
@@ -27,6 +27,7 @@ import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.RelVisitor;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.convert.ConverterImpl;
@@ -38,6 +39,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlDialect;
 
 import org.apache.calcite.util.ControlFlowException;
+import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelShuttle;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveRelNode;
 import org.apache.hadoop.hive.ql.optimizer.calcite.rules.jdbc.HiveJdbcImplementor;
 
@@ -84,6 +86,14 @@ public class HiveJdbcConverter extends ConverterImpl implements HiveRelNode {
       RelTraitSet traitSet,
       List<RelNode> inputs) {
     return new HiveJdbcConverter(getCluster(), traitSet, sole(inputs), convention, url, user);
+  }
+
+  @Override
+  public RelNode accept(RelShuttle shuttle) {
+    if (shuttle instanceof HiveRelShuttle) {
+      return ((HiveRelShuttle) shuttle).visit(this);
+    }
+    return super.accept(shuttle);
   }
 
   public RelNode copy(RelTraitSet traitSet, RelNode input) {

--- a/ql/src/test/queries/clientpositive/cbo_self_join_ambiguous_alias_cte.q
+++ b/ql/src/test/queries/clientpositive/cbo_self_join_ambiguous_alias_cte.q
@@ -1,0 +1,6 @@
+create table t1 (key int, value int);
+
+explain cbo
+with cte as
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1)
+select * from cte a join cte b join cte c 

--- a/ql/src/test/queries/clientpositive/cbo_self_join_ambiguous_alias_mv.q
+++ b/ql/src/test/queries/clientpositive/cbo_self_join_ambiguous_alias_mv.q
@@ -1,0 +1,13 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+create table t1 (key int, value int) stored as orc TBLPROPERTIES ('transactional'='true');
+
+create materialized view mv as
+select * from t1 where key < 6;
+
+explain cbo
+select * from 
+  (select * from t1 where key < 6) a join
+  (select * from t1 where key < 6) b join
+  (select * from t1 where key < 6) c;

--- a/ql/src/test/queries/clientpositive/cbo_self_join_ambiguous_alias_subquery.q
+++ b/ql/src/test/queries/clientpositive/cbo_self_join_ambiguous_alias_subquery.q
@@ -1,0 +1,7 @@
+create table t1 (key int, value int);
+
+explain cbo
+select * from 
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) a join
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) b join
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) c;

--- a/ql/src/test/results/clientpositive/llap/cbo_self_join_ambiguous_alias_cte.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_self_join_ambiguous_alias_cte.q.out
@@ -1,0 +1,34 @@
+PREHOOK: query: create table t1 (key int, value int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (key int, value int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, t1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[14][tables = [$hdt$_0, t1]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain cbo
+with cte as
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1)
+select * from cte a join cte b join cte c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+with cte as
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1)
+select * from cte a join cte b join cte c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(key=[$0], value=[$1], BLOCK__OFFSET__INSIDE__FILE=[$2], INPUT__FILE__NAME=[$3], ROW__ID=[$4], ROW__IS__DELETED=[$5], key0=[$12], value0=[$13], BLOCK__OFFSET__INSIDE__FILE0=[$14], INPUT__FILE__NAME0=[$15], ROW__ID0=[$16], ROW__IS__DELETED0=[$17], key1=[$6], value1=[$7], BLOCK__OFFSET__INSIDE__FILE1=[$8], INPUT__FILE__NAME1=[$9], ROW__ID1=[$10], ROW__IS__DELETED1=[$11])
+  HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(key=[$0], value=[$1], BLOCK__OFFSET__INSIDE__FILE=[$2], INPUT__FILE__NAME=[$3], ROW__ID=[$4], ROW__IS__DELETED=[$5], key0=[$6], value0=[$7], BLOCK__OFFSET__INSIDE__FILE0=[$8], INPUT__FILE__NAME0=[$9], ROW__ID0=[$10], ROW__IS__DELETED0=[$11])
+      HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+        HiveProject(key=[$0], value=[$1], BLOCK__OFFSET__INSIDE__FILE=[$2], INPUT__FILE__NAME=[$3], ROW__ID=[$4], ROW__IS__DELETED=[$5])
+          HiveTableScan(table=[[default, t1]], table:alias=[t1])
+        HiveTableScan(table=[[default, t1]], table:alias=[t1])
+    HiveTableScan(table=[[default, t1]], table:alias=[t1])
+

--- a/ql/src/test/results/clientpositive/llap/cbo_self_join_ambiguous_alias_mv.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_self_join_ambiguous_alias_mv.q.out
@@ -1,0 +1,52 @@
+PREHOOK: query: create table t1 (key int, value int) stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (key int, value int) stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: create materialized view mv as
+select * from t1 where key < 6
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mv
+POSTHOOK: query: create materialized view mv as
+select * from t1 where key < 6
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mv
+POSTHOOK: Lineage: mv.key SIMPLE [(t1)t1.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: mv.value SIMPLE [(t1)t1.FieldSchema(name:value, type:int, comment:null), ]
+Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, default.mv]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[14][tables = [$hdt$_0, default.mv]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain cbo
+select * from 
+  (select * from t1 where key < 6) a join
+  (select * from t1 where key < 6) b join
+  (select * from t1 where key < 6) c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from 
+  (select * from t1 where key < 6) a join
+  (select * from t1 where key < 6) b join
+  (select * from t1 where key < 6) c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(key=[$0], value=[$1], key0=[$4], value0=[$5], key1=[$2], value1=[$3])
+  HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(key=[$0], value=[$1], key0=[$2], value0=[$3])
+      HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+        HiveProject(key=[$0], value=[$1])
+          HiveTableScan(table=[[default, mv]], table:alias=[default.mv])
+        HiveTableScan(table=[[default, mv]], table:alias=[default.mv])
+    HiveTableScan(table=[[default, mv]], table:alias=[default.mv])
+

--- a/ql/src/test/results/clientpositive/llap/cbo_self_join_ambiguous_alias_subquery.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_self_join_ambiguous_alias_subquery.q.out
@@ -1,0 +1,36 @@
+PREHOOK: query: create table t1 (key int, value int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (key int, value int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, t1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[14][tables = [$hdt$_0, t1]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain cbo
+select * from 
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) a join
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) b join
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from 
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) a join
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) b join
+(select key, value, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED from t1) c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(key=[$0], value=[$1], BLOCK__OFFSET__INSIDE__FILE=[$2], INPUT__FILE__NAME=[$3], ROW__ID=[$4], ROW__IS__DELETED=[$5], key0=[$12], value0=[$13], BLOCK__OFFSET__INSIDE__FILE0=[$14], INPUT__FILE__NAME0=[$15], ROW__ID0=[$16], ROW__IS__DELETED0=[$17], key1=[$6], value1=[$7], BLOCK__OFFSET__INSIDE__FILE1=[$8], INPUT__FILE__NAME1=[$9], ROW__ID1=[$10], ROW__IS__DELETED1=[$11])
+  HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(key=[$0], value=[$1], BLOCK__OFFSET__INSIDE__FILE=[$2], INPUT__FILE__NAME=[$3], ROW__ID=[$4], ROW__IS__DELETED=[$5], key0=[$6], value0=[$7], BLOCK__OFFSET__INSIDE__FILE0=[$8], INPUT__FILE__NAME0=[$9], ROW__ID0=[$10], ROW__IS__DELETED0=[$11])
+      HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+        HiveProject(key=[$0], value=[$1], BLOCK__OFFSET__INSIDE__FILE=[$2], INPUT__FILE__NAME=[$3], ROW__ID=[$4], ROW__IS__DELETED=[$5])
+          HiveTableScan(table=[[default, t1]], table:alias=[t1])
+        HiveTableScan(table=[[default, t1]], table:alias=[t1])
+    HiveTableScan(table=[[default, t1]], table:alias=[t1])
+

--- a/ql/src/test/results/clientpositive/llap/external_jdbc_table2.q.out
+++ b/ql/src/test/results/clientpositive/llap/external_jdbc_table2.q.out
@@ -420,7 +420,7 @@ POSTHOOK: Input: default@db1_ext_auth2
 #### A masked pattern was here ####
 -20	-20	-20.0	-20.0	-20	8	9.0	11.0
 20	20	20.0	20.0	20	20	20.0	20.0
-Warning: Shuffle Join MERGEJOIN[10][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT db1_ext_auth1.ikey, b.ikey * 2 FROM db1_ext_auth1 JOIN (SELECT * FROM db1_ext_auth1) b
 PREHOOK: type: QUERY
@@ -512,7 +512,7 @@ FROM "EXTERNAL_JDBC_SIMPLE_DERBY2_TABLE1"
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[10][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: SELECT db1_ext_auth1.ikey, b.ikey * 2 FROM db1_ext_auth1 JOIN (SELECT * FROM db1_ext_auth1) b
 PREHOOK: type: QUERY
 PREHOOK: Input: default@db1_ext_auth1

--- a/ql/src/test/results/clientpositive/llap/external_jdbc_table4.q.out
+++ b/ql/src/test/results/clientpositive/llap/external_jdbc_table4.q.out
@@ -420,7 +420,7 @@ POSTHOOK: Input: default@db1_ext_auth2
 #### A masked pattern was here ####
 -20	-20	-20.0	-20.0	-20	8	9.0	11.0
 20	20	20.0	20.0	20	20	20.0	20.0
-Warning: Shuffle Join MERGEJOIN[10][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT db1_ext_auth1.ikey, b.ikey * 2 FROM db1_ext_auth1 JOIN (SELECT * FROM db1_ext_auth1) b
 PREHOOK: type: QUERY
@@ -512,7 +512,7 @@ FROM "EXTERNAL_JDBC_SIMPLE_DERBY2_TABLE1"
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[10][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: SELECT db1_ext_auth1.ikey, b.ikey * 2 FROM db1_ext_auth1 JOIN (SELECT * FROM db1_ext_auth1) b
 PREHOOK: type: QUERY
 PREHOOK: Input: default@db1_ext_auth1


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Collect all table aliases under joins
2. Introduce derived table whenever the same alias appears more than once

### Why are the changes needed?
Some queries that contain joins of the same table more than twice fail during compilation while trying to transform the optimized AST (obtained from CBO) to an Operator tree. The "Ambiguous table alias" exception is raised when a HiveJoin contains the same table scan multiple times (without an interleaving project) cause the generated AST is ambiguous.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile_regex=cbo_self_join.*
```