### PR TITLE
HIVE-29037: Negative elapsed time logging in HiveSplitGenerator

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
@@ -241,7 +241,7 @@ public class HiveSplitGenerator extends InputInitializer {
         mrSplit.writeTo(out);
       }
       LOG.debug("Split #{} event to output path: {} written in {} ms", count, filePath,
-          fileWriteStarted - Time.monotonicNow());
+          Time.monotonicNow() - fileWriteStarted);
     }
 
     Path getSerializedFilePath(int index) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-29037](https://issues.apache.org/jira/browse/HIVE-29037)


### Why are the changes needed?
To correct the negative logging


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
On local setup
