### PR TITLE
[HIVE-29542]Fix large-scale NULL results in LEFT JOIN aggregation queries by aligning MR local hash-table build and bucket-version handling

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecMapper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecMapper.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.exec.mr;
 
 import java.io.IOException;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,8 @@ import org.apache.hadoop.hive.ql.exec.MapOperator;
 import org.apache.hadoop.hive.ql.exec.MapredContext;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.OperatorUtils;
+import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
+import org.apache.hadoop.hive.ql.exec.TableScanOperator;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.vector.VectorMapOperator;
 import org.apache.hadoop.hive.ql.plan.MapWork;
@@ -104,6 +107,7 @@ public class ExecMapper extends MapReduceBase implements Mapper {
       // initialize map operator
       mo.initialize(job, null);
       mo.setChildren(job);
+      balanceRSOpbucketVersion(mo);
       l4j.info(mo.dump(0));
       // initialize map local work
       localWork = mrwork.getMapRedLocalWork();
@@ -136,6 +140,40 @@ public class ExecMapper extends MapReduceBase implements Mapper {
       } else {
         throw new RuntimeException("Map operator initialization failed", e);
       }
+    }
+  }
+
+  private static void balanceRSOpbucketVersion(Operator<? extends OperatorDesc> rootOp) {
+    List<Operator<? extends OperatorDesc>> needDealOps =
+        new ArrayList<Operator<? extends OperatorDesc>>();
+    visitChildGetRSOps(rootOp, needDealOps);
+    int bucketVersion = -1;
+    for (Operator<? extends OperatorDesc> operator : needDealOps) {
+      if (operator.getBucketingVersion() != 1 && operator.getBucketingVersion() != 2) {
+        operator.setBucketingVersion(-1);
+      }
+      if (operator.getBucketingVersion() > bucketVersion) {
+        bucketVersion = operator.getBucketingVersion();
+      }
+    }
+    for (Operator<? extends OperatorDesc> operator : needDealOps) {
+      l4j.info("update reduceSinkOperator name={}, opId={}, oldBucketVersion={}, newBucketVersion={}",
+          operator.getName(), operator.getOperatorId(), operator.getBucketingVersion(), bucketVersion);
+      operator.setBucketingVersion(bucketVersion);
+    }
+  }
+
+  private static void visitChildGetRSOps(
+      Operator<? extends OperatorDesc> rootOp, List<Operator<? extends OperatorDesc>> needDealOps) {
+    List<Operator<? extends OperatorDesc>> ops = rootOp.getChildOperators();
+    if (ops == null || ops.isEmpty()) {
+      return;
+    }
+    for (Operator<? extends OperatorDesc> op : ops) {
+      if (op instanceof ReduceSinkOperator || op instanceof TableScanOperator) {
+        needDealOps.add(op);
+      }
+      visitChildGetRSOps(op, needDealOps);
     }
   }
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/MapredLocalTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/MapredLocalTask.java
@@ -29,9 +29,12 @@ import java.io.Serializable;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -55,6 +58,7 @@ import org.apache.hadoop.hive.ql.QueryPlan;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.BucketMatcher;
 import org.apache.hadoop.hive.ql.exec.FetchOperator;
+import org.apache.hadoop.hive.ql.exec.HashTableSinkOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.SecureCmdDoAs;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
@@ -66,9 +70,13 @@ import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.HiveInputFormat;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.BucketMapJoinContext;
+import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.FetchWork;
+import org.apache.hadoop.hive.ql.plan.HashTableSinkDesc;
 import org.apache.hadoop.hive.ql.plan.MapredLocalWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.ql.plan.api.StageType;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
@@ -175,6 +183,7 @@ public class MapredLocalTask extends Task<MapredLocalWork> implements Serializab
       // write out the plan to a local file
       Path planPath = new Path(ctx.getLocalTmpPath(), "plan.xml");
       MapredLocalWork plan = getWork();
+      removeRowkeyInHashTable(plan);
       LOG.info("Generating plan file " + planPath.toString());
 
       OutputStream out = null;
@@ -370,6 +379,46 @@ public class MapredLocalTask extends Task<MapredLocalWork> implements Serializab
     }
   }
 
+  private void removeRowkeyInHashTable(MapredLocalWork plan) {
+    LinkedHashMap<String, Operator<? extends OperatorDesc>> aliasToWork = plan.getAliasToWork();
+    for (Map.Entry<String, Operator<? extends OperatorDesc>> entry : aliasToWork.entrySet()) {
+      if (!(entry.getValue() instanceof TableScanOperator)) {
+        continue;
+      }
+      TableScanOperator tsOp = (TableScanOperator) entry.getValue();
+      TableScanDesc tsDesc = tsOp.getConf();
+      if (tsDesc == null || !tsDesc.isTranscationalTable()) {
+        continue;
+      }
+      List<Operator<? extends OperatorDesc>> children = tsOp.getChildOperators();
+      if (children == null) {
+        continue;
+      }
+      for (Operator<? extends OperatorDesc> childOp : children) {
+        if (!(childOp instanceof HashTableSinkOperator)) {
+          continue;
+        }
+        HashTableSinkOperator hashOp = (HashTableSinkOperator) childOp;
+        Map<Byte, List<ExprNodeDesc>> exprs = ((HashTableSinkDesc) hashOp.getConf()).getExprs();
+        for (Map.Entry<Byte, List<ExprNodeDesc>> exprEntry : exprs.entrySet()) {
+          removeInnerKey(exprEntry.getValue());
+        }
+      }
+    }
+  }
+
+  private void removeInnerKey(List<ExprNodeDesc> columns) {
+    List<String> innerKeys = Arrays.asList("ROW__ID", "INPUT__FILE__NAME", "BLOCK__OFFSET__INSIDE__FILE");
+    List<ExprNodeDesc> needRemove = new ArrayList<ExprNodeDesc>();
+    for (ExprNodeDesc nodeDesc : columns) {
+      if (nodeDesc instanceof ExprNodeColumnDesc &&
+          innerKeys.contains(((ExprNodeColumnDesc) nodeDesc).getColumn())) {
+        needRemove.add(nodeDesc);
+      }
+    }
+    columns.removeAll(needRemove);
+  }
+
   public int executeInProcess(DriverContext driverContext) {
     // check the local work
     if (work == null) {
@@ -388,6 +437,7 @@ public class MapredLocalTask extends Task<MapredLocalWork> implements Serializab
     execContext.setJc(job);
     // set the local work, so all the operator can get this context
     execContext.setLocalWork(work);
+    removeRowkeyInHashTable(work);
     try {
       startForward(null);
       long currentTime = System.currentTimeMillis();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a correctness issue in MR execution path for a LEFT JOIN + aggregated-subquery query shape.

Changes in this PR:

1. `MapredLocalTask`:
   - Before local hash-table build, remove transactional internal columns from hash-table expressions:
     - `ROW__ID`
     - `INPUT__FILE__NAME`
     - `BLOCK__OFFSET__INSIDE__FILE`
   - Apply this cleanup in both local-task paths:
     - `executeInChildVM(...)`
     - `executeInProcess(...)`
   - This ensures consistent expression layout/key semantics during local map-join hash-table build.

2. `ExecMapper`:
   - Add bucket-version balancing across related `ReduceSinkOperator` / `TableScanOperator` nodes during mapper initialization.
   - This reduces mismatch risk caused by inconsistent bucketing version propagation in complex MR pipelines.

Touched files:
- `ql/src/java/org/apache/hadoop/hive/ql/exec/mr/MapredLocalTask.java`
- `ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecMapper.java`


### Why are the changes needed?

For this query pattern:
- outer `LEFT JOIN`
- right side as `JOIN + GROUP BY(stddev)` subquery

single-key runs can return expected results, while full-volume `INSERT OVERWRITE` may produce a large amount of unexpected NULLs on the right-side metric column.

The issue is caused by execution-path consistency gaps in MR local hash-table build and map-side bucket-version handling, which can lead to large-scale join probe mismatches.


### Does this PR introduce _any_ user-facing change?

Yes (behavioral correctness fix).

Previous behavior:
- For specific query shapes, full-volume runs could produce large-scale unexpected NULLs in the joined metric column.

New behavior:
- Join result consistency is restored between single-key and full-volume runs.
- Output matches expected LEFT JOIN semantics for the affected query shape.


### How was this patch tested?

1. Build/compile validation:
   - `mvn -pl ql -am -DskipTests -DskipITs compile`

2. Repro query validation (full-volume):
   - Run the repro `INSERT OVERWRITE` query (LEFT JOIN + aggregated subquery).
   - Verify NULL ratio of the joined metric column before/after patch.

3. Spot-check consistency:
   - Compare a known single-key query result with full-volume partition output for the same key.
   - Confirm the joined metric is no longer unexpectedly NULL.

(If required by reviewers, I can add focused regression tests for this query shape in follow-up.)