### PR TITLE
HIVE-29555: [HPLSQL]Errorcode handling is not proper in HPLSQL.

### DIFF
--- a/hplsql/src/main/java/org/apache/hive/hplsql/Exec.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Exec.java
@@ -768,7 +768,7 @@ public class Exec extends HplsqlBaseVisitor<Integer> implements Closeable {
    */
   public void setSqlNoData() {
     setSqlCode(SqlCodes.NO_DATA_FOUND);
-    setSqlState("01000");
+    setSqlState("02000");
   }
 
   public Integer run(String[] args) throws Exception {

--- a/hplsql/src/main/java/org/apache/hive/hplsql/Select.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Select.java
@@ -125,8 +125,8 @@ public class Select {
               exec.signal(Signal.Type.TOO_MANY_ROWS);
             }
           } else {
-            exec.setSqlCode(SqlCodes.NO_DATA_FOUND);
-            exec.signal(Signal.Type.NOTFOUND);
+            exec.setSqlNoData();
+            exec.signal(Signal.Type.NOTFOUND, null, null);
           }
         }
       } else if (ctx.parent instanceof HplsqlParser.StmtContext) { // Print all results for standalone SELECT statement
@@ -156,7 +156,7 @@ public class Select {
           exec.setSqlSuccess();
         } else {
           evalNull();
-          exec.setSqlCode(SqlCodes.NO_DATA_FOUND);
+          exec.setSqlNoData();
         }
       }
     } catch (QueryException e) {

--- a/hplsql/src/main/java/org/apache/hive/hplsql/Stmt.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Stmt.java
@@ -81,7 +81,8 @@ public class Stmt {
       exec.signal(Signal.Type.SQLEXCEPTION);
       return -1;
     }
-    exec.addVariable(new Var(name, Type.CURSOR, cur.value)); 
+    exec.addVariable(new Var(name, Type.CURSOR, cur.value));
+    exec.setSqlSuccess();
     return 0; 
   }
   
@@ -475,7 +476,7 @@ public class Stmt {
         exec.signal(queryResult);
         return 1;
       } else if (!exec.getOffline()) {
-        exec.setSqlCode(SqlCodes.SUCCESS);
+        exec.setSqlSuccess();
       }
       if (cursor.isWithReturn()) {
         exec.addReturnCursor(var);
@@ -507,8 +508,8 @@ public class Stmt {
       exec.signal(Signal.Type.SQLEXCEPTION);
       return 1;
     } else if (exec.getOffline()) {
-      exec.setSqlCode(SqlCodes.NO_DATA_FOUND);
-      exec.signal(Signal.Type.NOTFOUND);
+      exec.setSqlNoData();
+      exec.signal(Signal.Type.NOTFOUND, null, null);
       return 0;
     }
     // Assign values from the row to local variables
@@ -533,6 +534,7 @@ public class Stmt {
             break;
           }
         }
+        exec.setSqlSuccess();
       } else {
         if(queryResult.next()) {
           cursor.setFetch(true);
@@ -555,7 +557,7 @@ public class Stmt {
           exec.setSqlSuccess();
         } else {
           cursor.setFetch(false);
-          exec.setSqlCode(SqlCodes.NO_DATA_FOUND);
+          exec.setSqlNoData();
         }
       }
     } catch (QueryException e) {
@@ -581,7 +583,7 @@ public class Stmt {
     Var var = exec.findVariable(name);
     if(var != null && var.type == Type.CURSOR) {
       ((Cursor)var.value).close();
-      exec.setSqlCode(SqlCodes.SUCCESS);
+      exec.setSqlSuccess();
     } else if(trace) {
       trace(ctx, "Cursor not found: " + name);
     }
@@ -716,8 +718,8 @@ public class Stmt {
       exec.incRowCount();
       exec.setSqlSuccess();
     } else {
-      exec.setSqlCode(SqlCodes.NO_DATA_FOUND);
-      exec.signal(Signal.Type.NOTFOUND);
+      exec.setSqlNoData();
+      exec.signal(Signal.Type.NOTFOUND, null, null);
     }
   }
 
@@ -892,7 +894,7 @@ public class Stmt {
       exec.signal(query);
       return 1;
     }
-    exec.setSqlCode(SqlCodes.SUCCESS);
+    exec.setSqlSuccess();
     query.close();
     return 0; 
   }
@@ -1061,6 +1063,7 @@ public class Stmt {
       exec.signal(query);
       return 1;
     }
+    exec.setSqlSuccess();
     try {
       if (ctx.T_INTO() != null) {
         int cols = ctx.L_ID().size();
@@ -1082,7 +1085,7 @@ public class Stmt {
               trace(ctx, "Variable not found: " + ctx.L_ID(i).getText());
             }
           }
-          exec.setSqlCode(SqlCodes.SUCCESS);
+          exec.setSqlSuccess();
         }
       }
       // Print the results
@@ -1595,7 +1598,8 @@ public class Stmt {
     if (ctx.expr() != null) {
       eval(ctx.expr());
     }
-    exec.signal(Signal.Type.LEAVE_ROUTINE);    
+    exec.signal(Signal.Type.LEAVE_ROUTINE, null, null);
+    exec.setSqlSuccess();
     return 0; 
   }  
   

--- a/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
@@ -587,6 +587,56 @@ public class TestHplSqlViaBeeLine {
   }
 
   @Test
+  public void testErrorcodeWithBulkCollectFetch() throws Throwable {
+    String scriptText =
+        "SET hplsql.onerror='seterror';\n" +
+            "DROP TABLE IF EXISTS result;\n" +
+            "CREATE TABLE result (s string);\n" +
+            "DROP TABLE IF EXISTS emp;\n" +
+            "CREATE TABLE emp (name string, age int);\n" +
+            "INSERT INTO emp VALUES('alice', 20),('bob', 30);\n" +
+            "TYPE t_rows IS TABLE OF emp%ROWTYPE INDEX BY BINARY_INTEGER;\n" +
+            "SELECT * FROM UNKNOWN; --Exception expted and errorcode is set to -1\n" +
+            "PRINT 'First ERRORCODE: ' || errorcode\n" +
+            "DECLARE rows t_rows;\n" +
+            "DECLARE cur SYS_REFCURSOR;\n" +
+            "OPEN cur FOR SELECT * FROM emp;\n" +
+            "PRINT 'Second ERRORCODE: ' || errorcode\n" +
+            "SELECT * FROM UNKNOWN1; --Exception expted and errorcode is set to -1\n" +
+            "PRINT 'Third ERRORCODE: ' || errorcode\n" +
+            "FETCH cur BULK COLLECT INTO rows;\n" +
+            "PRINT 'Fourth ERRORCODE: ' || errorcode\n" +
+            "CLOSE cur;\n" +
+            "INSERT INTO result VALUES(rows(1).name || ' = ' || rows(1).age || ' ' || rows(2).name || ' = ' || rows(2).age);\n" +
+            "SELECT * FROM result;\n";
+    testScriptFile(scriptText, args(), "First ERRORCODE: -1.*Second ERRORCODE: 0.*Third ERRORCODE: -1.*Fourth ERRORCODE: 0.*alice = 20 bob = 30", OutStream.ERR);
+  }
+
+  @Test
+  public void testErrorCodeWithAllocateCursor() throws Throwable {
+    String scriptText =
+        "SET hplsql.onerror='seterror';\n" +
+            "DROP TABLE IF EXISTS issues;\n" +
+            "CREATE TABLE issues (id int, name string);\n" +
+            "CREATE PROCEDURE spOpenIssues \n" +
+            "  DYNAMIC RESULT SETS 1\n" +
+            "BEGIN\n" +
+            "  DECLARE cur CURSOR WITH RETURN FOR\n" +
+            "    SELECT id, name FROM issues;\n" +
+            "  OPEN cur;\n" +
+            "END;\n" +
+            "DECLARE id INT;\n" +
+            "DECLARE name VARCHAR(30);\n" +
+             "CALL spOpenIssues;\n" +
+            "SELECT * FROM UNKNOWN; --Exception expted and errorcode is set to -1\n" +
+            "PRINT 'First ERRORCODE: ' || errorcode\n" +
+            "ALLOCATE c1 CURSOR FOR PROCEDURE spOpenIssues;\n" +
+            "PRINT 'Second ERRORCODE: ' || errorcode\n" +
+            "CLOSE c1;";
+    testScriptFile(scriptText, args(), "First ERRORCODE: -1.*Second ERRORCODE: 0", OutStream.ERR);
+  }
+
+  @Test
   public void testDecimalCast() throws Throwable {
     String scriptText =
         "DECLARE\n" +
@@ -1417,6 +1467,17 @@ public class TestHplSqlViaBeeLine {
     testScriptFile(scriptText, args(),
         "^(.(?!(Caused by: org.apache.hadoop.hive.ql.metadata.InvalidTableException: Table not found def)))*$",
         OutStream.ERR);
+  }
+
+  @Test
+  public void testERRORCODEForExecuteStatements() throws Throwable {
+    String scriptText =
+        "SET hplsql.onerror='seterror';\n" +
+            "EXECUTE 'select * from unknown';\n" +
+            "PRINT 'First ERRORCODE: ' || errorcode\n" +
+            "EXECUTE 'select 1';\n" +
+            "PRINT 'Second ERRORCODE: ' || errorcode";
+    testScriptFile(scriptText, args(), "First ERRORCODE: -1.*Second ERRORCODE: 0", OutStream.ERR);
   }
 
   private static List<String> args() {


### PR DESCRIPTION
HIVE-29555: [HPLSQL]Errorcode handling is not proper in HPLSQL.
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When SQL statements are executed using EXECUTE/EXECUTE IMMEDIATE, in positive scenario the ERRORCODE is not set as SUCCESS. The default value for ERRORCODE is SUCCESS so even without setting the errorcode to success in positive scenario is fine but if the ERRORCODE is set as ERROR as a part of previous statement execution then another statement is executed successfully but still ERRORCODE is already set as ERROR which is not correct. Now in positive flow also we are setting SUCCESS for the ERRORCODE.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
To fix the error reported in [HIVE-29555](https://issues.apache.org/jira/browse/HIVE-29555).
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
Added testcase to test the scenario.
_mvn test -Dtest=TestHplSqlViaBeeLine#testERRORCODEForExecuteStatements -pl itests/hive-unit -Pitests_
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
