### PR TITLE
HIVE-29392: Add Support for CTR and GCM cipher transformations in AES…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5860,14 +5860,7 @@ public class HiveConf extends Configuration {
 
     HIVE_OTEL_RETRY_BACKOFF_MULTIPLIER("hive.otel.retry.backoff.multiplier", 5f,
         "The multiplier applied to the backoff interval for retries in the OTEL exporter."
-            + "This determines how much the backoff interval increases after each failed attempt, following an exponential backoff strategy."),
-
-    HIVE_UDF_AES_CIPHER_TRANSFORMATION("hive.udf.aes.cipher.transformation", "AES", 
-        new StringSet("AES", "AES/CTR/NoPadding", "AES/GCM/NoPadding"),
-        "This specifies the cipher transformation used by AES UDFs."
-            + "The default is the Electronic Codebook transformation (AES/ECB/PKCS5Padding) which encrypts each block " 
-            + "independently whereas Counter (CTR) & Galois/Counter Mode (GCM) provide stronger security using a " 
-            + "generated Initialization Vector (IV).");
+            + "This determines how much the backoff interval increases after each failed attempt, following an exponential backoff strategy.");
 
     public final String varname;
     public final String altName;

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5860,7 +5860,14 @@ public class HiveConf extends Configuration {
 
     HIVE_OTEL_RETRY_BACKOFF_MULTIPLIER("hive.otel.retry.backoff.multiplier", 5f,
         "The multiplier applied to the backoff interval for retries in the OTEL exporter."
-            + "This determines how much the backoff interval increases after each failed attempt, following an exponential backoff strategy.");
+            + "This determines how much the backoff interval increases after each failed attempt, following an exponential backoff strategy."),
+
+    HIVE_UDF_AES_CIPHER_TRANSFORMATION("hive.udf.aes.cipher.transformation", "AES", 
+        new StringSet("AES", "AES/CTR/NoPadding", "AES/GCM/NoPadding"),
+        "This specifies the cipher transformation used by AES UDFs."
+            + "The default is the Electronic Codebook transformation (AES/ECB/PKCS5Padding) which encrypts each block " 
+            + "independently whereas Counter (CTR) & Galois/Counter Mode (GCM) provide stronger security using a " 
+            + "generated Initialization Vector (IV).");
 
     public final String varname;
     public final String altName;

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFAesBase.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFAesBase.java
@@ -50,8 +50,8 @@ import org.apache.hadoop.io.Text;
  *
  */
 public abstract class GenericUDFAesBase extends GenericUDF {
-  protected transient Converter[] converters = new Converter[2];
-  protected transient PrimitiveCategory[] inputTypes = new PrimitiveCategory[2];
+  protected transient Converter[] converters = new Converter[3];
+  protected transient PrimitiveCategory[] inputTypes = new PrimitiveCategory[3];
   protected final BytesWritable output = new BytesWritable();
   protected transient boolean isStr0;
   protected transient boolean isStr1;
@@ -68,7 +68,7 @@ public abstract class GenericUDFAesBase extends GenericUDF {
 
   @Override
   public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
-    checkArgsSize(arguments, 2, 2);
+    checkArgsSize(arguments, 2, 3);
 
     checkArgPrimitive(arguments, 0);
     checkArgPrimitive(arguments, 1);
@@ -117,8 +117,18 @@ public abstract class GenericUDFAesBase extends GenericUDF {
       secretKey = getSecretKey(key, keyLength);
     }
 
-    HiveConf hiveConf = SessionState.getSessionConf();
-    String cipherTransform = HiveConf.getVar(hiveConf, HiveConf.ConfVars.HIVE_UDF_AES_CIPHER_TRANSFORMATION);
+    String cipherTransform = "AES";
+    
+    if (arguments.length == 3) {
+      checkArgPrimitive(arguments, 2);
+      checkArgGroups(arguments, 2, inputTypes, STRING_GROUP);
+      
+      String userDefinedMode = getConstantStringValue(arguments, 2);
+      if (userDefinedMode != null) {
+        cipherTransform = userDefinedMode;
+      }
+
+    }
 
     this.isGCM = AES_GCM_NOPADDING.equalsIgnoreCase(cipherTransform);
     this.isCTR = AES_CTR_NOPADDING.equalsIgnoreCase(cipherTransform);


### PR DESCRIPTION
… UDFs

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Extend support for cipher transformations in AES UDFs with Counter (CTR) &  Galois/Counter Mode (GCM) modes that provide stronger security as they use Initialization Vector.


### Why are the changes needed?
Currently, The AES UDFs only support one cipher transformation - AES/ECB/PKCS5Padding, which is inherently weak, as it produces the same ciphertext for identical blocks of plain text. 


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually Tested
