### PR TITLE
HIVE-29124: Avoid committing files when a task is aborted even though some source has completed.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
@@ -307,16 +307,11 @@ public class ReduceRecordProcessor extends RecordProcessor {
     }
     if (mergeWorkList != null) {
       for (BaseWork redWork : mergeWorkList) {
-        ((ReduceWork) redWork).getReducer().abort();
+        redWork.abort();
       }
     }
     if (reduceWork != null) {
-      List<HashTableDummyOperator> dummyOps = reduceWork.getDummyOps();
-      if (dummyOps != null) {
-        for (Operator<?> dummyOp : dummyOps) {
-          dummyOp.abort();
-        }
-      }
+      reduceWork.abort();
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordSource.java
@@ -520,6 +520,14 @@ public class ReduceRecordSource implements RecordSource {
     }
   }
 
+
+  /**
+   * Closes resources and returns whether the records were successfully processed.
+   * @return boolean indicating the success status:
+   * - true: All data has been processed successfully without exceptions.
+   * - false: Exceptions were encountered during data processing.
+   * @throws Exception unexpected errors occur during closing.
+   */
   boolean close() throws Exception {
     try {
       if (handleGroupKey && groupKey != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/BaseWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/BaseWork.java
@@ -545,4 +545,12 @@ public abstract class BaseWork extends AbstractOperatorDesc {
           String workName, RuntimeValuesInfo runtimeValuesInfo) {
     inputSourceToRuntimeValuesInfo.put(workName, runtimeValuesInfo);
   }
+
+  public void abort() {
+    if (dummyOps != null) {
+      for (Operator<?> dummyOp : dummyOps) {
+        dummyOp.abort();
+      }
+    }
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceWork.java
@@ -381,4 +381,12 @@ public class ReduceWork extends BaseWork {
   public TezEdgeProperty getEdgePropRef() {
     return edgeProp;
   }
+
+  @Override
+  public void abort() {
+    super.abort();
+    if (reducer != null) {
+      reducer.abort();
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two change:

* Does not allow abort to be set from true to false.
* dummyOps also aborts.  

### Why are the changes needed?

I found that when the task is almost completed (more precisely, when the source has been processed), but not closed, if an exception is thrown at this time, it may cause the file to be committed incorrectly.

Look at the below code. abort may be set from true to false. It is not reasonable. The correct logic is that as long as abort is set to true at one place, abort should always be true, then do not commit.
https://github.com/apache/hive/blob/9b07c5c7136863ae1eb469e7a3c11357299d2ea1/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java#L349

When I tried to reproduce this bug, I found that only [dummyOp.close(abort)](https://github.com/apache/hive/blob/9b07c5c7136863ae1eb469e7a3c11357299d2ea1/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java#L369) caused the problem. I initially thought that the problem would occur at [reducer.close(abort)](https://github.com/apache/hive/blob/9b07c5c7136863ae1eb469e7a3c11357299d2ea1/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java#L356) because the reduce op's abort was set to true in the abort. However, dummyOps was not properly aborted. Here, dummyOps should also be aborted. Therefore, the issue only occurs when dummyOps is used, such as in mapjoin.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Use real tasks. 

> Note: This is a low-probability issue, and I added sleep code at a specific location to increase the probability of this bug.