### PR TITLE
HIVE-13748: Support hyphen(-) in struct field names in TypeInfoUtils

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TypeInfoUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TypeInfoUtils.java
@@ -293,7 +293,7 @@ public final class TypeInfoUtils {
     };
 
     private static boolean isTypeChar(char c) {
-      return Character.isLetterOrDigit(c) || c == '_' || c == '.' || c == ' ' || c == '$';
+      return Character.isLetterOrDigit(c) || c == '_' || c == '.' || c == ' ' || c == '$' || c == '-';
     }
 
     /**

--- a/serde/src/test/org/apache/hadoop/hive/serde2/typeinfo/TestTypeInfoUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/typeinfo/TestTypeInfoUtils.java
@@ -52,6 +52,8 @@ public class TestTypeInfoUtils {
         "decimal(10, 2)",
         "decimal(10, 2 )",
         "decimal( 10, 2 )",
+        "struct<user-id:int>",
+        "struct<user-id:int,user-name:string>",
         "struct<user id:int,user group: int>"
     };
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, TypeInfoUtils rejects struct field names containing hyphens (for example, `aws-region`) during type parsing and throws an exception.

Related JIRA issues: [HIVE-13748](https://issues.apache.org/jira/browse/HIVE-13748) [HIVE-24181](https://issues.apache.org/jira/browse/HIVE-24181) [HIVE-20272](https://issues.apache.org/jira/browse/HIVE-20272)

### Why are the changes needed?
Tables backed by Hadoop catalogs can be created with struct field names containing hyphens. However, the same schemas fail during type parsing when using Hive-backed catalogs.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added Unit Test
