### PR TITLE
HIVE-29567: Data loss in query-based major compaction

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1558,6 +1558,10 @@ public class AcidUtils {
         FileStatus fStatus = itr.next();
         Path fPath = fStatus.getPath();
         if (fStatus.isDirectory()) {
+          if (baseFileFilter.accept(fPath) || deltaFileFilter.accept(fPath)
+              || deleteEventDeltaDirFilter.accept(fPath)) {
+            addToSnapshot(dirToSnapshots, fPath);
+          }
           stack.push(FileUtils.listStatusIterator(fs, fPath, acidHiddenFileFilter));
         } else {
           Path parentDirPath = fPath.getParent();

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -184,10 +184,13 @@ public class AcidCompactionService extends CompactionService {
        * multi-stmt txn. {@link Driver#setCompactionWriteIds(ValidWriteIdList, long)} */
       compactionTxn.open(ci);
 
-      final ValidTxnList validTxnList = msc.getValidTxns(compactionTxn.getTxnId());
+      final ValidTxnList validTxnList =
+          TxnUtils.createValidTxnListForCompactor(msc.getOpenTxns(), compactionTxn.getTxnId());
       //with this ValidWriteIdList is capped at whatever HWM validTxnList has
-      tblValidWriteIds = TxnUtils.createValidCompactWriteIdList(msc.getValidWriteIds(
-          Collections.singletonList(fullTableName), validTxnList.writeToString()).get(0));
+      tblValidWriteIds =
+          TxnUtils.createValidCompactWriteIdList(
+              msc.getValidWriteIds(List.of(fullTableName), validTxnList.writeToString()).get(0)
+          );
       LOG.debug("ValidCompactWriteIdList: " + tblValidWriteIds.writeToString());
       conf.set(ValidTxnList.VALID_TXNS_KEY, validTxnList.writeToString());
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnCommonUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnCommonUtils.java
@@ -41,6 +41,11 @@ public class TxnCommonUtils {
    * @return a valid txn list.
    */
   public static ValidTxnList createValidReadTxnList(GetOpenTxnsResponse txns, long currentTxn) {
+    return createValidReadTxnList(txns, currentTxn, true);
+  }
+
+  static ValidTxnList createValidReadTxnList(GetOpenTxnsResponse txns, long currentTxn,
+      boolean excludeCurrentTxn) {
     assert currentTxn <= txns.getTxn_high_water_mark();
     /*
      * The highWaterMark should be min(currentTxn,txns.getTxn_high_water_mark()) assuming currentTxn>0
@@ -61,7 +66,13 @@ public class TxnCommonUtils {
     // txn is read-only or aborted by AcidHouseKeeperService and compactor actually cleans up the aborted txns.
     // So, for such cases, we get negative value for sizeToHwm with found position for currentTxn, and so,
     // we just negate it to get the size.
-    int sizeToHwm = (currentTxn > 0) ? Math.abs(Collections.binarySearch(openTxns, currentTxn)) : openTxns.size();
+    int sizeToHwm;
+    if (currentTxn > 0) {
+      int pos = Collections.binarySearch(openTxns, currentTxn);
+      sizeToHwm = (pos >= 0 && !excludeCurrentTxn) ? pos + 1 : Math.abs(pos);
+    } else {
+      sizeToHwm = openTxns.size();
+    }
     sizeToHwm = Math.min(sizeToHwm, openTxns.size());
     long[] exceptions = new long[sizeToHwm];
     BitSet inAbortedBits = BitSet.valueOf(txns.getAbortedBits());
@@ -70,8 +81,9 @@ public class TxnCommonUtils {
     int i = 0;
     for (long txn : openTxns) {
       // For snapshot isolation, we don't care about txns greater than current txn and so stop here.
-      // Also, we need not include current txn to exceptions list.
-      if ((currentTxn > 0) && (txn >= currentTxn)) {
+      // When excludeCurrentTxn is true, we also exclude current txn from the exceptions list
+      // (own-txn exclusion for regular reads). When false, we include it (compaction worker).
+      if ((currentTxn > 0) && (excludeCurrentTxn ? txn >= currentTxn : txn > currentTxn)) {
         break;
       }
       if (inAbortedBits.get(i)) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnUtils.java
@@ -67,10 +67,12 @@ public class TxnUtils {
   private static final Logger LOG = LoggerFactory.getLogger(TxnUtils.class);
 
   /**
-   * Returns a valid txn list for cleaner.
-   * @param txns Response containing open txns list.
-   * @param minOpenTxn Minimum open txn which is min open write txn on the table in the case of abort cleanup.
-   * @param isAbortCleanup Whether the request is for abort cleanup.
+   * Returns a valid txn list for the cleaner. The high watermark is set to {@code minOpenTxn - 1}
+   * so the cleaner only sees transactions that committed before the oldest open write txn on the table.
+   *
+   * @param txns response containing the currently open txns list
+   * @param minOpenTxn minimum open write txn id on the table being cleaned
+   * @param isAbortCleanup whether the request is for abort cleanup
    * @return a valid txn list
    */
   public static ValidTxnList createValidTxnListForCleaner(GetOpenTxnsResponse txns, long minOpenTxn, boolean isAbortCleanup) {
@@ -104,6 +106,18 @@ public class TxnUtils {
     } else {
       return new ValidReadTxnList(exceptions, abortedBits, highWatermark, Long.MAX_VALUE);
     }
+  }
+
+  /**
+   * Returns a valid txn list for the compaction worker. The high watermark is capped at {@code compactionTxnId}
+   * and the compaction transaction itself is kept in the exceptions list as OPEN.
+   *
+   * @param txns open txns response from the metastore
+   * @param compactionTxnId the transaction ID of the compaction
+   * @return a valid txn list
+   */
+  public static ValidTxnList createValidTxnListForCompactor(GetOpenTxnsResponse txns, long compactionTxnId) {
+    return TxnCommonUtils.createValidReadTxnList(txns, compactionTxnId, false);
   }
 
   /**


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Introduced `createValidTxnListForCompactor` which creates same `validReadTxnList` keeping the compaction txn in the exceptions list as OPEN

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Data loss fix


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Cluster
None of the existing compaction tests spotted the problem due to diff in local and HDFS empty dir handling in AcidState.