### PR TITLE
HIVE-29210: Minor compaction produces duplicates conditionally in cas…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1165,11 +1165,7 @@ public class AcidUtils {
         }
       }
       else if (visibilityTxnId != parsedDelta.visibilityTxnId) {
-        if (visibilityTxnId < parsedDelta.visibilityTxnId) {
-          return 1;
-        } else {
-          return -1;
-        }
+        return visibilityTxnId < parsedDelta.visibilityTxnId ? 1 : -1;
       }
       else {
         return path.compareTo(parsedDelta.path);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1133,6 +1133,7 @@ public class AcidUtils {
      * overlapping writeId boundaries.  The sort order helps figure out the "best" set of files
      * to use to get data.
      * This sorts "wider" delta before "narrower" i.e. delta_5_20 sorts before delta_5_10 (and delta_11_20)
+     * In case of same min writeID, max writeID & statement ID, it sorts in the descending order of visibilityTxnID
      */
     @Override
     public int compareTo(ParsedDeltaLight parsedDelta) {
@@ -1161,6 +1162,13 @@ public class AcidUtils {
         }
         else {
           return 1;
+        }
+      }
+      else if (visibilityTxnId != parsedDelta.visibilityTxnId) {
+        if (visibilityTxnId < parsedDelta.visibilityTxnId) {
+          return 1;
+        } else {
+          return -1;
         }
       }
       else {
@@ -1452,7 +1460,8 @@ public class AcidUtils {
       }
       else if (prev != null && next.maxWriteId == prev.maxWriteId
                   && next.minWriteId == prev.minWriteId
-                  && next.statementId == prev.statementId) {
+                  && next.statementId == prev.statementId
+                  && (next.isDeleteDelta || prev.isDeleteDelta)) {
         // The 'next' parsedDelta may have everything equal to the 'prev' parsedDelta, except
         // the path. This may happen when we have split update and we have two types of delta
         // directories- 'delta_x_y' and 'delete_delta_x_y' for the SAME txn range.


### PR DESCRIPTION
…e of HMS instance running initiator crash

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Compactor cleaner fix to address duplicate directories created from multiple jobs running same compaction


### Why are the changes needed?
To address the race condition where multiple jobs running same compaction leads to duplicate data


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual Testing after reproducing the issue on a deployed cluster 
