### PR TITLE
HIVE-29102: Replace deprecated cwiki links and point to the Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,17 @@ Getting Started
 ===============
 
 - Installation Instructions and a quick tutorial:
-  https://cwiki.apache.org/confluence/display/Hive/GettingStarted
-  https://hive.apache.org/development/quickstart/
+  https://hive.apache.org/development/gettingstarted-latest
+  https://hive.apache.org/development/quickstart
 
 - Instructions to build Hive from source:
-  https://cwiki.apache.org/confluence/display/Hive/GettingStarted#GettingStarted-BuildingHivefromSource
+  https://hive.apache.org/development/gettingstarted-latest/#building-hive-from-source
 
 - A longer tutorial that covers more features of HiveQL:
-  https://cwiki.apache.org/confluence/display/Hive/Tutorial
+  https://hive.apache.org/docs/latest/user/tutorial
 
 - The HiveQL Language Manual:
-  https://cwiki.apache.org/confluence/display/Hive/LanguageManual
+  https://hive.apache.org/docs/latest/language/languagemanual
 
 
 Requirements

--- a/dev-support/hive-personality.sh
+++ b/dev-support/hive-personality.sh
@@ -28,7 +28,7 @@ function personality_globals
   #shellcheck disable=SC2034
   PATCH_BRANCH_DEFAULT=master
   #shellcheck disable=SC2034
-  PATCH_NAMING_RULE="http://cwiki.apache.org/confluence/display/Hive/HowToContribute"
+  PATCH_NAMING_RULE="https://hive.apache.org/community/resources/howtocontribute"
   #shellcheck disable=SC2034
   JIRA_ISSUE_RE='^HIVE-[0-9]+$'
   #shellcheck disable=SC2034

--- a/druid-handler/README.md
+++ b/druid-handler/README.md
@@ -18,4 +18,4 @@ limitations under the License.
 -->
 # Druid Storage Handler
 
-[Link for documentation]( https://cwiki.apache.org/confluence/display/Hive/Druid+Integration) 
+[Link for documentation](https://hive.apache.org/docs/latest/user/druid-integration)

--- a/hbase-handler/README.md
+++ b/hbase-handler/README.md
@@ -18,4 +18,4 @@ limitations under the License.
 -->
 # Hbase Storage Handler
 
-[Link for documentation]( https://cwiki.apache.org/confluence/display/Hive/HBaseIntegration)
+[Link for documentation](https://hive.apache.org/docs/latest/user/hbaseintegration)

--- a/hcatalog/README.txt
+++ b/hcatalog/README.txt
@@ -33,4 +33,4 @@ For the latest information about HCatalog, please visit our website at:
 
 and our wiki, at:
 
-   https://cwiki.apache.org/confluence/display/HCATALOG
+   https://hive.apache.org/docs/latest/hcatalog/hcatalog-base

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/data/schema/HCatFieldSchema.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/data/schema/HCatFieldSchema.java
@@ -264,7 +264,7 @@ similarly for mapKeyType/mapKeyTypeInfo */
   public HCatFieldSchema(String fieldName, Type type, Type mapKeyType, HCatSchema mapValueSchema, String comment) throws HCatException {
     assertTypeInCategory(type, Category.MAP, fieldName);
     //Hive only supports primitive map keys: 
-    //https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types#LanguageManualTypes-ComplexTypes
+    // https://hive.apache.org/docs/latest/language/languagemanual-types/#complex-types
     assertTypeInCategory(mapKeyType, Category.PRIMITIVE, fieldName);
     this.fieldName = fieldName;
     this.type = Type.MAP;

--- a/hcatalog/src/test/e2e/hcatalog/tests/hive_nightly.conf
+++ b/hcatalog/src/test/e2e/hcatalog/tests/hive_nightly.conf
@@ -1000,7 +1000,7 @@ $cfg = {
       # Need to test multiple insert  - Need harness enhancements
       # Need to test insert into directory - Need harness enhancements
       # Need to test casts
-      # Need to test all built in expressions and UDF (see https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF)
+      # Need to test all built in expressions and UDF (see https://hive.apache.org/docs/latest/language/languagemanual-udf)
       # Need to test xpath functionality
       # Need to test regular expression based projection
       # Need to test semi joins - Mysql doesn't support, how do I express semi-join?

--- a/hcatalog/src/test/e2e/templeton/README.txt
+++ b/hcatalog/src/test/e2e/templeton/README.txt
@@ -21,9 +21,9 @@ End to end tests in templeton runs tests against an existing templeton server.
 It runs hcat, mapreduce, streaming, hive and pig tests.
 This requires Hadoop cluster and Hive metastore running.
 
-It's a good idea to look at current versions of
-https://cwiki.apache.org/confluence/display/Hive/WebHCat+InstallWebHCat and 
-https://cwiki.apache.org/confluence/display/Hive/WebHCat+Configure
+It's a good idea to look at current versions of:
+https://hive.apache.org/docs/latest/webhcat/webhcat-installwebhcat
+https://hive.apache.org/docs/latest/webhcat/webhcat-configure
 
 See deployers/README.txt for help automating some of the steps in this document.
 
@@ -98,13 +98,13 @@ Tips:
 be obtained from Pig and the other two are obtained from your Hadoop distribution.
 For Hadoop 1.x you would need to upload hadoop-examples.jar twice to HDFS one as hclient.jar and other as hexamples.jar.
 For Hadoop 2.x you would need to upload hadoop-mapreduce-client-jobclient.jar to HDFS as hclient.jar and hadoop-mapreduce-examples.jar to HDFS as hexamples.jar. 
-Also see https://cwiki.apache.org/confluence/display/Hive/WebHCat+InstallWebHCat#WebHCatInstallWebHCat-HadoopDistributedCache
+Also see https://hive.apache.org/docs/latest/webhcat/webhcat-installwebhcat/#hadoop-distributed-cache
  for notes on additional JAR files to copy to HDFS.
 
 5. Make sure TEMPLETON_HOME environment variable is set
 
 6. hadoop/conf/core-site.xml should have items described in
-https://cwiki.apache.org/confluence/display/Hive/WebHCat+InstallWebHCat#WebHCatInstallWebHCat-Permissions
+https://hive.apache.org/docs/latest/webhcat/webhcat-installwebhcat/#permissions
 
 7. Currently Pig tar file available on http://pig.apache.org/ contains jar files compiled to work with Hadoop 1.x.
 To run WebHCat tests on Hadoop 2.x you need to build your own Pig tar for Hadoop 2. To do that download the 
@@ -173,7 +173,7 @@ and webhcat.proxyuser.hue.hosts defined, i.e. 'hue' should be allowed to imperso
 [Of course, 'hcat' proxyuser should be configured in core-site.xml for the command to succeed.]
 
 Furthermore, metastore side file based security should be enabled. 
-(See https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Authorization#LanguageManualAuthorization-MetastoreServerSecurity for more info) 
+(See https://hive.apache.org/docs/latest/language/languagemanual-authorization/#hive-authorization-options for more info) 
 
 To do this 3 properties in hive-site.xml should be configured:
 1) hive.security.metastore.authorization.manager set to 

--- a/hcatalog/src/test/e2e/templeton/deployers/config/hive/hive-site.xml
+++ b/hcatalog/src/test/e2e/templeton/deployers/config/hive/hive-site.xml
@@ -54,7 +54,7 @@
     <!--
     enable file based auth for Hive on metastore side, i.e. enforce metadata 
     security as if it were stored together with data
-    https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Authorization
+    https://hive.apache.org/docs/latest/language/languagemanual-authorization
     <property>
         <name>hive.metastore.execute.setugi</name>
         <value>true</value>

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/Server.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/Server.java
@@ -837,7 +837,7 @@ public class Server {
    * @param srcFile    name of hive script file to run, equivalent to "-f" from hive
    *                   command line
    * @param hiveArgs   additional command line argument passed to the hive command line.
-   *                   Please check https://cwiki.apache.org/Hive/languagemanual-cli.html
+   *                   Please check https://hive.apache.org/docs/latest/language/languagemanual-cli
    *                   for detailed explanation of command line arguments
    * @param otherFiles additional files to be shipped to the launcher, such as the jars
    *                   used in "add jar" statement in hive script

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/TeradataBinaryFileInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/TeradataBinaryFileInputFormat.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 
 /**
- * https://cwiki.apache.org/confluence/display/Hive/TeradataBinarySerde.
+ * https://hive.apache.org/docs/latest/user/teradatabinaryserde
  * FileInputFormat for Teradata binary files.
  *
  * In the Teradata Binary File, each record constructs as below:

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/TeradataBinaryFileOutputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/TeradataBinaryFileOutputFormat.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 import static java.lang.String.format;
 
 /**
- * https://cwiki.apache.org/confluence/display/Hive/TeradataBinarySerde.
+ * https://hive.apache.org/docs/latest/user/teradatabinaryserde
  * FileOutputFormat for Teradata binary files.
  *
  * In the Teradata Binary File, each record constructs as below:

--- a/ql/src/test/queries/clientpositive/char_udf1.q
+++ b/ql/src/test/queries/clientpositive/char_udf1.q
@@ -75,7 +75,7 @@ select
   ltrim(c2) = ltrim(c4)
 from char_udf_1 limit 1;
 
--- In hive wiki page https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF
+-- In hive wiki page https://hive.apache.org/docs/latest/language/languagemanual-udf
 -- we only allow A regexp B, not regexp (A,B).
 
 select

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -656,7 +656,7 @@ public final class ObjectInspectorUtils {
   }
 
   /**
-   * https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+   * https://hive.apache.org/docs/latest/language/languagemanual-ddl-bucketedtables
    * @param hashCode as produced by {@link #getBucketHashCode(Object[], ObjectInspector[])}
    */
   public static int getBucketNumber(int hashCode, int numberOfBuckets) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinarySerde.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinarySerde.java
@@ -77,7 +77,7 @@ import java.util.Properties;
 import static java.lang.String.format;
 
 /**
- * https://cwiki.apache.org/confluence/display/Hive/TeradataBinarySerde.
+ * https://hive.apache.org/docs/latest/user/teradatabinaryserde
  * TeradataBinarySerde handles the serialization and deserialization of Teradata Binary Record
  * passed from TeradataBinaryRecordReader.
  *


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace cwiki URL with hive website


### Why are the changes needed?
Check [HIVE-29102](https://issues.apache.org/jira/browse/HIVE-29102)


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?