### PR TITLE
Set hive.security.authorization.enabled to true by default

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3611,7 +3611,7 @@ public class HiveConf extends Configuration {
     SEMANTIC_ANALYZER_HOOK("hive.semantic.analyzer.hook", "", ""),
     HIVE_TEST_AUTHORIZATION_SQLSTD_HS2_MODE(
         "hive.test.authz.sstd.hs2.mode", false, "test hs2 mode from .q tests", true),
-    HIVE_AUTHORIZATION_ENABLED("hive.security.authorization.enabled", false,
+    HIVE_AUTHORIZATION_ENABLED("hive.security.authorization.enabled", true,
         "enable or disable the Hive client authorization"),
     HIVE_AUTHORIZATION_KERBEROS_USE_SHORTNAME("hive.security.authorization.kerberos.use.shortname", true,
         "use short name in Kerberos cluster"),


### PR DESCRIPTION
### Why are the changes needed?
In most real deployments the authorization is always enabled so it makes sense to set the default value to true. Changing the default is important for testing purposes since our testing should be focused on the most common deployment scenarios rather than the exceptions.

### Does this PR introduce _any_ user-facing change?
Yes/TBA

### How was this patch tested?
Existing tests