### PR TITLE
HIVE-29237: TestHiveCommitLocks flakyness

### DIFF
--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
 import org.mockito.AdditionalAnswers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
@@ -67,6 +68,7 @@ import static org.apache.iceberg.PartitionSpec.builderFor;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -84,6 +86,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Execution(SAME_THREAD)
 public class TestHiveCommitLocks {
   private static HiveTableOperations spyOps = null;
   private static HiveClientPool spyClientPool = null;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Test cases should run single-threaded.

### Why are the changes needed?
It can fail as the test cases are re-using resources.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran the test class manually. 
Flaky checker: https://ci.hive.apache.org/job/hive-flaky-check/900/
