### PR TITLE
HIVE-29237: Addendum: Hive: Refactor commit lock mechanism from HiveTableOperations (#6648)

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -304,16 +304,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
     return metaClients;
   }
 
-  void doUnlock(HiveLock lock) {
-    if (lock != null) {
-      try {
-        lock.unlock();
-      } catch (Exception e) {
-        LOG.warn("Failed to unlock {}.{}", database, tableName, e);
-      }
-    }
-  }
-
   /**
    * Returns if the hive engine related values should be enabled on the table, or not.
    * <p>

--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -281,7 +281,6 @@ public class TestHiveCommitLocks {
         .doReturn(acquiredLockResponse)
         .when(spyClient)
         .checkLock(eq(dummyLockId));
-    doNothing().when(spyOps).doUnlock(any());
     doNothing().when(spyClient).heartbeat(eq(0L), eq(dummyLockId));
 
     spyOps.doCommit(metadataV2, metadataV1);
@@ -307,7 +306,6 @@ public class TestHiveCommitLocks {
 
     doReturn(showLocksResponse).when(spyClient).showLocks(any());
     doReturn(acquiredLockResponse).when(spyClient).checkLock(eq(dummyLockId));
-    doNothing().when(spyOps).doUnlock(any());
     doNothing().when(spyClient).heartbeat(eq(0L), eq(dummyLockId));
 
     spyOps.doCommit(metadataV2, metadataV1);
@@ -569,11 +567,11 @@ public class TestHiveCommitLocks {
   }
 
   @Test
-  public void testLockHeartbeat() throws TException {
+  public void testLockHeartbeat() throws TException, InterruptedException {
     doReturn(acquiredLockResponse).when(spyClient).lock(any());
     doAnswer(AdditionalAnswers.answersWithDelay(2000, InvocationOnMock::callRealMethod))
-        .when(spyClient)
-        .getTable(any(), any());
+        .when(spyOps)
+        .loadHmsTable();
     doNothing().when(spyClient).heartbeat(eq(0L), eq(dummyLockId));
 
     spyOps.doCommit(metadataV2, metadataV1);


### PR DESCRIPTION
(cherry picked from commit 333227fbd13821365cec1bdbfcb9314a239bea0f)

Note: this is not a full port: it is about porting some missing changes from the previous port especially for test cases.

### What changes were proposed in this pull request?
Add missing ports from Iceberg in `TestHiveCommitLocks`.

### Why are the changes needed?
It lead to flakyness on downstream. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Manually ran TestHiveCommitLocks
- Flaky job checker: https://ci.hive.apache.org/job/hive-flaky-check/903/
