### PR TITLE
HIVE-29575: Upgrade GitHub Actions, setup-java and checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,13 @@ jobs:
     name: 'macOS (JDK 21)'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Set up JDK 21'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
-          java-version: 21
+            java-version: '21'
+            distribution: temurin
+            cache: maven
       - name: 'Build project'
         run: |
           mvn clean install -DskipTests -Pitests


### PR DESCRIPTION
**What changes were proposed in this pull request?**
This PR updates GitHub Actions dependencies used in CI, specifically upgrading actions/setup-java to v5 and actions/checkout to v3.

**Why are the changes needed?**
CI builds were failing due to incorrect or missing JAVA_HOME configuration when using the older version of actions/setup-java. Upgrading actions/setup-java resolves this.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
CI pipeline run shows successful build after upgrading actions/setup-java