### PR TITLE
HIVE-29365: Range predicate within the same histogram bucket leads to an estimate rowcount=1

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -492,7 +492,11 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
   private static double rangedSelectivity(KllFloatsSketch kll, float val1, float val2) {
     float[] splitPoints = new float[] { val1, val2 };
     double[] boundaries = kll.getCDF(splitPoints, QuantileSearchCriteria.EXCLUSIVE);
-    return boundaries[1] - boundaries[0];
+    // due to the way the KLL sketch is constructed,
+    // it is not possible to differentiate selectivity values below the error
+    // (e.g., if the error is 2%, a real selectivity of 1.5% might be estimated as 0% by KLL)
+    double normalizedRankError = kll.getNormalizedRankError(false);
+    return Math.max(boundaries[1] - boundaries[0], normalizedRankError);
   }
 
   /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
@@ -67,6 +67,7 @@ public class TestFilterSelectivityEstimator {
   private static final float[] VALUES = { 1, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5, 6, 7 };
   private static final KllFloatsSketch KLL = StatisticsTestUtils.createKll(VALUES);
   private static final float DELTA = Float.MIN_VALUE;
+  private static final double MIN_KLL_SELECTIVITY = 0.013294757464848584;
   private static final RexBuilder REX_BUILDER = new RexBuilder(new JavaTypeFactoryImpl(new HiveTypeSystemImpl()));
   private static final RelDataTypeFactory TYPE_FACTORY = REX_BUILDER.getTypeFactory();
   private static RelOptCluster relOptCluster;
@@ -240,12 +241,12 @@ public class TestFilterSelectivityEstimator {
 
   @Test
   public void testBetweenSelectivityRightLowerThanMin() {
-    Assert.assertEquals(0, betweenSelectivity(KLL, -1, 0), DELTA);
+    Assert.assertEquals(MIN_KLL_SELECTIVITY, betweenSelectivity(KLL, -1, 0), DELTA);
   }
 
   @Test
   public void testBetweenSelectivityLeftHigherThanMax() {
-    Assert.assertEquals(0, betweenSelectivity(KLL, 10, 11), DELTA);
+    Assert.assertEquals(MIN_KLL_SELECTIVITY, betweenSelectivity(KLL, 10, 11), DELTA);
   }
 
   @Test
@@ -399,7 +400,7 @@ public class TestFilterSelectivityEstimator {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
     RexNode filter = REX_BUILDER.makeCall(HiveBetween.INSTANCE, boolFalse, inputRef0, intMinus1, int0);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
-    Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
+    Assert.assertEquals(MIN_KLL_SELECTIVITY, estimator.estimateSelectivity(filter), DELTA);
   }
 
   @Test
@@ -407,7 +408,7 @@ public class TestFilterSelectivityEstimator {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
     RexNode filter = REX_BUILDER.makeCall(HiveBetween.INSTANCE, boolFalse, inputRef0, int10, int11);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
-    Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
+    Assert.assertEquals(MIN_KLL_SELECTIVITY, estimator.estimateSelectivity(filter), DELTA);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Take the error of the KLL sketch into account when estimating a selectivity.

### Why are the changes needed?
Without the change, some rowcounts are underestimated by several orders of magnitude.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test TestFilterSelectivityEstimator.
