### PR TITLE
HIVE-29231: Fix flaky TestEmbeddedHiveMetaStore.testDatabase by enforcing deterministic database lookup

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -1225,10 +1225,11 @@ public abstract class TestHiveMetaStore {
       assertEquals("location of the returned db is different from that of inserted db",
           warehouse.getDatabasePath(db2).toString(), db2.getLocationUri());
 
-      List<String> dbs = client.getDatabases(".*");
-
-      assertTrue("first database is not " + TEST_DB1_NAME, dbs.contains(TEST_DB1_NAME));
-      assertTrue("second database is not " + TEST_DB2_NAME, dbs.contains(TEST_DB2_NAME));
+      Database verifyDb1 = client.getDatabase(TEST_DB1_NAME);
+      assertNotNull("first database is not " + TEST_DB1_NAME, verifyDb1);
+      
+      Database verifyDb2 = client.getDatabase(TEST_DB2_NAME);
+      assertNotNull("second database is not " + TEST_DB2_NAME, verifyDb2);
 
       client.dropDatabase(TEST_DB1_NAME);
       client.dropDatabase(TEST_DB2_NAME);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes a nondeterministic behavior in `TestEmbeddedHiveMetaStore.testDatabase`
Previously, the test used `getDatabases(".*")` to verify database existence. However, this method relies on cached lists which may become stale when test execution order is randomized by [NonDex](https://github.com/TestingResearchIllinois/NonDex), which is a tool for detecting hidden assumptions in code by exploring non-deterministic behaviors of specifications that allow multiple valid implementations.


The fix is to replace getDatabases(".*") with direct getDatabase(name) calls in the test. This ensures consistent behavior regardless of test shuffling and avoids relying on potentially stale cached results.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The test was failing nondeterministically under NonDex with errors like:
```
java.lang.AssertionError: first database is not testdb1 in list: []
```

Root cause: Cached database lists may not reflect the actual state when randomized execution occurs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. I believe this improve the harness of tests without altering and damaging the core database operations being tested(add, find, drop).


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Failure observed with running NonDex:
```
mvn -pl standalone-metastore/metastore-server \
    edu.illinois:nondex-maven-plugin:2.2.1:nondex \
    -Dtest=org.apache.hadoop.hive.metastore.TestEmbeddedHiveMetaStore#testDatabase
```
Under environment:
```
Maven home: /home/anicaazhu/.sdkman/candidates/maven/current
Java version: 21.0.7, vendor: Oracle Corporation, runtime: /home/anicaazhu/.sdkman/candidates/java/21.0.7-oracle
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.16.8-arch3-1", arch: "amd64", family: "unix"
```

