### PR TITLE
HIVE-28676: Support custom partition patterns in MSCK repair table

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatConstants.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatConstants.java
@@ -148,7 +148,6 @@ public final class HCatConstants {
 
   public static final String HCAT_DYNAMIC_PTN_JOBID = HCAT_KEY_OUTPUT_BASE + ".dynamic.jobid";
   public static final boolean HCAT_IS_DYNAMIC_MAX_PTN_CHECK_ENABLED = false;
-  public static final String HCAT_DYNAMIC_CUSTOM_PATTERN = "hcat.dynamic.partitioning.custom.pattern";
 
   // Message Bus related properties.
   public static final String HCAT_DEFAULT_TOPIC_PREFIX = "hcat";

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatFileUtil.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatFileUtil.java
@@ -23,16 +23,12 @@ import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.hadoop.fs.Path;
 
+import static org.apache.hadoop.hive.metastore.utils.DynamicPartitioningCustomPattern.customPathPattern;
+
 public class HCatFileUtil {
-
-  // regex of the form: ${column name}. Following characters are not allowed in column name:
-  // whitespace characters, /, {, }, \
-  private static final Pattern customPathPattern = Pattern.compile("(\\$\\{)([^\\s/\\{\\}\\\\]+)(\\})");
-
   // This method parses the custom dynamic path and replaces each occurrence
   // of column name within regex pattern with its corresponding value, if provided
   public static String resolveCustomPath(OutputJobInfo jobInfo,

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatOutputFormat.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatOutputFormat.java
@@ -53,6 +53,8 @@ import org.apache.hive.hcatalog.data.schema.HCatSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN;
+
 /** The OutputFormat to use to write data to HCatalog. The key value is ignored and
  *  should be given as null. The value is the HCatRecord to write.*/
 @InterfaceAudience.Public
@@ -163,7 +165,7 @@ public class HCatOutputFormat extends HCatBaseOutputFormat {
           conf.set(HCatConstants.HCAT_DYNAMIC_PTN_JOBID, dynHash);
 
           // if custom pattern is set in case of dynamic partitioning, configure custom path
-          String customPattern = conf.get(HCatConstants.HCAT_DYNAMIC_CUSTOM_PATTERN);
+          String customPattern = conf.get(HCAT_CUSTOM_DYNAMIC_PATTERN);
           if (customPattern != null) {
             HCatFileUtil.setCustomPath(customPattern, outputJobInfo);
           }

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN;
 
 public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
 
@@ -125,7 +126,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
     generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
     HashMap<String, String> properties = new HashMap<String, String>();
     if (customDynamicPathPattern != null) {
-      properties.put(HCatConstants.HCAT_DYNAMIC_CUSTOM_PATTERN, customDynamicPathPattern);
+      properties.put(HCAT_CUSTOM_DYNAMIC_PATTERN, customDynamicPathPattern);
     }
     runMRCreate(null, dataColumns, writeRecords.subList(0,NUM_RECORDS/2), NUM_RECORDS/2,
         true, asSingleMapTask, properties);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AbstractAddPartitionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AbstractAddPartitionAnalyzer.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN;
+
 /**
  * Analyzer for add partition commands.
  */
@@ -70,7 +72,7 @@ abstract class AbstractAddPartitionAnalyzer extends AbstractAlterTableAnalyzer {
     }
 
     AlterTableAddPartitionDesc desc = new AlterTableAddPartitionDesc(table.getDbName(), table.getTableName(),
-        ifNotExists, partitions);
+        ifNotExists, partitions, conf.get(HCAT_CUSTOM_DYNAMIC_PATTERN));
     Task<DDLWork> ddlTask = TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc));
     rootTasks.add(ddlTask);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AlterTableAddPartitionDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AlterTableAddPartitionDesc.java
@@ -178,12 +178,20 @@ public class AlterTableAddPartitionDesc implements DDLDescWithWriteId, Serializa
 
   private ReplicationSpec replicationSpec = null; // TODO: make replicationSpec final too
 
+  private final String customPattern;
+
   public AlterTableAddPartitionDesc(String dbName, String tableName, boolean ifNotExists,
-      List<PartitionDesc> partitions) {
+                                    List<PartitionDesc> partitions) {
+    this(dbName, tableName, ifNotExists, partitions, null);
+  }
+
+  public AlterTableAddPartitionDesc(String dbName, String tableName, boolean ifNotExists,
+      List<PartitionDesc> partitions, String customPattern) {
     this.dbName = dbName;
     this.tableName = tableName;
     this.ifNotExists = ifNotExists;
     this.partitions = partitions;
+    this.customPattern = customPattern;
   }
 
   @Explain(displayName = "db name", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
@@ -239,6 +247,10 @@ public class AlterTableAddPartitionDesc implements DDLDescWithWriteId, Serializa
   @Override
   public boolean mayNeedWriteId() {
     return true;
+  }
+
+  public String getCustomPattern() {
+    return this.customPattern;
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AlterTableAddPartitionOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AlterTableAddPartitionOperation.java
@@ -80,7 +80,7 @@ public class AlterTableAddPartitionOperation extends DDLOperation<AlterTableAddP
   private List<Partition> getPartitions(Table table, long writeId) throws HiveException {
     List<Partition> partitions = new ArrayList<>(desc.getPartitions().size());
     for (AlterTableAddPartitionDesc.PartitionDesc partitionDesc : desc.getPartitions()) {
-      Partition partition = convertPartitionSpecToMetaPartition(table, partitionDesc);
+      Partition partition = convertPartitionSpecToMetaPartition(table, partitionDesc, desc.getCustomPattern());
       if (partition != null && writeId > 0) {
         partition.setWriteId(writeId);
       }
@@ -91,7 +91,7 @@ public class AlterTableAddPartitionOperation extends DDLOperation<AlterTableAddP
   }
 
   private Partition convertPartitionSpecToMetaPartition(Table table,
-      AlterTableAddPartitionDesc.PartitionDesc partitionSpec) throws HiveException {
+      AlterTableAddPartitionDesc.PartitionDesc partitionSpec, String customPattern) throws HiveException {
     Path location = partitionSpec.getLocation() != null ? new Path(table.getPath(), partitionSpec.getLocation()) : null;
     if (location != null) {
       // Ensure that it is a full qualified path (in most cases it will be since tbl.getPath() is full qualified)
@@ -99,7 +99,7 @@ public class AlterTableAddPartitionOperation extends DDLOperation<AlterTableAddP
     }
 
     Partition partition = org.apache.hadoop.hive.ql.metadata.Partition.createMetaPartitionObject(
-        table, partitionSpec.getPartSpec(), location);
+        table, partitionSpec.getPartSpec(), location, customPattern);
 
     if (partitionSpec.getPartParams() != null) {
       partition.setParameters(partitionSpec.getPartParams());

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/events/filesystem/FSTableEvent.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/events/filesystem/FSTableEvent.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN;
 
 public class FSTableEvent implements TableEvent {
   private final Path fromPathMetadata;
@@ -179,7 +180,7 @@ public class FSTableEvent implements TableEvent {
           sd.getBucketCols(), sd.getSortCols(), columnStatistics, writeId);
 
       AlterTableAddPartitionDesc addPartitionDesc = new AlterTableAddPartitionDesc(tblDesc.getDatabaseName(),
-          tblDesc.getTableName(), true, ImmutableList.of(partitionDesc));
+          tblDesc.getTableName(), true, ImmutableList.of(partitionDesc), hiveConf.get(HCAT_CUSTOM_DYNAMIC_PATTERN));
       addPartitionDesc.setReplicationSpec(replicationSpec());
       return addPartitionDesc;
     } catch (Exception e) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
@@ -415,7 +415,8 @@ public class ImportSemanticAnalyzer extends BaseSemanticAnalyzer {
         partitionSpec, location, partition.getParameters(), sd.getInputFormat(), sd.getOutputFormat(),
         sd.getNumBuckets(), sd.getCols(), sd.getSerdeInfo().getSerializationLib(), sd.getSerdeInfo().getParameters(),
         sd.getBucketCols(), sd.getSortCols(), null, writeId);
-    return new AlterTableAddPartitionDesc(dbName, tblDesc.getTableName(), true, ImmutableList.of(partitionDesc), conf.get(MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN));
+    return new AlterTableAddPartitionDesc(dbName, tblDesc.getTableName(), true, ImmutableList.of(partitionDesc),
+            conf.get(MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN));
   }
 
   private static ImportTableDesc getBaseCreateTableDescFromTable(String dbName,

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.ReplChangeManager;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
@@ -414,7 +415,7 @@ public class ImportSemanticAnalyzer extends BaseSemanticAnalyzer {
         partitionSpec, location, partition.getParameters(), sd.getInputFormat(), sd.getOutputFormat(),
         sd.getNumBuckets(), sd.getCols(), sd.getSerdeInfo().getSerializationLib(), sd.getSerdeInfo().getParameters(),
         sd.getBucketCols(), sd.getSortCols(), null, writeId);
-    return new AlterTableAddPartitionDesc(dbName, tblDesc.getTableName(), true, ImmutableList.of(partitionDesc));
+    return new AlterTableAddPartitionDesc(dbName, tblDesc.getTableName(), true, ImmutableList.of(partitionDesc), conf.get(MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN));
   }
 
   private static ImportTableDesc getBaseCreateTableDescFromTable(String dbName,

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreChecker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreChecker.java
@@ -111,9 +111,9 @@ public class TestHiveMetaStoreChecker {
     partCols.add(new FieldSchema(partCityName, serdeConstants.STRING_TYPE_NAME, ""));
 
     partColsExt = new ArrayList<FieldSchema>();
-    partColsExt.add(new FieldSchema(partCityName,serdeConstants.STRING_TYPE_NAME,""));
-    partColsExt.add(new FieldSchema(partStateName,serdeConstants.STRING_TYPE_NAME,""));
-    partColsExt.add(new FieldSchema(partIdName,serdeConstants.STRING_TYPE_NAME,""));
+    partColsExt.add(new FieldSchema(partCityName, serdeConstants.STRING_TYPE_NAME, ""));
+    partColsExt.add(new FieldSchema(partStateName, serdeConstants.STRING_TYPE_NAME, ""));
+    partColsExt.add(new FieldSchema(partIdName, serdeConstants.STRING_TYPE_NAME, ""));
 
     parts = new ArrayList<>();
     Map<String, String> part1 = new HashMap<>();
@@ -362,24 +362,25 @@ public class TestHiveMetaStoreChecker {
   }
 
   @Test
-  public void testCustomPartitionPatternCheck() throws HiveException, AlreadyExistsException, IOException, MetastoreException {
+  public void testCustomPartitionPatternCheck()
+          throws HiveException, AlreadyExistsException, IOException, MetastoreException {
     Table table = createTestExternalTable();
     Path tablePath = table.getDataLocation();
     fs = tablePath.getFileSystem(hive.getConf());
-    fs.mkdirs(new Path(tablePath,"const/CO/const2/1-denver"));
-    fs.mkdirs(new Path(tablePath,"const/CA/const2/1-sanjose"));
-    fs.mkdirs(new Path(tablePath,"const/CA/const2/2-sanfrancisco"));
-    fs.mkdirs(new Path(tablePath,"const/IL/const2/1-chicago"));
-    fs.mkdirs(new Path(tablePath,"const/TX/const2/1-dallas"));
-    fs.mkdirs(new Path(tablePath,"const/TX/const2/2-austin"));
-    fs.mkdirs(new Path(tablePath,"const/NY/const2/1-newyork"));
-    fs.createNewFile(new Path(tablePath,"const/CO/const2/1-denver/datafile"));
-    fs.createNewFile(new Path(tablePath,"const/CA/const2/1-sanjose/datafile"));
-    fs.createNewFile(new Path(tablePath,"const/CA/const2/2-sanfrancisco/datafile"));
-    fs.createNewFile(new Path(tablePath,"const/IL/const2/1-chicago/datafile"));
-    fs.createNewFile(new Path(tablePath,"const/TX/const2/1-dallas/datafile"));
-    fs.createNewFile(new Path(tablePath,"const/TX/const2/2-austin/datafile"));
-    fs.createNewFile(new Path(tablePath,"const/NY/const2/1-newyork/datafile"));
+    fs.mkdirs(new Path(tablePath, "const/CO/const2/1-denver"));
+    fs.mkdirs(new Path(tablePath, "const/CA/const2/1-sanjose"));
+    fs.mkdirs(new Path(tablePath, "const/CA/const2/2-sanfrancisco"));
+    fs.mkdirs(new Path(tablePath, "const/IL/const2/1-chicago"));
+    fs.mkdirs(new Path(tablePath, "const/TX/const2/1-dallas"));
+    fs.mkdirs(new Path(tablePath, "const/TX/const2/2-austin"));
+    fs.mkdirs(new Path(tablePath, "const/NY/const2/1-newyork"));
+    fs.createNewFile(new Path(tablePath, "const/CO/const2/1-denver/datafile"));
+    fs.createNewFile(new Path(tablePath, "const/CA/const2/1-sanjose/datafile"));
+    fs.createNewFile(new Path(tablePath, "const/CA/const2/2-sanfrancisco/datafile"));
+    fs.createNewFile(new Path(tablePath, "const/IL/const2/1-chicago/datafile"));
+    fs.createNewFile(new Path(tablePath, "const/TX/const2/1-dallas/datafile"));
+    fs.createNewFile(new Path(tablePath, "const/TX/const2/2-austin/datafile"));
+    fs.createNewFile(new Path(tablePath, "const/NY/const2/1-newyork/datafile"));
     CheckResult result = customChecker.checkMetastore(null, dbName, externalTableName, null, null);
     assertEquals(7, result.getPartitionsNotInMs().size());
     //cleanup

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreChecker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreChecker.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.metastore.CheckResult;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreChecker;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -56,6 +57,8 @@ import org.junit.Test;
 
 import com.google.common.collect.Lists;
 
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN;
+
 /**
  * TestHiveMetaStoreChecker.
  *
@@ -66,15 +69,22 @@ public class TestHiveMetaStoreChecker {
   private IMetaStoreClient msc;
   private FileSystem fs;
   private HiveMetaStoreChecker checker = null;
+  private HiveMetaStoreChecker customChecker = null;
 
   private final String catName = "hive";
   private final String dbName = "testhivemetastorechecker_db";
   private final String tableName = "testhivemetastorechecker_table";
+  private final String externalTableName = "testhivemetastorechecker_table_external";
 
   private final String partDateName = "partdate";
   private final String partCityName = "partcity";
 
+  private final String partIdName = "partid";
+
+  private final String partStateName = "partstate";
+
   private List<FieldSchema> partCols;
+  private List<FieldSchema> partColsExt;
   private List<Map<String, String>> parts;
 
   @Before
@@ -92,9 +102,18 @@ public class TestHiveMetaStoreChecker {
     SessionState ss = SessionState.start(conf);
     ss.initTxnMgr(conf);
 
+    HiveConf customConf = new HiveConf(conf);
+    customConf.set(HCAT_CUSTOM_DYNAMIC_PATTERN, "const/${partstate}/const2/${partid}-${partcity}");
+    customChecker = new HiveMetaStoreChecker(msc, customConf);
+
     partCols = new ArrayList<>();
     partCols.add(new FieldSchema(partDateName, serdeConstants.STRING_TYPE_NAME, ""));
     partCols.add(new FieldSchema(partCityName, serdeConstants.STRING_TYPE_NAME, ""));
+
+    partColsExt = new ArrayList<FieldSchema>();
+    partColsExt.add(new FieldSchema(partCityName,serdeConstants.STRING_TYPE_NAME,""));
+    partColsExt.add(new FieldSchema(partStateName,serdeConstants.STRING_TYPE_NAME,""));
+    partColsExt.add(new FieldSchema(partIdName,serdeConstants.STRING_TYPE_NAME,""));
 
     parts = new ArrayList<>();
     Map<String, String> part1 = new HashMap<>();
@@ -340,6 +359,32 @@ public class TestHiveMetaStoreChecker {
     // Found the highest writeId
     assertEquals(3, result.getPartitionsNotInMs().iterator().next().getMaxWriteId());
     assertEquals(200, result.getPartitionsNotInMs().iterator().next().getMaxTxnId());
+  }
+
+  @Test
+  public void testCustomPartitionPatternCheck() throws HiveException, AlreadyExistsException, IOException, MetastoreException {
+    Table table = createTestExternalTable();
+    Path tablePath = table.getDataLocation();
+    fs = tablePath.getFileSystem(hive.getConf());
+    fs.mkdirs(new Path(tablePath,"const/CO/const2/1-denver"));
+    fs.mkdirs(new Path(tablePath,"const/CA/const2/1-sanjose"));
+    fs.mkdirs(new Path(tablePath,"const/CA/const2/2-sanfrancisco"));
+    fs.mkdirs(new Path(tablePath,"const/IL/const2/1-chicago"));
+    fs.mkdirs(new Path(tablePath,"const/TX/const2/1-dallas"));
+    fs.mkdirs(new Path(tablePath,"const/TX/const2/2-austin"));
+    fs.mkdirs(new Path(tablePath,"const/NY/const2/1-newyork"));
+    fs.createNewFile(new Path(tablePath,"const/CO/const2/1-denver/datafile"));
+    fs.createNewFile(new Path(tablePath,"const/CA/const2/1-sanjose/datafile"));
+    fs.createNewFile(new Path(tablePath,"const/CA/const2/2-sanfrancisco/datafile"));
+    fs.createNewFile(new Path(tablePath,"const/IL/const2/1-chicago/datafile"));
+    fs.createNewFile(new Path(tablePath,"const/TX/const2/1-dallas/datafile"));
+    fs.createNewFile(new Path(tablePath,"const/TX/const2/2-austin/datafile"));
+    fs.createNewFile(new Path(tablePath,"const/NY/const2/1-newyork/datafile"));
+    CheckResult result = customChecker.checkMetastore(null, dbName, externalTableName, null, null);
+    assertEquals(7, result.getPartitionsNotInMs().size());
+    //cleanup
+    hive.dropTable(dbName, externalTableName);
+    fs.delete(tablePath, true);
   }
 
   @Test
@@ -810,6 +855,23 @@ public class TestHiveMetaStoreChecker {
     for (Map<String, String> partSpec : parts) {
       hive.createPartition(table, partSpec);
     }
+    return table;
+  }
+
+  private Table createTestExternalTable() throws AlreadyExistsException, HiveException {
+    Database db = new Database();
+    db.setName(dbName);
+    hive.createDatabase(db, true);
+
+    Table table = new Table(dbName, externalTableName);
+    table.setDbName(dbName);
+    table.setInputFormatClass(TextInputFormat.class);
+    table.setOutputFormatClass(HiveIgnoreKeyTextOutputFormat.class);
+    table.setPartCols(partColsExt);
+
+    hive.createTable(table);
+    table = hive.getTable(dbName, externalTableName);
+    table.setTableType(TableType.EXTERNAL_TABLE);
     return table;
   }
   private Table createNonPartitionedTable() throws Exception {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -30,6 +30,7 @@ import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getPar
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getPartitionColtoTypeMap;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getPartitionsByProjectSpec;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getPath;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.HCAT_CUSTOM_DYNAMIC_PATTERN;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.isPartitioned;
 
 import java.io.IOException;
@@ -50,6 +51,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
+import java.util.regex.Pattern;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
@@ -61,6 +63,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
 import org.apache.hadoop.hive.metastore.api.GetProjectionsSpec;
+import org.apache.hadoop.hive.metastore.utils.DynamicPartitioningCustomPattern;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.MetastoreException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -574,14 +577,27 @@ public class HiveMetaStoreChecker {
     private final ConcurrentLinkedQueue<PathDepthInfo> pendingPaths;
     private final boolean throwException;
     private final PathDepthInfo pd;
+    private final DynamicPartitioningCustomPattern compiledCustomPattern;
+    private final int maxDepth;
 
     private PathDepthInfoCallable(PathDepthInfo pd, List<String> partColNames, FileSystem fs,
-        ConcurrentLinkedQueue<PathDepthInfo> basePaths) {
+        ConcurrentLinkedQueue<PathDepthInfo> basePaths, String customPattern) {
       this.partColNames = partColNames;
       this.pd = pd;
       this.fs = fs;
       this.pendingPaths = basePaths;
       this.throwException = "throw".equals(MetastoreConf.getVar(conf, MetastoreConf.ConfVars.MSCK_PATH_VALIDATION));
+      if (customPattern != null) {
+        String[] parts = customPattern.split(Path.SEPARATOR);
+        this.compiledCustomPattern = new DynamicPartitioningCustomPattern.Builder()
+                .setCustomPattern(customPattern)
+                .build();
+        this.maxDepth = parts.length;
+      }
+      else {
+        this.compiledCustomPattern = null;
+        this.maxDepth = partColNames.size();
+      }
     }
 
     @Override
@@ -593,7 +609,15 @@ public class HiveMetaStoreChecker {
         throws IOException, MetastoreException {
       final Path currentPath = pd.p;
       final int currentDepth = pd.depth;
-      if (currentDepth == partColNames.size()) {
+      if (currentDepth == maxDepth) {
+        if (compiledCustomPattern != null) { //validate path against pattern
+          Pattern fullPattern = compiledCustomPattern.getPartitionCapturePattern();
+          String[] parts = currentPath.toString().split(Path.SEPARATOR);
+          String relPath = String.join(Path.SEPARATOR, Arrays.copyOfRange(parts, parts.length - maxDepth, parts.length));
+          if (!fullPattern.matcher(relPath).matches()) {
+            logOrThrowExceptionWithMsg("File path " + currentPath + " does not match custom partitioning pattern" + compiledCustomPattern.getCustomPattern());
+          }
+        }
         return currentPath;
       }
       List<FileStatus> fileStatuses = new ArrayList<>();
@@ -605,7 +629,7 @@ public class HiveMetaStoreChecker {
       }
       // found no files under a sub-directory under table base path; it is possible that the table
       // is empty and hence there are no partition sub-directories created under base path
-      if (fileStatuses.size() == 0 && currentDepth > 0) {
+      if (fileStatuses.isEmpty() && currentDepth > 0 && currentDepth < maxDepth) {
         // since maxDepth is not yet reached, we are missing partition
         // columns in currentPath
         logOrThrowExceptionWithMsg(
@@ -618,7 +642,14 @@ public class HiveMetaStoreChecker {
             logOrThrowExceptionWithMsg(
                 "MSCK finds a file rather than a directory when it searches for "
                     + fileStatus.getPath().toString());
-          } else {
+          } else if (fileStatus.isDirectory() && compiledCustomPattern != null) {
+            //since this is a restricted custom pattern, it could be almost anything
+            //when we hit max depth we can perform a validation check of entire path against pattern, to avoid creating regexen
+            //at every depth
+            Path nextPath = fileStatus.getPath();
+            pendingPaths.add(new PathDepthInfo(nextPath, currentDepth + 1));
+          }
+          else {
             // found a sub-directory at a depth less than number of partition keys
             // validate if the partition directory name matches with the corresponding
             // partition colName at currentDepth
@@ -677,7 +708,7 @@ public class HiveMetaStoreChecker {
         //process each level in parallel
         while(!nextLevel.isEmpty()) {
           futures.add(
-              executor.submit(new PathDepthInfoCallable(nextLevel.poll(), partColNames, fs, tempQueue)));
+              executor.submit(new PathDepthInfoCallable(nextLevel.poll(), partColNames, fs, tempQueue, conf.get(HCAT_CUSTOM_DYNAMIC_PATTERN))));
         }
         while(!futures.isEmpty()) {
           Path p = futures.poll().get();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -593,8 +593,7 @@ public class HiveMetaStoreChecker {
                 .setCustomPattern(customPattern)
                 .build();
         this.maxDepth = parts.length;
-      }
-      else {
+      } else {
         this.compiledCustomPattern = null;
         this.maxDepth = partColNames.size();
       }
@@ -613,9 +612,11 @@ public class HiveMetaStoreChecker {
         if (compiledCustomPattern != null) { //validate path against pattern
           Pattern fullPattern = compiledCustomPattern.getPartitionCapturePattern();
           String[] parts = currentPath.toString().split(Path.SEPARATOR);
-          String relPath = String.join(Path.SEPARATOR, Arrays.copyOfRange(parts, parts.length - maxDepth, parts.length));
+          String relPath = String.join(Path.SEPARATOR,
+                  Arrays.copyOfRange(parts, parts.length - maxDepth, parts.length));
           if (!fullPattern.matcher(relPath).matches()) {
-            logOrThrowExceptionWithMsg("File path " + currentPath + " does not match custom partitioning pattern" + compiledCustomPattern.getCustomPattern());
+            logOrThrowExceptionWithMsg("File path " + currentPath + " does not match custom partitioning pattern"
+                    + compiledCustomPattern.getCustomPattern());
           }
         }
         return currentPath;
@@ -644,12 +645,11 @@ public class HiveMetaStoreChecker {
                     + fileStatus.getPath().toString());
           } else if (fileStatus.isDirectory() && compiledCustomPattern != null) {
             //since this is a restricted custom pattern, it could be almost anything
-            //when we hit max depth we can perform a validation check of entire path against pattern, to avoid creating regexen
-            //at every depth
+            //when we hit max depth we can perform a validation check of entire path against pattern,
+            //to avoid creating regexen at every depth
             Path nextPath = fileStatus.getPath();
             pendingPaths.add(new PathDepthInfo(nextPath, currentDepth + 1));
-          }
-          else {
+          } else {
             // found a sub-directory at a depth less than number of partition keys
             // validate if the partition directory name matches with the corresponding
             // partition colName at currentDepth
@@ -708,7 +708,8 @@ public class HiveMetaStoreChecker {
         //process each level in parallel
         while(!nextLevel.isEmpty()) {
           futures.add(
-              executor.submit(new PathDepthInfoCallable(nextLevel.poll(), partColNames, fs, tempQueue, conf.get(HCAT_CUSTOM_DYNAMIC_PATTERN))));
+              executor.submit(new PathDepthInfoCallable(nextLevel.poll(), partColNames, fs, tempQueue,
+                      conf.get(HCAT_CUSTOM_DYNAMIC_PATTERN))));
         }
         while(!futures.isEmpty()) {
           Path p = futures.poll().get();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/DynamicPartitioningCustomPattern.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/DynamicPartitioningCustomPattern.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * When using msck repair table with custom partitioning patterns, we need to capture
+ * the partition keys from the pattern, and use those to construct a regex which will
+ * match the paths and extract the partition key values.*/
+public class DynamicPartitioningCustomPattern {
+
+    private final String customPattern;
+    private final Pattern partitionCapturePattern;
+    private final List<String> partitionColumns;
+
+    // regex of the form: ${column name}. Following characters are not allowed in column name:
+    // whitespace characters, /, {, }, \
+    public static final Pattern customPathPattern = Pattern.compile("(\\$\\{)([^\\s/\\{\\}\\\\]+)(\\})");
+
+    private DynamicPartitioningCustomPattern(String customPattern, Pattern partitionCapturePattern, List<String> partitionColumns) {
+        this.customPattern = customPattern;
+        this.partitionCapturePattern = partitionCapturePattern;
+        this.partitionColumns = partitionColumns;
+    }
+
+    /**
+     * @return stored custom pattern string
+     * */
+    public String getCustomPattern() {
+        return customPattern;
+    }
+
+    /**
+     * @return stored custom pattern regex matcher
+     * */
+    public Pattern getPartitionCapturePattern() {
+        return partitionCapturePattern;
+    }
+
+    /**
+     * @return list of partition key columns
+     * */
+    public List<String> getPartitionColumns() {
+        return partitionColumns;
+    }
+
+    public static class Builder {
+        private String customPattern;
+
+        public Builder setCustomPattern(String customPattern) {
+            this.customPattern = customPattern;
+            return this;
+        }
+
+        /**
+         * Constructs the regex to match the partition values in a path based on the custom pattern.
+         *
+         * @return custom partition pattern matcher */
+        public DynamicPartitioningCustomPattern build() {
+            StringBuffer sb = new StringBuffer();
+            Matcher m = customPathPattern.matcher(customPattern);
+            List<String> partColumns = new ArrayList<>();
+            while (m.find()) {
+                m.appendReplacement(sb, "(.*)");
+                partColumns.add(m.group(2));
+            }
+            m.appendTail(sb);
+            return new DynamicPartitioningCustomPattern(customPattern, Pattern.compile(sb.toString()), partColumns);
+        }
+    }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -1613,7 +1613,8 @@ public class MetaStoreServerUtils {
    * @return Partition name, for example partitiondate=2008-01-01
    */
   public static String getPartitionName(Path tablePath, Path partitionPath, Set<String> partCols,
-                                        Map<String, String> partitionColToTypeMap, Configuration conf) throws MetastoreException {
+                                        Map<String, String> partitionColToTypeMap, Configuration conf)
+          throws MetastoreException {
     StringBuilder result = null;
     String customPattern = conf.get(HCAT_CUSTOM_DYNAMIC_PATTERN);
     Path currPath = partitionPath;
@@ -1623,21 +1624,23 @@ public class MetaStoreServerUtils {
               .setCustomPattern(customPattern)
               .build();
       Pattern customPathPattern = compiledCustomPattern.getPartitionCapturePattern();
-      List<String> patternPartCols = compiledCustomPattern.getPartitionColumns(); //partition columns in order that they appear in the pattern
-      String relPath = partitionPath.toString().substring(tablePath.toString().length() + 1); //start after tablepath and the / afterwards
+      //partition columns in order that they appear in the pattern
+      List<String> patternPartCols = compiledCustomPattern.getPartitionColumns();
+      //relative path starts after tablepath and the / afterwards
+      String relPath = partitionPath.toString().substring(tablePath.toString().length() + 1);
       Matcher pathMatcher = customPathPattern.matcher(relPath);
       boolean didMatch = pathMatcher.matches();
       if (!didMatch) { //partition path doesn't match the pattern, should have been detected at an earlier step
-        throw new MetastoreException("Path " + relPath + "doesn't match custom partition pattern " + customPathPattern + "partitionPathFull: " + partitionPath);
+        throw new MetastoreException("Path " + relPath + "doesn't match custom partition pattern "
+                + customPathPattern + "partitionPathFull: " + partitionPath);
       }
-      if (patternPartCols.size() > 0) {
-          result = new StringBuilder(patternPartCols.get(0) + "=" + pathMatcher.group(1));
+      if (!patternPartCols.isEmpty()) {
+        result = new StringBuilder(patternPartCols.get(0) + "=" + pathMatcher.group(1));
       }
       for (int i = 1; i < patternPartCols.size(); i++) {
         result.append(Path.SEPARATOR).append(patternPartCols.get(i)).append("=").append(pathMatcher.group(i+1));
       }
-    }
-    else {
+    } else {
       while (currPath != null && !tablePath.equals(currPath)) {
         // format: partition=p_val
         // Add only when table partition colName matches


### PR DESCRIPTION
Adds support for custom partitioning patterns to MSCK repair table.

What changes were proposed in this pull request?
Adds support for custom partitioning patterns to MSCK repair table.

Why are the changes needed?
HCatStorer supports custom partitioning patterns when using dynamic partitioning, but Hive itself does not support this. This change adds support for non-pathological cases to Hive.

Does this PR introduce any user-facing change?
MSCK repair table with a configured custom partition pattern would previously ignore that pattern and error on finding nonstandard paths. With the code from this PR, it will respect the defined custom pattern when it extracts partition key values from the paths.

Is the change a dependency upgrade?
No

How was this patch tested?
A test was added to TestHiveMetastoreChecker to test the common kinds of custom patterns supported.

Adds support for custom partitioning patterns to MSCK repair table.