### PR TITLE
HIVE-29148: Replace IcebergSplit#blockLocations with Iceberg's utility

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -22,25 +22,17 @@ package org.apache.iceberg.mr.mapreduce;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.BlockLocation;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.mr.InputFormatConfig;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.SerializationUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 // Since this class extends `mapreduce.InputSplit and implements `mapred.InputSplit`, it can be returned by both MR v1
 // and v2 file formats.
 public class IcebergSplit extends InputSplit implements IcebergSplitContainer {
-  private static final Logger LOG = LoggerFactory.getLogger(IcebergSplit.class);
 
   public static final String[] ANYWHERE = new String[]{"*"};
 
@@ -78,31 +70,12 @@ public class IcebergSplit extends InputSplit implements IcebergSplitContainer {
     // getLocations() won't be accurate when called on worker nodes and will always return "*"
     if (locations == null && conf != null) {
       boolean localityPreferred = conf.getBoolean(InputFormatConfig.LOCALITY, false);
-      locations = localityPreferred ? blockLocations(taskGroup, conf) : ANYWHERE;
+      locations = localityPreferred ? Util.blockLocations(taskGroup, conf) : ANYWHERE;
     } else {
       locations = ANYWHERE;
     }
 
     return locations;
-  }
-
-  // We should move to Util.blockLocations once the following PR is merged and shipped
-  // https://github.com/apache/iceberg/pull/11053
-  private static String[] blockLocations(ScanTaskGroup<FileScanTask> task, Configuration conf) {
-    final Set<String> locationSets = Sets.newHashSet();
-    task.tasks().forEach(fileScanTask -> {
-      final Path path = new Path(fileScanTask.file().path().toString());
-      try {
-        final FileSystem fs = path.getFileSystem(conf);
-        for (BlockLocation location : fs.getFileBlockLocations(path, fileScanTask.start(), fileScanTask.length())) {
-          locationSets.addAll(Arrays.asList(location.getHosts()));
-        }
-      } catch (IOException e) {
-        LOG.warn("Failed to get block locations for path {}", path, e);
-      }
-    });
-
-    return locationSets.toArray(new String[0]);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

We would replace the custom `blockLocations` with the one in apache/iceberg.

https://issues.apache.org/jira/browse/HIVE-29148

### Why are the changes needed?

For consistency and maintainability.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit and integration tests