### PR TITLE
HIVE-29122: Vectorization - Support IGNORE NULLS for FIRST_VALUE and …

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorDecimalLastValue.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorDecimalLastValue.java
@@ -67,7 +67,7 @@ public class VectorPTFEvaluatorDecimalLastValue extends VectorPTFEvaluatorBase {
         lastValue.set(decimalColVector.vector[0]);
         isGroupResultNull = false;
       } else {
-        isGroupResultNull = true;
+        isGroupResultNull = doesRespectNulls() || !lastValue.isSet();
       }
     } else if (decimalColVector.noNulls) {
       lastValue.set(decimalColVector.vector[size - 1]);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorDoubleLastValue.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorDoubleLastValue.java
@@ -64,7 +64,7 @@ public class VectorPTFEvaluatorDoubleLastValue extends VectorPTFEvaluatorBase {
         lastValue = doubleColVector.vector[0];
         isGroupResultNull = false;
       } else {
-        isGroupResultNull = true;
+        isGroupResultNull = doesRespectNulls() || lastValue == null;
       }
     } else if (doubleColVector.noNulls) {
       lastValue = doubleColVector.vector[size - 1];

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLongLastValue.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLongLastValue.java
@@ -65,7 +65,7 @@ public class VectorPTFEvaluatorLongLastValue extends VectorPTFEvaluatorBase {
         lastValue = longColVector.vector[0];
         isGroupResultNull = false;
       } else {
-        isGroupResultNull = true;
+        isGroupResultNull = doesRespectNulls() || lastValue == null;
       }
     } else if (longColVector.noNulls) {
       lastValue = longColVector.vector[size - 1];

--- a/ql/src/test/queries/clientpositive/vectorized_first_last_value_ignore_nulls_decimal.q
+++ b/ql/src/test/queries/clientpositive/vectorized_first_last_value_ignore_nulls_decimal.q
@@ -56,14 +56,14 @@ FROM window_decimal_test;
 -- Test FIRST_VALUE and LAST_VALUE for decimal column with PARTITION BY clause
 set hive.vectorized.execution.enabled=false;
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test;
 
 -- Test FIRST_VALUE and LAST_VALUE for decimal column without IGNORE NULLS
@@ -82,14 +82,14 @@ FROM window_decimal_test;
 -- Test FIRST_VALUE and LAST_VALUE for decimal column with PARTITION BY clause and without IGNORE NULLS
 set hive.vectorized.execution.enabled=false;
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test;
 
 
@@ -125,14 +125,14 @@ FROM window_decimal_test;
 -- Test FIRST_VALUE and LAST_VALUE for decimal column with PARTITION BY clause
 set hive.vectorized.execution.enabled=false;
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test;
 
 -- Test FIRST_VALUE and LAST_VALUE for decimal column without IGNORE NULLS
@@ -151,14 +151,14 @@ FROM window_decimal_test;
 -- Test FIRST_VALUE and LAST_VALUE for decimal column with PARTITION BY clause and without IGNORE NULLS
 set hive.vectorized.execution.enabled=false;
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test;
 
 
@@ -189,13 +189,13 @@ SELECT id, decimal_col,
 FROM window_decimal_test;
 
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test;
 
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test;
 
 SELECT id, decimal_col,
@@ -209,11 +209,11 @@ SELECT id, decimal_col,
 FROM window_decimal_test;
 
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test;
 
 SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test;

--- a/ql/src/test/queries/clientpositive/vectorized_first_last_value_ignore_nulls_double.q
+++ b/ql/src/test/queries/clientpositive/vectorized_first_last_value_ignore_nulls_double.q
@@ -56,14 +56,14 @@ FROM window_double_test;
 -- Test FIRST_VALUE and LAST_VALUE for double column with PARTITION BY clause
 set hive.vectorized.execution.enabled=false;
 SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test;
 
 -- Test FIRST_VALUE and LAST_VALUE for double column without IGNORE NULLS
@@ -82,14 +82,14 @@ FROM window_double_test;
 -- Test FIRST_VALUE and LAST_VALUE for double column with PARTITION BY clause and without IGNORE NULLS
 set hive.vectorized.execution.enabled=false;
 SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test;
 
 
@@ -125,14 +125,14 @@ FROM window_double_test;
 -- Test FIRST_VALUE and LAST_VALUE for double column with PARTITION BY clause
 set hive.vectorized.execution.enabled=false;
 SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test;
 
 -- Test FIRST_VALUE and LAST_VALUE for double column without IGNORE NULLS
@@ -151,14 +151,14 @@ FROM window_double_test;
 -- Test FIRST_VALUE and LAST_VALUE for double column with PARTITION BY clause and without IGNORE NULLS
 set hive.vectorized.execution.enabled=false;
 SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test;
 
 
@@ -189,13 +189,13 @@ SELECT id, double_col,
 FROM window_double_test;
 
 SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test;
 
 SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test;
 
 SELECT id, double_col,
@@ -209,11 +209,11 @@ SELECT id, double_col,
 FROM window_double_test;
 
 SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test;
 
 SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test;

--- a/ql/src/test/queries/clientpositive/vectorized_first_last_value_ignore_nulls_int.q
+++ b/ql/src/test/queries/clientpositive/vectorized_first_last_value_ignore_nulls_int.q
@@ -56,14 +56,14 @@ FROM window_int_test;
 -- Test FIRST_VALUE and LAST_VALUE for int column with PARTITION BY clause
 set hive.vectorized.execution.enabled=false;
 SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test;
 
 -- Test FIRST_VALUE and LAST_VALUE for int column without IGNORE NULLS
@@ -82,14 +82,14 @@ FROM window_int_test;
 -- Test FIRST_VALUE and LAST_VALUE for int column with PARTITION BY clause and without IGNORE NULLS
 set hive.vectorized.execution.enabled=false;
 SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test;
 
 
@@ -125,14 +125,14 @@ FROM window_int_test;
 -- Test FIRST_VALUE and LAST_VALUE for int column with PARTITION BY clause
 set hive.vectorized.execution.enabled=false;
 SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test;
 
 -- Test FIRST_VALUE and LAST_VALUE for int column without IGNORE NULLS
@@ -151,14 +151,14 @@ FROM window_int_test;
 -- Test FIRST_VALUE and LAST_VALUE for int column with PARTITION BY clause and without IGNORE NULLS
 set hive.vectorized.execution.enabled=false;
 SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test;
 
 set hive.vectorized.execution.enabled=true;
 SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test;
 
 --========================================================================================
@@ -188,13 +188,13 @@ SELECT id, int_col,
 FROM window_int_test;
 
 SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test;
 
 SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test;
 
 SELECT id, int_col,
@@ -208,11 +208,11 @@ SELECT id, int_col,
 FROM window_int_test;
 
 SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test;
 
 SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test;

--- a/ql/src/test/results/clientpositive/llap/vectorized_first_last_value_ignore_nulls_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_first_last_value_ignore_nulls_decimal.q.out
@@ -192,68 +192,68 @@ id	decimal_col	first_decimal	last_decimal
 NULL	NULL	200.00	800.00
 NULL	800.00	200.00	800.00
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 id	decimal_col	first_decimal	last_decimal
-3	NULL	300.75	300.50
-3	300.75	300.75	300.50
-3	300.50	300.75	300.50
-5	500.20	500.20	500.20
-5	NULL	500.20	500.20
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	200.00	200.00
 2	200.00	200.00	200.00
 2	NULL	200.00	200.00
-4	NULL	400.00	400.00
+2	NULL	200.00	200.00
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+3	NULL	300.50	300.75
 4	400.00	400.00	400.00
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+4	NULL	400.00	400.00
+5	500.20	500.20	500.20
+5	NULL	500.20	500.20
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
 NULL	800.00	800.00	800.00
 NULL	NULL	800.00	800.00
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 id	decimal_col	first_decimal	last_decimal
-3	NULL	300.75	300.50
-3	300.75	300.75	300.50
-3	300.50	300.75	300.50
-5	500.20	500.20	500.20
-5	NULL	500.20	500.20
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	200.00	200.00
 2	200.00	200.00	200.00
 2	NULL	200.00	200.00
-4	NULL	400.00	400.00
+2	NULL	200.00	200.00
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+3	NULL	300.50	300.75
 4	400.00	400.00	400.00
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+4	NULL	400.00	400.00
+5	500.20	500.20	500.20
+5	NULL	500.20	500.20
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
 NULL	800.00	800.00	800.00
 NULL	NULL	800.00	800.00
@@ -324,70 +324,70 @@ id	decimal_col	first_decimal	last_decimal
 NULL	NULL	NULL	800.00
 NULL	800.00	NULL	800.00
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 id	decimal_col	first_decimal	last_decimal
-3	NULL	NULL	300.50
-3	300.75	NULL	300.50
-3	300.50	NULL	300.50
-5	500.20	500.20	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	200.00	200.00	200.00
+2	NULL	200.00	NULL
+2	NULL	200.00	NULL
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+3	NULL	300.50	NULL
+4	400.00	400.00	400.00
+4	NULL	400.00	NULL
+5	500.20	500.20	500.20
 5	NULL	500.20	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	200.00	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	400.00
-4	400.00	NULL	400.00
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
-NULL	800.00	800.00	NULL
+NULL	800.00	800.00	800.00
 NULL	NULL	800.00	NULL
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 id	decimal_col	first_decimal	last_decimal
-3	NULL	NULL	300.50
-3	300.75	NULL	300.50
-3	300.50	NULL	300.50
-5	500.20	500.20	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	200.00	200.00	200.00
+2	NULL	200.00	NULL
+2	NULL	200.00	NULL
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+3	NULL	300.50	NULL
+4	400.00	400.00	400.00
+4	NULL	400.00	NULL
+5	500.20	500.20	500.20
 5	NULL	500.20	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	200.00	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	400.00
-4	400.00	NULL	400.00
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
-NULL	800.00	800.00	NULL
+NULL	800.00	800.00	800.00
 NULL	NULL	800.00	NULL
 PREHOOK: query: SELECT id, decimal_col,
   FIRST_VALUE(decimal_col) IGNORE NULLS OVER(ORDER BY id ASC NULLS FIRST) AS first_decimal,
@@ -522,15 +522,15 @@ NULL	800.00	800.00	800.00
 6	610.00	800.00	610.00
 7	NULL	800.00	610.00
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
@@ -539,31 +539,31 @@ id	decimal_col	first_decimal	last_decimal
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	800.00	800.00
-NULL	800.00	800.00	800.00
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	200.00	200.00	200.00
-2	NULL	200.00	200.00
-2	NULL	200.00	200.00
-3	NULL	300.75	300.50
-3	300.75	300.75	300.50
-3	300.50	300.75	300.50
+3	NULL	NULL	NULL
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+4	NULL	NULL	NULL
 4	400.00	400.00	400.00
-4	NULL	400.00	400.00
-5	NULL	500.20	500.20
+5	NULL	NULL	NULL
 5	500.20	500.20	500.20
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	800.00	800.00	800.00
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
@@ -572,21 +572,21 @@ id	decimal_col	first_decimal	last_decimal
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	800.00	800.00
-NULL	800.00	800.00	800.00
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	200.00	200.00	200.00
-2	NULL	200.00	200.00
-2	NULL	200.00	200.00
-3	NULL	300.75	300.50
-3	300.75	300.75	300.50
-3	300.50	300.75	300.50
+3	NULL	NULL	NULL
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+4	NULL	NULL	NULL
 4	400.00	400.00	400.00
-4	NULL	400.00	400.00
-5	NULL	500.20	500.20
+5	NULL	NULL	NULL
 5	500.20	500.20	500.20
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	800.00	800.00	800.00
 PREHOOK: query: SELECT id, decimal_col,
   FIRST_VALUE(decimal_col) OVER(ORDER BY id ASC NULLS FIRST) AS first_decimal,
   LAST_VALUE(decimal_col) OVER(ORDER BY id ASC NULLS FIRST) AS last_decimal
@@ -654,15 +654,15 @@ NULL	800.00	NULL	800.00
 6	610.00	NULL	610.00
 7	NULL	NULL	NULL
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
@@ -671,31 +671,31 @@ id	decimal_col	first_decimal	last_decimal
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	800.00
-NULL	800.00	NULL	800.00
-2	200.00	200.00	NULL
-2	NULL	200.00	NULL
-2	NULL	200.00	NULL
-3	NULL	NULL	300.50
-3	300.75	NULL	300.50
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	200.00	NULL	200.00
+3	NULL	NULL	NULL
 3	300.50	NULL	300.50
-4	400.00	400.00	NULL
-4	NULL	400.00	NULL
-5	NULL	NULL	500.20
+3	300.75	NULL	300.75
+4	NULL	NULL	NULL
+4	400.00	NULL	400.00
+5	NULL	NULL	NULL
 5	500.20	NULL	500.20
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	800.00	NULL	800.00
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
@@ -704,21 +704,21 @@ id	decimal_col	first_decimal	last_decimal
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	800.00
-NULL	800.00	NULL	800.00
-2	200.00	200.00	NULL
-2	NULL	200.00	NULL
-2	NULL	200.00	NULL
-3	NULL	NULL	300.50
-3	300.75	NULL	300.50
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	200.00	NULL	200.00
+3	NULL	NULL	NULL
 3	300.50	NULL	300.50
-4	400.00	400.00	NULL
-4	NULL	400.00	NULL
-5	NULL	NULL	500.20
+3	300.75	NULL	300.75
+4	NULL	NULL	NULL
+4	400.00	NULL	400.00
+5	NULL	NULL	NULL
 5	500.20	NULL	500.20
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	800.00	NULL	800.00
 PREHOOK: query: SELECT id, decimal_col,
   FIRST_VALUE(decimal_col) IGNORE NULLS OVER(ORDER BY id) AS first_decimal,
   LAST_VALUE(decimal_col) IGNORE NULLS OVER(ORDER BY id) AS last_decimal
@@ -852,48 +852,48 @@ NULL	800.00	800.00	800.00
 6	610.00	800.00	610.00
 7	NULL	800.00	610.00
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 id	decimal_col	first_decimal	last_decimal
-3	NULL	300.75	300.50
-3	300.75	300.75	300.50
-3	300.50	300.75	300.50
-5	500.20	500.20	500.20
-5	NULL	500.20	500.20
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	200.00	200.00
 2	200.00	200.00	200.00
 2	NULL	200.00	200.00
-4	NULL	400.00	400.00
+2	NULL	200.00	200.00
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+3	NULL	300.50	300.75
 4	400.00	400.00	400.00
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+4	NULL	400.00	400.00
+5	500.20	500.20	500.20
+5	NULL	500.20	500.20
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
 NULL	800.00	800.00	800.00
 NULL	NULL	800.00	800.00
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
@@ -902,21 +902,21 @@ id	decimal_col	first_decimal	last_decimal
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	800.00	800.00
-NULL	800.00	800.00	800.00
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	200.00	200.00	200.00
-2	NULL	200.00	200.00
-2	NULL	200.00	200.00
-3	NULL	300.75	300.50
-3	300.75	300.75	300.50
-3	300.50	300.75	300.50
+3	NULL	NULL	NULL
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+4	NULL	NULL	NULL
 4	400.00	400.00	400.00
-4	NULL	400.00	400.00
-5	NULL	500.20	500.20
+5	NULL	NULL	NULL
 5	500.20	500.20	500.20
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	800.00	800.00	800.00
 PREHOOK: query: SELECT id, decimal_col,
   FIRST_VALUE(decimal_col) OVER(ORDER BY id) AS first_decimal,
   LAST_VALUE(decimal_col) OVER(ORDER BY id) AS last_decimal
@@ -984,48 +984,48 @@ NULL	800.00	NULL	800.00
 6	610.00	NULL	610.00
 7	NULL	NULL	NULL
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id, decimal_col) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 id	decimal_col	first_decimal	last_decimal
-3	NULL	NULL	300.50
-3	300.75	NULL	300.50
-3	300.50	NULL	300.50
-5	500.20	500.20	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	200.00	200.00	200.00
+2	NULL	200.00	NULL
+2	NULL	200.00	NULL
+3	300.50	300.50	300.50
+3	300.75	300.50	300.75
+3	NULL	300.50	NULL
+4	400.00	400.00	400.00
+4	NULL	400.00	NULL
+5	500.20	500.20	500.20
 5	NULL	500.20	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	200.00	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	400.00
-4	400.00	NULL	400.00
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
-NULL	800.00	800.00	NULL
+NULL	800.00	800.00	800.00
 NULL	NULL	800.00	NULL
 PREHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_decimal_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, decimal_col,
-  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_decimal,
-  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_decimal
+  FIRST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS first_decimal,
+  LAST_VALUE(decimal_col) OVER(PARTITION BY id ORDER BY id ASC, decimal_col ASC NULLS FIRST) AS last_decimal
 FROM window_decimal_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_decimal_test
@@ -1034,18 +1034,18 @@ id	decimal_col	first_decimal	last_decimal
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	800.00
-NULL	800.00	NULL	800.00
-2	200.00	200.00	NULL
-2	NULL	200.00	NULL
-2	NULL	200.00	NULL
-3	NULL	NULL	300.50
-3	300.75	NULL	300.50
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	200.00	NULL	200.00
+3	NULL	NULL	NULL
 3	300.50	NULL	300.50
-4	400.00	400.00	NULL
-4	NULL	400.00	NULL
-5	NULL	NULL	500.20
+3	300.75	NULL	300.75
+4	NULL	NULL	NULL
+4	400.00	NULL	400.00
+5	NULL	NULL	NULL
 5	500.20	NULL	500.20
-6	610.00	610.00	600.00
-6	600.00	610.00	600.00
+6	600.00	600.00	600.00
+6	610.00	600.00	610.00
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	800.00	NULL	800.00

--- a/ql/src/test/results/clientpositive/llap/vectorized_first_last_value_ignore_nulls_double.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_first_last_value_ignore_nulls_double.q.out
@@ -192,68 +192,68 @@ id	double_col	first_double	last_double
 NULL	NULL	25.5	80.5
 NULL	80.5	25.5	80.5
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 id	double_col	first_double	last_double
-3	NULL	32.5	30.5
-3	32.5	32.5	30.5
-3	30.5	32.5	30.5
-5	50.5	50.5	50.5
-5	NULL	50.5	50.5
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	25.5	25.5
 2	25.5	25.5	25.5
 2	NULL	25.5	25.5
-4	NULL	42.3	42.3
+2	NULL	25.5	25.5
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+3	NULL	30.5	32.5
 4	42.3	42.3	42.3
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+4	NULL	42.3	42.3
+5	50.5	50.5	50.5
+5	NULL	50.5	50.5
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
 NULL	80.5	80.5	80.5
 NULL	NULL	80.5	80.5
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 id	double_col	first_double	last_double
-3	NULL	32.5	30.5
-3	32.5	32.5	30.5
-3	30.5	32.5	30.5
-5	50.5	50.5	50.5
-5	NULL	50.5	50.5
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	25.5	25.5
 2	25.5	25.5	25.5
 2	NULL	25.5	25.5
-4	NULL	42.3	42.3
+2	NULL	25.5	25.5
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+3	NULL	30.5	32.5
 4	42.3	42.3	42.3
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+4	NULL	42.3	42.3
+5	50.5	50.5	50.5
+5	NULL	50.5	50.5
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
 NULL	80.5	80.5	80.5
 NULL	NULL	80.5	80.5
@@ -324,70 +324,70 @@ id	double_col	first_double	last_double
 NULL	NULL	NULL	80.5
 NULL	80.5	NULL	80.5
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 id	double_col	first_double	last_double
-3	NULL	NULL	30.5
-3	32.5	NULL	30.5
-3	30.5	NULL	30.5
-5	50.5	50.5	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	25.5	25.5	25.5
+2	NULL	25.5	NULL
+2	NULL	25.5	NULL
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+3	NULL	30.5	NULL
+4	42.3	42.3	42.3
+4	NULL	42.3	NULL
+5	50.5	50.5	50.5
 5	NULL	50.5	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	25.5	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	42.3
-4	42.3	NULL	42.3
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
-NULL	80.5	80.5	NULL
+NULL	80.5	80.5	80.5
 NULL	NULL	80.5	NULL
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 id	double_col	first_double	last_double
-3	NULL	NULL	30.5
-3	32.5	NULL	30.5
-3	30.5	NULL	30.5
-5	50.5	50.5	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	25.5	25.5	25.5
+2	NULL	25.5	NULL
+2	NULL	25.5	NULL
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+3	NULL	30.5	NULL
+4	42.3	42.3	42.3
+4	NULL	42.3	NULL
+5	50.5	50.5	50.5
 5	NULL	50.5	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	25.5	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	42.3
-4	42.3	NULL	42.3
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
-NULL	80.5	80.5	NULL
+NULL	80.5	80.5	80.5
 NULL	NULL	80.5	NULL
 PREHOOK: query: SELECT id, double_col,
   FIRST_VALUE(double_col) IGNORE NULLS OVER(ORDER BY id ASC NULLS FIRST) AS first_double,
@@ -522,15 +522,15 @@ NULL	80.5	80.5	80.5
 6	65.5	80.5	65.5
 7	NULL	80.5	65.5
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
@@ -539,31 +539,31 @@ id	double_col	first_double	last_double
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	80.5	80.5
-NULL	80.5	80.5	80.5
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	25.5	25.5	25.5
-2	NULL	25.5	25.5
-2	NULL	25.5	25.5
-3	NULL	32.5	30.5
-3	32.5	32.5	30.5
-3	30.5	32.5	30.5
+3	NULL	NULL	NULL
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+4	NULL	NULL	NULL
 4	42.3	42.3	42.3
-4	NULL	42.3	42.3
-5	NULL	50.5	50.5
+5	NULL	NULL	NULL
 5	50.5	50.5	50.5
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80.5	80.5	80.5
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
@@ -572,21 +572,21 @@ id	double_col	first_double	last_double
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	80.5	80.5
-NULL	80.5	80.5	80.5
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	25.5	25.5	25.5
-2	NULL	25.5	25.5
-2	NULL	25.5	25.5
-3	NULL	32.5	30.5
-3	32.5	32.5	30.5
-3	30.5	32.5	30.5
+3	NULL	NULL	NULL
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+4	NULL	NULL	NULL
 4	42.3	42.3	42.3
-4	NULL	42.3	42.3
-5	NULL	50.5	50.5
+5	NULL	NULL	NULL
 5	50.5	50.5	50.5
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80.5	80.5	80.5
 PREHOOK: query: SELECT id, double_col,
   FIRST_VALUE(double_col) OVER(ORDER BY id ASC NULLS FIRST) AS first_double,
   LAST_VALUE(double_col) OVER(ORDER BY id ASC NULLS FIRST) AS last_double
@@ -654,15 +654,15 @@ NULL	80.5	NULL	80.5
 6	65.5	NULL	65.5
 7	NULL	NULL	NULL
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
@@ -671,31 +671,31 @@ id	double_col	first_double	last_double
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	80.5
-NULL	80.5	NULL	80.5
-2	25.5	25.5	NULL
-2	NULL	25.5	NULL
-2	NULL	25.5	NULL
-3	NULL	NULL	30.5
-3	32.5	NULL	30.5
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	25.5	NULL	25.5
+3	NULL	NULL	NULL
 3	30.5	NULL	30.5
-4	42.3	42.3	NULL
-4	NULL	42.3	NULL
-5	NULL	NULL	50.5
+3	32.5	NULL	32.5
+4	NULL	NULL	NULL
+4	42.3	NULL	42.3
+5	NULL	NULL	NULL
 5	50.5	NULL	50.5
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80.5	NULL	80.5
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
@@ -704,21 +704,21 @@ id	double_col	first_double	last_double
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	80.5
-NULL	80.5	NULL	80.5
-2	25.5	25.5	NULL
-2	NULL	25.5	NULL
-2	NULL	25.5	NULL
-3	NULL	NULL	30.5
-3	32.5	NULL	30.5
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	25.5	NULL	25.5
+3	NULL	NULL	NULL
 3	30.5	NULL	30.5
-4	42.3	42.3	NULL
-4	NULL	42.3	NULL
-5	NULL	NULL	50.5
+3	32.5	NULL	32.5
+4	NULL	NULL	NULL
+4	42.3	NULL	42.3
+5	NULL	NULL	NULL
 5	50.5	NULL	50.5
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80.5	NULL	80.5
 PREHOOK: query: SELECT id, double_col,
   FIRST_VALUE(double_col) IGNORE NULLS OVER(ORDER BY id) AS first_double,
   LAST_VALUE(double_col) IGNORE NULLS OVER(ORDER BY id) AS last_double
@@ -852,48 +852,48 @@ NULL	80.5	80.5	80.5
 6	65.5	80.5	65.5
 7	NULL	80.5	65.5
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 id	double_col	first_double	last_double
-3	NULL	32.5	30.5
-3	32.5	32.5	30.5
-3	30.5	32.5	30.5
-5	50.5	50.5	50.5
-5	NULL	50.5	50.5
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	25.5	25.5
 2	25.5	25.5	25.5
 2	NULL	25.5	25.5
-4	NULL	42.3	42.3
+2	NULL	25.5	25.5
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+3	NULL	30.5	32.5
 4	42.3	42.3	42.3
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+4	NULL	42.3	42.3
+5	50.5	50.5	50.5
+5	NULL	50.5	50.5
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
 NULL	80.5	80.5	80.5
 NULL	NULL	80.5	80.5
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
@@ -902,21 +902,21 @@ id	double_col	first_double	last_double
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	80.5	80.5
-NULL	80.5	80.5	80.5
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	25.5	25.5	25.5
-2	NULL	25.5	25.5
-2	NULL	25.5	25.5
-3	NULL	32.5	30.5
-3	32.5	32.5	30.5
-3	30.5	32.5	30.5
+3	NULL	NULL	NULL
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+4	NULL	NULL	NULL
 4	42.3	42.3	42.3
-4	NULL	42.3	42.3
-5	NULL	50.5	50.5
+5	NULL	NULL	NULL
 5	50.5	50.5	50.5
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80.5	80.5	80.5
 PREHOOK: query: SELECT id, double_col,
   FIRST_VALUE(double_col) OVER(ORDER BY id) AS first_double,
   LAST_VALUE(double_col) OVER(ORDER BY id) AS last_double
@@ -984,48 +984,48 @@ NULL	80.5	NULL	80.5
 6	65.5	NULL	65.5
 7	NULL	NULL	NULL
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id, double_col) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 id	double_col	first_double	last_double
-3	NULL	NULL	30.5
-3	32.5	NULL	30.5
-3	30.5	NULL	30.5
-5	50.5	50.5	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	25.5	25.5	25.5
+2	NULL	25.5	NULL
+2	NULL	25.5	NULL
+3	30.5	30.5	30.5
+3	32.5	30.5	32.5
+3	NULL	30.5	NULL
+4	42.3	42.3	42.3
+4	NULL	42.3	NULL
+5	50.5	50.5	50.5
 5	NULL	50.5	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	25.5	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	42.3
-4	42.3	NULL	42.3
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
-NULL	80.5	80.5	NULL
+NULL	80.5	80.5	80.5
 NULL	NULL	80.5	NULL
 PREHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_double_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, double_col,
-  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_double,
-  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_double
+  FIRST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS first_double,
+  LAST_VALUE(double_col) OVER(PARTITION BY id ORDER BY id ASC, double_col ASC NULLS FIRST) AS last_double
 FROM window_double_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_double_test
@@ -1034,18 +1034,18 @@ id	double_col	first_double	last_double
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	80.5
-NULL	80.5	NULL	80.5
-2	25.5	25.5	NULL
-2	NULL	25.5	NULL
-2	NULL	25.5	NULL
-3	NULL	NULL	30.5
-3	32.5	NULL	30.5
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	25.5	NULL	25.5
+3	NULL	NULL	NULL
 3	30.5	NULL	30.5
-4	42.3	42.3	NULL
-4	NULL	42.3	NULL
-5	NULL	NULL	50.5
+3	32.5	NULL	32.5
+4	NULL	NULL	NULL
+4	42.3	NULL	42.3
+5	NULL	NULL	NULL
 5	50.5	NULL	50.5
-6	65.5	65.5	65.2
-6	65.2	65.5	65.2
+6	65.2	65.2	65.2
+6	65.5	65.2	65.5
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80.5	NULL	80.5

--- a/ql/src/test/results/clientpositive/llap/vectorized_first_last_value_ignore_nulls_int.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_first_last_value_ignore_nulls_int.q.out
@@ -192,68 +192,68 @@ id	int_col	first_int	last_int
 NULL	NULL	20	80
 NULL	80	20	80
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 id	int_col	first_int	last_int
-3	NULL	30	32
-3	30	30	32
-3	32	30	32
-5	50	50	50
-5	NULL	50	50
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	20	20
 2	20	20	20
 2	NULL	20	20
-4	NULL	40	40
+2	NULL	20	20
+3	30	30	30
+3	32	30	32
+3	NULL	30	32
 4	40	40	40
-6	62	62	60
-6	60	62	60
+4	NULL	40	40
+5	50	50	50
+5	NULL	50	50
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
 NULL	80	80	80
 NULL	NULL	80	80
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 id	int_col	first_int	last_int
-3	NULL	30	32
-3	30	30	32
-3	32	30	32
-5	50	50	50
-5	NULL	50	50
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	20	20
 2	20	20	20
 2	NULL	20	20
-4	NULL	40	40
+2	NULL	20	20
+3	30	30	30
+3	32	30	32
+3	NULL	30	32
 4	40	40	40
-6	62	62	60
-6	60	62	60
+4	NULL	40	40
+5	50	50	50
+5	NULL	50	50
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
 NULL	80	80	80
 NULL	NULL	80	80
@@ -324,70 +324,70 @@ id	int_col	first_int	last_int
 NULL	NULL	NULL	80
 NULL	80	NULL	80
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 id	int_col	first_int	last_int
-3	NULL	NULL	32
-3	30	NULL	32
-3	32	NULL	32
-5	50	50	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	20	20	20
+2	NULL	20	NULL
+2	NULL	20	NULL
+3	30	30	30
+3	32	30	32
+3	NULL	30	NULL
+4	40	40	40
+4	NULL	40	NULL
+5	50	50	50
 5	NULL	50	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	20	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	40
-4	40	NULL	40
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
-NULL	80	80	NULL
+NULL	80	80	80
 NULL	NULL	80	NULL
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 id	int_col	first_int	last_int
-3	NULL	NULL	32
-3	30	NULL	32
-3	32	NULL	32
-5	50	50	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	20	20	20
+2	NULL	20	NULL
+2	NULL	20	NULL
+3	30	30	30
+3	32	30	32
+3	NULL	30	NULL
+4	40	40	40
+4	NULL	40	NULL
+5	50	50	50
 5	NULL	50	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	20	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	40
-4	40	NULL	40
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
-NULL	80	80	NULL
+NULL	80	80	80
 NULL	NULL	80	NULL
 PREHOOK: query: SELECT id, int_col,
   FIRST_VALUE(int_col) IGNORE NULLS OVER(ORDER BY id ASC NULLS FIRST) AS first_int,
@@ -522,15 +522,15 @@ NULL	80	80	80
 6	62	80	62
 7	NULL	80	62
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
@@ -539,31 +539,31 @@ id	int_col	first_int	last_int
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	80	80
-NULL	80	80	80
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	20	20	20
-2	NULL	20	20
-2	NULL	20	20
-3	NULL	30	32
-3	30	30	32
+3	NULL	NULL	NULL
+3	30	30	30
 3	32	30	32
+4	NULL	NULL	NULL
 4	40	40	40
-4	NULL	40	40
-5	NULL	50	50
+5	NULL	NULL	NULL
 5	50	50	50
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80	80	80
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
@@ -572,21 +572,21 @@ id	int_col	first_int	last_int
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	80	80
-NULL	80	80	80
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	20	20	20
-2	NULL	20	20
-2	NULL	20	20
-3	NULL	30	32
-3	30	30	32
+3	NULL	NULL	NULL
+3	30	30	30
 3	32	30	32
+4	NULL	NULL	NULL
 4	40	40	40
-4	NULL	40	40
-5	NULL	50	50
+5	NULL	NULL	NULL
 5	50	50	50
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80	80	80
 PREHOOK: query: SELECT id, int_col,
   FIRST_VALUE(int_col) OVER(ORDER BY id ASC NULLS FIRST) AS first_int,
   LAST_VALUE(int_col) OVER(ORDER BY id ASC NULLS FIRST) AS last_int
@@ -654,15 +654,15 @@ NULL	80	NULL	80
 6	62	NULL	62
 7	NULL	NULL	NULL
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
@@ -671,31 +671,31 @@ id	int_col	first_int	last_int
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	80
-NULL	80	NULL	80
-2	20	20	NULL
-2	NULL	20	NULL
-2	NULL	20	NULL
-3	NULL	NULL	32
-3	30	NULL	32
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	20	NULL	20
+3	NULL	NULL	NULL
+3	30	NULL	30
 3	32	NULL	32
-4	40	40	NULL
-4	NULL	40	NULL
-5	NULL	NULL	50
+4	NULL	NULL	NULL
+4	40	NULL	40
+5	NULL	NULL	NULL
 5	50	NULL	50
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80	NULL	80
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
@@ -704,21 +704,21 @@ id	int_col	first_int	last_int
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	80
-NULL	80	NULL	80
-2	20	20	NULL
-2	NULL	20	NULL
-2	NULL	20	NULL
-3	NULL	NULL	32
-3	30	NULL	32
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	20	NULL	20
+3	NULL	NULL	NULL
+3	30	NULL	30
 3	32	NULL	32
-4	40	40	NULL
-4	NULL	40	NULL
-5	NULL	NULL	50
+4	NULL	NULL	NULL
+4	40	NULL	40
+5	NULL	NULL	NULL
 5	50	NULL	50
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80	NULL	80
 PREHOOK: query: SELECT id, int_col,
   FIRST_VALUE(int_col) IGNORE NULLS OVER(ORDER BY id) AS first_int,
   LAST_VALUE(int_col) IGNORE NULLS OVER(ORDER BY id) AS last_int
@@ -852,48 +852,48 @@ NULL	80	80	80
 6	62	80	62
 7	NULL	80	62
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 id	int_col	first_int	last_int
-3	NULL	30	32
-3	30	30	32
-3	32	30	32
-5	50	50	50
-5	NULL	50	50
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-2	NULL	20	20
 2	20	20	20
 2	NULL	20	20
-4	NULL	40	40
+2	NULL	20	20
+3	30	30	30
+3	32	30	32
+3	NULL	30	32
 4	40	40	40
-6	62	62	60
-6	60	62	60
+4	NULL	40	40
+5	50	50	50
+5	NULL	50	50
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
 NULL	80	80	80
 NULL	NULL	80	80
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
@@ -902,21 +902,21 @@ id	int_col	first_int	last_int
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	80	80
-NULL	80	80	80
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
 2	20	20	20
-2	NULL	20	20
-2	NULL	20	20
-3	NULL	30	32
-3	30	30	32
+3	NULL	NULL	NULL
+3	30	30	30
 3	32	30	32
+4	NULL	NULL	NULL
 4	40	40	40
-4	NULL	40	40
-5	NULL	50	50
+5	NULL	NULL	NULL
 5	50	50	50
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80	80	80
 PREHOOK: query: SELECT id, int_col,
   FIRST_VALUE(int_col) OVER(ORDER BY id) AS first_int,
   LAST_VALUE(int_col) OVER(ORDER BY id) AS last_int
@@ -984,48 +984,48 @@ NULL	80	NULL	80
 6	62	NULL	62
 7	NULL	NULL	NULL
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 id	int_col	first_int	last_int
-3	NULL	NULL	32
-3	30	NULL	32
-3	32	NULL	32
-5	50	50	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+1	NULL	NULL	NULL
+2	20	20	20
+2	NULL	20	NULL
+2	NULL	20	NULL
+3	30	30	30
+3	32	30	32
+3	NULL	30	NULL
+4	40	40	40
+4	NULL	40	NULL
+5	50	50	50
 5	NULL	50	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-1	NULL	NULL	NULL
-2	NULL	NULL	NULL
-2	20	NULL	NULL
-2	NULL	NULL	NULL
-4	NULL	NULL	40
-4	40	NULL	40
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
-NULL	80	80	NULL
+NULL	80	80	80
 NULL	NULL	80	NULL
 PREHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 PREHOOK: type: QUERY
 PREHOOK: Input: default@window_int_test
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT id, int_col,
-  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS first_int,
-  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC NULLS FIRST) AS last_int
+  FIRST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS first_int,
+  LAST_VALUE(int_col) OVER(PARTITION BY id ORDER BY id ASC, int_col ASC NULLS FIRST) AS last_int
 FROM window_int_test
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@window_int_test
@@ -1034,18 +1034,18 @@ id	int_col	first_int	last_int
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
 1	NULL	NULL	NULL
-NULL	NULL	NULL	80
-NULL	80	NULL	80
-2	20	20	NULL
-2	NULL	20	NULL
-2	NULL	20	NULL
-3	NULL	NULL	32
-3	30	NULL	32
+2	NULL	NULL	NULL
+2	NULL	NULL	NULL
+2	20	NULL	20
+3	NULL	NULL	NULL
+3	30	NULL	30
 3	32	NULL	32
-4	40	40	NULL
-4	NULL	40	NULL
-5	NULL	NULL	50
+4	NULL	NULL	NULL
+4	40	NULL	40
+5	NULL	NULL	NULL
 5	50	NULL	50
-6	62	62	60
-6	60	62	60
+6	60	60	60
+6	62	60	62
 7	NULL	NULL	NULL
+NULL	NULL	NULL	NULL
+NULL	80	NULL	80


### PR DESCRIPTION
…LAST_VALUE [ADDENDUM]

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is an addendum to https://issues.apache.org/jira/browse/HIVE-29122 and PR https://github.com/apache/hive/pull/6009

This is needed to improve tests for partitioned queries. For example, 
```
SELECT id, int_col,
  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS first_int,
  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id) AS last_int
FROM window_int_test
```
was changed to 
```
SELECT id, int_col,
  FIRST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS first_int,
  LAST_VALUE(int_col IGNORE NULLS) OVER(PARTITION BY id ORDER BY id, int_col) AS last_int
FROM window_int_test
```
to deterministically sort the individual partitions. `PARTITION BY id ORDER BY id` doesn't guarantee an order as `id` has the same value for each partition. 

Also fixed a bug in LAST_VALUE for all three types.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See above

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
```
mvn test -pl itests/qtest -Pitests -Dtest=TestMiniLlapLocalCliDriver -Dtest.output.overwrite=true -Dqfile="vectorized_first_last_value_ignore_nulls_double.q,vectorized_first_last_value_ignore_nulls_int.q,vectorized_first_last_value_ignore_nulls_decimal.q"
```