### PR TITLE
HIVE-29528: Cleanup managed DB dir after async drop

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CleanupRequest.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CleanupRequest.java
@@ -30,6 +30,8 @@ public class CleanupRequest {
   private final String location;
   private final List<Path> obsoleteDirs;
   private final boolean purge;
+  private final boolean softDelete;
+  private final boolean sourceOfReplication;
   private final String runAs;
   private final String dbName;
   private final String fullPartitionName;
@@ -38,6 +40,8 @@ public class CleanupRequest {
     this.location = builder.location;
     this.obsoleteDirs = builder.obsoleteDirs;
     this.purge = builder.purge;
+    this.softDelete = builder.softDelete;
+    this.sourceOfReplication = builder.sourceOfReplication;
     this.runAs = builder.runAs;
     this.dbName = builder.dbName;
     this.fullPartitionName = builder.fullPartitionName;
@@ -53,6 +57,14 @@ public class CleanupRequest {
 
   public boolean isPurge() {
     return purge;
+  }
+
+  public boolean isSoftDelete() {
+    return softDelete;
+  }
+
+  public boolean isSourceOfReplication() {
+    return sourceOfReplication;
   }
 
   public String runAs() {
@@ -74,6 +86,8 @@ public class CleanupRequest {
     private String location;
     private List<Path> obsoleteDirs;
     private boolean purge;
+    private boolean softDelete;
+    private boolean sourceOfReplication;
     private String runAs;
     private String dbName;
     private String fullPartitionName;
@@ -90,6 +104,16 @@ public class CleanupRequest {
 
     public CleanupRequestBuilder setPurge(boolean purge) {
       this.purge = purge;
+      return this;
+    }
+
+    public CleanupRequestBuilder setSoftDelete(boolean softDelete) {
+      this.softDelete = softDelete;
+      return this;
+    }
+
+    public CleanupRequestBuilder setSourceOfReplication(boolean sourceOfReplication) {
+      this.sourceOfReplication = sourceOfReplication;
       return this;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/FSRemover.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/FSRemover.java
@@ -99,17 +99,18 @@ public class FSRemover {
     LOG.info("About to remove {} obsolete directories from {}. {}", cr.getObsoleteDirs().size(),
             cr.getLocation(), CompactorUtil.getDebugInfo(cr.getObsoleteDirs()));
     boolean needCmRecycle;
+    Database db = null;
     try {
-      Database db = metadataCache.computeIfAbsent(cr.getDbName(),
+      db = metadataCache.computeIfAbsent(cr.getDbName(),
               () -> CompactorUtil.resolveDatabase(conf, cr.getDbName()));
       needCmRecycle = ReplChangeManager.isSourceOfReplication(db);
     } catch (NoSuchObjectException ex) {
       // can not drop a database which is a source of replication
-      needCmRecycle = false;
+      needCmRecycle = cr.isSourceOfReplication();
     } catch (RuntimeException ex) {
       if (ex.getCause() instanceof NoSuchObjectException) {
         // can not drop a database which is a source of replication
-        needCmRecycle = false;
+        needCmRecycle = cr.isSourceOfReplication();
       } else {
         throw ex;
       }
@@ -126,6 +127,20 @@ public class FSRemover {
         deleted.add(dead);
       }
     }
+    removeDatabaseDirIfNecessary(db, cr, fs);
     return deleted;
+  }
+
+  private void removeDatabaseDirIfNecessary(Database db, CleanupRequest cr, FileSystem fs) throws IOException {
+    if (db != null || !cr.isSoftDelete()) {
+      return;
+    }
+    Path databasePath = new Path(cr.getLocation()).getParent();
+    if (FileUtils.isDirEmpty(fs, databasePath)) {
+      if (cr.isSourceOfReplication()) {
+        replChangeManager.recycle(databasePath, ReplChangeManager.RecycleType.MOVE, cr.isPurge());
+      }
+      FileUtils.deleteDir(fs, databasePath, cr.isPurge(), conf);
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/FSRemover.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/FSRemover.java
@@ -127,20 +127,21 @@ public class FSRemover {
         deleted.add(dead);
       }
     }
-    removeDatabaseDirIfNecessary(db, cr, fs);
+    removeDbDirIfOrphaned(db, cr, fs);
     return deleted;
   }
 
-  private void removeDatabaseDirIfNecessary(Database db, CleanupRequest cr, FileSystem fs) throws IOException {
+  private void removeDbDirIfOrphaned(Database db, CleanupRequest cr, FileSystem fs) throws IOException {
     if (db != null || !cr.isSoftDelete()) {
       return;
     }
     Path databasePath = new Path(cr.getLocation()).getParent();
-    if (FileUtils.isDirEmpty(fs, databasePath)) {
-      if (cr.isSourceOfReplication()) {
-        replChangeManager.recycle(databasePath, ReplChangeManager.RecycleType.MOVE, cr.isPurge());
-      }
-      FileUtils.deleteDir(fs, databasePath, cr.isPurge(), conf);
+    if (!FileUtils.isDirEmpty(fs, databasePath)) {
+      return;
     }
+    if (cr.isSourceOfReplication()) {
+      replChangeManager.recycle(databasePath, ReplChangeManager.RecycleType.MOVE, cr.isPurge());
+    }
+    FileUtils.deleteDir(fs, databasePath, cr.isPurge(), conf);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/handler/CompactionCleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/handler/CompactionCleaner.java
@@ -198,8 +198,7 @@ class CompactionCleaner extends TaskHandler {
       deleted = fsRemover.clean(getCleaningRequestBasedOnLocation(ci, path));
     }
     if (!deleted.isEmpty()) {
-      ci.setSoftDelete(true);
-      txnHandler.markCleaned(ci);
+      txnHandler.markCleaned(ci.asSoftDeleted());
     } else {
       txnHandler.clearCleanerStart(ci);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/handler/CompactionCleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/handler/CompactionCleaner.java
@@ -287,6 +287,8 @@ class CompactionCleaner extends TaskHandler {
         .setFullPartitionName(ci.getFullPartitionName())
         .setRunAs(ci.runAs)
         .setPurge(ifPurge)
+        .setSoftDelete(true)
+        .setSourceOfReplication(ci.isSourceOfReplication())
         .setObsoleteDirs(Collections.singletonList(obsoletePath))
         .build();
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.ql;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1827,11 +1828,9 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
 
     runCleaner(hiveConf);
 
-    stat = fs.listStatus(new Path(getWarehouseDir(), database + ".db"),
-      t -> t.getName().matches("(mv_)?" + tableName + "2" + SOFT_DELETE_TABLE_PATTERN));
-    if (stat.length != 0) {
-      Assert.fail("Table data was not removed from FS");
-    }
+    Assert.assertThrows(database + ".db directory should not exist", FileNotFoundException.class, () -> {
+      fs.listStatus(new Path(getWarehouseDir(), database + ".db"));
+    });
   }
   
   @Test

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AcidEventListener.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AcidEventListener.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.metastore;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.metastore.api.CompactionRequest;
 import org.apache.hadoop.hive.metastore.api.CompactionType;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -91,6 +92,10 @@ public class AcidEventListener extends TransactionalMetaStoreEventListener {
             rqst.setRunas(TxnUtils.findUserToRunAs(table.getSd().getLocation(), table, conf));
             rqst.putToProperties("location", table.getSd().getLocation());
             rqst.putToProperties("ifPurge", Boolean.toString(isMustPurge(tableEvent.getEnvironmentContext(), table)));
+            if (Boolean.parseBoolean(tableEvent.getEnvironmentContext().getProperties()
+                .get(ReplConst.SOURCE_OF_REPLICATION))) {
+              rqst.putToProperties(ReplConst.SOURCE_OF_REPLICATION, Boolean.TRUE.toString());
+            }
             txnHandler.submitForCleanup(rqst, table.getWriteId(), currentTxn);
           } catch (InterruptedException | IOException e) {
             throwMetaException(e);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/DropDatabaseHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/DropDatabaseHandler.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.metastore.Batchable;
 import org.apache.hadoop.hive.metastore.HMSHandler;
 import org.apache.hadoop.hive.metastore.IHMSHandler;
@@ -136,6 +137,9 @@ public class DropDatabaseHandler
         if (isSoftDelete) {
           context = new EnvironmentContext();
           context.putToProperties(hive_metastoreConstants.TXN_ID, String.valueOf(request.getTxnId()));
+          if (ReplChangeManager.isSourceOfReplication(db)) {
+            context.putToProperties(ReplConst.SOURCE_OF_REPLICATION, Boolean.TRUE.toString());
+          }
           request.setDeleteManagedDir(false);
         }
         DropTableRequest dropRequest = new DropTableRequest(name, table.getTableName());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.metastore.txn.entities;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.hadoop.hive.common.ValidCompactorWriteIdList;
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.metastore.api.CompactionInfoStruct;
 import org.apache.hadoop.hive.metastore.api.CompactionType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -377,5 +378,9 @@ public class CompactionInfo implements Comparable<CompactionInfo> {
 
   public boolean isSoftDelete() {
     return softDelete;
+  }
+
+  public boolean isSourceOfReplication() {
+    return Boolean.parseBoolean(getProperty(ReplConst.SOURCE_OF_REPLICATION));
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/entities/CompactionInfo.java
@@ -372,8 +372,9 @@ public class CompactionInfo implements Comparable<CompactionInfo> {
     return type == CompactionType.ABORT_TXN_CLEANUP;
   }
 
-  public void setSoftDelete(boolean softDelete) {
-    this.softDelete = softDelete;
+  public CompactionInfo asSoftDeleted() {
+    this.softDelete = true;
+    return this;
   }
 
   public boolean isSoftDelete() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
After the cleaner thread finishes deleting ACID table data and directories, the parent managed database directory is also evaluated for cleanup. If the database directory is empty, it is deleted as part of the cleanup process.

### Why are the changes needed?
When soft delete is enabled, orphaned database directories remaining indefinitely in the filesystem, leading to potential storage bloat and inconsistencies between HMS metadata and filesystem state.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested manually
