### PR TITLE
HIVE-29524: Missing num_nulls statistic for partition columns

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/Statistics.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/Statistics.java
@@ -258,7 +258,7 @@ public class Statistics implements Serializable {
         if (cs.getNumNulls() < 0 || existing.getNumNulls() < 0) {
           existing.setNumNulls(-1);
         } else {
-          existing.setNumNulls(StatsUtils.safeAdd(existing.getNumNulls(), cs.getNumNulls()));
+          existing.setNumNulls(Math.max(existing.getNumNulls(), cs.getNumNulls()));
         }
         existing.setCountDistint(Math.max(existing.getCountDistint(), cs.getCountDistint()));
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
@@ -602,6 +602,7 @@ public class StatsUtils {
     partCS.setAvgColLen(StatsUtils.getAvgColLenOf(conf,
         ci.getObjectInspector(), partCS.getColumnType()));
     partCS.setRange(getRangePartitionColumn(partList, ci.getInternalName(), ci.getType().getTypeName()));
+    partCS.setNumNulls(getNumNullsForPartCol(partList, ci.getInternalName(), conf));
     return partCS;
   }
 
@@ -611,6 +612,24 @@ public class StatsUtils {
       distinctVals.add(partition.getSpec().get(partColName));
     }
     return distinctVals.size();
+  }
+
+  private static long getNumNullsForPartCol(PartitionIterable partitions, String partColName, HiveConf conf) {
+    long numNulls = 0;
+    String defaultPartitionName = HiveConf.getVar(conf, HiveConf.ConfVars.DEFAULT_PARTITION_NAME);
+    for (Partition partition : partitions) {
+      String partVal = partition.getSpec().get(partColName);
+      if (partVal != null && partVal.equals(defaultPartitionName)) {
+        Map<String, String> parameters = partition.getParameters();
+        if (parameters != null && parameters.get(StatsSetupConst.ROW_COUNT) != null) {
+          long rowCount = Long.parseLong(parameters.get(StatsSetupConst.ROW_COUNT));
+          if (rowCount > 0) {
+            numNulls = safeAdd(numNulls, rowCount);
+          }
+        }
+      }
+    }
+    return numNulls;
   }
 
   private static Range getRangePartitionColumn(PartitionIterable partitions, String partColName,

--- a/ql/src/test/queries/clientpositive/part_num_nulls.q
+++ b/ql/src/test/queries/clientpositive/part_num_nulls.q
@@ -1,0 +1,18 @@
+CREATE TABLE emp (eid INT, ename STRING) partitioned by (bdate INT, location STRING);
+
+INSERT INTO emp
+VALUES (1, 'Bob', 20200101, 'Paris'),
+       (2, 'Alice', 20200102, 'Paris'),
+       (3, 'Sam', 20200103, null),
+       (4, 'John', null, 'New York'),
+       (5, 'Jane', null, null),
+       (6, 'Tom', null, 'New York'),
+       (7, null, 20200103, 'New York'),
+       (8, null, 20200103, 'Paris'),
+       (null, 'Tom', 20200109, null),
+       (null, 'Jane', 20200110, null);
+
+DESCRIBE FORMATTED emp eid;
+DESCRIBE FORMATTED emp ename;
+DESCRIBE FORMATTED emp bdate;
+DESCRIBE FORMATTED emp location;

--- a/ql/src/test/results/clientpositive/llap/part_num_nulls.q.out
+++ b/ql/src/test/results/clientpositive/llap/part_num_nulls.q.out
@@ -1,0 +1,139 @@
+PREHOOK: query: CREATE TABLE emp (eid INT, ename STRING) partitioned by (bdate INT, location STRING)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@emp
+POSTHOOK: query: CREATE TABLE emp (eid INT, ename STRING) partitioned by (bdate INT, location STRING)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@emp
+PREHOOK: query: INSERT INTO emp
+VALUES (1, 'Bob', 20200101, 'Paris'),
+       (2, 'Alice', 20200102, 'Paris'),
+       (3, 'Sam', 20200103, null),
+       (4, 'John', null, 'New York'),
+       (5, 'Jane', null, null),
+       (6, 'Tom', null, 'New York'),
+       (7, null, 20200103, 'New York'),
+       (8, null, 20200103, 'Paris'),
+       (null, 'Tom', 20200109, null),
+       (null, 'Jane', 20200110, null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@emp
+POSTHOOK: query: INSERT INTO emp
+VALUES (1, 'Bob', 20200101, 'Paris'),
+       (2, 'Alice', 20200102, 'Paris'),
+       (3, 'Sam', 20200103, null),
+       (4, 'John', null, 'New York'),
+       (5, 'Jane', null, null),
+       (6, 'Tom', null, 'New York'),
+       (7, null, 20200103, 'New York'),
+       (8, null, 20200103, 'Paris'),
+       (null, 'Tom', 20200109, null),
+       (null, 'Jane', 20200110, null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@emp
+POSTHOOK: Output: default@emp@bdate=20200101/location=Paris
+POSTHOOK: Output: default@emp@bdate=20200102/location=Paris
+POSTHOOK: Output: default@emp@bdate=20200103/location=New York
+POSTHOOK: Output: default@emp@bdate=20200103/location=Paris
+POSTHOOK: Output: default@emp@bdate=20200103/location=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Output: default@emp@bdate=20200109/location=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Output: default@emp@bdate=20200110/location=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Output: default@emp@bdate=__HIVE_DEFAULT_PARTITION__/location=New York
+POSTHOOK: Output: default@emp@bdate=__HIVE_DEFAULT_PARTITION__/location=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Lineage: emp PARTITION(bdate=20200101,location=Paris).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200101,location=Paris).ename SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200102,location=Paris).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200102,location=Paris).ename SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200103,location=New York).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200103,location=New York).ename SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200103,location=Paris).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200103,location=Paris).ename SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200103,location=__HIVE_DEFAULT_PARTITION__).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200103,location=__HIVE_DEFAULT_PARTITION__).ename SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200109,location=__HIVE_DEFAULT_PARTITION__).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200109,location=__HIVE_DEFAULT_PARTITION__).ename SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200110,location=__HIVE_DEFAULT_PARTITION__).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=20200110,location=__HIVE_DEFAULT_PARTITION__).ename SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=__HIVE_DEFAULT_PARTITION__,location=New York).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=__HIVE_DEFAULT_PARTITION__,location=New York).ename SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=__HIVE_DEFAULT_PARTITION__,location=__HIVE_DEFAULT_PARTITION__).eid SCRIPT []
+POSTHOOK: Lineage: emp PARTITION(bdate=__HIVE_DEFAULT_PARTITION__,location=__HIVE_DEFAULT_PARTITION__).ename SCRIPT []
+PREHOOK: query: DESCRIBE FORMATTED emp eid
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@emp
+POSTHOOK: query: DESCRIBE FORMATTED emp eid
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@emp
+col_name            	eid                 
+data_type           	int                 
+min                 	1                   
+max                 	8                   
+num_nulls           	2                   
+distinct_count      	8                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"eid\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED emp ename
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@emp
+POSTHOOK: query: DESCRIBE FORMATTED emp ename
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@emp
+col_name            	ename               
+data_type           	string              
+min                 	                    
+max                 	                    
+num_nulls           	2                   
+distinct_count      	6                   
+avg_col_len         	5.0                 
+max_col_len         	5                   
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"ename\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED emp bdate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@emp
+POSTHOOK: query: DESCRIBE FORMATTED emp bdate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@emp
+col_name            	bdate               
+data_type           	int                 
+min                 	20200101            
+max                 	20200110            
+num_nulls           	3                   
+distinct_count      	6                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	                    
+comment             	                    
+COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"bdate\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED emp location
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@emp
+POSTHOOK: query: DESCRIBE FORMATTED emp location
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@emp
+col_name            	location            
+data_type           	string              
+min                 	                    
+max                 	                    
+num_nulls           	4                   
+distinct_count      	3                   
+avg_col_len         	100.0               
+max_col_len         	100                 
+num_trues           	                    
+num_falses          	                    
+bit_vector          	                    
+comment             	                    
+COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"location\":\"true\"}}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
num_nulls statistics should be computed for partition columns

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, the num_nulls statistics is not populated and is always zero which is wrong information to the user and also, any estimations that rely on [ColStatistics.getNumNulls](https://github.com/apache/hive/blob/931d4bb62b26de699240c816df439e00644e3dcb/ql/src/java/org/apache/hadoop/hive/ql/plan/ColStatistics.java#L72) will also be inaccurate.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, num_nulls metrics which was not populated earlier and always defaulted to zero, will be rightly computed and visible to user.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual Testing & Qtest