### PR TITLE
HIVE-28551 Stale results when executing queries over recreated transactional tables

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -15186,7 +15186,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     String queryString = getQueryStringForCache(astNode);
     if (queryString != null) {
       ValidTxnWriteIdList writeIdList = getQueryValidTxnWriteIdList();
-      lookupInfo = new QueryResultsCache.LookupInfo(queryString, () -> writeIdList);
+      Set<Long> involvedTables = tablesFromReadEntities(inputs).stream()
+          .map(Table::getTTable)
+          .map(org.apache.hadoop.hive.metastore.api.Table::getId)
+          .collect(Collectors.toSet());
+      lookupInfo = new QueryResultsCache.LookupInfo(queryString, () -> writeIdList, involvedTables);
     }
     return lookupInfo;
   }

--- a/ql/src/test/queries/clientpositive/results_cache_invalidation3.q
+++ b/ql/src/test/queries/clientpositive/results_cache_invalidation3.q
@@ -1,0 +1,16 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+set hive.query.results.cache.enabled=true;
+set hive.query.results.cache.nontransactional.tables.enabled=false;
+set hive.fetch.task.conversion=none;
+
+CREATE TABLE author (fname STRING) STORED AS ORC TBLPROPERTIES('transactional'='true');
+INSERT INTO author VALUES ('Victor');
+SELECT fname FROM author;
+
+DROP TABLE author;
+
+CREATE TABLE author (fname STRING) STORED AS ORC TBLPROPERTIES('transactional'='true');
+INSERT INTO author VALUES ('Alexander');
+SELECT fname FROM author;

--- a/ql/src/test/queries/clientpositive/results_cache_invalidation4.q
+++ b/ql/src/test/queries/clientpositive/results_cache_invalidation4.q
@@ -1,0 +1,16 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+set hive.query.results.cache.enabled=true;
+set hive.query.results.cache.nontransactional.tables.enabled=true;
+set hive.fetch.task.conversion=none;
+
+CREATE TABLE author (fname STRING) STORED AS ORC;
+INSERT INTO author VALUES ('Victor');
+SELECT fname FROM author;
+
+DROP TABLE author;
+
+CREATE TABLE author (fname STRING) STORED AS ORC;
+INSERT INTO author VALUES ('Alexander');
+SELECT fname FROM author;

--- a/ql/src/test/results/clientpositive/llap/results_cache_invalidation3.q.out
+++ b/ql/src/test/results/clientpositive/llap/results_cache_invalidation3.q.out
@@ -1,0 +1,62 @@
+PREHOOK: query: CREATE TABLE author (fname STRING) STORED AS ORC TBLPROPERTIES('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@author
+POSTHOOK: query: CREATE TABLE author (fname STRING) STORED AS ORC TBLPROPERTIES('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@author
+PREHOOK: query: INSERT INTO author VALUES ('Victor')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@author
+POSTHOOK: query: INSERT INTO author VALUES ('Victor')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@author
+POSTHOOK: Lineage: author.fname SCRIPT []
+PREHOOK: query: SELECT fname FROM author
+PREHOOK: type: QUERY
+PREHOOK: Input: default@author
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT fname FROM author
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@author
+#### A masked pattern was here ####
+Victor
+PREHOOK: query: DROP TABLE author
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@author
+PREHOOK: Output: database:default
+PREHOOK: Output: default@author
+POSTHOOK: query: DROP TABLE author
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@author
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@author
+PREHOOK: query: CREATE TABLE author (fname STRING) STORED AS ORC TBLPROPERTIES('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@author
+POSTHOOK: query: CREATE TABLE author (fname STRING) STORED AS ORC TBLPROPERTIES('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@author
+PREHOOK: query: INSERT INTO author VALUES ('Alexander')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@author
+POSTHOOK: query: INSERT INTO author VALUES ('Alexander')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@author
+POSTHOOK: Lineage: author.fname SCRIPT []
+PREHOOK: query: SELECT fname FROM author
+PREHOOK: type: QUERY
+PREHOOK: Input: default@author
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT fname FROM author
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@author
+#### A masked pattern was here ####
+Alexander

--- a/ql/src/test/results/clientpositive/llap/results_cache_invalidation4.q.out
+++ b/ql/src/test/results/clientpositive/llap/results_cache_invalidation4.q.out
@@ -1,0 +1,62 @@
+PREHOOK: query: CREATE TABLE author (fname STRING) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@author
+POSTHOOK: query: CREATE TABLE author (fname STRING) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@author
+PREHOOK: query: INSERT INTO author VALUES ('Victor')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@author
+POSTHOOK: query: INSERT INTO author VALUES ('Victor')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@author
+POSTHOOK: Lineage: author.fname SCRIPT []
+PREHOOK: query: SELECT fname FROM author
+PREHOOK: type: QUERY
+PREHOOK: Input: default@author
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT fname FROM author
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@author
+#### A masked pattern was here ####
+Victor
+PREHOOK: query: DROP TABLE author
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@author
+PREHOOK: Output: database:default
+PREHOOK: Output: default@author
+POSTHOOK: query: DROP TABLE author
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@author
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@author
+PREHOOK: query: CREATE TABLE author (fname STRING) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@author
+POSTHOOK: query: CREATE TABLE author (fname STRING) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@author
+PREHOOK: query: INSERT INTO author VALUES ('Alexander')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@author
+POSTHOOK: query: INSERT INTO author VALUES ('Alexander')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@author
+POSTHOOK: Lineage: author.fname SCRIPT []
+PREHOOK: query: SELECT fname FROM author
+PREHOOK: type: QUERY
+PREHOOK: Input: default@author
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT fname FROM author
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@author
+#### A masked pattern was here ####
+Alexander


### PR DESCRIPTION
### What changes were proposed in this pull request?
A query result cache entry may only match if the table ids are the same for all tables used by the query.
This PR continues the work of an old PR: https://github.com/apache/hive/pull/5482.

### Why are the changes needed?
Otherwise we get unexpected results, see [HIVE-28551](https://issues.apache.org/jira/browse/HIVE-28551).

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
qfile tests
