### PR TITLE
HIVE-29560: Fix JdbcColumn DECIMAL class mapping to BigDecimal

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/JdbcColumn.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/JdbcColumn.java
@@ -18,7 +18,7 @@
 
 package org.apache.hive.jdbc;
 
-import java.math.BigInteger;
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -97,7 +97,7 @@ public class JdbcColumn {
       case Types.TIMESTAMP_WITH_TIMEZONE:
         return TimestampTZ.class.getName();
       case Types.DECIMAL:
-        return BigInteger.class.getName();
+        return BigDecimal.class.getName();
       case Types.BINARY:
         return byte[].class.getName();
       case Types.OTHER:


### PR DESCRIPTION
## What changes were proposed in this pull request?

`JdbcColumn.columnClassName()` currently maps `Types.DECIMAL` to
`BigInteger.class.getName()`, which is incorrect for DECIMAL semantics.
This PR changes the mapping to `BigDecimal.class.getName()`.

## Why are the changes needed?

JDBC `DECIMAL` should map to `java.math.BigDecimal`, not `BigInteger`.
The current behavior may cause type mismatch and incorrect metadata
interpretation by JDBC clients.

## Does this PR introduce _any_ user-facing change?

Yes.
For DECIMAL columns, JDBC metadata now reports
`java.math.BigDecimal` as the column class name.

## How was this patch tested?

- Built JDBC module successfully:
  - `mvn -pl jdbc -DskipTests compile`
- Verified code change in:
  - `jdbc/src/java/org/apache/hive/jdbc/JdbcColumn.java`