### PR TITLE
HIVE-29212: Restrict function creation using blacklisted UDFs

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
@@ -142,6 +142,22 @@ public final class FunctionUtils {
   }
 
   /**
+   * Retrieves the display name of a UDF (User Defined Function) from its class
+   * by inspecting the `@Description` annotation.
+   *
+   * @param udfClass The class of the UDF to inspect.
+   * @return The name of the UDF as specified in the `name` field of the `@Description` annotation,
+   *         or `null` if the annotation is not present.
+   */
+  public static String getFuncNameFromClass(Class<?> udfClass) {
+    if (udfClass.isAnnotationPresent(Description.class)) {
+      Description description = udfClass.getAnnotation(Description.class);
+      return description.name();
+    }
+    return null;
+  }
+
+  /**
    * Function type, for permanent functions.
    * Currently just JAVA, though we could support Groovy later on.
    */


### PR DESCRIPTION

### What changes were proposed in this pull request?
1. Restricting temporary or permanent function creation with Blacklisted UDFs
2. Changing Default blacklisted UDFs to include reflect, in_file, java_method functions


### Why are the changes needed?
These functions using blacklisted udfs can be exploited; a security hole


### Does this PR introduce _any_ user-facing change?
Yes, the User will see Semantic Exception and function creation will fail using blacklisted UDF class 

### How was this patch tested?
Manually
