### PR TITLE
HIVE-29566: Tez client creation fails with docker LLAP mode on client reconnect - LlapTaskSchedulerMetrics init is not idempotent

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/JvmMetrics.java
+++ b/common/src/java/org/apache/hadoop/hive/common/JvmMetrics.java
@@ -51,8 +51,12 @@ public class JvmMetrics implements MetricsSource {
     JvmMetrics impl;
 
     synchronized JvmMetrics init(String processName, String sessionId) {
+      return init(processName, sessionId, DefaultMetricsSystem.instance());
+    }
+
+    synchronized JvmMetrics init(String processName, String sessionId, MetricsSystem ms) {
       if (impl == null) {
-        impl = create(processName, sessionId, DefaultMetricsSystem.instance());
+        impl = create(processName, sessionId, ms);
       }
       return impl;
     }
@@ -85,6 +89,10 @@ public class JvmMetrics implements MetricsSource {
 
   public static JvmMetrics initSingleton(String processName, String sessionId) {
     return Singleton.INSTANCE.init(processName, sessionId);
+  }
+
+  public static JvmMetrics initSingleton(String processName, String sessionId, MetricsSystem ms) {
+    return Singleton.INSTANCE.init(processName, sessionId, ms);
   }
 
   @Override

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonExecutorMetrics.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonExecutorMetrics.java
@@ -236,7 +236,7 @@ public class LlapDaemonExecutorMetrics implements MetricsSource {
       int numExecutorsConfigured, int waitQueueSizeConfigured, final int[] intervals, int timedWindowAverageDataPoints,
       long timedWindowAverageWindowLength, int simpleAverageWindowDataSize) {
     MetricsSystem ms = LlapMetricsSystem.instance();
-    JvmMetrics jm = JvmMetrics.create(MetricsUtils.METRICS_PROCESS_NAME, sessionId, ms);
+    JvmMetrics jm = JvmMetrics.initSingleton(MetricsUtils.METRICS_PROCESS_NAME, sessionId, ms);
     return ms.register(displayName, "LlapDaemon Executor Metrics",
         new LlapDaemonExecutorMetrics(displayName, jm, sessionId, numExecutorsConfigured, waitQueueSizeConfigured,
             intervals, timedWindowAverageDataPoints, timedWindowAverageWindowLength, simpleAverageWindowDataSize));

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -454,9 +454,9 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       this.pauseMonitor = new JvmPauseMonitor(conf);
       pauseMonitor.start();
       String displayName = "LlapTaskSchedulerMetrics-" + MetricsUtils.getHostName();
-      String sessionId = conf.get("llap.daemon.metrics.sessionid");
-      // TODO: Not sure about the use of this. Should we instead use workerIdentity as sessionId?
-      this.metrics = LlapTaskSchedulerMetrics.create(displayName, sessionId);
+      String metricsSessionId = conf.get("llap.daemon.metrics.sessionid");
+      // TODO: HIVE-29569: Not sure about the use of this. Should we instead use workerIdentity as sessionId?
+      this.metrics = LlapTaskSchedulerMetrics.create(displayName, metricsSessionId);
     } else {
       this.metrics = null;
       this.pauseMonitor = null;

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -454,9 +454,9 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       this.pauseMonitor = new JvmPauseMonitor(conf);
       pauseMonitor.start();
       String displayName = "LlapTaskSchedulerMetrics-" + MetricsUtils.getHostName();
-      String metricsSessionId = conf.get("llap.daemon.metrics.sessionid");
+      String sessionId = conf.get("llap.daemon.metrics.sessionid");
       // TODO: HIVE-29569: Not sure about the use of this. Should we instead use workerIdentity as sessionId?
-      this.metrics = LlapTaskSchedulerMetrics.create(displayName, metricsSessionId);
+      this.metrics = LlapTaskSchedulerMetrics.create(displayName, sessionId);
     } else {
       this.metrics = null;
       this.pauseMonitor = null;

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/LlapTaskSchedulerMetrics.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/LlapTaskSchedulerMetrics.java
@@ -106,16 +106,12 @@ public class LlapTaskSchedulerMetrics implements MetricsSource {
     this.registry.tag(ProcessName, MetricsUtils.METRICS_PROCESS_NAME).tag(SessionId, sessionId);
   }
 
-  public static LlapTaskSchedulerMetrics create(String displayName, String metricsSessionId) {
+  public static LlapTaskSchedulerMetrics create(String displayName, String sessionId) {
     return METRICS.computeIfAbsent(displayName, name -> {
       MetricsSystem ms = LlapMetricsSystem.instance();
-      // TODO: HIVE-29569: Cleanup usage of llap.daemon.metrics.sessionid
-      // Using different displayNames within the same JVM can still trigger an issue even after fixing HIVE-29566,
-      // however it has not been observed in practice (including tests).
-      // This highlights the need to clean up this area.
-      JvmMetrics jm = JvmMetrics.create(MetricsUtils.METRICS_PROCESS_NAME, metricsSessionId, ms);
+      JvmMetrics jm = JvmMetrics.initSingleton(MetricsUtils.METRICS_PROCESS_NAME, sessionId, ms);
       return ms.register(name, "Llap Task Scheduler Metrics",
-          new LlapTaskSchedulerMetrics(name, jm, metricsSessionId));
+          new LlapTaskSchedulerMetrics(name, jm, sessionId));
     });
   }
 

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/LlapTaskSchedulerMetrics.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/LlapTaskSchedulerMetrics.java
@@ -31,6 +31,8 @@ import static org.apache.hadoop.hive.llap.tezplugins.metrics.LlapTaskSchedulerIn
 import static org.apache.hadoop.metrics2.impl.MsInfo.ProcessName;
 import static org.apache.hadoop.metrics2.impl.MsInfo.SessionId;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.hadoop.hive.common.JvmMetrics;
 import org.apache.hadoop.hive.llap.metrics.LlapMetricsSystem;
 import org.apache.hadoop.hive.llap.metrics.MetricsUtils;
@@ -51,6 +53,9 @@ import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
  */
 @Metrics(about = "Llap Task Scheduler Metrics", context = "scheduler")
 public class LlapTaskSchedulerMetrics implements MetricsSource {
+  private static final ConcurrentHashMap<String, LlapTaskSchedulerMetrics> INSTANCES =
+      new ConcurrentHashMap<>();
+
   private final String name;
   private final JvmMetrics jvmMetrics;
   private final String sessionId;
@@ -102,10 +107,12 @@ public class LlapTaskSchedulerMetrics implements MetricsSource {
   }
 
   public static LlapTaskSchedulerMetrics create(String displayName, String sessionId) {
-    MetricsSystem ms = LlapMetricsSystem.instance();
-    JvmMetrics jm = JvmMetrics.create(MetricsUtils.METRICS_PROCESS_NAME, sessionId, ms);
-    return ms.register(displayName, "Llap Task Scheduler Metrics",
-        new LlapTaskSchedulerMetrics(displayName, jm, sessionId));
+    return INSTANCES.computeIfAbsent(displayName, name -> {
+      MetricsSystem ms = LlapMetricsSystem.instance();
+      JvmMetrics jm = JvmMetrics.initSingleton(MetricsUtils.METRICS_PROCESS_NAME, sessionId);
+      return ms.register(name, "Llap Task Scheduler Metrics",
+          new LlapTaskSchedulerMetrics(name, jm, sessionId));
+    });
   }
 
   @Override

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/LlapTaskSchedulerMetrics.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/LlapTaskSchedulerMetrics.java
@@ -53,7 +53,7 @@ import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
  */
 @Metrics(about = "Llap Task Scheduler Metrics", context = "scheduler")
 public class LlapTaskSchedulerMetrics implements MetricsSource {
-  private static final ConcurrentHashMap<String, LlapTaskSchedulerMetrics> INSTANCES =
+  private static final ConcurrentHashMap<String, LlapTaskSchedulerMetrics> METRICS =
       new ConcurrentHashMap<>();
 
   private final String name;
@@ -106,12 +106,16 @@ public class LlapTaskSchedulerMetrics implements MetricsSource {
     this.registry.tag(ProcessName, MetricsUtils.METRICS_PROCESS_NAME).tag(SessionId, sessionId);
   }
 
-  public static LlapTaskSchedulerMetrics create(String displayName, String sessionId) {
-    return INSTANCES.computeIfAbsent(displayName, name -> {
+  public static LlapTaskSchedulerMetrics create(String displayName, String metricsSessionId) {
+    return METRICS.computeIfAbsent(displayName, name -> {
       MetricsSystem ms = LlapMetricsSystem.instance();
-      JvmMetrics jm = JvmMetrics.initSingleton(MetricsUtils.METRICS_PROCESS_NAME, sessionId);
+      // TODO: HIVE-29569: Cleanup usage of llap.daemon.metrics.sessionid
+      // Using different displayNames within the same JVM can still trigger an issue even after fixing HIVE-29566,
+      // however it has not been observed in practice (including tests).
+      // This highlights the need to clean up this area.
+      JvmMetrics jm = JvmMetrics.create(MetricsUtils.METRICS_PROCESS_NAME, metricsSessionId, ms);
       return ms.register(name, "Llap Task Scheduler Metrics",
-          new LlapTaskSchedulerMetrics(name, jm, sessionId));
+          new LlapTaskSchedulerMetrics(name, jm, metricsSessionId));
     });
   }
 

--- a/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/metrics/TestLlapTaskSchedulerMetrics.java
+++ b/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/metrics/TestLlapTaskSchedulerMetrics.java
@@ -1,7 +1,11 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/metrics/TestLlapTaskSchedulerMetrics.java
+++ b/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/metrics/TestLlapTaskSchedulerMetrics.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.llap.tezplugins.metrics;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link LlapTaskSchedulerMetrics}.
+ */
+public class TestLlapTaskSchedulerMetrics {
+
+  /**
+   * Verifies that creating metrics for multiple Tez sessions within the same JVM does not fail.
+   * Each call to {@code LlapTaskSchedulerMetrics.create()} with the same display name must return
+   * the existing instance without re-registering, otherwise the metrics system (a static singleton)
+   * would throw {@code MetricsException: Metrics source X already exists!} on the second call.
+   */
+  @Test
+  public void testCreateIsIdempotentAcrossSessions() {
+    LlapTaskSchedulerMetrics first = LlapTaskSchedulerMetrics.create("LlapTaskSchedulerMetrics-hiveserver2",
+        "session-1");
+    assertNotNull(first);
+
+    // Must not throw MetricsException: Metrics source LlapTaskScheduler already exists!
+    LlapTaskSchedulerMetrics second = LlapTaskSchedulerMetrics.create("LlapTaskSchedulerMetrics-hiveserver2",
+        "session-2");
+    assertNotNull(second);
+  }
+}

--- a/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/metrics/TestLlapTaskSchedulerMetrics.java
+++ b/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/metrics/TestLlapTaskSchedulerMetrics.java
@@ -44,4 +44,22 @@ public class TestLlapTaskSchedulerMetrics {
         "session-2");
     assertNotNull(second);
   }
+
+  /**
+   * Verifies that creating metrics with different display names does not fail.
+   * Each unique display name triggers a new source registration, but JvmMetrics must only be
+   * registered once regardless of display name — otherwise the second call would throw
+   * {@code MetricsException: Metrics source JvmMetrics already exists!}.
+   */
+  @Test
+  public void testCreateWithDifferentDisplayNamesIsIdempotent() {
+    LlapTaskSchedulerMetrics first = LlapTaskSchedulerMetrics.create("LlapTaskSchedulerMetrics-host1",
+        "session-1");
+    assertNotNull(first);
+
+    // Must not throw MetricsException: Metrics source JvmMetrics already exists!
+    LlapTaskSchedulerMetrics second = LlapTaskSchedulerMetrics.create("LlapTaskSchedulerMetrics-host2",
+        "session-2");
+    assertNotNull(second);
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make LlapTaskSchedulerMetrics initialization idempotent. This hits in testing scenarios, where in the case of a tez LocalClient against llap, the llap scheduler metrics can be initialized multiple times (which is not the case in a real world cluster, where a TezAM initializes this only once).

### Why are the changes needed?
See the issue description on Jira.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested pre-patch, see Jira.

Post patch, with the latest changes:
```
# build hive
mvn install -DskipTests -nsu -Pdist
cp packaging/target/apache-hive-4.3.0-SNAPSHOT-bin.tar.gz packaging/cache

export HIVE_VERSION=4.3.0-SNAPSHOT

# do the same as pre-patch testing to confirm (be mindful of new hive version)
 ./stop-hive.sh --cleanup
 
 export POSTGRES_LOCAL_PATH=...
./build.sh -hive 4.3.0-SNAPSHOT -hadoop 3.4.1 -tez 0.10.5
./start-hive.sh --llap
docker compose --profile llap logs -f
 
 #FIRST
 beeline -u 'jdbc:hive2://localhost:10000/' -e "DROP table IF EXISTS iceberg_table; CREATE TABLE iceberg_table (id BIGINT) STORED BY iceberg; INSERT INTO iceberg_table VALUES(1);"
 
 #SECOND
 beeline -u 'jdbc:hive2://localhost:10000/' -e "DROP table IF EXISTS iceberg_table; CREATE TABLE iceberg_table (id BIGINT) STORED BY iceberg; INSERT INTO iceberg_table VALUES(1);"

```