### PR TITLE
HIVE-29377: Fix inconsistency for partition filter LIKE clause

### DIFF
--- a/ql/src/test/queries/clientpositive/ppd_like_filter.q
+++ b/ql/src/test/queries/clientpositive/ppd_like_filter.q
@@ -28,5 +28,8 @@ select * from test_tbl where b like '___';
 select * from test_tbl where b like '%%%';
 select * from test_tbl where b like '%\\\\%';
 
-
-
+select * from test_tbl where b like 'a.*';
+select * from test_tbl where b like 'd.\%.*';
+select * from test_tbl where b like 'd.\\%.*';
+select * from test_tbl where b like 'd.\\\\%.*';
+select * from test_tbl where b like '.\\_.*';

--- a/ql/src/test/results/clientpositive/llap/ppd_like_filter.q.out
+++ b/ql/src/test/results/clientpositive/llap/ppd_like_filter.q.out
@@ -256,3 +256,51 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_tbl
 POSTHOOK: Input: default@test_tbl@b=d_%5C%25ae
 #### A masked pattern was here ####
+PREHOOK: query: select * from test_tbl where b like 'a.*'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_tbl
+PREHOOK: Input: default@test_tbl@b=abc
+PREHOOK: Input: default@test_tbl@b=af%25
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_tbl where b like 'a.*'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_tbl
+POSTHOOK: Input: default@test_tbl@b=abc
+POSTHOOK: Input: default@test_tbl@b=af%25
+#### A masked pattern was here ####
+PREHOOK: query: select * from test_tbl where b like 'd.\%.*'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_tbl
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_tbl where b like 'd.\%.*'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_tbl
+#### A masked pattern was here ####
+PREHOOK: query: select * from test_tbl where b like 'd.\\%.*'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_tbl
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_tbl where b like 'd.\\%.*'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_tbl
+#### A masked pattern was here ####
+PREHOOK: query: select * from test_tbl where b like 'd.\\\\%.*'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_tbl
+PREHOOK: Input: default@test_tbl@b=d_%5C%25ae
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_tbl where b like 'd.\\\\%.*'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_tbl
+POSTHOOK: Input: default@test_tbl@b=d_%5C%25ae
+#### A masked pattern was here ####
+PREHOOK: query: select * from test_tbl where b like '.\\_.*'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_tbl
+PREHOOK: Input: default@test_tbl@b=d_%5C%25ae
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_tbl where b like '.\\_.*'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_tbl
+POSTHOOK: Input: default@test_tbl@b=d_%5C%25ae
+#### A masked pattern was here ####

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -856,6 +856,15 @@ public class DatabaseProduct implements Configurable {
     return batch;
   }
 
+  public String escapeClause() {
+    if (isMYSQL()) {
+      // MySQL does not support ESCAPE '\'
+      return " ESCAPE '\\\\' ";
+    } else {
+      return " ESCAPE '\\' ";
+    }
+  }
+
   // This class implements the Configurable interface for the benefit
   // of "plugin" instances created via reflection (see invocation of
   // ReflectionUtils.newInstance in method determineDatabaseProduct)


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Use `ESCAPE '\\\\'` for MySQL db.
2. Supports `.*` and `.` pattern for Direct SQL query.

### Why are the changes needed?
1. Fix bug on Direct SQL for MySQL db
2. Make results consistent between Direct SQL and JDO.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add test in `ppd_like_filter.q`:
```bash
mvn test -pl itests/qtest -Pitests -Dtest=TestMiniLlapLocalCliDriver -Dtest.output.overwrite=true -Dqfile=ppd_like_filter.q -Dtest.metastore.db=mysql
```
The result will be a little different in different dbs because in derby the ESCAPE is '\\' but in MySQL the ESCAPE is '\\\\'.
