### PR TITLE
HIVE-29241: Distinguish the default location of the database by catalog

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestMiniClusters.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestMiniClusters.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.llap.LlapItUtils;
 import org.apache.hadoop.hive.llap.daemon.MiniLlapCluster;
 import org.apache.hadoop.hive.llap.io.api.LlapProxy;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.tez.TezSession;
 import org.apache.hadoop.hive.ql.lockmgr.zookeeper.CuratorFrameworkSingleton;
@@ -544,6 +545,7 @@ public class QTestMiniClusters {
     // Different paths if running locally vs a remote fileSystem. Ideally this difference should not
     // exist.
     Path warehousePath;
+    Path warehouseCatPath;
     Path jarPath;
     Path userInstallPath;
     if (isLocalFs) {
@@ -554,16 +556,19 @@ public class QTestMiniClusters {
       // Create a fake fs root for local fs
       Path localFsRoot = new Path(path, "localfs");
       warehousePath = new Path(localFsRoot, "warehouse");
+      warehouseCatPath = new Path(localFsRoot, "catalog");
       jarPath = new Path(localFsRoot, "jar");
       userInstallPath = new Path(localFsRoot, "user_install");
     } else {
       // TODO Why is this changed from the default in hive-conf?
       warehousePath = new Path(fsUriString, "/build/ql/test/data/warehouse/");
+      warehouseCatPath = new Path(fsUriString, "/build/ql/test/data/catalog/");
       jarPath = new Path(new Path(fsUriString, "/user"), "hive");
       userInstallPath = new Path(fsUriString, "/user");
     }
 
     warehousePath = fs.makeQualified(warehousePath);
+    warehouseCatPath = fs.makeQualified(warehouseCatPath);
     jarPath = fs.makeQualified(jarPath);
     userInstallPath = fs.makeQualified(userInstallPath);
 
@@ -571,6 +576,7 @@ public class QTestMiniClusters {
 
     // Remote dirs
     conf.setVar(ConfVars.METASTORE_WAREHOUSE, warehousePath.toString());
+    MetastoreConf.setVar(conf, MetastoreConf.ConfVars.WAREHOUSE_CATALOG, warehouseCatPath.toString());
     conf.setVar(ConfVars.HIVE_JAR_DIRECTORY, jarPath.toString());
     conf.setVar(ConfVars.HIVE_USER_INSTALL_DIR, userInstallPath.toString());
     // ConfVars.SCRATCH_DIR - {test.tmp.dir}/scratchdir

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -1132,10 +1132,10 @@ createCatalogStatement
     : KW_CREATE KW_CATALOG
         ifNotExists?
         name=identifier
-        catLocation
+        catLocation?
         catalogComment?
         (KW_PROPERTIES catprops=properties)?
-    -> ^(TOK_CREATECATALOG $name catLocation ifNotExists? catalogComment? $catprops?)
+    -> ^(TOK_CREATECATALOG $name catLocation? ifNotExists? catalogComment? $catprops?)
     ;
 
 catLocation

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/catalog/create/CreateCatalogAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/catalog/create/CreateCatalogAnalyzer.java
@@ -50,7 +50,7 @@ public class CreateCatalogAnalyzer extends BaseSemanticAnalyzer {
     String locationUrl = null;
     boolean ifNotExists = false;
     String comment = null;
-    Map<String, String> props = null;
+    Map<String, String> props = new HashMap<>();
 
     for (int i = 1; i < root.getChildCount(); i++) {
       ASTNode childNode = (ASTNode) root.getChild(i);
@@ -73,10 +73,7 @@ public class CreateCatalogAnalyzer extends BaseSemanticAnalyzer {
       }
     }
 
-    // Initialize props if null, and set default type to native if not specified
-    if (props == null) {
-      props = new HashMap<>();
-    }
+    // Set default type to hive if not specified
     checkCatalogType(props);
 
     CreateCatalogDesc desc = new CreateCatalogDesc(catalogName, comment, locationUrl, ifNotExists, props);
@@ -87,15 +84,10 @@ public class CreateCatalogAnalyzer extends BaseSemanticAnalyzer {
   }
 
   private static void checkCatalogType(Map<String, String> props) throws SemanticException {
-    String catalogType = props.get("type");
-    // Set default type to native if not specified
-    if (Strings.isNullOrEmpty(catalogType)) {
-      props.put("type", CatalogUtil.NATIVE);
-      return;
-    }
+    String catalogType = props.get(CatalogUtil.TYPE);
     // Normalize and validate catalog type (fail fast on invalid input)
     try {
-      props.put("type", CatalogUtil.normalizeCatalogType(catalogType));
+      props.put(CatalogUtil.TYPE, CatalogUtil.normalizeCatalogType(catalogType));
     } catch (IllegalArgumentException e) {
       throw new SemanticException(String.format("type '%s' is not valid", catalogType));
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/catalog/create/CreateCatalogAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/catalog/create/CreateCatalogAnalyzer.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hive.ql.ddl.catalog.create;
 
-import com.google.common.base.Strings;
 import org.apache.hadoop.hive.metastore.CatalogUtil;
 import org.apache.hadoop.hive.metastore.api.Catalog;
 import org.apache.hadoop.hive.ql.QueryState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/catalog/create/CreateCatalogAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/catalog/create/CreateCatalogAnalyzer.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hive.ql.ddl.catalog.create;
 
+import com.google.common.base.Strings;
+import org.apache.hadoop.hive.metastore.CatalogUtil;
 import org.apache.hadoop.hive.metastore.api.Catalog;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory;
@@ -29,6 +31,7 @@ import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -43,16 +46,19 @@ public class CreateCatalogAnalyzer extends BaseSemanticAnalyzer {
   @Override
   public void analyzeInternal(ASTNode root) throws SemanticException {
     String catalogName = unescapeIdentifier(root.getChild(0).getText());
-    String locationUrl = unescapeSQLString(root.getChild(1).getChild(0).getText());
-    outputs.add(toWriteEntity(locationUrl));
 
+    String locationUrl = null;
     boolean ifNotExists = false;
     String comment = null;
     Map<String, String> props = null;
 
-    for (int i = 2; i < root.getChildCount(); i++) {
+    for (int i = 1; i < root.getChildCount(); i++) {
       ASTNode childNode = (ASTNode) root.getChild(i);
       switch (childNode.getToken().getType()) {
+        case HiveParser.TOK_CATALOGLOCATION:
+          locationUrl = unescapeSQLString(childNode.getChild(0).getText());
+          outputs.add(toWriteEntity(locationUrl));
+          break;
         case HiveParser.TOK_IFNOTEXISTS:
           ifNotExists = true;
           break;
@@ -67,10 +73,31 @@ public class CreateCatalogAnalyzer extends BaseSemanticAnalyzer {
       }
     }
 
+    // Initialize props if null, and set default type to native if not specified
+    if (props == null) {
+      props = new HashMap<>();
+    }
+    checkCatalogType(props);
+
     CreateCatalogDesc desc = new CreateCatalogDesc(catalogName, comment, locationUrl, ifNotExists, props);
     Catalog catalog = new Catalog(catalogName, locationUrl);
 
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
     outputs.add(new WriteEntity(catalog, WriteEntity.WriteType.DDL_NO_LOCK));
+  }
+
+  private static void checkCatalogType(Map<String, String> props) throws SemanticException {
+    String catalogType = props.get("type");
+    // Set default type to native if not specified
+    if (Strings.isNullOrEmpty(catalogType)) {
+      props.put("type", CatalogUtil.NATIVE);
+      return;
+    }
+    // Normalize and validate catalog type (fail fast on invalid input)
+    try {
+      props.put("type", CatalogUtil.normalizeCatalogType(catalogType));
+    } catch (IllegalArgumentException e) {
+      throw new SemanticException(String.format("type '%s' is not valid", catalogType));
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/catalog/create/CreateCatalogOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/catalog/create/CreateCatalogOperation.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.ddl.catalog.create;
 
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Catalog;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.ddl.DDLOperation;
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
@@ -37,7 +38,11 @@ public class CreateCatalogOperation extends DDLOperation<CreateCatalogDesc> {
 
   @Override
   public int execute() throws Exception {
-    Catalog catalog = new Catalog(desc.getName(), desc.getLocationUri());
+    String catLocationUri = Optional.ofNullable(desc.getLocationUri())
+            .orElse(MetastoreConf.getVar(context.getConf(),
+                    MetastoreConf.ConfVars.WAREHOUSE_CATALOG) + "/" + desc.getName());
+
+    Catalog catalog = new Catalog(desc.getName(), catLocationUri);
     catalog.setDescription(desc.getComment());
     Optional.ofNullable(desc.getCatlogProperties())
             .ifPresent(catalog::setParameters);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/create/CreateDatabaseAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/create/CreateDatabaseAnalyzer.java
@@ -19,13 +19,13 @@
 package org.apache.hadoop.hive.ql.ddl.database.create;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.metastore.api.DataConnector;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.DatabaseType;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
-import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.ddl.DDLUtils;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
@@ -51,10 +52,9 @@ public class CreateDatabaseAnalyzer extends BaseSemanticAnalyzer {
   @Override
   public void analyzeInternal(ASTNode root) throws SemanticException {
     Pair<String, String> catDbNamePair = DDLUtils.getCatDbNamePair((ASTNode) root.getChild(0));
-    String catalogName = catDbNamePair.getLeft();
-    if (catalogName != null && getCatalog(catalogName) == null) {
-      throw new SemanticException(ErrorMsg.CATALOG_NOT_EXISTS, catalogName);
-    }
+    String catalogName = Optional.ofNullable(catDbNamePair.getLeft())
+            .orElse(HiveUtils.getCurrentCatalogOrDefault(conf));
+
     String databaseName = catDbNamePair.getRight();
 
     boolean ifNotExists = false;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/create/CreateDatabaseOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/create/CreateDatabaseOperation.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.ql.ddl.DDLOperation;
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
 /**
@@ -83,7 +84,7 @@ public class CreateDatabaseOperation extends DDLOperation<CreateDatabaseDesc> {
   private void makeLocationQualified(Database database) throws HiveException {
     String catalogName = database.getCatalogName().toLowerCase();
     String dbName = database.getName().toLowerCase();
-    boolean isDefaultCatalog = Warehouse.DEFAULT_CATALOG_NAME.equalsIgnoreCase(catalogName);
+    boolean isDefaultCatalog = HiveUtils.isDefaultCatalog(catalogName, context.getConf());
 
     // -------- External location --------
     if (database.isSetLocationUri()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveUtils.java
@@ -573,4 +573,8 @@ public final class HiveUtils {
             .map(SessionState::getCurrentCatalog)
             .orElseGet(() -> getDefaultCatalog(conf));
   }
+
+  public static boolean isDefaultCatalog(String catName, Configuration conf) {
+    return catName == null || catName.isEmpty() || getDefaultCatalog(conf).equals(catName);
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
@@ -181,7 +181,7 @@ public class SessionHiveMetaStoreClient extends MetaStoreClientWrapper {
   }
 
   private boolean isDefaultCatalog(String catName) {
-    return catName == null || catName.isEmpty() || getDefaultCatalog(conf).equals(catName);
+    return HiveUtils.isDefaultCatalog(catName, conf);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/EximUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/EximUtil.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.repl.DumpType;
@@ -391,7 +392,7 @@ public class EximUtil {
     try {
       String catName = database.getCatalogName();
       String dbName = database.getName().toLowerCase();
-      boolean isDefaultCatalog = Warehouse.DEFAULT_CATALOG_NAME.equals(catName);
+      boolean isDefaultCatalog = HiveUtils.isDefaultCatalog(catName, conf);
 
       // external warehouse root
       String whLocation = MetastoreConf.getVar(conf,

--- a/ql/src/java/org/apache/hadoop/hive/ql/queryhistory/repository/AbstractRepository.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/queryhistory/repository/AbstractRepository.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.PartitionTransform;
 import org.apache.hadoop.hive.ql.parse.TransformSpec;
@@ -39,6 +40,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
 
 public abstract class AbstractRepository implements QueryHistoryRepository {
   protected Logger LOG = LoggerFactory.getLogger(getClass());
@@ -82,7 +85,11 @@ public abstract class AbstractRepository implements QueryHistoryRepository {
       db = hive.getDatabase(QUERY_HISTORY_DB_NAME);
       if (db == null) {
         LOG.warn("Database ({}) for query history table hasn't been found, auto-creating one", QUERY_HISTORY_DB_NAME);
-        String location = getDatabaseLocation(QUERY_HISTORY_DB_NAME);
+        db = new Database();
+        // TODO catalog. The Hive Query History functionality is currently limited to the default catalog.
+        db.setCatalogName(getDefaultCatalog(conf));
+        db.setName(QUERY_HISTORY_DB_NAME);
+        String location = getDatabaseLocation(db);
         db = new Database(QUERY_HISTORY_DB_NAME, QUERY_HISTORY_DB_COMMENT,
             location, null);
         hive.createDatabase(db, false);
@@ -93,8 +100,8 @@ public abstract class AbstractRepository implements QueryHistoryRepository {
     }
   }
 
-  private String getDatabaseLocation(String databaseName) throws Exception {
-    return warehouse.getDefaultExternalDatabasePath(databaseName).toUri().toString();
+  private String getDatabaseLocation(Database db) throws Exception {
+    return warehouse.getDefaultExternalDatabasePath(db).toUri().toString();
   }
 
   protected Table initTable(Hive hive, Database db) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/queryhistory/repository/AbstractRepository.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/queryhistory/repository/AbstractRepository.java
@@ -85,13 +85,12 @@ public abstract class AbstractRepository implements QueryHistoryRepository {
       db = hive.getDatabase(QUERY_HISTORY_DB_NAME);
       if (db == null) {
         LOG.warn("Database ({}) for query history table hasn't been found, auto-creating one", QUERY_HISTORY_DB_NAME);
-        db = new Database();
-        // TODO catalog. The Hive Query History functionality is currently limited to the default catalog.
-        db.setCatalogName(getDefaultCatalog(conf));
-        db.setName(QUERY_HISTORY_DB_NAME);
-        String location = getDatabaseLocation(db);
+        // TODO catalog. The Hive Query History functionality is currently limited to the default catalog. Depend on HIVE-29561
         db = new Database(QUERY_HISTORY_DB_NAME, QUERY_HISTORY_DB_COMMENT,
-            location, null);
+            null, null);
+        db.setCatalogName(getDefaultCatalog(conf));
+        String location = getDatabaseLocation(db);
+        db.setLocationUri(location);
         hive.createDatabase(db, false);
       }
       return db;

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
@@ -132,6 +132,8 @@ public class StorageBasedAuthorizationProvider extends HiveAuthorizationProvider
     Path root = null;
     try {
       initWh();
+      // TODO catalog. Need to determine auth root path based on catalog name.
+      //  Not sure how to get catalog name yet. Use getWhRoot(String) instead.
       root = wh.getWhRoot();
       // When we have some path in outputs, we should check access on that path, usually happens when
       // we have HiveOperation.CREATEDATABASE query with some location
@@ -455,7 +457,7 @@ public class StorageBasedAuthorizationProvider extends HiveAuthorizationProvider
       initWh();
       String location = db.getLocationUri();
       if (location == null) {
-        return wh.getDefaultDatabasePath(db.getName());
+        return wh.getDefaultDatabasePath(db);
       } else {
         return wh.getDnsPath(wh.getDatabasePath(db));
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
@@ -133,7 +133,7 @@ public class StorageBasedAuthorizationProvider extends HiveAuthorizationProvider
     try {
       initWh();
       // TODO catalog. Need to determine auth root path based on catalog name.
-      //  Not sure how to get catalog name yet. Use getWhRoot(String) instead.
+      //  If the catalog name is available, use `wh.getWhRoot(catName)` to obtain the auth path. Depend on HIVE-29562
       root = wh.getWhRoot();
       // When we have some path in outputs, we should check access on that path, usually happens when
       // we have HiveOperation.CREATEDATABASE query with some location

--- a/ql/src/test/queries/clientnegative/lockneg_try_lock_cat_db_in_use.q
+++ b/ql/src/test/queries/clientnegative/lockneg_try_lock_cat_db_in_use.q
@@ -1,7 +1,7 @@
 set hive.lock.numretries=0;
 set hive.support.concurrency=true;
 
-CREATE CATALOG testcat LOCATION '/tmp/testcat' COMMENT 'Hive test catalog';
+CREATE CATALOG testcat LOCATION '/tmp/testcat' COMMENT 'Hive test catalog' PROPERTIES('type'='native');
 create database testcat.lockneg9;
 
 lock database testcat.lockneg9 shared;

--- a/ql/src/test/queries/clientnegative/lockneg_try_lock_cat_db_in_use.q
+++ b/ql/src/test/queries/clientnegative/lockneg_try_lock_cat_db_in_use.q
@@ -1,7 +1,7 @@
 set hive.lock.numretries=0;
 set hive.support.concurrency=true;
 
-CREATE CATALOG testcat LOCATION '/tmp/testcat' COMMENT 'Hive test catalog' PROPERTIES('type'='native');
+CREATE CATALOG testcat LOCATION '/tmp/testcat' COMMENT 'Hive test catalog';
 create database testcat.lockneg9;
 
 lock database testcat.lockneg9 shared;

--- a/ql/src/test/queries/clientpositive/catalog.q
+++ b/ql/src/test/queries/clientpositive/catalog.q
@@ -7,14 +7,14 @@ dfs -mkdir -p hdfs:///tmp/test_cat;
 -- SORT_QUERY_RESULTS
 SHOW CATALOGS;
 
--- CREATE with comment
-CREATE CATALOG test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog';
+-- CREATE with comment and default location
+CREATE CATALOG test_cat COMMENT 'Hive test catalog' PROPERTIES('type'='NATIVE');
 
 -- DESCRIBE
 DESC CATALOG test_cat;
 
 -- CREATE INE already exists
-CREATE CATALOG IF NOT EXISTS test_cat LOCATION 'hdfs:///tmp/test_cat';
+CREATE CATALOG IF NOT EXISTS test_cat LOCATION 'hdfs:///tmp/test_cat' PROPERTIES('type'='native');
 SHOW CATALOGS;
 
 -- DROP
@@ -22,7 +22,7 @@ DROP CATALOG test_cat;
 SHOW CATALOGS;
 
 -- CREATE INE doesn't exist
-CREATE CATALOG IF NOT EXISTS test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog' PROPERTIES('key1'='value1');;
+CREATE CATALOG IF NOT EXISTS test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog' PROPERTIES('type'='native');
 SHOW CATALOGS;
 
 -- DROP IE exists
@@ -33,7 +33,7 @@ SHOW CATALOGS;
 DROP CATALOG IF EXISTS test_cat;
 
 -- SHOW
-CREATE CATALOG test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog';
+CREATE CATALOG test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog' PROPERTIES('type'='native');
 SHOW CATALOGS;
 
 -- SHOW pattern

--- a/ql/src/test/queries/clientpositive/catalog.q
+++ b/ql/src/test/queries/clientpositive/catalog.q
@@ -8,13 +8,13 @@ dfs -mkdir -p hdfs:///tmp/test_cat;
 SHOW CATALOGS;
 
 -- CREATE with comment and default location
-CREATE CATALOG test_cat COMMENT 'Hive test catalog' PROPERTIES('type'='NATIVE');
+CREATE CATALOG test_cat COMMENT 'Hive test catalog';
 
 -- DESCRIBE
 DESC CATALOG test_cat;
 
 -- CREATE INE already exists
-CREATE CATALOG IF NOT EXISTS test_cat LOCATION 'hdfs:///tmp/test_cat' PROPERTIES('type'='native');
+CREATE CATALOG IF NOT EXISTS test_cat LOCATION 'hdfs:///tmp/test_cat';
 SHOW CATALOGS;
 
 -- DROP
@@ -22,7 +22,7 @@ DROP CATALOG test_cat;
 SHOW CATALOGS;
 
 -- CREATE INE doesn't exist
-CREATE CATALOG IF NOT EXISTS test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog' PROPERTIES('type'='native');
+CREATE CATALOG IF NOT EXISTS test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog' PROPERTIES('type'='hive');
 SHOW CATALOGS;
 
 -- DROP IE exists
@@ -33,7 +33,7 @@ SHOW CATALOGS;
 DROP CATALOG IF EXISTS test_cat;
 
 -- SHOW
-CREATE CATALOG test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog' PROPERTIES('type'='native');
+CREATE CATALOG test_cat LOCATION 'hdfs:///tmp/test_cat' COMMENT 'Hive test catalog' PROPERTIES('type'='hive');
 SHOW CATALOGS;
 
 -- SHOW pattern

--- a/ql/src/test/queries/clientpositive/catalog_database.q
+++ b/ql/src/test/queries/clientpositive/catalog_database.q
@@ -7,7 +7,7 @@ CREATE DATABASE testdb;
 -- The list of databases in the catalog 'hive' should only contain the default and the testdb.
 SHOW DATABASES;
 
--- CREATE a new catalog with comment
+-- CREATE a new native catalog with comment
 CREATE CATALOG testcat LOCATION '/tmp/testcat' COMMENT 'Hive test catalog';
 
 -- Check catalogs list

--- a/ql/src/test/results/clientpositive/llap/catalog.q.out
+++ b/ql/src/test/results/clientpositive/llap/catalog.q.out
@@ -3,14 +3,12 @@ PREHOOK: type: SHOWCATALOGS
 POSTHOOK: query: SHOW CATALOGS
 POSTHOOK: type: SHOWCATALOGS
 hive
-#### A masked pattern was here ####
+PREHOOK: query: CREATE CATALOG test_cat COMMENT 'Hive test catalog' PROPERTIES('type'='NATIVE')
 PREHOOK: type: CREATECATALOG
 PREHOOK: Output: catalog:test_cat
-PREHOOK: Output: hdfs://### HDFS PATH ###
-#### A masked pattern was here ####
+POSTHOOK: query: CREATE CATALOG test_cat COMMENT 'Hive test catalog' PROPERTIES('type'='NATIVE')
 POSTHOOK: type: CREATECATALOG
 POSTHOOK: Output: catalog:test_cat
-POSTHOOK: Output: hdfs://### HDFS PATH ###
 PREHOOK: query: DESC CATALOG test_cat
 PREHOOK: type: DESCCATALOG
 PREHOOK: Input: catalog:test_cat

--- a/ql/src/test/results/clientpositive/llap/catalog.q.out
+++ b/ql/src/test/results/clientpositive/llap/catalog.q.out
@@ -3,10 +3,10 @@ PREHOOK: type: SHOWCATALOGS
 POSTHOOK: query: SHOW CATALOGS
 POSTHOOK: type: SHOWCATALOGS
 hive
-PREHOOK: query: CREATE CATALOG test_cat COMMENT 'Hive test catalog' PROPERTIES('type'='NATIVE')
+PREHOOK: query: CREATE CATALOG test_cat COMMENT 'Hive test catalog'
 PREHOOK: type: CREATECATALOG
 PREHOOK: Output: catalog:test_cat
-POSTHOOK: query: CREATE CATALOG test_cat COMMENT 'Hive test catalog' PROPERTIES('type'='NATIVE')
+POSTHOOK: query: CREATE CATALOG test_cat COMMENT 'Hive test catalog'
 POSTHOOK: type: CREATECATALOG
 POSTHOOK: Output: catalog:test_cat
 PREHOOK: query: DESC CATALOG test_cat

--- a/ql/src/test/results/clientpositive/llap/database_location.q.out
+++ b/ql/src/test/results/clientpositive/llap/database_location.q.out
@@ -160,6 +160,7 @@ STAGE DEPENDENCIES:
 STAGE PLANS:
   Stage: Stage-0
     Create Database
+      catalogName: hive
       database type:
 #### A masked pattern was here ####
       name: db3

--- a/ql/src/test/results/clientpositive/llap/db_ddl_explain.q.out
+++ b/ql/src/test/results/clientpositive/llap/db_ddl_explain.q.out
@@ -10,6 +10,7 @@ STAGE DEPENDENCIES:
 STAGE PLANS:
   Stage: Stage-0
     Create Database
+      catalogName: hive
       database type:
       name: d
 

--- a/ql/src/test/results/clientpositive/tez/explainanalyze_3.q.out
+++ b/ql/src/test/results/clientpositive/tez/explainanalyze_3.q.out
@@ -93,7 +93,7 @@ POSTHOOK: type: CREATEDATABASE
 POSTHOOK: Output: database:newDB
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 Stage-0
-  Create Database{"name:":"newDB"}
+  Create Database{"catalogName:":"hive","name:":"newDB"}
 
 #### A masked pattern was here ####
 PREHOOK: type: CREATEDATABASE

--- a/ql/src/test/results/clientpositive/tez/explainuser_3.q.out
+++ b/ql/src/test/results/clientpositive/tez/explainuser_3.q.out
@@ -117,7 +117,7 @@ POSTHOOK: type: CREATEDATABASE
 POSTHOOK: Output: database:newDB
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 Stage-0
-  Create Database{"name:":"newDB"}
+  Create Database{"catalogName:":"hive","name:":"newDB"}
 
 #### A masked pattern was here ####
 PREHOOK: type: CREATEDATABASE

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/CatalogUtil.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/CatalogUtil.java
@@ -18,27 +18,25 @@
 
 package org.apache.hadoop.hive.metastore;
 
-public class CatalogUtil {
-    // Catalog type constants
-    public static final String NATIVE = "native";
-    public static final String ICEBERG = "iceberg";
+import com.google.common.base.Strings;
 
+public class CatalogUtil {
+    public static final String TYPE = "type";
+
+    // Supported Catalog types
     public enum CatalogType {
-        NATIVE,
+        HIVE,
         ICEBERG
     }
 
     /**
-     * Check if the given catalog type name is valid.
-     * @param name catalog type name (case-insensitive)
+     * Check if the given catalog type is valid.
+     * @param type catalog type (case-insensitive)
      * @return true if valid, false otherwise
      */
-    public static boolean isValidCatalogType(String name) {
-        if (name == null || name.trim().isEmpty()) {
-            return false;
-        }
+    public static boolean isValidCatalogType(String type) {
         try {
-            CatalogType.valueOf(name.toUpperCase().trim());
+            CatalogType.valueOf(type.toUpperCase().trim());
             return true;
         } catch (IllegalArgumentException e) {
             return false;
@@ -47,18 +45,19 @@ public class CatalogUtil {
 
     /**
      * Normalize catalog type to standard lowercase format.
-     * @param name catalog type name (case-insensitive)
+     * @param type catalog type (case-insensitive)
      * @return normalized catalog type in lowercase
      * @throws IllegalArgumentException if the catalog type is null, empty, or invalid
      */
-    public static String normalizeCatalogType(String name) {
-        if (name == null || name.trim().isEmpty()) {
-            throw new IllegalArgumentException("Catalog type cannot be null or empty");
+    public static String normalizeCatalogType(String type) {
+        if (Strings.isNullOrEmpty(type)) {
+            // Set default type to hive if not specified
+            return CatalogType.HIVE.name();
         }
-        if (!isValidCatalogType(name)) {
-            throw new IllegalArgumentException("Invalid catalog type: " + name);
+        if (!isValidCatalogType(type)) {
+            throw new IllegalArgumentException("Invalid catalog type: " + type);
         }
-        return name.trim().toLowerCase();
+        return type.trim().toLowerCase();
     }
 }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/CatalogUtil.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/CatalogUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+public class CatalogUtil {
+    // Catalog type constants
+    public static final String NATIVE = "native";
+    public static final String ICEBERG = "iceberg";
+
+    public enum CatalogType {
+        NATIVE,
+        ICEBERG
+    }
+
+    /**
+     * Check if the given catalog type name is valid.
+     * @param name catalog type name (case-insensitive)
+     * @return true if valid, false otherwise
+     */
+    public static boolean isValidCatalogType(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return false;
+        }
+        try {
+            CatalogType.valueOf(name.toUpperCase().trim());
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Normalize catalog type to standard lowercase format.
+     * @param name catalog type name (case-insensitive)
+     * @return normalized catalog type in lowercase
+     * @throws IllegalArgumentException if the catalog type is null, empty, or invalid
+     */
+    public static String normalizeCatalogType(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("Catalog type cannot be null or empty");
+        }
+        if (!isValidCatalogType(name)) {
+            throw new IllegalArgumentException("Invalid catalog type: " + name);
+        }
+        return name.trim().toLowerCase();
+    }
+}
+

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
@@ -631,6 +631,8 @@ public class ReplChangeManager {
     FileSystem cmFs = cmroot.getFileSystem(conf);
     cmFs.setPermission(cmroot, new FsPermission("770"));
     try {
+      // TODO catalog. The Repl function is currently only available for the default catalog path ConfVars.WAREHOUSE.
+      //  We may consider adding new created native catalog path (ConfVars.WAREHOUSE_CATALOG) later.
       FileStatus warehouseStatus = cmFs.getFileStatus(new Path(MetastoreConf.get(conf, ConfVars.WAREHOUSE.getVarname())));
       String warehouseOwner = warehouseStatus.getOwner();
       String warehouseGroup = warehouseStatus.getGroup();

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
@@ -632,7 +632,7 @@ public class ReplChangeManager {
     cmFs.setPermission(cmroot, new FsPermission("770"));
     try {
       // TODO catalog. The Repl function is currently only available for the default catalog path ConfVars.WAREHOUSE.
-      //  We may consider adding new created native catalog path (ConfVars.WAREHOUSE_CATALOG) later.
+      //  We may consider adding new created native catalog path (ConfVars.WAREHOUSE_CATALOG) later. Depend on HIVE-29278.
       FileStatus warehouseStatus = cmFs.getFileStatus(new Path(MetastoreConf.get(conf, ConfVars.WAREHOUSE.getVarname())));
       String warehouseOwner = warehouseStatus.getOwner();
       String warehouseGroup = warehouseStatus.getGroup();

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -73,10 +73,14 @@ public class Warehouse {
   private static final String CAT_DB_TABLE_SEPARATOR = ".";
 
   private Path whRoot;
+  private Path whCatRoot;
   private Path whRootExternal;
+  private Path whCatRootExternal;
   private final Configuration conf;
   private final String whRootString;
+  private final String whCatRootString;
   private final String whRootExternalString;
+  private final String whCatRootExternalString;
   private final boolean isTenantBasedStorage;
 
   public static final Logger LOG = LoggerFactory.getLogger("hive.metastore.warehouse");
@@ -86,15 +90,24 @@ public class Warehouse {
 
   public Warehouse(Configuration conf) throws MetaException {
     this.conf = conf;
-    whRootString = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE);
-    if (StringUtils.isBlank(whRootString)) {
-      throw new MetaException(ConfVars.WAREHOUSE.getVarname()
-          + " is not set in the config or blank");
-    }
+
+    whRootString = getRequiredVar(conf, ConfVars.WAREHOUSE);
+    whCatRootString = getRequiredVar(conf, ConfVars.WAREHOUSE_CATALOG);
+
     whRootExternalString = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE_EXTERNAL);
+    whCatRootExternalString = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE_CATALOG_EXTERNAL);
+
     cm = ReplChangeManager.getInstance(conf);
     storageAuthCheck = MetastoreConf.getBoolVar(conf, ConfVars.AUTHORIZATION_STORAGE_AUTH_CHECKS);
     isTenantBasedStorage = MetastoreConf.getBoolVar(conf, ConfVars.ALLOW_TENANT_BASED_STORAGE);
+  }
+
+  private static String getRequiredVar(Configuration conf, ConfVars var) throws MetaException {
+    String value = MetastoreConf.getVar(conf, var);
+    if (StringUtils.isBlank(value)) {
+      throw new MetaException(var.getVarname() + " is not set in the config or blank");
+    }
+    return value;
   }
 
   /**
@@ -156,26 +169,61 @@ public class Warehouse {
    * This involves opening the FileSystem corresponding to the warehouse root
    * dir (but that should be ok given that this is only called during DDL
    * statements for non-external tables).
+   *
+   * @deprecated use {@link #getWhRoot(String)}
    */
   public Path getWhRoot() throws MetaException {
-    if (whRoot != null) {
-      return whRoot;
-    }
-    whRoot = getDnsPath(new Path(whRootString));
-    return whRoot;
+    return getWhRoot(DEFAULT_CATALOG_NAME);
   }
 
-  public Path getWhRootExternal() throws MetaException {
-    if (whRootExternal != null) {
-      return whRootExternal;
+  public Path getWhRoot(String catalogName) throws MetaException {
+    boolean isDefault = DEFAULT_CATALOG_NAME.equals(catalogName.trim());
+
+    Path rootDir = isDefault ? whRoot : whCatRoot;
+    if (rootDir == null) {
+      rootDir = getDnsPath(new Path(isDefault ? whRootString : whCatRootString));
+      if (isDefault) {
+        whRoot = rootDir;
+      } else {
+        whCatRoot = rootDir;
+      }
     }
-    if (!hasExternalWarehouseRoot()) {
-      whRootExternal = getWhRoot();
-    } else {
-      whRootExternal = getDnsPath(new Path(whRootExternalString));
-    }
-    return whRootExternal;
+
+    return isDefault ? rootDir : new Path(rootDir, catalogName);
   }
+
+
+
+  /**
+   * @deprecated use {@link #getWhRootExternal(String)}
+   */
+  public Path getWhRootExternal() throws MetaException {
+    return getWhRootExternal(DEFAULT_CATALOG_NAME);
+  }
+
+  public Path getWhRootExternal(String catalogName) throws MetaException {
+    boolean isDefault = DEFAULT_CATALOG_NAME.equals(catalogName.trim());
+
+    Path rootExDir = isDefault ? whRootExternal : whCatRootExternal;
+    if (rootExDir != null) {
+      return rootExDir;
+    }
+
+    if (isDefault) {
+      rootExDir = hasExternalWarehouseRoot()
+              ? getDnsPath(new Path(whRootExternalString))
+              : getWhRoot(catalogName);
+      whRootExternal = rootExDir;
+      return rootExDir;
+    }
+
+    rootExDir = hasExternalWarehouseRoot(catalogName)
+            ? getDnsPath(new Path(whCatRootExternalString, catalogName))
+            : getWhRoot(catalogName);
+    whCatRootExternal = rootExDir;
+    return rootExDir;
+  }
+
 
   /**
    * Build the database path based on catalog name and database name.  This should only be used
@@ -191,16 +239,16 @@ public class Warehouse {
    */
   public Path determineDatabasePath(Catalog cat, Database db) throws MetaException {
     if (db.getType() == DatabaseType.REMOTE) {
-      return getDefaultDatabasePath(db.getName(), true);
+      return getDefaultDatabasePath(db, true);
     }
     if (db.isSetLocationUri()) {
       return getDnsPath(new Path(db.getLocationUri()));
     }
-    if (cat == null || cat.getName().equalsIgnoreCase(DEFAULT_CATALOG_NAME)) {
+    if (cat.getName().equalsIgnoreCase(DEFAULT_CATALOG_NAME)) {
       if (db.getName().equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
-        return getWhRootExternal();
+        return getWhRootExternal(cat.getName());
       } else {
-        return new Path(getWhRootExternal(), dbDirFromDbName(db));
+        return new Path(getWhRootExternal(cat.getName()), dbDirFromDbName(db));
       }
     } else {
       return new Path(getDnsPath(new Path(cat.getLocationUri())), dbDirFromDbName(db));
@@ -225,7 +273,7 @@ public class Warehouse {
     }
     if (db.getCatalogName().equalsIgnoreCase(DEFAULT_CATALOG_NAME) &&
         db.getName().equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
-      return getWhRoot();
+      return getWhRoot(DEFAULT_CATALOG_NAME);
     }
     // this is for backward-compatibility where certain DBs do not have managedLocationUri set
     return new Path(db.getLocationUri());
@@ -241,9 +289,9 @@ public class Warehouse {
    */
   public Path getDatabaseExternalPath(Database db) throws MetaException {
       Path dbPath = new Path(db.getLocationUri());
-      if (FileUtils.isSubdirectory(getWhRoot().toString(), dbPath.toString() + Path.SEPARATOR)) {
+      if (FileUtils.isSubdirectory(getWhRoot(db.getCatalogName()).toString(), dbPath.toString() + Path.SEPARATOR)) {
         // db metadata incorrect, find new location based on external warehouse root
-        dbPath = getDefaultExternalDatabasePath(db.getName());
+        dbPath = getDefaultExternalDatabasePath(db);
       }
       return getDnsPath(dbPath);
   }
@@ -264,12 +312,15 @@ public class Warehouse {
       return new Path(db.getLocationUri());
     }
     if (db.getName().equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
-      return getWhRoot();
+      return getWhRoot(db.getCatalogName());
     }
 
-    return new Path(getWhRoot(), db.getName().toLowerCase() + DATABASE_WAREHOUSE_SUFFIX);
+    return new Path(getWhRoot(db.getCatalogName()), db.getName().toLowerCase() + DATABASE_WAREHOUSE_SUFFIX);
   }
 
+  /**
+   * @deprecated use {@link #getDefaultDatabasePath(Database)}
+   */
   public Path getDefaultDatabasePath(String dbName) throws MetaException {
     // TODO CAT - I am fairly certain that most calls to this are in error.  This should only be
     // used when the database location is unset, which should never happen except when a
@@ -279,27 +330,56 @@ public class Warehouse {
     return getDefaultDatabasePath(dbName, false);
   }
 
+  public Path getDefaultDatabasePath(Database db) throws MetaException {
+    return getDefaultDatabasePath(db, false);
+  }
+
+  /**
+   * @deprecated use {@link #getDefaultExternalDatabasePath(Database)}
+   */
   public Path getDefaultExternalDatabasePath(String dbName) throws MetaException {
     return getDefaultDatabasePath(dbName, true);
   }
 
-  // should only be used to determine paths before the creation of databases
-  public Path getDefaultDatabasePath(String dbName, boolean inExternalWH) throws MetaException {
-    if (inExternalWH) {
-      if (dbName.equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
-        return getWhRootExternal();
-      }
-      return new Path(getWhRootExternal(), dbName.toLowerCase() + DATABASE_WAREHOUSE_SUFFIX);
-    } else {
-      if (dbName.equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
-        return getWhRoot();
-      }
-      return new Path(getWhRoot(), dbName.toLowerCase() + DATABASE_WAREHOUSE_SUFFIX);
-    }
+  public Path getDefaultExternalDatabasePath(Database db) throws MetaException {
+    return getDefaultDatabasePath(db, true);
   }
 
+  /**
+   * @deprecated use {@link #getDefaultDatabasePath(Database, boolean)}
+   */
+  // should only be used to determine paths before the creation of databases
+  public Path getDefaultDatabasePath(String dbName, boolean inExternalWH) throws MetaException {
+    Database db = new Database();
+    db.setName(dbName);
+    db.setCatalogName(DEFAULT_CATALOG_NAME);
+    return getDefaultDatabasePath(db, inExternalWH);
+  }
+
+  public Path getDefaultDatabasePath(Database db, boolean inExternalWH) throws MetaException {
+    String catalogName = db.getCatalogName() != null ? db.getCatalogName() : DEFAULT_CATALOG_NAME;
+    String dbName = db.getName();
+
+    Path whRoot = inExternalWH ? getWhRootExternal(catalogName) : getWhRoot(catalogName);
+
+    if (dbName.equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
+      return whRoot;
+    }
+
+    return new Path(whRoot, dbName.toLowerCase() + DATABASE_WAREHOUSE_SUFFIX);
+  }
+
+  /**
+   * @deprecated use {@link #hasExternalWarehouseRoot(String)}
+   */
   private boolean hasExternalWarehouseRoot() {
-    return !StringUtils.isBlank(whRootExternalString);
+    return hasExternalWarehouseRoot(DEFAULT_CATALOG_NAME);
+  }
+
+  private boolean hasExternalWarehouseRoot(String catalogName) {
+    return catalogName.equalsIgnoreCase(DEFAULT_CATALOG_NAME)
+            ? !StringUtils.isBlank(whRootExternalString)
+            : !StringUtils.isBlank(whCatRootExternalString);
   }
 
   /**
@@ -319,10 +399,10 @@ public class Warehouse {
     Path dbPath = null;
     if (isExternal) {
       dbPath = new Path(db.getLocationUri());
-      if (FileUtils.isSubdirectory(getWhRoot().toString(), dbPath.toString()) ||
-          getWhRoot().equals(dbPath)) {
+      if (FileUtils.isSubdirectory(getWhRoot(db.getCatalogName()).toString(), dbPath.toString()) ||
+          getWhRoot(db.getCatalogName()).equals(dbPath)) {
         // db metadata incorrect, find new location based on external warehouse root
-        dbPath = getDefaultExternalDatabasePath(db.getName());
+        dbPath = getDefaultExternalDatabasePath(db);
       }
     } else {
       dbPath = getDatabaseManagedPath(db);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1776,6 +1776,15 @@ public class MetastoreConf {
         "hive.metastore.warehouse.external.dir", "",
         "Default location for external tables created in the warehouse. " +
         "If not set or null, then the normal warehouse location will be used as the default location."),
+    WAREHOUSE_CATALOG("metastore.warehouse.catalog.dir",
+            "hive.metastore.warehouse.catalog.dir", "/user/hive/catalog/warehouse",
+            "Base location for databases in non-default catalogs. If the name of the catalog to which the db belongs is testcat, " +
+                    "then the default path prefix for the db is /user/hive/catalog/warehouse/testcat."),
+    WAREHOUSE_CATALOG_EXTERNAL("metastore.warehouse.catalog.external.dir",
+            "hive.metastore.warehouse.catalog.external.dir", "",
+            "Base location for external tables created in the warehouse of non-default catalogs. " +
+                    "If not set or null, then the normal warehouse location (MetastoreConf.WAREHOUSE_CATALOG) " +
+                    "will be used as the default location."),
     WM_DEFAULT_POOL_SIZE("metastore.wm.default.pool.size",
         "hive.metastore.wm.default.pool.size", 4,
         "The size of a default pool to create when creating an empty resource plan;\n" +

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -79,7 +79,10 @@ public class HMSCatalogFactory {
     if (configUri != null && !configUri.isEmpty()) {
       properties.put("uri", configUri);
     }
-    // TODO catalog. Consider adding new created native catalog warehouse(MetastoreConf.ConfVars.WAREHOUSE_CATALOG) later.
+    // TODO catalog. Currently, `configWarehouse` is determined by the path of the default catalog. We need to consider whether,
+    //  in the case of a non-default catalog, `configWarehouse` should be determined by the specific catalog path instead.
+    //  Need to consider adding new created native/internal catalog warehouse(MetastoreConf.ConfVars.WAREHOUSE_CATALOG) later.
+    //  Create HIVE-28879 to track this issue.
     final String configWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE);
     if (configWarehouse != null) {
       properties.put("warehouse", configWarehouse);

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -79,6 +79,7 @@ public class HMSCatalogFactory {
     if (configUri != null && !configUri.isEmpty()) {
       properties.put("uri", configUri);
     }
+    // TODO catalog. Consider adding new created native catalog warehouse(MetastoreConf.ConfVars.WAREHOUSE_CATALOG) later.
     final String configWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE);
     if (configWarehouse != null) {
       properties.put("warehouse", configWarehouse);

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -704,6 +704,8 @@
             <test.tmp.dir>${test.tmp.dir}</test.tmp.dir>
             <metastore.warehouse.dir>${test.warehouse.scheme}${test.warehouse.dir}</metastore.warehouse.dir>
             <hive.metastore.warehouse.external.dir>${test.warehouse.scheme}${test.warehouse.external.dir}</hive.metastore.warehouse.external.dir>
+            <metastore.warehouse.catalog.dir>${test.warehouse.scheme}${test.warehouse.dir}</metastore.warehouse.catalog.dir>
+            <hive.metastore.warehouse.catalog.external.dir>${test.warehouse.scheme}${test.warehouse.external.dir}</hive.metastore.warehouse.catalog.external.dir>
           </systemPropertyVariables>
           <additionalClasspathElements>
             <additionalClasspathElement>${log4j.conf.dir}</additionalClasspathElement>

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -184,12 +184,12 @@ public class HMSHandler extends PrivilegeHandler {
         // One time update issue.  When the new 'hive' catalog is created in an upgrade the
         // script does not know the location of the warehouse.  So we need to update it.
         LOG.info("Setting location of default catalog, as it hasn't been done after upgrade");
-        defaultCat.setLocationUri(wh.getWhRoot().toString());
+        defaultCat.setLocationUri(wh.getWhRoot(DEFAULT_CATALOG_NAME).toString());
         ms.alterCatalog(defaultCat.getName(), defaultCat);
       }
 
     } catch (NoSuchObjectException e) {
-      Catalog cat = new Catalog(DEFAULT_CATALOG_NAME, wh.getWhRoot().toString());
+      Catalog cat = new Catalog(DEFAULT_CATALOG_NAME, wh.getWhRoot(DEFAULT_CATALOG_NAME).toString());
       long time = System.currentTimeMillis() / 1000;
       cat.setCreateTime((int) time);
       cat.setDescription(Warehouse.DEFAULT_CATALOG_COMMENT);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
@@ -815,7 +815,7 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
           LOG.debug("Processor has atleast one of ACID write capabilities, setting current locationUri " + db.getLocationUri() + " as managedLocationUri");
           db.setManagedLocationUri(new Path(db.getLocationUri()).toString());
         }
-        Path extWhLocation = hmsHandler.getWh().getDefaultExternalDatabasePath(db.getName());
+        Path extWhLocation = hmsHandler.getWh().getDefaultExternalDatabasePath(db);
         LOG.info("Database's location is a managed location, setting to a new default path based on external warehouse path:" + extWhLocation.toString());
         db.setLocationUri(extWhLocation.toString());
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -720,14 +720,10 @@ public class ObjectStore implements RawStore, Configurable {
     }
 
     String catalogType = parameters.get("type");
-    if (catalogType == null || catalogType.trim().isEmpty()) {
-      parameters.put("type", CatalogUtil.NATIVE);
-    } else {
-      try {
-        parameters.put("type", CatalogUtil.normalizeCatalogType(catalogType));
-      } catch (IllegalArgumentException e) {
-        throw new MetaException("Invalid catalog type: " + catalogType);
-      }
+    try {
+      parameters.put("type", CatalogUtil.normalizeCatalogType(catalogType));
+    } catch (IllegalArgumentException e) {
+      throw new MetaException("Invalid catalog type: " + catalogType);
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -694,6 +694,9 @@ public class ObjectStore implements RawStore, Configurable {
   @Override
   public void createCatalog(Catalog cat) throws MetaException {
     LOG.debug("Creating catalog {}", cat);
+
+    ensureCatalogType(cat);
+
     boolean committed = false;
     MCatalog mCat = catToMCat(cat);
     try {
@@ -702,6 +705,29 @@ public class ObjectStore implements RawStore, Configurable {
       committed = commitTransaction();
     } finally {
       rollbackAndCleanup(committed, null);
+    }
+  }
+
+  /**
+   * Ensure catalog has a valid type, default to NATIVE if not specified.
+   * Also normalizes the type to lowercase (e.g., "NATIVE" -> "native").
+   */
+  private void ensureCatalogType(Catalog cat) throws MetaException {
+    Map<String, String> parameters = cat.getParameters();
+    if (parameters == null) {
+      parameters = new HashMap<>();
+      cat.setParameters(parameters);
+    }
+
+    String catalogType = parameters.get("type");
+    if (catalogType == null || catalogType.trim().isEmpty()) {
+      parameters.put("type", CatalogUtil.NATIVE);
+    } else {
+      try {
+        parameters.put("type", CatalogUtil.normalizeCatalogType(catalogType));
+      } catch (IllegalArgumentException e) {
+        throw new MetaException("Invalid catalog type: " + catalogType);
+      }
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -709,8 +709,8 @@ public class ObjectStore implements RawStore, Configurable {
   }
 
   /**
-   * Ensure catalog has a valid type, default to NATIVE if not specified.
-   * Also normalizes the type to lowercase (e.g., "NATIVE" -> "native").
+   * Ensure catalog has a valid type, default to hive if not specified.
+   * Also normalizes the type to lowercase (e.g., "HIVE" -> "hive").
    */
   private void ensureCatalogType(Catalog cat) throws MetaException {
     Map<String, String> parameters = cat.getParameters();
@@ -719,9 +719,9 @@ public class ObjectStore implements RawStore, Configurable {
       cat.setParameters(parameters);
     }
 
-    String catalogType = parameters.get("type");
+    String catalogType = parameters.get(CatalogUtil.TYPE);
     try {
-      parameters.put("type", CatalogUtil.normalizeCatalogType(catalogType));
+      parameters.put(CatalogUtil.TYPE, CatalogUtil.normalizeCatalogType(catalogType));
     } catch (IllegalArgumentException e) {
       throw new MetaException("Invalid catalog type: " + catalogType);
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/BaseHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/BaseHandler.java
@@ -701,11 +701,11 @@ public abstract class BaseHandler extends FacebookBase implements IHMSHandler {
       ms.getDatabase(DEFAULT_CATALOG_NAME, DEFAULT_DATABASE_NAME);
     } catch (NoSuchObjectException e) {
       LOG.info("Started creating a default database with name: {}", DEFAULT_DATABASE_NAME);
-      Database db = new Database(DEFAULT_DATABASE_NAME, DEFAULT_DATABASE_COMMENT,
-          wh.getDefaultDatabasePath(DEFAULT_DATABASE_NAME, true).toString(), null);
+      Database db = new Database(DEFAULT_DATABASE_NAME, DEFAULT_DATABASE_COMMENT, null, null);
+      db.setCatalogName(DEFAULT_CATALOG_NAME);
+      db.setLocationUri(wh.getDefaultDatabasePath(db, true).toString());
       db.setOwnerName(PUBLIC);
       db.setOwnerType(PrincipalType.ROLE);
-      db.setCatalogName(DEFAULT_CATALOG_NAME);
       long time = System.currentTimeMillis() / 1000;
       db.setCreateTime((int) time);
       db.setType(DatabaseType.NATIVE);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/CreateDatabaseHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/CreateDatabaseHandler.java
@@ -225,8 +225,8 @@ public class CreateDatabaseHandler
 
     String passedInURI = db.getLocationUri();
     String passedInManagedURI = db.getManagedLocationUri();
-    Path defaultDbExtPath = wh.getDefaultDatabasePath(db.getName(), true);
-    Path defaultDbMgdPath = wh.getDefaultDatabasePath(db.getName(), false);
+    Path defaultDbExtPath = wh.getDefaultDatabasePath(db, true);
+    Path defaultDbMgdPath = wh.getDefaultDatabasePath(db, false);
     Path dbExtPath = (passedInURI != null) ?
         wh.getDnsPath(new Path(passedInURI)) : wh.determineDatabasePath(cat, db);
     Path dbMgdPath = (passedInManagedURI != null) ? wh.getDnsPath(new Path(passedInManagedURI)) : null;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/MetaStoreTestUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/MetaStoreTestUtils.java
@@ -164,15 +164,18 @@ public class MetaStoreTestUtils {
                                             boolean createTransactionalTables) throws Exception {
     Exception metaStoreException = null;
     String warehouseDir = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE);
+    String warehouseCatDir = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE_CATALOG);
 
     for (int tryCount = 0; tryCount < MetaStoreTestUtils.RETRY_COUNT; tryCount++) {
       try {
         int metaStorePort = findFreePort();
         if (!keepWarehousePath) {
           // Setting metastore instance specific warehouse directory, postfixing with port
-          Path postfixedWarehouseDir = new Path(warehouseDir, String.valueOf(metaStorePort));
-          MetastoreConf.setVar(conf, ConfVars.WAREHOUSE, postfixedWarehouseDir.toString());
-          warehouseDir = postfixedWarehouseDir.toString();
+          warehouseDir = new Path(warehouseDir, String.valueOf(metaStorePort)).toString();
+          MetastoreConf.setVar(conf, ConfVars.WAREHOUSE, warehouseDir);
+
+          warehouseCatDir = new Path(warehouseCatDir, String.valueOf(metaStorePort)).toString();
+          MetastoreConf.setVar(conf, ConfVars.WAREHOUSE_CATALOG, warehouseCatDir);
         }
 
         String jdbcUrl = MetastoreConf.getVar(conf, ConfVars.CONNECT_URL_KEY);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


The main objectives of this PR are:  
1) Allow location to be omitted when creating a catalog. At the same time, it is necessary to determine catalogs that do not require a location, such as JDBC catalogs.  

2) For newly created catalogs, the location of their databases will be determined by the two newly added parameters: `metastore.warehouse.catalog.dir` and `metastore.warehouse.catalog.external.dir`. This helps better ensure that the location of the default Hive catalog's databases and tables remains unaffected.  

 For example, if metastore.warehouse.catalog.dir is hdfs://ns1/testdir, then the location for a newly created catalog named testcat would be hdfs://ns1/testdir/testcat. Consequently, the default path for a database like testdb created under this catalog would be hdfs://ns1/testdir/testcat/testdb.


3) Modify the semantics of catalog creation. The `type` parameter must be specified when creating a catalog to distinguish its type. Based on this type, it will be determined whether the catalog's databases and tables require a location, or whether the catalog type supports creating databases and tables.
`CREATE CATALOG test_cat COMMENT 'Hive test catalog' PROPERTIES('type'='hive');`


BTW, While working on this PR, some tasks need to be carried forward. For these follow-up tasks, I have created sub-tickets. You can also search for the `TODO catalog` comments in the catalog for more details on these follow-up tasks.
HIVE-29564
HIVE-29562
HIVE-29561
HIVE-29278

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The paths of databases and tables created under a non-default catalog may interfere with those under the default Hive catalog. We need to introduce parameters to distinguish the paths for databases and tables under non-default catalogs, ensuring that the paths of the default Hive catalog remain unaffected.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing tests.