### PR TITLE
HIVE-29225: Premature deletion of scratch directories during output streaming

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3822,6 +3822,11 @@ public class HiveConf extends Configuration {
         "To cleanup the Hive scratchdir when starting the Hive Server"),
     HIVE_SCRATCH_DIR_LOCK("hive.scratchdir.lock", false,
         "To hold a lock file in scratchdir to prevent to be removed by cleardanglingscratchdir"),
+    HIVE_SCRATCH_DIR_CLEANUP_GRACE_PERIOD("hive.scratchdir.cleanup.grace.period.hours","0h",
+        new TimeValidator(TimeUnit.HOURS),
+        "Prevents cleanup of scratch directories that have been modified within the specified time window. " +
+        "Useful for avoiding premature deletion while queries are still returning results." +
+        "Not enabled by default."),
     HIVE_INSERT_INTO_MULTILEVEL_DIRS("hive.insert.into.multilevel.dirs", false,
         "Where to insert into multilevel directories like\n" +
         "\"insert directory '/HIVEFT25686/china/' from table\""),


### PR DESCRIPTION
**ROOT-CAUSE:**
Please see https://issues.apache.org/jira/browse/HIVE-29225 for the detailed problem description and steps to reproduce. In short, scratch directories may be deleted prematurely while Hive is still streaming output to the client.

**SOLUTION:**
A new configuration property has been introduced:
```
hive.scratchdir.cleanup.grace.period.hours
```
This property defines a grace period to prevent cleanup of scratch directories that have been modified within the specified time window.

- Default value is `0h` (disabled by default).
- When Hive finishes output streaming, it updates the scratch directory’s last modified time.
- The cleanup logic now checks this timestamp and skips deletion if the directory was updated within the grace period.

This ensures directories are not removed prematurely while still in use.

**TESTING:**
Added a dedicated unit test to validate the new functionality:
<img width="1442" height="851" alt="the-test" src="https://github.com/user-attachments/assets/a73b7bc9-aa74-49be-ba4a-6d37b7d27e04" />

Verified that all existing tests in `TestClearDanglingScratchDir` continue to pass:
<img width="1309" height="421" alt="scratch-dir-tests" src="https://github.com/user-attachments/assets/a114c263-85c0-414a-bbb9-a94f9132d0cf" />
