### PR TITLE
HIVE-19996: Beeline performance poor with drivers having slow DatabaseMetaData.getPrimaryKeys impl

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/TableOutputFormat.java
+++ b/beeline/src/java/org/apache/hive/beeline/TableOutputFormat.java
@@ -122,14 +122,14 @@ class TableOutputFormat implements OutputFormat {
 
       if (row.isMeta) {
         v = beeLine.getColorBuffer().center(row.values[i], row.sizes[i]);
-        if (beeLine.getOpts().getColor() && rows.isPrimaryKey(i)) {
+        if (beeLine.getOpts().getColor() && rows.isPrimaryKeyCol(i)) {
           buf.cyan(v.getMono());
         } else {
           buf.bold(v.getMono());
         }
       } else {
         v = beeLine.getColorBuffer().pad(row.values[i], row.sizes[i]);
-        if (beeLine.getOpts().getColor() && rows.isPrimaryKey(i)) {
+        if (beeLine.getOpts().getColor() && rows.isPrimaryKeyCol(i)) {
           buf.cyan(v.getMono());
         } else {
           buf.append(v.getMono());

--- a/beeline/src/test/org/apache/hive/beeline/BeelineMock.java
+++ b/beeline/src/test/org/apache/hive/beeline/BeelineMock.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.beeline;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BeelineMock extends BeeLine {
+  public BeelineMock() {
+    this.allPrintedLines = new ArrayList<>();
+  }
+
+  private String lastPrintedLine;
+  private List<String> allPrintedLines;
+
+  @Override
+  final void output(final ColorBuffer msg, boolean newline, PrintStream out) {
+    lastPrintedLine = msg.getMono();
+    allPrintedLines.add(msg.getColor());
+    super.output(msg, newline, out);
+  }
+
+  public String getLastPrintedLine() {
+    return lastPrintedLine;
+  }
+
+  public List<String> getAllPrintedLines() {
+    return allPrintedLines;
+  }
+}

--- a/beeline/src/test/org/apache/hive/beeline/TestTableOutputFormat.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestTableOutputFormat.java
@@ -17,35 +17,33 @@
  */
 package org.apache.hive.beeline;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 
-import java.io.PrintStream;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
+
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import static org.mockito.Mockito.mock;
 
 public class TestTableOutputFormat {
 
-  public class BeelineMock extends BeeLine {
-
-    private String lastPrintedLine;
-
-    @Override
-    final void output(final ColorBuffer msg, boolean newline, PrintStream out) {
-      lastPrintedLine = msg.getMono();
-      super.output(msg, newline, out);
-    }
-
-    private String getLastPrintedLine() {
-      return lastPrintedLine;
-    }
-  }
+  private static final String CYAN = "\033[1;36m";
+  private static final String GREEN = "\033[1;32m";
 
   private final String[][] mockRowData = {
     {"key1", "aaa"},
@@ -53,8 +51,14 @@ public class TestTableOutputFormat {
     {"key3", "ccccccccccccccccccccccccccc"},
     {"key4", "ddddddddddddddd"}
   };
+
   private BeelineMock mockBeeline;
+  private DatabaseConnection dbConnection;
+  private Connection mockSqlConnection;
+  private DatabaseMetaData mockDatabaseMetaData;
   private ResultSet mockResultSet;
+  private ResultSetMetaData mockResultSetMetaData;
+  private ResultSet mockMetadataResultSet;
   private TestBufferedRows.MockRow mockRow;
 
   /**
@@ -63,24 +67,190 @@ public class TestTableOutputFormat {
    */
   @Test
   public final void testPrint() throws SQLException {
+    String EXP_LAST_LINE = "+-------+------------------------------+";
+
     setupMockData();
     BufferedRows bfRows = new BufferedRows(mockBeeline, mockResultSet);
     TableOutputFormat instance = new TableOutputFormat(mockBeeline);
-    String expResult = "+-------+------------------------------+";
+
     instance.print(bfRows);
+
     String outPutResults = mockBeeline.getLastPrintedLine();
-    assertEquals(expResult, outPutResults);
+    assertEquals(EXP_LAST_LINE, outPutResults);
+  }
+
+  /**
+   * If the DatabaseConnection doesn't provide metadata, there is nothing to color
+   */
+  @Test
+  public void testColoringWithNoTableMetadata() throws SQLException {
+    setupMockData();
+    when(mockResultSetMetaData.getTableName(anyInt())).thenReturn(null);
+
+    BufferedRows bfRows = new BufferedRows(mockBeeline, mockResultSet);
+    TableOutputFormat instance = new TableOutputFormat(mockBeeline);
+
+    instance.print(bfRows);
+
+    List<String> allPrintedLines = mockBeeline.getAllPrintedLines();
+    assertColumnHasColor(allPrintedLines, 1, GREEN);
+    assertColumnHasColor(allPrintedLines, 2, GREEN);
+  }
+
+  /**
+   * The primary key has one column. It should be CYAN. The second column should be green
+   */
+  @Test
+  public void testSingleColumnPrimaryKey() throws SQLException {
+    setupMockData();
+    mockBeeline.getOpts().setColor(true);
+
+    BufferedRows bfRows = new BufferedRows(mockBeeline, mockResultSet);
+    TableOutputFormat instance = new TableOutputFormat(mockBeeline);
+
+    instance.print(bfRows);
+
+    List<String> allPrintedLines = mockBeeline.getAllPrintedLines();
+
+    // PK column is CYAN
+    assertColumnHasColor(allPrintedLines, 1, CYAN);
+    // non-PK column is green
+    assertColumnHasColor(allPrintedLines, 2, GREEN);
+  }
+
+  /**
+   * Default behavior: coloring is disabled
+   */
+  @Test
+  public void testMonoTableOutputFormat() throws SQLException {
+    setupMockData();
+    mockBeeline.getOpts().setColor(false);
+    BufferedRows bfRows = new BufferedRows(mockBeeline, mockResultSet);
+    TableOutputFormat instance = new TableOutputFormat(mockBeeline);
+
+    instance.print(bfRows);
+
+    List<String> allPrintedLines = mockBeeline.getAllPrintedLines();
+    for (String line : allPrintedLines) {
+      assertFalse(line.contains("\033["));
+    }
+  }
+
+  /**
+   * No primary key column - all columns should be green
+   */
+  @Test
+  public void testColoredWithoutPrimaryKey() throws SQLException {
+    setupMockData();
+    mockBeeline.getOpts().setColor(true);
+    when(mockMetadataResultSet.next()).thenReturn(false);
+
+    BufferedRows bfRows = new BufferedRows(mockBeeline, mockResultSet);
+    TableOutputFormat instance = new TableOutputFormat(mockBeeline);
+
+    instance.print(bfRows);
+
+    List<String> allPrintedLines = mockBeeline.getAllPrintedLines();
+
+    assertColumnHasColor(allPrintedLines, 1, GREEN);
+    assertColumnHasColor(allPrintedLines, 2, GREEN);
+  }
+
+  /**
+   * The output contains one single table. And both columns are part of the PK
+   */
+  @Test
+  public void testColoredWithPrimaryKeyHasMultipleColumns() throws SQLException {
+    setupMockData();
+    mockBeeline.getOpts().setColor(true);
+    when(mockMetadataResultSet.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+
+    BufferedRows bfRows = new BufferedRows(mockBeeline, mockResultSet);
+    TableOutputFormat instance = new TableOutputFormat(mockBeeline);
+
+    instance.print(bfRows);
+
+    List<String> allPrintedLines = mockBeeline.getAllPrintedLines();
+
+    // PK column are CYAN
+    assertColumnHasColor(allPrintedLines, 1, CYAN);
+    assertColumnHasColor(allPrintedLines, 2, CYAN);
+  }
+
+  /**
+   * The output contains two tables. Both columns are PKs
+   */
+  @Test
+  public void testColoredWithMultipleTablesWithPrimaryKeys() throws SQLException {
+    setupMockData();
+    mockBeeline.getOpts().setColor(true);
+
+    when(mockResultSetMetaData.getTableName(eq(1))).thenReturn("Table");
+    when(mockResultSetMetaData.getTableName(eq(2))).thenReturn("Table2");
+
+    DatabaseMetaData databaseMetaData2 = mock(DatabaseMetaData.class);
+    ResultSet resultSet2 = mock(ResultSet.class);
+    when(resultSet2.next()).thenReturn(true).thenReturn(false);
+    when(resultSet2.getString(eq("COLUMN_NAME"))).thenReturn("Value");
+    when(databaseMetaData2.getPrimaryKeys(anyString(), isNull(), eq("Table2"))).thenReturn(resultSet2);
+    when(databaseMetaData2.getConnection()).thenReturn(mockSqlConnection);
+    when(dbConnection.getDatabaseMetaData()).thenReturn(mockDatabaseMetaData, databaseMetaData2);
+
+    BufferedRows bfRows = new BufferedRows(mockBeeline, mockResultSet);
+    TableOutputFormat instance = new TableOutputFormat(mockBeeline);
+
+    instance.print(bfRows);
+
+    List<String> allPrintedLines = mockBeeline.getAllPrintedLines();
+
+    // PK column are CYAN
+    assertColumnHasColor(allPrintedLines, 1, CYAN);
+    assertColumnHasColor(allPrintedLines, 2, CYAN);
+  }
+
+  private boolean cellHasColor(List<String> table, int row, int col, String color) {
+    String rowText = table.get(row);
+    String split = rowText.split("\\|")[col];
+    return split.contains(color);
+  }
+
+  private void assertColumnHasColor(List<String> allPrintedLines, int col, String color) {
+    assertTrue(cellHasColor(allPrintedLines, 1, col, color));
+    assertTrue(cellHasColor(allPrintedLines, 3, col, color));
+    assertTrue(cellHasColor(allPrintedLines, 4, col, color));
+    assertTrue(cellHasColor(allPrintedLines, 5, col, color));
+    assertTrue(cellHasColor(allPrintedLines, 6, col, color));
   }
 
   private void setupMockData() throws SQLException {
     mockBeeline = new BeelineMock();
+    mockBeeline.getOpts().setColor(true);
     mockResultSet = mock(ResultSet.class);
 
-    ResultSetMetaData mockResultSetMetaData = mock(ResultSetMetaData.class);
+    mockSqlConnection = mock(Connection.class);
+    when(mockSqlConnection.getCatalog()).thenReturn("Catalog");
+
+    mockResultSetMetaData = mock(ResultSetMetaData.class);
     when(mockResultSetMetaData.getColumnCount()).thenReturn(2);
     when(mockResultSetMetaData.getColumnLabel(1)).thenReturn("Key");
     when(mockResultSetMetaData.getColumnLabel(2)).thenReturn("Value");
+    when(mockResultSetMetaData.getTableName(anyInt())).thenReturn("Table");
+    when(mockResultSetMetaData.getColumnName(eq(1))).thenReturn("Key");
+    when(mockResultSetMetaData.getColumnName(eq(2))).thenReturn("Value");
     when(mockResultSet.getMetaData()).thenReturn(mockResultSetMetaData);
+
+    mockMetadataResultSet = mock(ResultSet.class);
+    when(mockMetadataResultSet.next()).thenReturn(true).thenReturn(false);
+    when(mockMetadataResultSet.getString(eq("COLUMN_NAME"))).thenReturn("Key", "Value");
+
+    mockDatabaseMetaData = mock(DatabaseMetaData.class);
+    when(mockDatabaseMetaData.getPrimaryKeys(anyString(), isNull(), anyString())).thenReturn(mockMetadataResultSet);
+
+    dbConnection = mock(DatabaseConnection.class);
+    when(dbConnection.getDatabaseMetaData()).thenReturn(mockDatabaseMetaData);
+    when(mockDatabaseMetaData.getConnection()).thenReturn(mockSqlConnection);
+
+    mockBeeline.getDatabaseConnections().setConnection(dbConnection);
 
     mockRow = new TestBufferedRows.MockRow();
     // returns true as long as there is more data in mockResultData array
@@ -99,22 +269,16 @@ public class TestTableOutputFormat {
       }
     });
 
-    when(mockResultSet.getObject(anyInt())).thenAnswer(new Answer<String>() {
-      @Override
-      public String answer(final InvocationOnMock invocation) {
-        Object[] args = invocation.getArguments();
-        int index = ((Integer) args[0]);
-        return mockRow.getColumn(index);
-      }
+    when(mockResultSet.getObject(anyInt())).thenAnswer((Answer<String>) invocation -> {
+      Object[] args = invocation.getArguments();
+      int index = ((Integer) args[0]);
+      return mockRow.getColumn(index);
     });
 
-    when(mockResultSet.getString(anyInt())).thenAnswer(new Answer<String>() {
-      @Override
-      public String answer(final InvocationOnMock invocation) {
-        Object[] args = invocation.getArguments();
-        int index = ((Integer) args[0]);
-        return mockRow.getColumn(index);
-      }
+    when(mockResultSet.getString(anyInt())).thenAnswer((Answer<String>) invocation -> {
+      Object[] args = invocation.getArguments();
+      int index = ((Integer) args[0]);
+      return mockRow.getColumn(index);
     });
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
DatabaseMetaData.getPrimaryKeys can query the table metadata once for each column. It can cause significant slowness. 
Now we can query that info once, during the initialization of the Rows object.


### Why are the changes needed?
To fix the performance issue.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Added extra tests for TestTableOutputFormat
- Manual test on a test table
