### PR TITLE
AntiJoin rule fails to apply with an extra constant in the SELECT clause

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveCalciteUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveCalciteUtil.java
@@ -1249,7 +1249,7 @@ public class HiveCalciteUtil {
 
     for (RexNode node : expressions) {
       ImmutableBitSet inputBits = RelOptUtil.InputFinder.bits(node);
-      if (rightBitmap.contains(inputBits)) {
+      if (!inputBits.isEmpty() && rightBitmap.contains(inputBits)) {
         return true;
       }
     }

--- a/ql/src/test/queries/clientpositive/antijoin.q
+++ b/ql/src/test/queries/clientpositive/antijoin.q
@@ -25,6 +25,9 @@ explain select a.key, a.value from t1_n55 a left join t2_n33 b on a.key=b.key wh
 explain cbo select a.key, a.value from t1_n55 a left join t2_n33 b on a.key=b.key where b.key is null;
 select a.key, a.value from t1_n55 a left join t2_n33 b on a.key=b.key where b.key is null;
 
+explain cbo select a.key, a.value, 123 from t1_n55 a left join t2_n33 b on a.key=b.key where b.key is null;
+select a.key, a.value, 123 from t1_n55 a left join t2_n33 b on a.key=b.key where b.key is null;
+
 explain select a.key, a.value from t1_n55 a left join t2_n33 b on a.key=b.key join t3_n12 c on a.key=c.key where b.key is null  sort by a.key, a.value;
 explain cbo select a.key, a.value from t1_n55 a left join t2_n33 b on a.key=b.key join t3_n12 c on a.key=c.key where b.key is null  sort by a.key, a.value;
 select a.key, a.value from t1_n55 a left join t2_n33 b on a.key=b.key join t3_n12 c on a.key=c.key where b.key is null  sort by a.key, a.value;

--- a/ql/src/test/results/clientpositive/llap/antijoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/antijoin.q.out
@@ -369,6 +369,40 @@ POSTHOOK: Input: default@t2_n33
 5	val_5
 5	val_5
 9	val_9
+PREHOOK: query: explain cbo select a.key, a.value, 123 from t1_n55 a left join t2_n33 b on a.key=b.key where b.key is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1_n55
+PREHOOK: Input: default@t2_n33
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo select a.key, a.value, 123 from t1_n55 a left join t2_n33 b on a.key=b.key where b.key is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1_n55
+POSTHOOK: Input: default@t2_n33
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(key=[$0], value=[$1], _o__c2=[123])
+  HiveAntiJoin(condition=[=($0, $2)], joinType=[anti])
+    HiveProject(key=[$0], value=[$1])
+      HiveTableScan(table=[[default, t1_n55]], table:alias=[a])
+    HiveProject(key=[$0])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveTableScan(table=[[default, t2_n33]], table:alias=[b])
+
+PREHOOK: query: select a.key, a.value, 123 from t1_n55 a left join t2_n33 b on a.key=b.key where b.key is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1_n55
+PREHOOK: Input: default@t2_n33
+#### A masked pattern was here ####
+POSTHOOK: query: select a.key, a.value, 123 from t1_n55 a left join t2_n33 b on a.key=b.key where b.key is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1_n55
+POSTHOOK: Input: default@t2_n33
+#### A masked pattern was here ####
+2	val_2	123
+5	val_5	123
+5	val_5	123
+5	val_5	123
+9	val_9	123
 PREHOOK: query: explain select a.key, a.value from t1_n55 a left join t2_n33 b on a.key=b.key join t3_n12 c on a.key=c.key where b.key is null  sort by a.key, a.value
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1_n55


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix a bug in HiveCalciteUtil#hasAnyExpressionFromRightSide.

### Why are the changes needed?
Adding constants to the SELECT clause should not prevent the Antijoin rule from doing its job

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Extended antijoin.q: added a check for the query result and the CBO explanation
