### PR TITLE
HIVE-29517: Make schema upgrade scripts idempotent and rerunnable

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/DbErrorCodes.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/DbErrorCodes.java
@@ -50,7 +50,7 @@ public interface DbErrorCodes {
     @Override
     public boolean isIgnorable(SQLException e) {
       String state = e.getSQLState();
-      String code  = String.valueOf(e.getErrorCode());
+      String code = String.valueOf(e.getErrorCode());
       return duplicateCodes.contains(state) || duplicateCodes.contains(code)
           || missingCodes.contains(state)   || missingCodes.contains(code);
     }
@@ -134,12 +134,12 @@ public interface DbErrorCodes {
       return NOOP;
     }
     return switch (dbType.toLowerCase()) {
-      case "postgres" -> POSTGRES;
-      case "derby", "derby.clean" -> DERBY;
-      case "mysql", "mariadb" -> MYSQL;
-      case "oracle" -> ORACLE;
-      case "mssql" -> MSSQL;
-      default -> NOOP;
+    case "postgres" -> POSTGRES;
+    case "derby", "derby.clean" -> DERBY;
+    case "mysql", "mariadb" -> MYSQL;
+    case "oracle" -> ORACLE;
+    case "mssql" -> MSSQL;
+    default -> NOOP;
     };
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/DbErrorCodes.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/DbErrorCodes.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.tools.schematool;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.sql.SQLException;
+import java.util.Set;
+
+/**
+ * Per-database ignorable DDL error codes for idempotent schema upgrades.
+ * This is used by {@link IdempotentDDLExecutor} to determine whether a given {@link SQLException}
+ * can be safely ignored (e.g. because it indicates an object already exists or is already gone).
+ * <p> 
+ * Use {@link #forDbType(String)} to get the right instance.
+ */
+public interface DbErrorCodes {
+
+  /** @return true if the exception can be safely ignored (object already exists or already gone). */
+  boolean isIgnorable(SQLException e);
+
+  /**
+   * Checks both {@link SQLException#getSQLState()} and {@code String.valueOf(getErrorCode())}
+   * against {@code duplicateCodes} and {@code missingCodes}.
+   */
+  class Codes implements DbErrorCodes {
+    private final Set<String> duplicateCodes;
+    private final Set<String> missingCodes;
+
+    Codes(Set<String> duplicateCodes, Set<String> missingCodes) {
+      this.duplicateCodes = duplicateCodes;
+      this.missingCodes = missingCodes;
+    }
+
+    @Override
+    public boolean isIgnorable(SQLException e) {
+      String state = e.getSQLState();
+      String code  = String.valueOf(e.getErrorCode());
+      return duplicateCodes.contains(state) || duplicateCodes.contains(code)
+          || missingCodes.contains(state)   || missingCodes.contains(code);
+    }
+  }
+
+  DbErrorCodes POSTGRES = new Codes(
+      ImmutableSet.of(
+          "42P07",  // duplicate table
+          "42701",  // duplicate column
+          "42710"   // duplicate object (e.g. constraint, index)
+      ),
+      ImmutableSet.of(
+          "42P01",  // undefined table
+          "42703",  // undefined column
+          "42704"   // undefined object
+      )
+  );
+
+  DbErrorCodes DERBY = new Codes(
+      ImmutableSet.of(
+          "X0Y32",  // table/view already exists
+          "X0Y68",  // index already exists
+          "42Z93"   // duplicate constraint (same column set already constrained)
+      ),
+      ImmutableSet.of(
+          "42Y55",  // table/view does not exist
+          "42X14",  // column does not exist
+          "42X65",  // index does not exist
+          "42X86"   // constraint does not exist on table (ALTER TABLE DROP CONSTRAINT)
+      )
+  );
+
+  DbErrorCodes MYSQL = new Codes(
+      ImmutableSet.of(
+          "1050",   // ER_TABLE_EXISTS_ERROR: table already exists
+          "1060",   // ER_DUP_FIELDNAME: duplicate column name
+          "1061"    // ER_DUP_KEYNAME: duplicate key name
+      ),
+      ImmutableSet.of(
+          "1051",   // ER_BAD_TABLE_ERROR: unknown table (DROP TABLE)
+          "1054",   // ER_BAD_FIELD_ERROR: unknown column (CHANGE COLUMN on already-renamed column)
+          "1091"    // ER_CANT_DROP_FIELD_OR_KEY: column or index does not exist (DROP COLUMN/INDEX)
+      )
+  );
+
+  DbErrorCodes ORACLE = new Codes(
+      ImmutableSet.of(
+          "955",    // ORA-00955: name already used by an existing object
+          "957",    // ORA-00957: duplicate column name (RENAME COLUMN target already exists)
+          "1430",   // ORA-01430: column being added already exists in table
+          "2261"    // ORA-02261: unique or primary key already exists in the table
+      ),
+      ImmutableSet.of(
+          "942",    // ORA-00942: table or view does not exist
+          "904",    // ORA-00904: invalid identifier (column does not exist)
+          "1418",   // ORA-01418: specified index does not exist
+          "2443"    // ORA-02443: cannot drop constraint - nonexistent constraint
+      )
+  );
+
+  DbErrorCodes MSSQL = new Codes(
+      ImmutableSet.of(
+          "2714",   // There is already an object named '...' in the database
+          "2705",   // Column names in each table must be unique (duplicate column)
+          "1913"    // There is already an index named '...' on table '...'
+      ),
+      ImmutableSet.of(
+          "3701",   // Cannot drop object because it does not exist or you do not have permission
+          "3728",   // DROP CONSTRAINT: not a constraint
+          "4924",   // ALTER TABLE DROP COLUMN: column does not exist
+          "15248"   // sp_rename: parameter @objname is ambiguous or @objtype is wrong (column already renamed)
+      )
+  );
+
+  /** No-op instance for unrecognized database types; never ignores any error. */
+  DbErrorCodes NOOP = e -> false;
+
+  /** Returns the {@link DbErrorCodes} for the given db-type string, or {@link #NOOP} if unrecognized. */
+  static DbErrorCodes forDbType(String dbType) {
+    if (dbType == null) {
+      return NOOP;
+    }
+    return switch (dbType.toLowerCase()) {
+      case "postgres" -> POSTGRES;
+      case "derby", "derby.clean" -> DERBY;
+      case "mysql", "mariadb" -> MYSQL;
+      case "oracle" -> ORACLE;
+      case "mssql" -> MSSQL;
+      default -> NOOP;
+    };
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/HiveSchemaHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/HiveSchemaHelper.java
@@ -311,6 +311,10 @@ public class HiveSchemaHelper {
           }
           currentCommand = null;
         }
+
+        if (currentCommand != null && !isNonExecCommand(currentCommand)) {
+          throw new IllegalArgumentException("Unterminated SQL statement at end of script: " + scriptFile);
+        }
       }
       return commands;
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/HiveSchemaHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/HiveSchemaHelper.java
@@ -266,12 +266,14 @@ public class HiveSchemaHelper {
     }
 
     @Override
-    public List<String> getExecutableCommands(String scriptDir, String scriptFile) throws IllegalFormatException, IOException {
+    public List<String> getExecutableCommands(String scriptDir, String scriptFile)
+        throws IllegalFormatException, IOException {
       return getExecutableCommands(scriptDir, scriptFile, false);
     }
 
     @Override
-    public List<String> getExecutableCommands(String scriptDir, String scriptFile, boolean fixQuotes) throws IllegalFormatException, IOException {
+    public List<String> getExecutableCommands(String scriptDir, String scriptFile, boolean fixQuotes) 
+        throws IllegalFormatException, IOException {
       List<String> commands = new java.util.ArrayList<>();
 
       try (BufferedReader bfReader = 
@@ -280,36 +282,26 @@ public class HiveSchemaHelper {
         String currentCommand = null;
 
         while ((currLine = bfReader.readLine()) != null) {
-          currLine = currLine.trim();
-
-          if (fixQuotes && !getQuoteCharacter().equals(DEFAULT_QUOTE)) {
-            currLine = currLine.replace("\\\"", getQuoteCharacter());
-          }
+          currLine = fixQuotesFromCurrentLine(fixQuotes, currLine.trim());
 
           if (currLine.isEmpty()) {
             continue;
           }
 
-          if (currentCommand == null) {
-            currentCommand = currLine;
-          } else {
-            currentCommand = currentCommand + " " + currLine;
-          }
+          currentCommand = currentCommand == null ? currLine : currentCommand + " " + currLine;
 
-          if (isPartialCommand(currLine)) {
-            continue;
-          }
-
-          if (!isNonExecCommand(currentCommand)) {
-            currentCommand = cleanseCommand(currentCommand);
-            if (isNestedScript(currentCommand)) {
-              String currScript = getScriptName(currentCommand);
-              commands.addAll(getExecutableCommands(scriptDir, currScript, fixQuotes));
-            } else {
-              commands.add(currentCommand.trim());
+          if (!isPartialCommand(currLine)) {
+            if (!isNonExecCommand(currentCommand)) {
+              currentCommand = cleanseCommand(currentCommand);
+              if (isNestedScript(currentCommand)) {
+                String currScript = getScriptName(currentCommand);
+                commands.addAll(getExecutableCommands(scriptDir, currScript, fixQuotes));
+              } else {
+                commands.add(currentCommand.trim());
+              }
             }
+            currentCommand = null;
           }
-          currentCommand = null;
         }
 
         if (currentCommand != null && !isNonExecCommand(currentCommand)) {
@@ -317,6 +309,13 @@ public class HiveSchemaHelper {
         }
       }
       return commands;
+    }
+
+    private String fixQuotesFromCurrentLine(boolean fixQuotes, String currLine) {
+      if (fixQuotes && !getQuoteCharacter().equals(DEFAULT_QUOTE)) {
+        currLine = currLine.replace("\\\"", getQuoteCharacter());
+      }
+      return currLine;
     }
 
     @Override

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/HiveSchemaHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/HiveSchemaHelper.java
@@ -42,7 +42,7 @@ public class HiveSchemaHelper {
   public static final String DB_HIVE = "hive";
   public static final String DB_MSSQL = "mssql";
   public static final String DB_MYSQL = "mysql";
-  public static final String DB_POSTGRACE = "postgres";
+  public static final String DB_POSTGRES = "postgres";
   public static final String DB_ORACLE = "oracle";
   public static final String EMBEDDED_HS2_URL =
       "jdbc:hive2://?hive.conf.restricted.list=;hive.security.authorization.sqlstd.confwhitelist=.*;"
@@ -186,6 +186,18 @@ public class HiveSchemaHelper {
      */
     String buildCommand(String scriptDir, String scriptFile, boolean fixQuotes)
         throws IllegalFormatException, IOException;
+
+    /**
+     * Parse the script and return a list of individual, executable SQL commands.
+     */
+    List<String> getExecutableCommands(String scriptDir, String scriptFile)
+        throws IllegalFormatException, IOException;
+
+    /**
+     * Parse the script and return a list of individual, executable SQL commands.
+     */
+    List<String> getExecutableCommands(String scriptDir, String scriptFile, boolean fixQuotes) 
+        throws IllegalFormatException, IOException;
   }
 
   /**
@@ -254,6 +266,56 @@ public class HiveSchemaHelper {
     }
 
     @Override
+    public List<String> getExecutableCommands(String scriptDir, String scriptFile) throws IllegalFormatException, IOException {
+      return getExecutableCommands(scriptDir, scriptFile, false);
+    }
+
+    @Override
+    public List<String> getExecutableCommands(String scriptDir, String scriptFile, boolean fixQuotes) throws IllegalFormatException, IOException {
+      List<String> commands = new java.util.ArrayList<>();
+
+      try (BufferedReader bfReader = 
+               new BufferedReader(new FileReader(scriptDir + File.separatorChar + scriptFile))) {
+        String currLine;
+        String currentCommand = null;
+
+        while ((currLine = bfReader.readLine()) != null) {
+          currLine = currLine.trim();
+
+          if (fixQuotes && !getQuoteCharacter().equals(DEFAULT_QUOTE)) {
+            currLine = currLine.replace("\\\"", getQuoteCharacter());
+          }
+
+          if (currLine.isEmpty()) {
+            continue;
+          }
+
+          if (currentCommand == null) {
+            currentCommand = currLine;
+          } else {
+            currentCommand = currentCommand + " " + currLine;
+          }
+
+          if (isPartialCommand(currLine)) {
+            continue;
+          }
+
+          if (!isNonExecCommand(currentCommand)) {
+            currentCommand = cleanseCommand(currentCommand);
+            if (isNestedScript(currentCommand)) {
+              String currScript = getScriptName(currentCommand);
+              commands.addAll(getExecutableCommands(scriptDir, currScript, fixQuotes));
+            } else {
+              commands.add(currentCommand.trim());
+            }
+          }
+          currentCommand = null;
+        }
+      }
+      return commands;
+    }
+
+    @Override
     public String buildCommand(
       String scriptDir, String scriptFile) throws IllegalFormatException, IOException {
       return buildCommand(scriptDir, scriptFile, false);
@@ -262,50 +324,16 @@ public class HiveSchemaHelper {
     @Override
     public String buildCommand(
       String scriptDir, String scriptFile, boolean fixQuotes) throws IllegalFormatException, IOException {
-      BufferedReader bfReader =
-          new BufferedReader(new FileReader(scriptDir + File.separatorChar + scriptFile));
-      String currLine;
+      List<String> commands = getExecutableCommands(scriptDir, scriptFile, fixQuotes);
       StringBuilder sb = new StringBuilder();
-      String currentCommand = null;
-      while ((currLine = bfReader.readLine()) != null) {
-        currLine = currLine.trim();
-
-        if (fixQuotes && !getQuoteCharacter().equals(DEFAULT_QUOTE)) {
-          currLine = currLine.replace("\\\"", getQuoteCharacter());
+      for (String cmd : commands) {
+        sb.append(cmd);
+        if (usingSqlLine) {
+          sb.append(";");
         }
-
-        if (currLine.isEmpty()) {
-          continue; // skip empty lines
-        }
-
-        if (currentCommand == null) {
-          currentCommand = currLine;
-        } else {
-          currentCommand = currentCommand + " " + currLine;
-        }
-        if (isPartialCommand(currLine)) {
-          // if its a partial line, continue collecting the pieces
-          continue;
-        }
-
-        // if this is a valid executable command then add it to the buffer
-        if (!isNonExecCommand(currentCommand)) {
-          currentCommand = cleanseCommand(currentCommand);
-          if (isNestedScript(currentCommand)) {
-            // if this is a nested sql script then flatten it
-            String currScript = getScriptName(currentCommand);
-            sb.append(buildCommand(scriptDir, currScript));
-          } else {
-            // Now we have a complete statement, process it
-            // write the line to buffer
-            sb.append(currentCommand);
-            if (usingSqlLine) sb.append(";");
-            sb.append(System.getProperty("line.separator"));
-          }
-        }
-        currentCommand = null;
+        sb.append(System.lineSeparator());
       }
-      bfReader.close();
+      
       return sb.toString();
     }
 
@@ -581,7 +609,7 @@ public class HiveSchemaHelper {
       return new MSSQLCommandParser(dbOpts, msUsername, msPassword, conf, usingSqlLine);
     } else if (dbName.equalsIgnoreCase(DB_MYSQL)) {
       return new MySqlCommandParser(dbOpts, msUsername, msPassword, conf, usingSqlLine);
-    } else if (dbName.equalsIgnoreCase(DB_POSTGRACE)) {
+    } else if (dbName.equalsIgnoreCase(DB_POSTGRES)) {
       return new PostgresCommandParser(dbOpts, msUsername, msPassword, conf, usingSqlLine);
     } else if (dbName.equalsIgnoreCase(DB_ORACLE)) {
       return new OracleCommandParser(dbOpts, msUsername, msPassword, conf, usingSqlLine);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
@@ -37,13 +37,16 @@ public class IdempotentDDLExecutor {
   private final Connection conn;
   private final DbErrorCodes errorCodes;
   private final HiveSchemaHelper.NestedScriptParser parser;
+  private final boolean fixQuotes;
   private final boolean verbose;
 
   public IdempotentDDLExecutor(
-      Connection conn, String dbType, HiveSchemaHelper.NestedScriptParser parser, boolean verbose) {
+      Connection conn, String dbType, HiveSchemaHelper.NestedScriptParser parser,
+      boolean fixQuotes, boolean verbose) {
     this.conn = conn;
     this.errorCodes = DbErrorCodes.forDbType(dbType);
     this.parser = parser;
+    this.fixQuotes = fixQuotes;
     this.verbose = verbose;
   }
 
@@ -52,7 +55,7 @@ public class IdempotentDDLExecutor {
     conn.setAutoCommit(true);
 
     File file = new File(scriptFile);
-    List<String> commands = parser.getExecutableCommands(file.getParent(), file.getName());
+    List<String> commands = parser.getExecutableCommands(file.getParent(), file.getName(), fixQuotes);
 
     for (String sqlStmt : commands) {
       if (!sqlStmt.isEmpty()) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
@@ -67,7 +67,8 @@ public class IdempotentDDLExecutor {
   private void executeStatement(String sqlStmt) throws SQLException {
     if (verbose) {
       LOG.info("Executing: {}", sqlStmt);
-    } else if (LOG.isDebugEnabled()) {
+    } 
+    if (LOG.isDebugEnabled()) {
       LOG.debug("Executing: {}", sqlStmt);
     }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
@@ -60,13 +60,13 @@ public class IdempotentDDLExecutor {
       }
     }
     if (verbose) {
-      System.out.println("Completed successfully.");
+      LOG.info("Completed successfully.");
     }
   }
 
   private void executeStatement(String sqlStmt) throws SQLException {
     if (verbose) {
-      System.out.println("Executing: " + sqlStmt);
+      LOG.info("Executing: {}", sqlStmt);
     } else if (LOG.isDebugEnabled()) {
       LOG.debug("Executing: {}", sqlStmt);
     }
@@ -75,12 +75,8 @@ public class IdempotentDDLExecutor {
       stmt.execute(sqlStmt);
     } catch (SQLException e) {
       if (isDdlStatement(sqlStmt) && errorCodes.isIgnorable(e)) {
-        String msg = String.format("Object already exists or was already dropped. " +
-            "Statement: %s, ErrorCode: %d, SQLState: %s", sqlStmt, e.getErrorCode(), e.getSQLState());
-        if (verbose) {
-          System.out.println(msg);
-        }
-        LOG.info(msg);
+        LOG.info("Object already exists or was already dropped. Statement: {}, ErrorCode: {}, SQLState: {}",
+            sqlStmt, e.getErrorCode(), e.getSQLState());
       } else {
         LOG.error("SQL Error executing: {}. Error Code: {}, SQLState: {}", sqlStmt, e.getErrorCode(), e.getSQLState());
         throw e;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
@@ -26,9 +26,13 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 public class IdempotentDDLExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(IdempotentDDLExecutor.class);
+  private static final Set<String> DDL_FIRST_TOKENS = Set.of(
+      "CREATE", "ALTER", "DROP", "RENAME", "TRUNCATE", "COMMENT");
 
   private final Connection conn;
   private final DbErrorCodes errorCodes;
@@ -70,7 +74,7 @@ public class IdempotentDDLExecutor {
     try (Statement stmt = conn.createStatement()) {
       stmt.execute(sqlStmt);
     } catch (SQLException e) {
-      if (errorCodes.isIgnorable(e)) {
+      if (isDdlStatement(sqlStmt) && errorCodes.isIgnorable(e)) {
         String msg = String.format("Object already exists or was already dropped. " +
             "Statement: %s, ErrorCode: %d, SQLState: %s", sqlStmt, e.getErrorCode(), e.getSQLState());
         if (verbose) {
@@ -82,5 +86,48 @@ public class IdempotentDDLExecutor {
         throw e;
       }
     }
+  }
+
+  private boolean isDdlStatement(String sqlStmt) {
+    if (sqlStmt == null) {
+      return false;
+    }
+
+    String trimmed = sqlStmt.trim();
+    if (trimmed.isEmpty()) {
+      return false;
+    }
+
+    // We only inspect the first one or two keywords for statement type classification.
+    String[] tokens = trimmed.split("\\s+", 3);
+    if (tokens.length == 0) {
+      return false;
+    }
+
+    String first = normalizeToken(tokens[0]).toUpperCase(Locale.ROOT);
+    if (DDL_FIRST_TOKENS.contains(first)) {
+      return true;
+    }
+
+    if (("EXEC".equals(first) || "EXECUTE".equals(first)) && tokens.length > 1) {
+      String second = normalizeToken(tokens[1]);
+      return "SP_RENAME".equalsIgnoreCase(second) || isDropHelperProcedure(second);
+    }
+
+    return false;
+  }
+
+  private String normalizeToken(String token) {
+    if (token == null || token.isEmpty()) {
+      return "";
+    }
+    if (token.endsWith(";")) {
+      return token.substring(0, token.length() - 1);
+    }
+    return token;
+  }
+
+  private boolean isDropHelperProcedure(String token) {
+    return token != null && token.toUpperCase(Locale.ROOT).startsWith("#DROP_");
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/IdempotentDDLExecutor.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.tools.schematool;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+public class IdempotentDDLExecutor {
+  private static final Logger LOG = LoggerFactory.getLogger(IdempotentDDLExecutor.class);
+
+  private final Connection conn;
+  private final DbErrorCodes errorCodes;
+  private final HiveSchemaHelper.NestedScriptParser parser;
+  private final boolean verbose;
+
+  public IdempotentDDLExecutor(
+      Connection conn, String dbType, HiveSchemaHelper.NestedScriptParser parser, boolean verbose) {
+    this.conn = conn;
+    this.errorCodes = DbErrorCodes.forDbType(dbType);
+    this.parser = parser;
+    this.verbose = verbose;
+  }
+
+  public void executeScript(String scriptFile) throws SQLException, IOException {
+    LOG.info("Executing script line-by-line via IdempotentDDLExecutor: {}", scriptFile);
+    conn.setAutoCommit(true);
+
+    File file = new File(scriptFile);
+    List<String> commands = parser.getExecutableCommands(file.getParent(), file.getName());
+
+    for (String sqlStmt : commands) {
+      if (!sqlStmt.isEmpty()) {
+        executeStatement(sqlStmt);
+      }
+    }
+    if (verbose) {
+      System.out.println("Completed successfully.");
+    }
+  }
+
+  private void executeStatement(String sqlStmt) throws SQLException {
+    if (verbose) {
+      System.out.println("Executing: " + sqlStmt);
+    } else if (LOG.isDebugEnabled()) {
+      LOG.debug("Executing: {}", sqlStmt);
+    }
+
+    try (Statement stmt = conn.createStatement()) {
+      stmt.execute(sqlStmt);
+    } catch (SQLException e) {
+      if (errorCodes.isIgnorable(e)) {
+        String msg = String.format("Object already exists or was already dropped. " +
+            "Statement: %s, ErrorCode: %d, SQLState: %s", sqlStmt, e.getErrorCode(), e.getSQLState());
+        if (verbose) {
+          System.out.println(msg);
+        }
+        LOG.info(msg);
+      } else {
+        LOG.error("SQL Error executing: {}. Error Code: {}, SQLState: {}", sqlStmt, e.getErrorCode(), e.getSQLState());
+        throw e;
+      }
+    }
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
@@ -21,7 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -37,16 +36,11 @@ import org.apache.hadoop.util.ExitUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sqlline.SqlLine;
-
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
 import java.net.URI;
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
@@ -258,7 +258,7 @@ public class MetastoreSchemaTool {
 
   protected NestedScriptParser getDbCommandParser(String dbType, String metaDbType) {
     return HiveSchemaHelper.getDbCommandParser(dbType, dbOpts, userName,
-        passWord, conf, null, true);
+        passWord, conf, metaDbType, false);
   }
 
   protected MetaStoreConnectionInfo getConnectionInfo(boolean printInfo) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
@@ -311,7 +311,8 @@ public class MetastoreSchemaTool {
     try (Connection conn = getConnectionToMetastore(true)) {
       conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
       NestedScriptParser parser = getDbCommandParser(dbType, metaDbType);
-      IdempotentDDLExecutor idempotentExecutor = new IdempotentDDLExecutor(conn, dbType, parser, verbose);
+      IdempotentDDLExecutor idempotentExecutor =
+          new IdempotentDDLExecutor(conn, dbType, parser, metaDbType != null, verbose);
       idempotentExecutor.executeScript(sqlScriptFile);
       LOG.info("Script executed successfully.");
     } catch (Exception e) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
@@ -315,6 +315,7 @@ public class MetastoreSchemaTool {
   protected void execSql(String sqlScriptFile) throws IOException {
     LOG.info("Going to run script <{}> via Idempotent JDBC Executor", sqlScriptFile);
     try (Connection conn = getConnectionToMetastore(true)) {
+      conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
       NestedScriptParser parser = getDbCommandParser(dbType, metaDbType);
       IdempotentDDLExecutor idempotentExecutor = new IdempotentDDLExecutor(conn, dbType, parser, verbose);
       idempotentExecutor.executeScript(sqlScriptFile);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
@@ -305,33 +305,22 @@ public class MetastoreSchemaTool {
     execSql(scriptDir + File.separatorChar + scriptFile);
   }
 
-  // Generate the beeline args per hive conf and execute the given script
+  /**
+   * Executes the given SQL script file against the metastore database via {@link IdempotentDDLExecutor}.
+   * Each statement in the script is executed individually over a direct JDBC connection with
+   * auto-commit enabled. Errors that indicate an object already exists or is already gone are
+   * silently ignored according to the per-database {@link DbErrorCodes}; all other SQL errors are
+   * rethrown as {@link IOException}.
+   */
   protected void execSql(String sqlScriptFile) throws IOException {
-    CommandBuilder builder =
-        new CommandBuilder(conf, url, driver, userName, passWord, sqlScriptFile)
-            .setVerbose(verbose);
-
-    // run the script using SqlLine
-    SqlLine sqlLine = new SqlLine();
-    ByteArrayOutputStream outputForLog = null;
-    if (!verbose) {
-      OutputStream out;
-      if (LOG.isDebugEnabled()) {
-        out = outputForLog = new ByteArrayOutputStream();
-      } else {
-        out = new NullOutputStream();
-      }
-      sqlLine.setOutputStream(new PrintStream(out));
-      System.setProperty("sqlline.silent", "true");
-    }
-    LOG.info("Going to run command <" + builder.buildToLog() + ">");
-    SqlLine.Status status = sqlLine.begin(builder.buildToRun(), null, false);
-    if (LOG.isDebugEnabled() && outputForLog != null) {
-      LOG.debug("Received following output from Sqlline:");
-      LOG.debug(outputForLog.toString("UTF-8"));
-    }
-    if (status != SqlLine.Status.OK) {
-      throw new IOException("Schema script failed, errorcode " + status);
+    LOG.info("Going to run script <{}> via Idempotent JDBC Executor", sqlScriptFile);
+    try (Connection conn = getConnectionToMetastore(true)) {
+      NestedScriptParser parser = getDbCommandParser(dbType, metaDbType);
+      IdempotentDDLExecutor idempotentExecutor = new IdempotentDDLExecutor(conn, dbType, parser, verbose);
+      idempotentExecutor.executeScript(sqlScriptFile);
+      LOG.info("Script executed successfully.");
+    } catch (Exception e) {
+      throw new IOException("Schema script failed, error: " + e.getMessage(), e);
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/SchemaToolCommandLine.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/SchemaToolCommandLine.java
@@ -240,10 +240,10 @@ public class SchemaToolCommandLine {
 
   private static final Set<String> VALID_DB_TYPES = ImmutableSet.of(HiveSchemaHelper.DB_DERBY,
       HiveSchemaHelper.DB_HIVE, HiveSchemaHelper.DB_MSSQL, HiveSchemaHelper.DB_MYSQL,
-      HiveSchemaHelper.DB_POSTGRACE, HiveSchemaHelper.DB_ORACLE);
+      HiveSchemaHelper.DB_POSTGRES, HiveSchemaHelper.DB_ORACLE);
 
   private static final Set<String> VALID_META_DB_TYPES = ImmutableSet.of(HiveSchemaHelper.DB_DERBY,
-      HiveSchemaHelper.DB_MSSQL, HiveSchemaHelper.DB_MYSQL, HiveSchemaHelper.DB_POSTGRACE,
+      HiveSchemaHelper.DB_MSSQL, HiveSchemaHelper.DB_MYSQL, HiveSchemaHelper.DB_POSTGRES,
       HiveSchemaHelper.DB_ORACLE);
 
   private void validate() throws ParseException {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
@@ -579,7 +579,8 @@ public class TestSchemaToolForMetastore {
             "alter table TEST_E add constraint TEST_E_FK foreign key (FK_COL) references TEST_E(ID);"
         };
         dropScripts = new String[]{
-            "alter table TEST_E drop constraint TEST_E_FK;",
+            "create procedure #DROP_FK_HELPER as begin alter table TEST_E drop constraint TEST_E_FK end;",
+            "exec #DROP_FK_HELPER;",
             "alter table TEST_E drop constraint TEST_E_UQ;"
         };
       }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
@@ -525,9 +525,9 @@ public class TestSchemaToolForMetastore {
   @Test
   public void testIdempotentAddColumnOperations() throws Exception {
     String addColumnStmt = switch (dbms.getDbType()) {
-      case "oracle" -> "alter table TEST_C add (NEW_COL integer);";
-      case "mssql"  -> "alter table TEST_C add NEW_COL int;";
-      default       -> "alter table TEST_C add column NEW_COL int;";
+    case "oracle" -> "alter table TEST_C add (NEW_COL integer);";
+    case "mssql" -> "alter table TEST_C add NEW_COL int;";
+    default -> "alter table TEST_C add column NEW_COL int;";
     };
     String[] addScripts = new String[]{
         "create table TEST_C (ID int);",
@@ -547,10 +547,9 @@ public class TestSchemaToolForMetastore {
         "create index TEST_IDX on TEST_D (ID);"
     };
     String dropIndexStmt = switch (dbms.getDbType()) {
-      case "derby"    -> "drop index \"APP\".\"TEST_IDX\";";
-      case "oracle",
-           "postgres" -> "drop index TEST_IDX;";
-      default         -> "drop index TEST_IDX on TEST_D;";
+    case "derby" -> "drop index \"APP\".\"TEST_IDX\";";
+    case "oracle", "postgres" -> "drop index TEST_IDX;";
+    default -> "drop index TEST_IDX on TEST_D;";
     };
     String[] dropScripts = new String[]{dropIndexStmt};
     executeWithIdempotencyCheck("IndexOperations-create", createScripts);
@@ -562,38 +561,38 @@ public class TestSchemaToolForMetastore {
     String[] createScripts;
     String[] dropScripts;
     switch (dbms.getDbType()) {
-      case "mysql" -> {
-        createScripts = new String[]{
-            "create table TEST_E (ID int primary key, FK_COL int, "
-                + "constraint TEST_E_FK foreign key (FK_COL) references TEST_E(ID));"
-        };
-        dropScripts = new String[]{
-            "alter table TEST_E drop foreign key TEST_E_FK;",
-            "alter table TEST_E drop key TEST_E_FK;",
-            "alter table TEST_E drop column FK_COL;"
-        };
-      }
-      case "mssql" -> {
-        createScripts = new String[]{
-            "create table TEST_E (ID int primary key, FK_COL int, VAL int);",
-            "alter table TEST_E add constraint TEST_E_UQ unique (VAL);",
-            "alter table TEST_E add constraint TEST_E_FK foreign key (FK_COL) references TEST_E(ID);"
-        };
-        dropScripts = new String[]{
-            "create procedure #DROP_FK_HELPER as begin alter table TEST_E drop constraint TEST_E_FK end;",
+    case "mysql" -> {
+      createScripts = new String[] {
+          "create table TEST_E (ID int primary key, FK_COL int, "
+              + "constraint TEST_E_FK foreign key (FK_COL) references TEST_E(ID));"
+      };
+      dropScripts = new String[] {
+          "alter table TEST_E drop foreign key TEST_E_FK;",
+          "alter table TEST_E drop key TEST_E_FK;",
+          "alter table TEST_E drop column FK_COL;"
+      };
+    }
+    case "mssql" -> {
+      createScripts = new String[] {
+          "create table TEST_E (ID int primary key, FK_COL int, VAL int);",
+          "alter table TEST_E add constraint TEST_E_UQ unique (VAL);",
+          "alter table TEST_E add constraint TEST_E_FK foreign key (FK_COL) references TEST_E(ID);"
+      };
+      dropScripts = new String[] {
+          "create procedure #DROP_FK_HELPER as begin alter table TEST_E drop constraint TEST_E_FK end;",
             "exec #DROP_FK_HELPER;",
-            "alter table TEST_E drop constraint TEST_E_UQ;"
-        };
-      }
-      default -> {
-        createScripts = new String[]{
-            "create table TEST_E (ID int, VAL int);",
-            "alter table TEST_E add constraint TEST_E_UQ unique (ID);"
-        };
-        dropScripts = new String[]{
-            "alter table TEST_E drop constraint TEST_E_UQ;"
-        };
-      }
+          "alter table TEST_E drop constraint TEST_E_UQ;"
+      };
+    }
+    default -> {
+      createScripts = new String[] {
+          "create table TEST_E (ID int, VAL int);",
+          "alter table TEST_E add constraint TEST_E_UQ unique (ID);"
+      };
+      dropScripts = new String[] {
+          "alter table TEST_E drop constraint TEST_E_UQ;"
+      };
+    }
     }
     executeWithIdempotencyCheck("ConstraintOperations-add", createScripts);
     executeWithIdempotencyCheck("ConstraintOperations-drop", dropScripts);
@@ -609,35 +608,35 @@ public class TestSchemaToolForMetastore {
     String[] alterScripts;
     String[] dropScripts = new String[]{"alter table TEST_F drop column COL_RENAMED;"};
     switch (dbms.getDbType()) {
-      case "derby" -> {
-        alterScripts = new String[]{
-            "create table \"TEST_F\" (\"ID\" int, \"COL_MOD\" varchar(10), \"COL_RENAME\" varchar(10));",
-            "alter table \"TEST_F\" alter \"COL_MOD\" set data type varchar(50);",
-            "rename column \"APP\".\"TEST_F\".\"COL_RENAME\" to \"COL_RENAMED\";"
+    case "derby" -> {
+      alterScripts = new String[] {
+          "create table \"TEST_F\" (\"ID\" int, \"COL_MOD\" varchar(10), \"COL_RENAME\" varchar(10));",
+          "alter table \"TEST_F\" alter \"COL_MOD\" set data type varchar(50);",
+          "rename column \"APP\".\"TEST_F\".\"COL_RENAME\" to \"COL_RENAMED\";"
+      };
+      dropScripts = new String[] {"alter table \"TEST_F\" drop column \"COL_RENAMED\";"};
+    }
+    case "mssql" -> alterScripts = new String[] {
+        "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
+        "alter table TEST_F alter column COL_MOD varchar(50) not null;",
+        "exec sp_rename 'TEST_F.COL_RENAME', 'COL_RENAMED', 'COLUMN';"
+    };
+    case "oracle" -> alterScripts = new String[] {
+        "create table TEST_F (ID integer, COL_MOD varchar(10), COL_RENAME varchar(10));",
+        "alter table TEST_F modify (COL_MOD varchar(50));",
+        "alter table TEST_F rename column COL_RENAME to COL_RENAMED;"
+    };
+    case "postgres" -> alterScripts = new String[] {
+        "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
+        "alter table TEST_F alter column COL_MOD type varchar(50);",
+        "alter table TEST_F rename column COL_RENAME to COL_RENAMED;"
+    };
+    default -> // mysql: CHANGE COLUMN renames and redefines in one statement
+        alterScripts = new String[] {
+            "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
+            "alter table TEST_F modify column COL_MOD varchar(50);",
+            "alter table TEST_F change column COL_RENAME COL_RENAMED varchar(10);"
         };
-        dropScripts = new String[]{"alter table \"TEST_F\" drop column \"COL_RENAMED\";"};
-      }
-      case "mssql" -> alterScripts = new String[]{
-          "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
-          "alter table TEST_F alter column COL_MOD varchar(50) not null;",
-          "exec sp_rename 'TEST_F.COL_RENAME', 'COL_RENAMED', 'COLUMN';"
-      };
-      case "oracle" -> alterScripts = new String[]{
-          "create table TEST_F (ID integer, COL_MOD varchar(10), COL_RENAME varchar(10));",
-          "alter table TEST_F modify (COL_MOD varchar(50));",
-          "alter table TEST_F rename column COL_RENAME to COL_RENAMED;"
-      };
-      case "postgres" -> alterScripts = new String[]{
-          "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
-          "alter table TEST_F alter column COL_MOD type varchar(50);",
-          "alter table TEST_F rename column COL_RENAME to COL_RENAMED;"
-      };
-      default -> // mysql: CHANGE COLUMN renames and redefines in one statement
-          alterScripts = new String[]{
-              "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
-              "alter table TEST_F modify column COL_MOD varchar(50);",
-              "alter table TEST_F change column COL_RENAME COL_RENAMED varchar(10);"
-          };
     }
     executeWithIdempotencyCheck("AlterColumnOperations-alter", alterScripts);
     executeWithIdempotencyCheck("AlterColumnOperations-drop", dropScripts);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
@@ -220,7 +220,7 @@ public class TestSchemaToolForMetastore {
 
     // Test invalid case
     String[] scripts = new String[] {
-        "update TBLS set SD_ID=null"
+        "update TBLS set SD_ID=null;"
     };
     File scriptFile = generateTestScript(scripts);
     schemaTool.execSql(scriptFile.getPath());
@@ -308,7 +308,7 @@ public class TestSchemaToolForMetastore {
     boolean isValid = validator.validateSchemaVersions();
     // Test an invalid case with multiple versions
     String[] scripts = new String[] {
-        "insert into VERSION values(100, '2.2.0', 'Hive release version 2.2.0')"
+        "insert into VERSION values(100, '2.2.0', 'Hive release version 2.2.0');"
     };
     File scriptFile = generateTestScript(scripts);
     schemaTool.execSql(scriptFile.getPath());
@@ -316,7 +316,7 @@ public class TestSchemaToolForMetastore {
     Assert.assertFalse(isValid);
 
     scripts = new String[] {
-        "delete from VERSION where VER_ID = 100"
+        "delete from VERSION where VER_ID = 100;"
     };
     scriptFile = generateTestScript(scripts);
     schemaTool.execSql(scriptFile.getPath());
@@ -325,7 +325,7 @@ public class TestSchemaToolForMetastore {
 
     // Test an invalid case without version
     scripts = new String[] {
-        "delete from VERSION"
+        "delete from VERSION;"
     };
     scriptFile = generateTestScript(scripts);
     schemaTool.execSql(scriptFile.getPath());

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
@@ -486,6 +486,162 @@ public class TestSchemaToolForMetastore {
     validateMetastoreDbPropertiesTable();
   }
 
+  /**
+   * Runs {@code ddlScripts} twice. The first run applies all DDL normally. The second run
+   * re-runs the same script from scratch — exactly as a re-run of a failed upgrade would —
+   * and must not throw, because {@link IdempotentDDLExecutor} swallows "already exists" and
+   * "already gone" errors via {@link DbErrorCodes}.
+   */
+  private void executeWithIdempotencyCheck(String testName, String[] ddlScripts) throws Exception {
+    File scriptFile = generateTestScript(ddlScripts);
+    try {
+      schemaTool.execSql(scriptFile.getPath());
+    } catch (Exception e) {
+      Assert.fail("[" + testName + "] First run failed for " + dbms.getDbType() + ": " + e.getMessage());
+    }
+    try {
+      schemaTool.execSql(scriptFile.getPath());
+    } catch (IOException e) {
+      Assert.fail("[" + testName + "] Idempotent retry failed for " + dbms.getDbType()
+          + " — DbErrorCodes did not cover the error: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testIdempotentTableOperations() throws Exception {
+    String[] createScripts = new String[]{
+        "create table TEST_A (ID int);",
+        "create table TEST_B (ID int primary key, NAME varchar(50));"
+    };
+    String[] dropScripts = new String[]{
+        "drop table TEST_A;",
+        "drop table TEST_B;"
+    };
+    executeWithIdempotencyCheck("TableOperations-create", createScripts);
+    executeWithIdempotencyCheck("TableOperations-drop", dropScripts);
+  }
+
+  @Test
+  public void testIdempotentAddColumnOperations() throws Exception {
+    String addColumnStmt = switch (dbms.getDbType()) {
+      case "oracle" -> "alter table TEST_C add (NEW_COL integer);";
+      case "mssql"  -> "alter table TEST_C add NEW_COL int;";
+      default       -> "alter table TEST_C add column NEW_COL int;";
+    };
+    String[] addScripts = new String[]{
+        "create table TEST_C (ID int);",
+        addColumnStmt
+    };
+    String[] dropScripts = new String[]{
+        "alter table TEST_C drop column NEW_COL;"
+    };
+    executeWithIdempotencyCheck("AddColumnOperations-add", addScripts);
+    executeWithIdempotencyCheck("AddColumnOperations-drop", dropScripts);
+  }
+
+  @Test
+  public void testIdempotentIndexOperations() throws Exception {
+    String[] createScripts = new String[]{
+        "create table TEST_D (ID int, VAL int);",
+        "create index TEST_IDX on TEST_D (ID);"
+    };
+    String dropIndexStmt = switch (dbms.getDbType()) {
+      case "derby"    -> "drop index \"APP\".\"TEST_IDX\";";
+      case "oracle",
+           "postgres" -> "drop index TEST_IDX;";
+      default         -> "drop index TEST_IDX on TEST_D;";
+    };
+    String[] dropScripts = new String[]{dropIndexStmt};
+    executeWithIdempotencyCheck("IndexOperations-create", createScripts);
+    executeWithIdempotencyCheck("IndexOperations-drop", dropScripts);
+  }
+
+  @Test
+  public void testIdempotentConstraintOperations() throws Exception {
+    String[] createScripts;
+    String[] dropScripts;
+    switch (dbms.getDbType()) {
+      case "mysql" -> {
+        createScripts = new String[]{
+            "create table TEST_E (ID int primary key, FK_COL int, "
+                + "constraint TEST_E_FK foreign key (FK_COL) references TEST_E(ID));"
+        };
+        dropScripts = new String[]{
+            "alter table TEST_E drop foreign key TEST_E_FK;",
+            "alter table TEST_E drop key TEST_E_FK;",
+            "alter table TEST_E drop column FK_COL;"
+        };
+      }
+      case "mssql" -> {
+        createScripts = new String[]{
+            "create table TEST_E (ID int primary key, FK_COL int, VAL int);",
+            "alter table TEST_E add constraint TEST_E_UQ unique (VAL);",
+            "alter table TEST_E add constraint TEST_E_FK foreign key (FK_COL) references TEST_E(ID);"
+        };
+        dropScripts = new String[]{
+            "alter table TEST_E drop constraint TEST_E_FK;",
+            "alter table TEST_E drop constraint TEST_E_UQ;"
+        };
+      }
+      default -> {
+        createScripts = new String[]{
+            "create table TEST_E (ID int, VAL int);",
+            "alter table TEST_E add constraint TEST_E_UQ unique (ID);"
+        };
+        dropScripts = new String[]{
+            "alter table TEST_E drop constraint TEST_E_UQ;"
+        };
+      }
+    }
+    executeWithIdempotencyCheck("ConstraintOperations-add", createScripts);
+    executeWithIdempotencyCheck("ConstraintOperations-drop", dropScripts);
+  }
+
+  /**
+   * Tests ALTER COLUMN type change and RENAME COLUMN — the same concept across all DBs
+   * with DB-specific syntax, matching heavy use of MODIFY/ALTER COLUMN/SET DATA TYPE
+   * and RENAME COLUMN in real upgrade scripts.
+   */
+  @Test
+  public void testIdempotentAlterColumnOperations() throws Exception {
+    String[] alterScripts;
+    String[] dropScripts = new String[]{"alter table TEST_F drop column COL_RENAMED;"};
+    switch (dbms.getDbType()) {
+      case "derby" -> {
+        alterScripts = new String[]{
+            "create table \"TEST_F\" (\"ID\" int, \"COL_MOD\" varchar(10), \"COL_RENAME\" varchar(10));",
+            "alter table \"TEST_F\" alter \"COL_MOD\" set data type varchar(50);",
+            "rename column \"APP\".\"TEST_F\".\"COL_RENAME\" to \"COL_RENAMED\";"
+        };
+        dropScripts = new String[]{"alter table \"TEST_F\" drop column \"COL_RENAMED\";"};
+      }
+      case "mssql" -> alterScripts = new String[]{
+          "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
+          "alter table TEST_F alter column COL_MOD varchar(50) not null;",
+          "exec sp_rename 'TEST_F.COL_RENAME', 'COL_RENAMED', 'COLUMN';"
+      };
+      case "oracle" -> alterScripts = new String[]{
+          "create table TEST_F (ID integer, COL_MOD varchar(10), COL_RENAME varchar(10));",
+          "alter table TEST_F modify (COL_MOD varchar(50));",
+          "alter table TEST_F rename column COL_RENAME to COL_RENAMED;"
+      };
+      case "postgres" -> alterScripts = new String[]{
+          "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
+          "alter table TEST_F alter column COL_MOD type varchar(50);",
+          "alter table TEST_F rename column COL_RENAME to COL_RENAMED;"
+      };
+      default -> // mysql: CHANGE COLUMN renames and redefines in one statement
+          alterScripts = new String[]{
+              "create table TEST_F (ID int, COL_MOD varchar(10), COL_RENAME varchar(10));",
+              "alter table TEST_F modify column COL_MOD varchar(50);",
+              "alter table TEST_F change column COL_RENAME COL_RENAMED varchar(10);"
+          };
+    }
+    executeWithIdempotencyCheck("AlterColumnOperations-alter", alterScripts);
+    executeWithIdempotencyCheck("AlterColumnOperations-drop", dropScripts);
+  }
+
+
   private File generateTestScript(String [] stmts) throws IOException {
     File testScriptFile = File.createTempFile("schematest", ".sql");
     testScriptFile.deleteOnExit();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
@@ -501,9 +501,10 @@ public class TestSchemaToolForMetastore {
     }
     try {
       schemaTool.execSql(scriptFile.getPath());
-    } catch (IOException e) {
+    } catch (Exception e) {
       Assert.fail("[" + testName + "] Idempotent retry failed for " + dbms.getDbType()
-          + " — DbErrorCodes did not cover the error: " + e.getMessage());
+          + " — possible missing DbErrorCodes mapping or underlying SQL/configuration issue. "
+          + "Exception: " + e + ", cause: " + e.getCause());
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
https://issues.apache.org/jira/browse/HIVE-29517

Make upgrade scripts idempotent by letting DDLs silently fail if the DDL is retrying statements which were already executed.
For example, if the upgrade script creates a table, and then fails later, when we re-run it we can allow it to silently fail on the "CREATE" statement again and just move on to the next statement.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This makes upgrades easier. If a script fails we can re-run it without having to manually clean up tables.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
```
mvn test -pl standalone-metastore/metastore-server -Dtest.groups= -Dtest="TestSchemaToolForMetastore#testIdempotent*"
```