### PR TITLE
HIVE-29507: Create a slim hive-iceberg-handler core JAR

### DIFF
--- a/iceberg/iceberg-handler/pom.xml
+++ b/iceberg/iceberg-handler/pom.xml
@@ -144,36 +144,38 @@
   <build>
     <plugins>
       <plugin>
-        <!-- Unpacking all Iceberg related classes into the iceberg-handler jar for consumption by external
-                components -->
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
+        <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <id>unpack</id>
-            <phase>generate-sources</phase>
+            <phase>package</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>shade</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.apache.hive</groupId>
-                  <artifactId>hive-iceberg-shading</artifactId>
-                  <version>${project.version}</version>
-                  <type>jar</type>
-                  <overWrite>true</overWrite>
-                  <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hive</groupId>
-                  <artifactId>hive-iceberg-catalog</artifactId>
-                  <version>${project.version}</version>
-                  <type>jar</type>
-                  <overWrite>true</overWrite>
-                  <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.hive:hive-iceberg-shading</include>
+                  <include>org.apache.hive:hive-iceberg-catalog</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <!-- Create a slim jar without dependencies -->
+        <executions>
+          <execution>
+            <id>core-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>core</classifier>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Create a slim `hive-iceberg-handler` core JAR file to avoid `InvalidClassException`.

Before:

* `iceberg-shading`
  * `maven-shade-plugin` shades Iceberg and other dependencies.
* `iceberg-handler`
  * `maven-dependency-plugin` unpacks `iceberg-shading` and `iceberg-catalog` then packs them together.

After:
* `iceberg-shading`
  * `maven-shade-plugin` shades Iceberg and other dependencies.
* `iceberg-handler`
  * `maven-shade-plugin` shades `iceberg-shading` and `iceberg-catalog` without relocation, which results the same JAR file as `maven-dependency-plugin` did.
  * `maven-jar-plugin` creates a new slim JAR without shaded classes.

`maven-dependency-plugin` in `iceberg-handler` overwrites the class directory, so `maven-jar-plugin` is affected. Its solution is to use `<configuration><includes></includes></configuration>`, but as there are many shared Java packages across artifacts, almost 100 individual class names should be explicitly configured. That number looks hard to maintain when any class is changed in those packages.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`HiveIcebergStorageHandler` was used for interoperability use cases between Apache Hive 3.x and Apache Spark. The handler was packaged in `iceberg-hive-runtime.jar` until Apache Iceberg 1.7. The Hive runtime is deleted from Apache Iceberg 1.8. Apache Hive also provides `hive-iceberg-handler.jar`. Apache Spark can import `hive-iceberg-handler.jar` and `iceberg-spark-runtime.jar` together for interoperability use cases.

However, there are differences between classes in `iceberg-spark-runtime.jar` and `hive-iceberg-handler.jar` while there's no such between in `iceberg-spark-runtime.jar` and `iceberg-hive-runtime.jar`. It causes an `InvalidClassException`. For example,

> java.io.InvalidClassException: org.apache.iceberg.BaseFile; local class incompatible: stream classdesc serialVersionUID = 8569836863676564712, local class serialVersionUID = -8072381884098305524

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Built locally.