### PR TITLE
HIVE-29481: Fix create table with transactional=false and transactional_properties=insert_only to create a translated to external table

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreTransformer.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreTransformer.java
@@ -1276,7 +1276,7 @@ public class TestHiveMetastoreTransformer {
       table_params = new StringBuilder();
       table_params.append("key1=val1");
       table_params.append(";");
-      table_params.append("transactional_properties=insert_only");
+      table_params.append("transactional=true;transactional_properties=insert_only");
       tProps.put("PROPERTIES", table_params.toString());
 
       List<String> capabilities = new ArrayList<>();

--- a/ql/src/test/queries/clientpositive/translated_external_create.q
+++ b/ql/src/test/queries/clientpositive/translated_external_create.q
@@ -1,0 +1,17 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.create.as.acid=true;
+set hive.default.fileformat.managed=ORC;
+set hive.metastore.client.capabilities=HIVEFULLACIDWRITE,HIVEMANAGEDINSERTWRITE;
+set metastore.metadata.transformer.class=org.apache.hadoop.hive.metastore.MetastoreDefaultTransformer;
+
+-- Should create translated external table when transactional=false
+create table translated_table1 (i int) tblproperties('transactional'='false');
+desc formatted translated_table1;
+
+-- Should create translated external table when transactional=false and have transactional_properties
+create table translated_table2 (i int) tblproperties('transactional'='false', 'transactional_properties'='default');
+desc formatted translated_table2;
+
+create table translated_table3 (i int) tblproperties('transactional'='false', 'transactional_properties'='insert_only');
+desc formatted translated_table3;

--- a/ql/src/test/results/clientpositive/llap/translated_external_create.q.out
+++ b/ql/src/test/results/clientpositive/llap/translated_external_create.q.out
@@ -1,0 +1,135 @@
+PREHOOK: query: create table translated_table1 (i int) tblproperties('transactional'='false')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@translated_table1
+POSTHOOK: query: create table translated_table1 (i int) tblproperties('transactional'='false')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@translated_table1
+PREHOOK: query: desc formatted translated_table1
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@translated_table1
+POSTHOOK: query: desc formatted translated_table1
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@translated_table1
+# col_name            	data_type           	comment             
+i                   	int                 	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"i\":\"true\"}}
+	EXTERNAL            	TRUE                
+	TRANSLATED_TO_EXTERNAL	TRUE                
+	bucketing_version   	2                   
+	external.table.purge	TRUE                
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	#Masked#
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
+PREHOOK: query: create table translated_table2 (i int) tblproperties('transactional'='false', 'transactional_properties'='default')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@translated_table2
+POSTHOOK: query: create table translated_table2 (i int) tblproperties('transactional'='false', 'transactional_properties'='default')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@translated_table2
+PREHOOK: query: desc formatted translated_table2
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@translated_table2
+POSTHOOK: query: desc formatted translated_table2
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@translated_table2
+# col_name            	data_type           	comment             
+i                   	int                 	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"i\":\"true\"}}
+	EXTERNAL            	TRUE                
+	TRANSLATED_TO_EXTERNAL	TRUE                
+	bucketing_version   	2                   
+	external.table.purge	TRUE                
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	#Masked#
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
+PREHOOK: query: create table translated_table3 (i int) tblproperties('transactional'='false', 'transactional_properties'='insert_only')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@translated_table3
+POSTHOOK: query: create table translated_table3 (i int) tblproperties('transactional'='false', 'transactional_properties'='insert_only')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@translated_table3
+PREHOOK: query: desc formatted translated_table3
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@translated_table3
+POSTHOOK: query: desc formatted translated_table3
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@translated_table3
+# col_name            	data_type           	comment             
+i                   	int                 	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"i\":\"true\"}}
+	EXTERNAL            	TRUE                
+	TRANSLATED_TO_EXTERNAL	TRUE                
+	bucketing_version   	2                   
+	external.table.purge	TRUE                
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	#Masked#
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.metastore;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.ACCESSTYPE_NONE;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.ACCESSTYPE_READONLY;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.ACCESSTYPE_READWRITE;
-import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.CTAS_LEGACY_CONFIG;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_TRANSACTIONAL;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.EXTERNAL_TABLE_PURGE;
@@ -630,10 +629,6 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
       params = new HashMap<>();
     }
     String tableType = newTable.getTableType();
-    String txnal = null;
-    String txn_properties = null;
-    boolean isInsertAcid = false;
-
     String dbName = table.getDbName();
     Database db = null;
     try {
@@ -642,13 +637,9 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
       throw new MetaException("Database " + dbName + " for table " + table.getTableName() + " could not be found");
     }
 
-      if (TableType.MANAGED_TABLE.name().equals(tableType)) {
+    if (TableType.MANAGED_TABLE.name().equals(tableType)) {
       LOG.debug("Table is a MANAGED_TABLE");
-      txnal = params.get(TABLE_IS_TRANSACTIONAL);
-      txn_properties = params.get(TABLE_TRANSACTIONAL_PROPERTIES);
-      isInsertAcid = (txn_properties != null && txn_properties.equalsIgnoreCase("insert_only"));
-      boolean ctas_legacy_config = params.containsKey(CTAS_LEGACY_CONFIG) && params.get(CTAS_LEGACY_CONFIG).equalsIgnoreCase("true") ? true : false;
-      if (((txnal == null || txnal.equalsIgnoreCase("FALSE")) && !isInsertAcid) || (ctas_legacy_config && (txnal == null || txnal.equalsIgnoreCase("FALSE")))) { // non-ACID MANAGED TABLE
+      if (!Boolean.parseBoolean(params.get(TABLE_IS_TRANSACTIONAL))) { // non-ACID MANAGED TABLE
         LOG.info("Converting " + newTable.getTableName() + " to EXTERNAL tableType for " + processorId);
         newTable.setTableType(TableType.EXTERNAL_TABLE.toString());
         params.remove(TABLE_IS_TRANSACTIONAL);
@@ -682,9 +673,8 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
           throw new MetaException("Processor has no capabilities, cannot create an ACID table.");
         }
 
-
         newTable = validateTablePaths(table);
-        if (isInsertAcid) { // MICRO_MANAGED Tables
+        if (MetaStoreUtils.isInsertOnlyTableParam(table.getParameters())) { // MICRO_MANAGED Tables
           if (processorCapabilities.contains(HIVEMANAGEDINSERTWRITE)) {
             LOG.debug("Processor has required capabilities to be able to create INSERT-only tables");
             return newTable;


### PR DESCRIPTION
### What changes were proposed in this pull request?
`insert_only` is meaningful only when `transactional` is `true`. Have modified to create a translated to external table when create table has `'transactional'='false','transactional_properties'='insert_only'` table properties, making it consistent with following cases:
1. create table with `'transactional'='false','transactional_properties'='default'`
2. create table with `'transactional'='false'`

### Why are the changes needed?
When a table is created with `'transactional'='false','transactional_properties'='insert_only'` table properties and data is inserted to it, data queries fail.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added new tests
