### PR TITLE
HIVE-29123: Extend ProtobufInputFormat to handle EOFException for par…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/protobuf/LenientProtobufMessageInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/protobuf/LenientProtobufMessageInputFormat.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.io.protobuf;
+
+import com.google.protobuf.MessageLite;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.tez.dag.history.logging.proto.ProtoMessageWritable;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+/**
+ * Lenient variant of ProtobufMessageInputFormat that tolerates read failures
+ * in SequenceFileRecordReader by using a forgiving subclass.
+ */
+public class LenientProtobufMessageInputFormat<K, V extends MessageLite>
+    extends ProtobufMessageInputFormat<K, V> {
+
+  private static final String PROTO_CLASS = "proto.class";
+
+  @Override
+  public RecordReader<K, ProtoMessageWritable<V>> getRecordReader(InputSplit split, JobConf job, Reporter reporter)
+      throws IOException {
+    final RecordReader<K, ProtoMessageWritable<V>> reader = super.getRecordReader(split, job, reporter);
+    return new SafeRecordReader<>(reader);
+  }
+
+  private class SafeRecordReader<K, V extends MessageLite> implements RecordReader<K, ProtoMessageWritable<V>> {
+
+    final RecordReader<K, ProtoMessageWritable<V>> mainReader;
+
+    private SafeRecordReader(RecordReader reader) throws IOException {
+      mainReader = reader;
+    }
+
+    @Override
+    public ProtoMessageWritable<V> createValue() {
+      return mainReader != null ? mainReader.createValue() : null;
+    }
+
+    @Override
+    public K createKey() {
+      return mainReader != null ? mainReader.createKey() : null;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (mainReader != null) {
+        mainReader.close();
+      }
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return mainReader != null ? mainReader.getPos() : 0;
+    }
+
+    @Override
+    public float getProgress() throws IOException {
+      return mainReader != null ? mainReader.getProgress() : 1.0f;
+    }
+
+    @Override
+    public boolean next(K arg0, ProtoMessageWritable<V> arg1) throws IOException {
+      try {
+        return mainReader != null ? mainReader.next(arg0, arg1) : false;
+      } catch (EOFException e) {
+        return false;
+      }
+    }
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.2.0.hive.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/hive/hive-schema-4.2.0.hive.sql
@@ -1597,7 +1597,7 @@ PARTITIONED BY (
   `date` string
 )
 ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageSerDe'
-STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageInputFormat'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.LenientProtobufMessageInputFormat'
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION '_REPLACE_WITH_QUERY_DATA_LOCATION_'
 TBLPROPERTIES (
@@ -1610,7 +1610,7 @@ PARTITIONED BY (
   `date` string
 )
 ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageSerDe'
-STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageInputFormat'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.LenientProtobufMessageInputFormat'
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION '_REPLACE_WITH_APP_DATA_LOCATION_'
 TBLPROPERTIES (
@@ -1623,7 +1623,7 @@ PARTITIONED BY (
   `date` string
 )
 ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageSerDe'
-STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageInputFormat'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.LenientProtobufMessageInputFormat'
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION '_REPLACE_WITH_DAG_DATA_LOCATION_'
 TBLPROPERTIES (
@@ -1636,7 +1636,7 @@ PARTITIONED BY (
   `date` string
 )
 ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageSerDe'
-STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageInputFormat'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.LenientProtobufMessageInputFormat'
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION '_REPLACE_WITH_DAG_META_LOCATION_'
 TBLPROPERTIES (

--- a/standalone-metastore/metastore-server/src/main/sql/hive/upgrade-4.1.0-to-4.2.0.hive.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/hive/upgrade-4.1.0-to-4.2.0.hive.sql
@@ -1,3 +1,59 @@
 SELECT 'Upgrading MetaStore schema from 4.1.0 to 4.2.0';
 
+-- HIVE-29123
+DROP TABLE IF EXISTS `PROTO_HIVE_QUERY_DATA`;
+CREATE EXTERNAL TABLE IF NOT EXISTS `PROTO_HIVE_QUERY_DATA`
+PARTITIONED BY (
+  `date` string
+)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageSerDe'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.LenientProtobufMessageInputFormat'
+OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION '_REPLACE_WITH_QUERY_DATA_LOCATION_'
+TBLPROPERTIES (
+  'proto.class'='org.apache.hadoop.hive.ql.hooks.proto.HiveHookEvents$HiveHookEventProto',
+  'proto.maptypes'='org.apache.hadoop.hive.ql.hooks.proto.MapFieldEntry'
+);
+
+DROP TABLE IF EXISTS `PROTO_TEZ_APP_DATA`;
+CREATE EXTERNAL TABLE IF NOT EXISTS `PROTO_TEZ_APP_DATA`
+PARTITIONED BY (
+  `date` string
+)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageSerDe'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.LenientProtobufMessageInputFormat'
+OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION '_REPLACE_WITH_APP_DATA_LOCATION_'
+TBLPROPERTIES (
+  'proto.class'='org.apache.tez.dag.history.logging.proto.HistoryLoggerProtos$HistoryEventProto',
+  'proto.maptypes'='KVPair'
+);
+
+DROP TABLE IF EXISTS `PROTO_TEZ_DAG_DATA`;
+CREATE EXTERNAL TABLE IF NOT EXISTS `PROTO_TEZ_DAG_DATA`
+PARTITIONED BY (
+  `date` string
+)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageSerDe'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.LenientProtobufMessageInputFormat'
+OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION '_REPLACE_WITH_DAG_DATA_LOCATION_'
+TBLPROPERTIES (
+  'proto.class'='org.apache.tez.dag.history.logging.proto.HistoryLoggerProtos$HistoryEventProto',
+  'proto.maptypes'='KVPair'
+);
+
+DROP TABLE IF EXISTS `PROTO_TEZ_DAG_META`;
+CREATE EXTERNAL TABLE IF NOT EXISTS `PROTO_TEZ_DAG_META`
+PARTITIONED BY (
+  `date` string
+)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.protobuf.ProtobufMessageSerDe'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.protobuf.LenientProtobufMessageInputFormat'
+OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION '_REPLACE_WITH_DAG_META_LOCATION_'
+TBLPROPERTIES (
+  'proto.class'='org.apache.tez.dag.history.logging.proto.HistoryLoggerProtos$ManifestEntryProto'
+);
+
 SELECT 'Finished upgrading MetaStore schema from 4.1.0 to 4.2.0';


### PR DESCRIPTION
…tially written proto files

### What changes were proposed in this pull request?
This PR introduces a more lenient version of ProtobufInputFormat that ignores EOFException when reading partially written proto files.
ProtobufMessageInputFormat skips zero-byte files by creating <SafeRecordReader>, which ignores EOFException. 


### Why are the changes needed?
Abrupt AM termination or OOM failures can result in partially written protobuf files. When reading data from the corresponding external table, these incomplete files may trigger an EOFException, causing the entire query to fail.

To improve resilience, it would be better to gracefully skip unreadable or corrupted proto files and continue reading the remaining valid data, instead of failing the entire query.


### Does this PR introduce _any_ user-facing change?
Yes, this would silently skip reading partially written proto files instead of failing with EOFException.

### How was this patch tested?
Manually tested with a sample partially written dag data file.
