### PR TITLE
HIVE-29201: Disable flaky query_iceberg_metadata_of_unpartitioned_table.q

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/query_iceberg_metadata_of_unpartitioned_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/query_iceberg_metadata_of_unpartitioned_table.q
@@ -1,3 +1,4 @@
+--! qt:disabled:HIVE-29201
 -- SORT_QUERY_RESULTS
 -- Mask the file size values as it can have slight variability, causing test flakiness
 --! qt:replace:/("file_size_in_bytes":)\d+/$1#Masked#/


### PR DESCRIPTION
### Why are the changes needed?
Flakiness

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
 mvn test -Dtest=TestIcebergCliDriver -Dqfile=query_iceberg_metadata_of_unpartitioned_table.q
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hive.cli.TestIcebergCliDriver
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 57.24 s -- in org.apache.hadoop.hive.cli.TestIcebergCliDriver
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
```

