### PR TITLE
HIVE-29496: Subsequent transactional materialized view rebuild fails when source tables are iceberg tables

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc9.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc9.q
@@ -1,0 +1,28 @@
+-- Test subsequent rebuild of transactional MV when source table is Iceberg.
+
+-- SORT_QUERY_RESULTS
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.support.concurrency=true;
+
+create table ice_basetable (a int, b string) stored by iceberg;
+insert into ice_basetable values (1, 'alfred'),(2, 'bob'),(2, 'bonnie'),(3, 'calvin'),(3, 'charlie');
+
+create materialized view mv_acid  STORED AS ORC TBLPROPERTIES ('transactional'='true') as
+select b, a from ice_basetable;
+
+create materialized view mv_insert_only STORED AS ORC TBLPROPERTIES ('transactional'='true', 'transactional_properties'='insert_only') as
+select b, a from ice_basetable;
+
+select * from mv_acid;
+select * from mv_insert_only;
+
+insert into ice_basetable values (5, 'amia');
+alter materialized view mv_acid rebuild;
+alter materialized view mv_insert_only rebuild;
+
+insert into ice_basetable values (4, 'mania');
+alter materialized view mv_acid rebuild;
+alter materialized view mv_insert_only rebuild;
+
+select * from mv_acid;
+select * from mv_insert_only;

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc9.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc9.q.out
@@ -1,0 +1,156 @@
+PREHOOK: query: create table ice_basetable (a int, b string) stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_basetable
+POSTHOOK: query: create table ice_basetable (a int, b string) stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_basetable
+PREHOOK: query: insert into ice_basetable values (1, 'alfred'),(2, 'bob'),(2, 'bonnie'),(3, 'calvin'),(3, 'charlie')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_basetable
+POSTHOOK: query: insert into ice_basetable values (1, 'alfred'),(2, 'bob'),(2, 'bonnie'),(3, 'calvin'),(3, 'charlie')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_basetable
+PREHOOK: query: create materialized view mv_acid  STORED AS ORC TBLPROPERTIES ('transactional'='true') as
+select b, a from ice_basetable
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@ice_basetable
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mv_acid
+POSTHOOK: query: create materialized view mv_acid  STORED AS ORC TBLPROPERTIES ('transactional'='true') as
+select b, a from ice_basetable
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@ice_basetable
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mv_acid
+POSTHOOK: Lineage: mv_acid.a SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mv_acid.b SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:b, type:string, comment:null), ]
+PREHOOK: query: create materialized view mv_insert_only STORED AS ORC TBLPROPERTIES ('transactional'='true', 'transactional_properties'='insert_only') as
+select b, a from ice_basetable
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@ice_basetable
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mv_insert_only
+POSTHOOK: query: create materialized view mv_insert_only STORED AS ORC TBLPROPERTIES ('transactional'='true', 'transactional_properties'='insert_only') as
+select b, a from ice_basetable
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@ice_basetable
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mv_insert_only
+POSTHOOK: Lineage: mv_insert_only.a SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mv_insert_only.b SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:b, type:string, comment:null), ]
+PREHOOK: query: select * from mv_acid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv_acid
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mv_acid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv_acid
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+alfred	1
+bob	2
+bonnie	2
+calvin	3
+charlie	3
+PREHOOK: query: select * from mv_insert_only
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv_insert_only
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mv_insert_only
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv_insert_only
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+alfred	1
+bob	2
+bonnie	2
+calvin	3
+charlie	3
+PREHOOK: query: insert into ice_basetable values (5, 'amia')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_basetable
+POSTHOOK: query: insert into ice_basetable values (5, 'amia')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_basetable
+PREHOOK: query: alter materialized view mv_acid rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@ice_basetable
+PREHOOK: Output: default@mv_acid
+POSTHOOK: query: alter materialized view mv_acid rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@ice_basetable
+POSTHOOK: Output: default@mv_acid
+POSTHOOK: Lineage: mv_acid.a SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mv_acid.b SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:b, type:string, comment:null), ]
+PREHOOK: query: alter materialized view mv_insert_only rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@ice_basetable
+PREHOOK: Output: default@mv_insert_only
+POSTHOOK: query: alter materialized view mv_insert_only rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@ice_basetable
+POSTHOOK: Output: default@mv_insert_only
+POSTHOOK: Lineage: mv_insert_only.a SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mv_insert_only.b SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:b, type:string, comment:null), ]
+PREHOOK: query: insert into ice_basetable values (4, 'mania')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_basetable
+POSTHOOK: query: insert into ice_basetable values (4, 'mania')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_basetable
+PREHOOK: query: alter materialized view mv_acid rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@ice_basetable
+PREHOOK: Output: default@mv_acid
+POSTHOOK: query: alter materialized view mv_acid rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@ice_basetable
+POSTHOOK: Output: default@mv_acid
+POSTHOOK: Lineage: mv_acid.a SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mv_acid.b SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:b, type:string, comment:null), ]
+PREHOOK: query: alter materialized view mv_insert_only rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@ice_basetable
+PREHOOK: Output: default@mv_insert_only
+POSTHOOK: query: alter materialized view mv_insert_only rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@ice_basetable
+POSTHOOK: Output: default@mv_insert_only
+POSTHOOK: Lineage: mv_insert_only.a SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mv_insert_only.b SIMPLE [(ice_basetable)ice_basetable.FieldSchema(name:b, type:string, comment:null), ]
+PREHOOK: query: select * from mv_acid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv_acid
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mv_acid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv_acid
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+alfred	1
+amia	5
+bob	2
+bonnie	2
+calvin	3
+charlie	3
+mania	4
+PREHOOK: query: select * from mv_insert_only
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv_insert_only
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mv_insert_only
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv_insert_only
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+alfred	1
+amia	5
+bob	2
+bonnie	2
+calvin	3
+charlie	3
+mania	4

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -213,6 +213,9 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
         HiveTxnManager txnManager = getTxnMgr();
         LockState state;
         try {
+          // trigger txn id generation
+          queryState.getValidTxnList();
+
           state = txnManager.acquireMaterializationRebuildLock(new LockMaterializationRebuildRequest(tableName.getCat(),
               tableName.getDb(), tableName.getTable(), txnManager.getCurrentTxnId())).getState();
         } catch (LockException e) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -179,6 +179,24 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
 
     LOG.debug("Rebuilding materialized view " + tableName.getNotEmptyDbTable());
     super.analyzeInternal(rewrittenAST);
+
+    if (!this.ctx.isExplainPlan() && AcidUtils.isTransactionalTable(mvTable)) {
+      // Acquire lock for the given materialized view. Only one rebuild per materialized view can be triggered at a
+      // given time, as otherwise we might produce incorrect results if incremental maintenance is triggered.
+      HiveTxnManager txnManager = getTxnMgr();
+      LockState state;
+      try {
+        state = txnManager.acquireMaterializationRebuildLock(new LockMaterializationRebuildRequest(tableName.getCat(),
+            tableName.getDb(), tableName.getTable(), txnManager.getCurrentTxnId())).getState();
+      } catch (LockException e) {
+        throw new SemanticException("Exception acquiring lock for rebuilding the materialized view", e);
+      }
+      if (state != LockState.ACQUIRED) {
+        throw new SemanticException(
+            "Another process is rebuilding the materialized view " + tableName.getNotEmptyDbTable());
+      }
+    }
+
     queryState.setCommandType(HiveOperation.ALTER_MATERIALIZED_VIEW_REBUILD);
   }
 
@@ -206,23 +224,6 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
           tableName.getEscapedNotEmptyDbTable(), viewText);
       rewrittenAST = ParseUtils.parse(rewrittenInsertStatement, ctx);
       this.ctx.addSubContext(ctx);
-
-      if (!this.ctx.isExplainPlan() && AcidUtils.isTransactionalTable(table)) {
-        // Acquire lock for the given materialized view. Only one rebuild per materialized view can be triggered at a
-        // given time, as otherwise we might produce incorrect results if incremental maintenance is triggered.
-        HiveTxnManager txnManager = getTxnMgr();
-        LockState state;
-        try {
-          state = txnManager.acquireMaterializationRebuildLock(new LockMaterializationRebuildRequest(tableName.getCat(),
-              tableName.getDb(), tableName.getTable(), txnManager.getCurrentTxnId())).getState();
-        } catch (LockException e) {
-          throw new SemanticException("Exception acquiring lock for rebuilding the materialized view", e);
-        }
-        if (state != LockState.ACQUIRED) {
-          throw new SemanticException(
-              "Another process is rebuilding the materialized view " + tableName.getNotEmptyDbTable());
-        }
-      }
     } catch (Exception e) {
       throw new SemanticException(e);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.LockMaterializationRebuildRequest;
 import org.apache.hadoop.hive.metastore.api.LockState;
+import org.apache.hadoop.hive.metastore.api.TxnType;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryProperties;
@@ -213,9 +214,7 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
         HiveTxnManager txnManager = getTxnMgr();
         LockState state;
         try {
-          // trigger txn id generation
-          queryState.getValidTxnList();
-
+          txnManager.openTxn(ctx, conf.getUser(), TxnType.MATER_VIEW_REBUILD);
           state = txnManager.acquireMaterializationRebuildLock(new LockMaterializationRebuildRequest(tableName.getCat(),
               tableName.getDb(), tableName.getTable(), txnManager.getCurrentTxnId())).getState();
         } catch (LockException e) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -179,24 +179,6 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
 
     LOG.debug("Rebuilding materialized view " + tableName.getNotEmptyDbTable());
     super.analyzeInternal(rewrittenAST);
-
-    if (!this.ctx.isExplainPlan() && AcidUtils.isTransactionalTable(mvTable)) {
-      // Acquire lock for the given materialized view. Only one rebuild per materialized view can be triggered at a
-      // given time, as otherwise we might produce incorrect results if incremental maintenance is triggered.
-      HiveTxnManager txnManager = getTxnMgr();
-      LockState state;
-      try {
-        state = txnManager.acquireMaterializationRebuildLock(new LockMaterializationRebuildRequest(tableName.getCat(),
-            tableName.getDb(), tableName.getTable(), txnManager.getCurrentTxnId())).getState();
-      } catch (LockException e) {
-        throw new SemanticException("Exception acquiring lock for rebuilding the materialized view", e);
-      }
-      if (state != LockState.ACQUIRED) {
-        throw new SemanticException(
-            "Another process is rebuilding the materialized view " + tableName.getNotEmptyDbTable());
-      }
-    }
-
     queryState.setCommandType(HiveOperation.ALTER_MATERIALIZED_VIEW_REBUILD);
   }
 
@@ -224,6 +206,23 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
           tableName.getEscapedNotEmptyDbTable(), viewText);
       rewrittenAST = ParseUtils.parse(rewrittenInsertStatement, ctx);
       this.ctx.addSubContext(ctx);
+
+      if (!this.ctx.isExplainPlan() && AcidUtils.isTransactionalTable(table)) {
+        // Acquire lock for the given materialized view. Only one rebuild per materialized view can be triggered at a
+        // given time, as otherwise we might produce incorrect results if incremental maintenance is triggered.
+        HiveTxnManager txnManager = getTxnMgr();
+        LockState state;
+        try {
+          state = txnManager.acquireMaterializationRebuildLock(new LockMaterializationRebuildRequest(tableName.getCat(),
+              tableName.getDb(), tableName.getTable(), txnManager.getCurrentTxnId())).getState();
+        } catch (LockException e) {
+          throw new SemanticException("Exception acquiring lock for rebuilding the materialized view", e);
+        }
+        if (state != LockState.ACQUIRED) {
+          throw new SemanticException(
+              "Another process is rebuilding the materialized view " + tableName.getNotEmptyDbTable());
+        }
+      }
     } catch (Exception e) {
       throw new SemanticException(e);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -214,7 +214,9 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
         HiveTxnManager txnManager = getTxnMgr();
         LockState state;
         try {
-          txnManager.openTxn(ctx, conf.getUser(), TxnType.MATER_VIEW_REBUILD);
+          if (!txnManager.isTxnOpen()) {
+            txnManager.openTxn(ctx, conf.getUser(), TxnType.MATER_VIEW_REBUILD);
+          }
           state = txnManager.acquireMaterializationRebuildLock(new LockMaterializationRebuildRequest(tableName.getCat(),
               tableName.getDb(), tableName.getTable(), txnManager.getCurrentTxnId())).getState();
         } catch (LockException e) {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Open an ACID transaction before lock acquisition for materialized view rebuilds

### Why are the changes needed?
When the base tables of an MV are not ACID tables no ACID txn is opened before generating the MV rebuild plan and the current transaction ID defaults to 0, and this value is passed to the lock acquisition request. This prevents the subsequent rebuild of transactional MVs when the source tables are Iceberg.

When source tables are ACID-compliant, the transaction ID is set before the rebuild plan is generated; therefore, this scenario remains unaffected.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergLlapLocalCliDriver -Dqfile=mv_iceberg_orc9.q -pl itests/qtest-iceberg -Pitests
```
