### PR TITLE
HIVE-29130: Remove jline 2.x

### DIFF
--- a/accumulo-handler/pom.xml
+++ b/accumulo-handler/pom.xml
@@ -32,6 +32,10 @@
       <artifactId>accumulo-core</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils-core</artifactId>
         </exclusion>

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -329,6 +329,10 @@
           <groupId>tomcat</groupId>
           <artifactId>jasper-runtime</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -103,6 +103,10 @@
           <groupId>tomcat</groupId>
           <artifactId>jasper-compiler</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -103,10 +103,6 @@
           <groupId>tomcat</groupId>
           <artifactId>jasper-compiler</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>jline</groupId>
-          <artifactId>jline</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -113,6 +113,10 @@
           <groupId>tomcat</groupId>
           <artifactId>jasper-runtime</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -135,6 +135,10 @@
           <groupId>tomcat</groupId>
           <artifactId>jasper-runtime</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -318,6 +318,10 @@
           <groupId>tomcat</groupId>
           <artifactId>jasper-runtime</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/itests/qtest-accumulo/pom.xml
+++ b/itests/qtest-accumulo/pom.xml
@@ -436,6 +436,10 @@
               <groupId>commons-beanutils</groupId>
               <artifactId>commons-beanutils-core</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>jline</groupId>
+              <artifactId>jline</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
         <!-- Override the thrift dependency pulled in for metaserver -->

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -43,6 +43,10 @@
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils-core</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -416,6 +416,12 @@
       <groupId>org.apache.hive.hcatalog</groupId>
       <artifactId>hive-hcatalog-pig-adapter</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hive.hcatalog</groupId>

--- a/packaging/src/main/assembly/beeline.xml
+++ b/packaging/src/main/assembly/beeline.xml
@@ -48,8 +48,7 @@
                 <include>org.apache.hive:hive-service-rpc:jar</include>
                 <include>commons-cli:commons-cli:jar</include>
                 <include>commons-io:commons-io:jar</include>
-                <include>commons-logging:commons-logging:jar</include>
-                <include>jline:jline:jar</include>
+                <include>org.jline:jline:jar</include>
                 <include>org.apache.thrift:libthrift:jar</include>
                 <include>org.slf4j:slf4j-api:jar</include>
                 <include>net.sf.supercsv:super-csv:jar</include>

--- a/pom.xml
+++ b/pom.xml
@@ -1732,6 +1732,13 @@
                   <searchTransitive>true</searchTransitive>
                   <message>Banned log4j:log4j dependency/transitive dependency was found!</message>
                 </bannedDependencies>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>jline:jline</exclude>
+                  </excludes>
+                  <searchTransitive>true</searchTransitive>
+                  <message>A banned jline2.x dependency/transitive dependency was found!</message>
+                </bannedDependencies>
               </rules>
               <fail>true</fail>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1736,6 +1736,9 @@
                   <excludes>
                     <exclude>jline:jline</exclude>
                   </excludes>
+                  <includes>
+                    <include>jline:jline:1.0</include>
+                  </includes>
                   <searchTransitive>true</searchTransitive>
                   <message>A banned jline2.x dependency/transitive dependency was found!</message>
                 </bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1736,6 +1736,12 @@
                   <excludes>
                     <exclude>jline:jline</exclude>
                   </excludes>
+                  <!--
+                    Allowing jline 1.0 because pig 0.16.0 depends upon it. Otherwise
+                    causing UT failure in hcatalog/hcatalog-pig-adapter module. The
+                    below includes tag can be removed once pig moves to jline 3.x or
+                    support for pig is dropped from hive.
+                  -->
                   <includes>
                     <include>jline:jline:1.0</include>
                   </includes>

--- a/standalone-metastore/metastore-common/pom.xml
+++ b/standalone-metastore/metastore-common/pom.xml
@@ -253,10 +253,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
       <version>${zookeeper.version}</version>
@@ -564,29 +560,6 @@
         </executions>
       </plugin>
       <!-- TODO MS-SPLIT javadoc plugin -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-banned-dependencies</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <excludes>
-                    <!--LGPL licenced library-->
-                    <exclude>com.google.code.findbugs:annotations</exclude>
-                  </excludes>
-                </bannedDependencies>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -307,10 +307,6 @@
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
     </dependency>
@@ -656,29 +652,6 @@
         </executions>
       </plugin>
       <!-- TODO MS-SPLIT javadoc plugin -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-banned-dependencies</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <excludes>
-                    <!--LGPL licenced library-->
-                    <exclude>com.google.code.findbugs:annotations</exclude>
-                  </excludes>
-                </bannedDependencies>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -66,7 +66,6 @@
     <antlr.version>4.9.3</antlr.version>
     <apache-directory-server.version>2.0.0-M24</apache-directory-server.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
-    <commons-logging.version>1.1.3</commons-logging.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <datasketches.version>2.0.0</datasketches.version>
     <datanucleus-api-jdo.version>6.0.3</datanucleus-api-jdo.version>
@@ -353,11 +352,6 @@
         <version>${jline.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.cronutils</groupId>
         <artifactId>cron-utils</artifactId>
         <version>${cron-utils.version}</version>
@@ -582,6 +576,53 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven.checkstyle.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>enforce-banned-dependencies</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <bannedDependencies>
+                    <excludes>
+                      <!--LGPL licenced library-->
+                      <exclude>com.google.code.findbugs:annotations</exclude>
+                    </excludes>
+                    <message>A banned license dependency was found!</message>
+                  </bannedDependencies>
+                  <bannedDependencies>
+                    <excludes>
+                      <!-- Move to SLF4J -->
+                      <exclude>commons-logging:commons-logging</exclude>
+                      <exclude>ch.qos.reload4j:reload4j</exclude>
+                    </excludes>
+                    <searchTransitive>false</searchTransitive>
+                    <message>A banned logging dependency was found!</message>
+                  </bannedDependencies>
+                  <bannedDependencies>
+                    <excludes>
+                      <exclude>log4j:log4j</exclude>
+                    </excludes>
+                    <searchTransitive>true</searchTransitive>
+                    <message>Banned log4j:log4j dependency/transitive dependency was found!</message>
+                  </bannedDependencies>
+                  <bannedDependencies>
+                    <excludes>
+                      <exclude>jline:jline</exclude>
+                    </excludes>
+                    <searchTransitive>true</searchTransitive>
+                    <message>A banned jline2.x dependency/transitive dependency was found!</message>
+                  </bannedDependencies>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -28,7 +28,6 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <commons-logging.version>1.1.3</commons-logging.version>
     <guava.version>22.0</guava.version>
     <hadoop.version>3.4.1</hadoop.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Although Hive has moved to Jline3, 2.x was also getting shipped in packaging.


### Why are the changes needed?
To have single Jline jar. Check [HIVE-29130](https://issues.apache.org/jira/browse/HIVE-29130) for more details


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
On local setup 
