### PR TITLE
HIVE-29180: SonarQube reports issues unrelated to changes in the pull request

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,9 +119,11 @@ def sonarAnalysis(args) {
       -Dsonar.host.url=https://sonarcloud.io \
       """+args+" -DskipTests -Dit.skipTests -Dmaven.javadoc.skip"
 
+      // Sonar scanner runs in a separate JVM so JAVA_OPTS (notably heap size)
+      // must be passed via the appropriate environment variable
       sh """#!/bin/bash -e
       sw java 21 && . /etc/profile.d/java.sh
-      export MAVEN_OPTS=-Xmx5G
+      export SONAR_SCANNER_JAVA_OPTS=-Xmx8g
       """+mvnCmd
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set/Increase heapsize to 8GB for SonarScanner agent that runs in separate JVM

### Why are the changes needed?
The reason is that the base branch (master) did not have a valid scan for over a month since the SonarScanner was consistently failing with OutOfMemoryError.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested the change using the "Replay" functionality on a previously failed job on master. Sonar step finished successfully in 21 minutes after setting the heap size to 8GB: https://ci.hive.apache.org/job/hive-precommit/job/master/2662/