### PR TITLE
HIVE-29398: Make it possible to use longStats instead of timestampStats in ColumnStatisticsData

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
@@ -832,13 +832,21 @@ public class StatsUtils {
       cs.setNumNulls(csd.getBinaryStats().getNumNulls());
     } else if (colTypeLowerCase.equals(serdeConstants.TIMESTAMP_TYPE_NAME)) {
       cs.setAvgColLen(JavaDataModel.get().lengthOfTimestamp());
-      cs.setNumNulls(csd.getTimestampStats().getNumNulls());
-      Long lowVal = (csd.getTimestampStats().getLowValue() != null) ? csd.getTimestampStats().getLowValue()
-          .getSecondsSinceEpoch() : null;
-      Long highVal = (csd.getTimestampStats().getHighValue() != null) ? csd.getTimestampStats().getHighValue()
-          .getSecondsSinceEpoch() : null;
-      cs.setRange(lowVal, highVal);
-      cs.setHistogram(csd.getTimestampStats().getHistogram());
+      if (csd.isSetTimestampStats()) {
+        cs.setNumNulls(csd.getTimestampStats().getNumNulls());
+        Long lowVal = (csd.getTimestampStats().getLowValue() != null) ? csd.getTimestampStats().getLowValue()
+            .getSecondsSinceEpoch() : null;
+        Long highVal = (csd.getTimestampStats().getHighValue() != null) ? csd.getTimestampStats().getHighValue()
+            .getSecondsSinceEpoch() : null;
+        cs.setRange(lowVal, highVal);
+        cs.setHistogram(csd.getTimestampStats().getHistogram());
+      } else if (csd.isSetLongStats()) {
+        cs.setNumNulls(csd.getLongStats().getNumNulls());
+        Long lowVal = csd.getLongStats().isSetLowValue() ? csd.getLongStats().getLowValue() : null;
+        Long highVal = csd.getLongStats().isSetHighValue() ? csd.getLongStats().getHighValue() : null;
+        cs.setRange(lowVal, highVal);
+        cs.setHistogram(csd.getLongStats().getHistogram());
+      }
     } else if (colTypeLowerCase.equals(serdeConstants.TIMESTAMPLOCALTZ_TYPE_NAME)) {
       cs.setAvgColLen(JavaDataModel.get().lengthOfTimestamp());
     } else if (colTypeLowerCase.startsWith(serdeConstants.DECIMAL_TYPE_NAME)) {
@@ -879,13 +887,13 @@ public class StatsUtils {
   }
 
   public static void fillColumnStatisticsData(ColumnStatisticsData data, ColStatistics cs,
-      String colType) throws MetaException {
+      String colType, boolean timestampAsLong) throws MetaException {
     ColStatistics.Range r = cs.getRange();
     Object lowValue = (r != null) ? r.minValue : null;
     Object highValue = (r != null) ? r.maxValue : null;
     StatObjectConverter.fillColumnStatisticsData(colType, data, lowValue, highValue,
         cs.getNumNulls(), cs.getCountDistint(), cs.getBitVectors(), cs.getHistogram(),
-        cs.getAvgColLen(), cs.getAvgColLen(), cs.getNumTrues(), cs.getNumFalses());
+        cs.getAvgColLen(), cs.getAvgColLen(), cs.getNumTrues(), cs.getNumFalses(), timestampAsLong);
   }
 
   private static void fillColStatisticsFromLongStatsData(ColStatistics cs, LongColumnStatsData longStats,

--- a/ql/src/test/org/apache/hadoop/hive/ql/ddl/table/info/desc/TestDescTableOperation.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/ddl/table/info/desc/TestDescTableOperation.java
@@ -102,7 +102,7 @@ class TestDescTableOperation {
       // Capture the ColStatistics passed to fillColumnStatisticsData
       ArgumentCaptor<ColStatistics> colStatsCaptor = ArgumentCaptor.forClass(ColStatistics.class);
       statsUtils.when(() -> StatsUtils.fillColumnStatisticsData(any(ColumnStatisticsData.class),
-          colStatsCaptor.capture(), any(String.class))).thenCallRealMethod();
+          colStatsCaptor.capture(), any(String.class), any(Boolean.class))).thenCallRealMethod();
 
       DescTableOperation operation = new DescTableOperation(mockContext, mockDesc);
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1505,6 +1505,11 @@ public class MetastoreConf {
     STATS_AUTO_UPDATE_WORKER_COUNT("metastore.stats.auto.analyze.worker.count",
         "hive.metastore.stats.auto.analyze.worker.count", 1,
         "Number of parallel analyze commands to run for background stats update."),
+    HIVE_STATS_LEGACY_TIMESTAMP_AS_LONG("metastore.stats.legacy.timestamp.as.long",
+        "hive.metastore.stats.legacy.timestamp.as.long", false,
+        "If true, store the timestamp stats in the long stats field, " +
+            "instead of the newer timestamp stats field.\nUse only if a dependent client" +
+            " (e.g. Impala) does not yet support the timestamp stats field.\nThe default value is false."),
     STORAGE_SCHEMA_READER_IMPL("metastore.storage.schema.reader.impl", "metastore.storage.schema.reader.impl",
         SERDE_STORAGE_SCHEMA_READER_CLASS,
         "The class to use to read schemas from storage.  It must implement " +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlAggrStats.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlAggrStats.java
@@ -70,6 +70,7 @@ class DirectSqlAggrStats {
   private static final Logger LOG = LoggerFactory.getLogger(DirectSqlAggrStats.class);
   private final PersistenceManager pm;
   private final int batchSize;
+  private final boolean timestampAsLong;
 
   @java.lang.annotation.Target(java.lang.annotation.ElementType.FIELD)
   @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
@@ -88,6 +89,7 @@ class DirectSqlAggrStats {
       configBatchSize = dbType.needsInBatching() ? 1000 : NO_BATCHING;
     }
     this.batchSize = configBatchSize;
+    this.timestampAsLong = MetastoreConf.getBoolVar(conf, MetastoreConf.ConfVars.HIVE_STATS_LEGACY_TIMESTAMP_AS_LONG);
     ImmutableMap.Builder<String, String> fieldNameToTableNameBuilder =
         new ImmutableMap.Builder<>();
 
@@ -446,8 +448,8 @@ class DirectSqlAggrStats {
     StatObjectConverter.fillColumnStatisticsData(cso.getColType(), data, row[LONG_LOW_VALUE.idx()],
         row[LONG_HIGH_VALUE.idx()], row[DOUBLE_LOW_VALUE.idx()], row[DOUBLE_HIGH_VALUE.idx()], row[BIG_DECIMAL_LOW_VALUE.idx()], row[BIG_DECIMAL_HIGH_VALUE.idx()],
         row[NUM_NULLS.idx()], row[NUM_DISTINCTS.idx()], row[AVG_COL_LEN.idx()], row[MAX_COL_LEN.idx()], row[NUM_TRUES.idx()], row[NUM_FALSES.idx()],
-        avgLong, avgDouble, avgDecimal, row[SUM_NUM_DISTINCTS.idx()],
-        useDensityFunctionForNDVEstimation, ndvTuner);
+        avgLong, avgDouble, avgDecimal, row[SUM_NUM_DISTINCTS.idx()], useDensityFunctionForNDVEstimation, ndvTuner,
+        timestampAsLong);
     return cso;
   }
 
@@ -457,8 +459,8 @@ class DirectSqlAggrStats {
     Object llow = row[i++], lhigh = row[i++], dlow = row[i++], dhigh = row[i++],
         declow = row[i++], dechigh = row[i++], nulls = row[i++], dist = row[i++], bitVector = row[i++],
         histogram = row[i++], avglen = row[i++], maxlen = row[i++], trues = row[i++], falses = row[i];
-    StatObjectConverter.fillColumnStatisticsData(cso.getColType(), data,
-        llow, lhigh, dlow, dhigh, declow, dechigh, nulls, dist, bitVector, histogram, avglen, maxlen, trues, falses);
+    StatObjectConverter.fillColumnStatisticsData(cso.getColType(), data, llow, lhigh, dlow, dhigh, declow, dechigh,
+        nulls, dist, bitVector, histogram, avglen, maxlen, trues, falses, timestampAsLong);
     return cso;
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -1805,7 +1805,6 @@ class MetaStoreDirectSql {
     return partsFound;
   }
 
-
   @SuppressWarnings("unchecked")
   private <T> T executeWithArray(Query query, Object[] params, String sql) throws MetaException {
     return executeWithArray(query, params, sql, -1);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -9568,6 +9568,7 @@ public class ObjectStore implements RawStore, Configurable {
       boolean allowSql, boolean allowJdo) throws MetaException, NoSuchObjectException {
     final boolean enableBitVector = MetastoreConf.getBoolVar(getConf(), ConfVars.STATS_FETCH_BITVECTOR);
     final boolean enableKll = MetastoreConf.getBoolVar(getConf(), ConfVars.STATS_FETCH_KLL);
+    final boolean timestampAsLong = MetastoreConf.getBoolVar(getConf(), ConfVars.HIVE_STATS_LEGACY_TIMESTAMP_AS_LONG);
     return new GetStatHelper(normalizeIdentifier(catName), normalizeIdentifier(dbName),
         normalizeIdentifier(tableName), allowSql, allowJdo, null) {
       @Override
@@ -9591,7 +9592,8 @@ public class ObjectStore implements RawStore, Configurable {
           if (desc.getLastAnalyzed() > mStat.getLastAnalyzed()) {
             desc.setLastAnalyzed(mStat.getLastAnalyzed());
           }
-          statObjs.add(StatObjectConverter.getTableColumnStatisticsObj(mStat, enableBitVector, enableKll));
+          statObjs.add(
+              StatObjectConverter.getTableColumnStatisticsObj(mStat, enableBitVector, enableKll, timestampAsLong));
           Deadline.checkTimeout();
         }
         ColumnStatistics colStat = new ColumnStatistics(desc, statObjs);
@@ -9692,6 +9694,7 @@ public class ObjectStore implements RawStore, Configurable {
       String engine, boolean allowSql, boolean allowJdo) throws MetaException, NoSuchObjectException {
     final boolean enableBitVector = MetastoreConf.getBoolVar(getConf(), ConfVars.STATS_FETCH_BITVECTOR);
     final boolean enableKll = MetastoreConf.getBoolVar(getConf(), ConfVars.STATS_FETCH_KLL);
+    final boolean timestampAsLong = MetastoreConf.getBoolVar(getConf(), ConfVars.HIVE_STATS_LEGACY_TIMESTAMP_AS_LONG);
     return new GetListHelper<ColumnStatistics>(catName, dbName, tableName, allowSql, allowJdo) {
       @Override
       protected List<ColumnStatistics> getSqlResult(
@@ -9724,7 +9727,8 @@ public class ObjectStore implements RawStore, Configurable {
             csd = StatObjectConverter.getPartitionColumnStatisticsDesc(mStatsObj);
             curList = new ArrayList<>(colNames.size());
           }
-          curList.add(StatObjectConverter.getPartitionColumnStatisticsObj(mStatsObj, enableBitVector, enableKll));
+          curList.add(StatObjectConverter.getPartitionColumnStatisticsObj(mStatsObj, enableBitVector, enableKll,
+              timestampAsLong));
           lastPartName = partName;
           Deadline.checkTimeout();
         }


### PR DESCRIPTION
[HIVE-29398](https://issues.apache.org/jira/browse/HIVE-29398)

### What changes were proposed in this pull request?
Add a property to store the timestamp statistics in the long stats field instead of the timestamp stats field. This has been the legacy behavior before HIVE-22311 has been merged.

### Why are the changes needed?
Other projects that use the Hive Metastore (e.g., Impala) are still expecting the long stats field. Adding the property makes it possible to switch back to the old behavior.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I've added a unit test and I've manually verified that the stats of a timestamp field in Impala behaves as expected.

1. Add the property `'hive.metastore.stats.legacy.timestamp.as.long': 'true',` to `fe/src/test/resources/hive-site.xml.py`
1. Build Impala using Hive with this patch
1. Start Impala and an Impala shell (`./bin/impala-shell.sh`)
1. Execute the following: `create table a(t timestamp); insert into a(t) values ('2026-01-02 12:34:45'), (null), ('1999-01-03 11:12:23'); compute stats a; show column stats a;`
1. The `#Distinct Values` is 2 and `#Nulls` is 1, so the patch works as expected; without the patch, or if you change the property of step 1 to false, `#Distinct Values` and `#Nulls` are both -1