### PR TITLE
HIVE-29513: Increase HikariCP connection timeout default from 30s to 60s

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DataSourceProvider.java
@@ -20,7 +20,9 @@ package org.apache.hadoop.hive.metastore.datasource;
 import java.io.Closeable;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 
 import com.google.common.collect.Iterables;
@@ -51,16 +53,36 @@ public interface DataSourceProvider {
    * @return The pooling type string associated with the data source.
    */
   String getPoolingType();
-
+  
   /**
-   * @param hdpConfig
+   * @param hdpConfig Hadoop configuration object
+   * @param prefix the prefix for connection pool specific properties
+   * @param timeDurationConfigs map of property names (without prefix) to their default values in milliseconds.
    * @return subset of properties prefixed by a connection pool specific substring
    */
-  static Properties getPrefixedProperties(Configuration hdpConfig, String factoryPrefix) {
+  static Properties getPrefixedProperties(Configuration hdpConfig, String prefix,
+      Map<String, Long> timeDurationConfigs) {
     Properties dataSourceProps = new Properties();
     Iterables.filter(
-        hdpConfig, (entry -> entry.getKey() != null && entry.getKey().startsWith(factoryPrefix)))
-        .forEach(entry -> dataSourceProps.put(entry.getKey(), entry.getValue()));
+        hdpConfig, (entry -> entry.getKey() != null && entry.getKey().startsWith(prefix)))
+        .forEach(entry -> {
+          String fullKey = entry.getKey();
+          String keyName = fullKey.substring(prefix.length() + 1);
+          Long defaultVal = timeDurationConfigs.get(keyName);
+          if (defaultVal != null) {
+            long timeMs = hdpConfig.getTimeDuration(fullKey, defaultVal, TimeUnit.MILLISECONDS);
+            dataSourceProps.setProperty(fullKey, String.valueOf(timeMs));
+          } else {
+            dataSourceProps.setProperty(fullKey, entry.getValue());
+          }
+        });
+    
+    // Setting defaults for time duration configs if not set already
+    timeDurationConfigs.forEach((keyName, defaultVal) -> {
+      String fullKey = prefix + "." + keyName;
+      dataSourceProps.putIfAbsent(fullKey, String.valueOf(defaultVal));
+    });
+    
     return dataSourceProps;
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -40,6 +40,7 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
   private static final Logger LOG = LoggerFactory.getLogger(HikariCPDataSourceProvider.class);
 
   static final String HIKARI = "hikaricp";
+  static final long DEFAULT_CONNECTION_TIMEOUT_MS = 60000;
 
   @Override
   public DataSource create(Configuration hdpConfig, int maxPoolSize) throws SQLException {
@@ -65,6 +66,9 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     if (!StringUtils.isEmpty(poolName)) {
       config.setPoolName(poolName);
     }
+
+    long connectionTimeout = hdpConfig.getLong(HIKARI + ".connectionTimeout", DEFAULT_CONNECTION_TIMEOUT_MS);
+    config.setConnectionTimeout(connectionTimeout);
 
     // It's kind of a waste to create a fixed size connection pool as same as the TxnHandler#connPool,
     // TxnHandler#connPoolMutex is mostly used for MutexAPI that is primarily designed to

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -31,7 +31,6 @@ import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 /**
  * DataSourceProvider for the HikariCP connection pool.
@@ -43,6 +42,10 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
   static final String HIKARI = "hikaricp";
   static final long DEFAULT_CONNECTION_TIMEOUT_MS = 60000;
 
+  private static final Map<String, Long> TIME_DURATION_CONFIGS = Map.of(
+      "connectionTimeout", DEFAULT_CONNECTION_TIMEOUT_MS
+  );
+
   @Override
   public DataSource create(Configuration hdpConfig, int maxPoolSize) throws SQLException {
     String poolName = DataSourceProvider.getDataSourceName(hdpConfig);
@@ -52,10 +55,9 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     String user = DataSourceProvider.getMetastoreJdbcUser(hdpConfig);
     String passwd = DataSourceProvider.getMetastoreJdbcPasswd(hdpConfig);
 
-    Properties properties = replacePrefix(DataSourceProvider.getPrefixedProperties(hdpConfig, HIKARI));
-    //  connectionTimeout is handled separately with getTimeDuration()
-    properties.remove("connectionTimeout");
-
+    Properties properties = replacePrefix(
+        DataSourceProvider.getPrefixedProperties(hdpConfig, HIKARI, TIME_DURATION_CONFIGS));
+    
     HikariConfig config;
     try {
       config = new HikariConfig(properties);
@@ -69,10 +71,6 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     if (!StringUtils.isEmpty(poolName)) {
       config.setPoolName(poolName);
     }
-
-    long connectionTimeout = hdpConfig.getTimeDuration(HIKARI + ".connectionTimeout", 
-        DEFAULT_CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    config.setConnectionTimeout(connectionTimeout);
 
     // It's kind of a waste to create a fixed size connection pool as same as the TxnHandler#connPool,
     // TxnHandler#connPoolMutex is mostly used for MutexAPI that is primarily designed to

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -31,6 +31,7 @@ import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 /**
  * DataSourceProvider for the HikariCP connection pool.
@@ -52,6 +53,8 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     String passwd = DataSourceProvider.getMetastoreJdbcPasswd(hdpConfig);
 
     Properties properties = replacePrefix(DataSourceProvider.getPrefixedProperties(hdpConfig, HIKARI));
+    //  connectionTimeout is handled separately with getTimeDuration()
+    properties.remove("connectionTimeout");
 
     HikariConfig config;
     try {
@@ -67,7 +70,8 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
       config.setPoolName(poolName);
     }
 
-    long connectionTimeout = hdpConfig.getLong(HIKARI + ".connectionTimeout", DEFAULT_CONNECTION_TIMEOUT_MS);
+    long connectionTimeout = hdpConfig.getTimeDuration(HIKARI + ".connectionTimeout", 
+        DEFAULT_CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     config.setConnectionTimeout(connectionTimeout);
 
     // It's kind of a waste to create a fixed size connection pool as same as the TxnHandler#connPool,

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
@@ -100,17 +100,29 @@ public class TestDataSourceProviderFactory {
   }
 
   @Test
-  public void testHikariCpConnectionTimeout60Seconds() throws SQLException {
-    MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
-    conf.set(HikariCPDataSourceProvider.HIKARI + ".initializationFailTimeout", "-1");
+  public void testHikariCpConnectionTimeout() throws SQLException {
+    Object[][] timeoutConfigs = {
+        {"90000", 90000L},
+        {"60s", 60000L},
+        {"90000ms", 90000L}
+    };
 
-    DataSourceProvider dsp = DataSourceProviderFactory.tryGetDataSourceProviderOrNull(conf);
-    Assert.assertNotNull(dsp);
+    for (Object[] config : timeoutConfigs) {
+      String timeoutValue = (String) config[0];
+      long expectedValue = (long) config[1];
 
-    DataSource ds = dsp.create(conf);
-    Assert.assertTrue(ds instanceof HikariDataSource);
-    HikariDataSource hds = (HikariDataSource) ds;
-    Assert.assertEquals(60000L, hds.getConnectionTimeout());
+      MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
+      conf.set(HikariCPDataSourceProvider.HIKARI + ".connectionTimeout", timeoutValue);
+      conf.set(HikariCPDataSourceProvider.HIKARI + ".initializationFailTimeout", "-1");
+      
+      DataSourceProvider dsp = DataSourceProviderFactory.tryGetDataSourceProviderOrNull(conf);
+      Assert.assertNotNull(dsp);
+
+      DataSource ds = dsp.create(conf);
+      Assert.assertTrue(ds instanceof HikariDataSource);
+      HikariDataSource hds = (HikariDataSource) ds;
+      Assert.assertEquals(expectedValue, hds.getConnectionTimeout());
+    }
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
@@ -72,7 +72,7 @@ public class TestDataSourceProviderFactory {
     DataSource ds = dsp.create(conf);
     Assert.assertTrue(ds instanceof HikariDataSource);
     HikariDataSource hds = (HikariDataSource) ds;
-    Assert.assertEquals(30000L, hds.getConnectionTimeout());
+    Assert.assertEquals(60000L, hds.getConnectionTimeout());
     Assert.assertEquals(1800000L, hds.getMaxLifetime());
     Assert.assertEquals(0L, hds.getLeakDetectionThreshold());
     Assert.assertEquals(1L, hds.getInitializationFailTimeout());
@@ -97,6 +97,20 @@ public class TestDataSourceProviderFactory {
     Assert.assertEquals(50000L, hds.getMaxLifetime());
     Assert.assertEquals(3600L, hds.getLeakDetectionThreshold());
     Assert.assertEquals(-1L, hds.getInitializationFailTimeout());
+  }
+
+  @Test
+  public void testHikariCpConnectionTimeout60Seconds() throws SQLException {
+    MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
+    conf.set(HikariCPDataSourceProvider.HIKARI + ".initializationFailTimeout", "-1");
+
+    DataSourceProvider dsp = DataSourceProviderFactory.tryGetDataSourceProviderOrNull(conf);
+    Assert.assertNotNull(dsp);
+
+    DataSource ds = dsp.create(conf);
+    Assert.assertTrue(ds instanceof HikariDataSource);
+    HikariDataSource hds = (HikariDataSource) ds;
+    Assert.assertEquals(60000L, hds.getConnectionTimeout());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set HikariCP connection timeout to an explicit default of 60 seconds (60,000 ms) in HikariCPDataSourceProvider, making it configurable via `hikaricp.connectionTimeout` property. 

### Why are the changes needed?

MetaStore experiences connection timeout errors when database response is slow or during peak load, as HikariCP's implicit 30-second default is insufficient. 


### Does this PR introduce _any_ user-facing change?

Yes. Connection timeout default changes from HikariCP's implicit 30 seconds to Hive's explicit 60 seconds. Users can override this by setting `hikaricp.connectionTimeout` in `hive-site.xml`.

### How was this patch tested?

Added/updated unit tests in TestDataSourceProviderFactory: 