### PR TITLE
HIVE-29104: fix git URL in --version output

### DIFF
--- a/common/src/scripts/saveVersion.sh
+++ b/common/src/scripts/saveVersion.sh
@@ -36,7 +36,7 @@ if [ "$revision" = "" ]; then
         revision=`git log -1 --pretty=format:"%H"`
         hostname=`hostname`
         branch=`git branch | sed -n -e 's/^* //p'`
-        url="git://${hostname}${cwd}"
+        url="https://github.com/apache/hive.git"
     elif [ -d .svn ]; then
         revision=`svn info ../ | sed -n -e 's/Last Changed Rev: \(.*\)/\1/p'`
         url=`svn info ../ | sed -n -e 's/^URL: \(.*\)/\1/p'`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Ensure hive version displays correct git repository URL


### Why are the changes needed?
Currently the hive version prints the local repo path of the user who built it, it can't be accessed by anyone, better to have Git remote repo which is "https://github.com/apache/hive.git"
Old version display:
Hive 4.3.0-SNAPSHOT
Git git://VWK/Users/mahesh/Code/opensource/hive -r 843168bfabe01a3c07275626445d83cea560df32
Compiled by maheshrajus on Mon Apr 6 13:01:54 IST 2026
From source with checksum 1d2b9efb1c932f5e999a0c8548537147

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested the git URL after build.
1) clone the code: https://github.com/apache/hive.git
2) build the code and check for the version.

Output after fix: 
Hive 4.3.0-SNAPSHOT
Git https://github.com/apache/hive.git -r 843168bfabe01a3c07275626445d83cea560df32
Compiled by maheshrajus on Wed Apr 1 22:24:14 IST 2026
From source with checksum 91c15760fcbe65fc66caa3e5e08b6e80