### PR TITLE
HIVE-29146: Query with WITH clause fails during split generation when CTE materaliazation is enabled

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13719,7 +13719,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   public void validate() throws SemanticException {
     boolean wasAcidChecked = false;
     // Validate inputs and outputs have right protectmode to execute the query
-    for (ReadEntity readEntity : getInputs()) {
+    for (ReadEntity readEntity : getAllInputs()) {
       ReadEntity.Type type = readEntity.getType();
 
       if (type != ReadEntity.Type.TABLE &&
@@ -13744,7 +13744,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       }
     }
 
-    for (WriteEntity writeEntity : getOutputs()) {
+    for (WriteEntity writeEntity : getAllOutputs()) {
       WriteEntity.Type type = writeEntity.getType();
 
       if (type == WriteEntity.Type.PARTITION || type == WriteEntity.Type.DUMMYPARTITION) {

--- a/ql/src/test/queries/clientpositive/cte_mat_acid_1.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_acid_1.q
@@ -1,0 +1,16 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+set hive.optimize.cte.materialize.threshold=2;
+set hive.optimize.cte.materialize.full.aggregate.only=false;
+
+create table t1 (a int, b int) stored as orc TBLPROPERTIES ('transactional'='true');
+
+with cte as (
+  select a, count(*) as c1 from t1
+  group by a)
+select cte1.a, cte1.c1
+ from cte cte1,
+      cte cte2
+where cte1.a = cte2.a
+  and cte1.a > 10;

--- a/ql/src/test/results/clientpositive/llap/cte_mat_acid_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_acid_1.q.out
@@ -1,0 +1,36 @@
+PREHOOK: query: create table t1 (a int, b int) stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (a int, b int) stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: with cte as (
+  select a, count(*) as c1 from t1
+  group by a)
+select cte1.a, cte1.c1
+ from cte cte1,
+      cte cte2
+where cte1.a = cte2.a
+  and cte1.a > 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@cte
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cte
+#### A masked pattern was here ####
+POSTHOOK: query: with cte as (
+  select a, count(*) as c1 from t1
+  group by a)
+select cte1.a, cte1.c1
+ from cte cte1,
+      cte cte2
+where cte1.a = cte2.a
+  and cte1.a > 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@cte
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cte
+#### A masked pattern was here ####


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When validating Read and WriteEntities after semantic analysis Hive looks for transactional (ACID) tables and sets the `ValidWriteIdList` if any found. However only the main query's entities are checked.
This patch propose that all Read and WriteEntities should be checked by iterating through all the CTE's too.

### Why are the changes needed?
When 
* CTE materialization is enabled
* and the CTE is materialized
* and the CTE definition references at least one ACID table
* and the main query doesn't reference any ACID table
the `ValidWriteIdList` is not set hence exception is thrown when executing the CTE materialization plan


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=cte_mat_acid_1.q -pl itests/qtest -Pitests
```