### PR TITLE
HIVE-14609: HS2 cannot drop a function whose associated jar file has been removed

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/AbstractFunctionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/AbstractFunctionAnalyzer.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hive.ql.exec.FunctionUtils;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.hooks.Entity.Type;
+import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
@@ -42,6 +43,10 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 public abstract class AbstractFunctionAnalyzer extends BaseSemanticAnalyzer {
   public AbstractFunctionAnalyzer(QueryState queryState) throws SemanticException {
     super(queryState);
+  }
+
+  public AbstractFunctionAnalyzer(QueryState queryState, Hive db) throws SemanticException {
+    super(queryState, db);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/AbstractFunctionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/AbstractFunctionAnalyzer.java
@@ -45,7 +45,7 @@ public abstract class AbstractFunctionAnalyzer extends BaseSemanticAnalyzer {
     super(queryState);
   }
 
-  public AbstractFunctionAnalyzer(QueryState queryState, Hive db) throws SemanticException {
+  protected AbstractFunctionAnalyzer(QueryState queryState, Hive db) throws SemanticException {
     super(queryState, db);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/drop/DropFunctionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/drop/DropFunctionAnalyzer.java
@@ -24,10 +24,13 @@ import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.FunctionInfo;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
+import org.apache.hadoop.hive.ql.exec.FunctionUtils;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
 import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
 import org.apache.hadoop.hive.ql.ddl.function.AbstractFunctionAnalyzer;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
@@ -41,6 +44,14 @@ public class DropFunctionAnalyzer extends AbstractFunctionAnalyzer {
     super(queryState);
   }
 
+  public DropFunctionAnalyzer(QueryState queryState, Hive db) throws SemanticException {
+    super(queryState, db);
+  }
+
+  protected FunctionInfo getFunctionInfo(String functionName) throws SemanticException {
+    return FunctionRegistry.getFunctionInfo(functionName);
+  }
+
   @Override
   public void analyzeInternal(ASTNode root) throws SemanticException {
     String functionName = root.getChild(0).getText();
@@ -48,12 +59,18 @@ public class DropFunctionAnalyzer extends AbstractFunctionAnalyzer {
     boolean throwException = !ifExists && !HiveConf.getBoolVar(conf, ConfVars.DROP_IGNORES_NON_EXISTENT);
     boolean isTemporary = (root.getFirstChildWithType(HiveParser.TOK_TEMPORARY) != null);
 
-    FunctionInfo info = FunctionRegistry.getFunctionInfo(functionName);
+    FunctionInfo info = getFunctionInfo(functionName);
     if (info == null) {
-      if (throwException) {
+      // getFunctionInfo returns null when the function's JAR resource cannot be loaded (e.g. the
+      // HDFS file was deleted). For permanent functions fall back to a direct metastore lookup so
+      // that an orphaned definition can still be removed without the JAR being present.
+      if (!isTemporary && functionExistsInMetastore(functionName)) {
+        LOG.warn("Function {} has unavailable resources; proceeding with drop using metastore metadata only.",
+            functionName);
+      } else if (throwException) {
         throw new SemanticException(ErrorMsg.INVALID_FUNCTION.getMsg(functionName));
       } else {
-        return; // Fail silently
+        return;
       }
     } else if (info.isBuiltIn()) {
       throw new SemanticException(ErrorMsg.DROP_NATIVE_FUNCTION.getMsg(functionName));
@@ -62,6 +79,17 @@ public class DropFunctionAnalyzer extends AbstractFunctionAnalyzer {
     DropFunctionDesc desc = new DropFunctionDesc(functionName, isTemporary, null);
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
 
-    addEntities(functionName, info.getClassName(), isTemporary, null);
+    String className = info != null ? info.getClassName() : null;
+    addEntities(functionName, className, isTemporary, null);
+  }
+
+  private boolean functionExistsInMetastore(String functionName) {
+    try {
+      String[] parts = FunctionUtils.getQualifiedFunctionNameParts(functionName.toLowerCase());
+      db.getFunction(parts[0], parts[1]);
+      return true;
+    } catch (HiveException e) {
+      return false;
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/drop/DropFunctionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/drop/DropFunctionAnalyzer.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 
+import java.util.List;
+
 /**
  * Analyzer for function dropping commands.
  */
@@ -48,10 +50,6 @@ public class DropFunctionAnalyzer extends AbstractFunctionAnalyzer {
     super(queryState, db);
   }
 
-  protected FunctionInfo getFunctionInfo(String functionName) throws SemanticException {
-    return FunctionRegistry.getFunctionInfo(functionName);
-  }
-
   @Override
   public void analyzeInternal(ASTNode root) throws SemanticException {
     String functionName = root.getChild(0).getText();
@@ -59,7 +57,7 @@ public class DropFunctionAnalyzer extends AbstractFunctionAnalyzer {
     boolean throwException = !ifExists && !HiveConf.getBoolVar(conf, ConfVars.DROP_IGNORES_NON_EXISTENT);
     boolean isTemporary = (root.getFirstChildWithType(HiveParser.TOK_TEMPORARY) != null);
 
-    FunctionInfo info = getFunctionInfo(functionName);
+    FunctionInfo info = FunctionRegistry.getFunctionInfo(functionName);
     if (info == null) {
       // getFunctionInfo returns null when the function's JAR resource cannot be loaded (e.g. the
       // HDFS file was deleted). For permanent functions fall back to a direct metastore lookup so
@@ -86,8 +84,8 @@ public class DropFunctionAnalyzer extends AbstractFunctionAnalyzer {
   private boolean functionExistsInMetastore(String functionName) {
     try {
       String[] parts = FunctionUtils.getQualifiedFunctionNameParts(functionName.toLowerCase());
-      db.getFunction(parts[0], parts[1]);
-      return true;
+      List<String> functions = db.getFunctions(parts[0], parts[1]);
+      return functions != null && functions.contains(parts[1]);
     } catch (HiveException e) {
       return false;
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/ddl/function/drop/TestDropFunctionAnalyzer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/ddl/function/drop/TestDropFunctionAnalyzer.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.function.drop;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.FunctionType;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.exec.FunctionInfo;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.plan.HiveOperation;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.ParseUtils;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for DropFunctionAnalyzer focusing on the case where the function's JAR resource is
+ * unavailable (e.g. deleted from HDFS after the function was registered).
+ */
+public class TestDropFunctionAnalyzer {
+
+  private HiveConf conf;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    conf = new HiveConfForTest(getClass());
+    SessionState.start(conf);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    SessionState ss = SessionState.get();
+    if (ss != null) {
+      ss.close();
+    }
+  }
+
+  /** Simulates JAR-unavailable by returning null from getFunctionInfo. */
+  private DropFunctionAnalyzer analyzerWithUnavailableJar(Hive mockDb) throws SemanticException {
+    QueryState queryState = QueryState.getNewQueryState(conf, null);
+    queryState.setCommandType(HiveOperation.DROPFUNCTION);
+    return new DropFunctionAnalyzer(queryState, mockDb) {
+      @Override
+      protected FunctionInfo getFunctionInfo(String functionName) throws SemanticException {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * When getFunctionInfo returns null (JAR unavailable) but the function still exists in the
+   * metastore, DROP FUNCTION must proceed and emit a drop task so the orphaned definition is
+   * actually removed.
+   */
+  @Test
+  void testDropSucceedsWhenJarUnavailableButFunctionInMetastore() throws Exception {
+    Hive mockDb = mock(Hive.class);
+    Function msFunction = new Function("dummy", "default", "com.example.DummyUDF",
+        "user", PrincipalType.USER, 0, FunctionType.JAVA, Collections.emptyList());
+    Database msDatabase = new Database("default", "", "/tmp", Collections.emptyMap());
+
+    when(mockDb.getFunction("default", "dummy")).thenReturn(msFunction);
+    when(mockDb.getDatabase("default")).thenReturn(msDatabase);
+    when(mockDb.getDatabase(any(), eq("default"))).thenReturn(msDatabase);
+
+    DropFunctionAnalyzer analyzer = analyzerWithUnavailableJar(mockDb);
+    analyzer.analyzeInternal(parse("drop function dummy"));
+
+    assertEquals(1, analyzer.getRootTasks().size(), "Expected one DROP task even when JAR is unavailable");
+  }
+
+  /**
+   * When the function does not exist in either the session registry or the metastore, DROP FUNCTION
+   * (without IF EXISTS) must surface the error to the client.
+   */
+  @Test
+  void testDropThrowsWhenFunctionNotInMetastore() throws Exception {
+    conf.setBoolVar(ConfVars.DROP_IGNORES_NON_EXISTENT, false);
+    Hive mockDb = mock(Hive.class);
+    when(mockDb.getFunction(anyString(), anyString())).thenThrow(new HiveException("not found"));
+
+    DropFunctionAnalyzer analyzer = analyzerWithUnavailableJar(mockDb);
+    assertThrows(SemanticException.class, () -> analyzer.analyzeInternal(parse("drop function dummy")),
+        "Expected SemanticException when function not in registry or metastore");
+  }
+
+  /**
+   * DROP FUNCTION IF EXISTS must silently succeed (no task, no exception) when the function is
+   * absent from both the session registry and the metastore.
+   */
+  @Test
+  void testDropIfExistsSilentWhenFunctionAbsent() throws Exception {
+    Hive mockDb = mock(Hive.class);
+    when(mockDb.getFunction(anyString(), anyString())).thenThrow(new HiveException("not found"));
+
+    DropFunctionAnalyzer analyzer = analyzerWithUnavailableJar(mockDb);
+    analyzer.analyzeInternal(parse("drop function if exists dummy"));
+
+    assertEquals(0, analyzer.getRootTasks().size(), "Expected no tasks when function is absent and IF EXISTS is set");
+  }
+
+  private ASTNode parse(String sql) throws Exception {
+    return ParseUtils.parse(sql, new Context(conf));
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/ddl/function/drop/TestDropFunctionAnalyzer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/ddl/function/drop/TestDropFunctionAnalyzer.java
@@ -53,12 +53,12 @@ import org.junit.jupiter.api.Test;
  * Tests for DropFunctionAnalyzer focusing on the case where the function's JAR resource is
  * unavailable (e.g. deleted from HDFS after the function was registered).
  */
-public class TestDropFunctionAnalyzer {
+class TestDropFunctionAnalyzer {
 
   private HiveConf conf;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     conf = new HiveConfForTest(getClass());
     SessionState.start(conf);
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/ddl/function/drop/TestDropFunctionAnalyzer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/ddl/function/drop/TestDropFunctionAnalyzer.java
@@ -24,9 +24,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -37,10 +39,9 @@ import org.apache.hadoop.hive.metastore.api.FunctionType;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.QueryState;
-import org.apache.hadoop.hive.ql.exec.FunctionInfo;
+import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.ParseUtils;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
@@ -48,6 +49,7 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 /**
  * Tests for DropFunctionAnalyzer focusing on the case where the function's JAR resource is
@@ -71,38 +73,37 @@ class TestDropFunctionAnalyzer {
     }
   }
 
-  /** Simulates JAR-unavailable by returning null from getFunctionInfo. */
-  private DropFunctionAnalyzer analyzerWithUnavailableJar(Hive mockDb) throws SemanticException {
+  private DropFunctionAnalyzer createAnalyzer(Hive mockDb) throws SemanticException {
     QueryState queryState = QueryState.getNewQueryState(conf, null);
     queryState.setCommandType(HiveOperation.DROPFUNCTION);
-    return new DropFunctionAnalyzer(queryState, mockDb) {
-      @Override
-      protected FunctionInfo getFunctionInfo(String functionName) throws SemanticException {
-        return null;
-      }
-    };
+    return new DropFunctionAnalyzer(queryState, mockDb);
   }
 
   /**
-   * When getFunctionInfo returns null (JAR unavailable) but the function still exists in the
-   * metastore, DROP FUNCTION must proceed and emit a drop task so the orphaned definition is
-   * actually removed.
+   * When FunctionRegistry.getFunctionInfo returns null (JAR unavailable) but the function still
+   * exists in the metastore, DROP FUNCTION must proceed and emit a drop task so the orphaned
+   * definition is actually removed.
    */
   @Test
   void testDropSucceedsWhenJarUnavailableButFunctionInMetastore() throws Exception {
     Hive mockDb = mock(Hive.class);
+    Database msDatabase = new Database("default", "", "/tmp", Collections.emptyMap());
     Function msFunction = new Function("dummy", "default", "com.example.DummyUDF",
         "user", PrincipalType.USER, 0, FunctionType.JAVA, Collections.emptyList());
-    Database msDatabase = new Database("default", "", "/tmp", Collections.emptyMap());
 
+    when(mockDb.getFunctions("default", "dummy")).thenReturn(List.of("dummy"));
     when(mockDb.getFunction("default", "dummy")).thenReturn(msFunction);
     when(mockDb.getDatabase("default")).thenReturn(msDatabase);
     when(mockDb.getDatabase(any(), eq("default"))).thenReturn(msDatabase);
 
-    DropFunctionAnalyzer analyzer = analyzerWithUnavailableJar(mockDb);
-    analyzer.analyzeInternal(parse("drop function dummy"));
+    try (MockedStatic<FunctionRegistry> registry = mockStatic(FunctionRegistry.class)) {
+      registry.when(() -> FunctionRegistry.getFunctionInfo("dummy")).thenReturn(null);
 
-    assertEquals(1, analyzer.getRootTasks().size(), "Expected one DROP task even when JAR is unavailable");
+      DropFunctionAnalyzer analyzer = createAnalyzer(mockDb);
+      analyzer.analyzeInternal(parse("drop function dummy"));
+
+      assertEquals(1, analyzer.getRootTasks().size(), "Expected one DROP task even when JAR is unavailable");
+    }
   }
 
   /**
@@ -113,11 +114,15 @@ class TestDropFunctionAnalyzer {
   void testDropThrowsWhenFunctionNotInMetastore() throws Exception {
     conf.setBoolVar(ConfVars.DROP_IGNORES_NON_EXISTENT, false);
     Hive mockDb = mock(Hive.class);
-    when(mockDb.getFunction(anyString(), anyString())).thenThrow(new HiveException("not found"));
+    when(mockDb.getFunctions(anyString(), anyString())).thenReturn(Collections.emptyList());
 
-    DropFunctionAnalyzer analyzer = analyzerWithUnavailableJar(mockDb);
-    assertThrows(SemanticException.class, () -> analyzer.analyzeInternal(parse("drop function dummy")),
-        "Expected SemanticException when function not in registry or metastore");
+    try (MockedStatic<FunctionRegistry> registry = mockStatic(FunctionRegistry.class)) {
+      registry.when(() -> FunctionRegistry.getFunctionInfo("dummy")).thenReturn(null);
+
+      DropFunctionAnalyzer analyzer = createAnalyzer(mockDb);
+      assertThrows(SemanticException.class, () -> analyzer.analyzeInternal(parse("drop function dummy")),
+          "Expected SemanticException when function not in registry or metastore");
+    }
   }
 
   /**
@@ -127,12 +132,16 @@ class TestDropFunctionAnalyzer {
   @Test
   void testDropIfExistsSilentWhenFunctionAbsent() throws Exception {
     Hive mockDb = mock(Hive.class);
-    when(mockDb.getFunction(anyString(), anyString())).thenThrow(new HiveException("not found"));
+    when(mockDb.getFunctions(anyString(), anyString())).thenReturn(Collections.emptyList());
 
-    DropFunctionAnalyzer analyzer = analyzerWithUnavailableJar(mockDb);
-    analyzer.analyzeInternal(parse("drop function if exists dummy"));
+    try (MockedStatic<FunctionRegistry> registry = mockStatic(FunctionRegistry.class)) {
+      registry.when(() -> FunctionRegistry.getFunctionInfo("dummy")).thenReturn(null);
 
-    assertEquals(0, analyzer.getRootTasks().size(), "Expected no tasks when function is absent and IF EXISTS is set");
+      DropFunctionAnalyzer analyzer = createAnalyzer(mockDb);
+      analyzer.analyzeInternal(parse("drop function if exists dummy"));
+
+      assertEquals(0, analyzer.getRootTasks().size(), "Expected no tasks when function is absent and IF EXISTS is set");
+    }
   }
 
   private ASTNode parse(String sql) throws Exception {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add an extra metastore call in `DropFunctionAnalyzer` if the function info retrieval wasn't successful.

### Why are the changes needed?
Because with the patch it's impossible to DROP a function whose associated jar is deleted, which is extremely inconvenient.


### Does this PR introduce _any_ user-facing change?
Under normal circumstances, no.

### How was this patch tested?
Unit test added (`testDropSucceedsWhenJarUnavailableButFunctionInMetastore`), also, more importantly, local HS2 testing is done, confirmed the behavior pre/post patch:

```
# one shell
mvn clean install -Dtest=StartMiniHS2Cluster -DminiHS2.clusterType=llap -DminiHS2.run=true -DminiHS2.usePortsFromConf=true -T 1C -Denforcer.skip=true -pl itests/hive-unit -Pitests -nsu -DminiHS2.isMetastoreRemote=true

# another shell

# parse HDFS address from the logs like this: "2026-04-23T06:21:12,204  INFO [main] shims.HadoopShimsSecure: Namenode null (ns=null) address: localhost/127.0.0.1:63222"
HDFS=hdfs://$(grep "Namenode.*address:" itests/hive-unit/target/surefire-reports/*.txt 2>/dev/null | grep -oP 'localhost/\K[^:]+:\d+' | head -1) && echo "HDFS: $HDFS"
JAR="./ql/target/hive-exec-4.3.0-SNAPSHOT.jar"

hdfs dfs -put -f $JAR $HDFS/tmp/test-udf.jar

beeline -u 'jdbc:hive2://localhost:10000/' -e "CREATE DATABASE IF NOT EXISTS testdb; CREATE FUNCTION testdb.myfunc AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFToString' USING JAR '$HDFS/tmp/test-udf.jar';"

hdfs dfs -rm $HDFS/tmp/test-udf.jar

beeline -u 'jdbc:hive2://localhost:10000/' -e "DROP FUNCTION testdb.myfunc;"

beeline -u 'jdbc:hive2://localhost:10000/' -e "SHOW FUNCTIONS LIKE 'testdb.myfunc';"
```

important to note that DROP FUNCTION is apparently successful w/wo the patch, and and exception appears in HS2 logs (which is good), but the function is only dropped successfully with the patch

pre-patch:
```
beeline -u 'jdbc:hive2://localhost:10000/' -e "SHOW FUNCTIONS LIKE 'testdb.myfunc';"


+----------------+
|    tab_name    |
+----------------+
| testdb.myfunc  |
+----------------+
```

post-patch:

```
beeline -u 'jdbc:hive2://localhost:10000/' -e "SHOW FUNCTIONS LIKE 'testdb.myfunc';"


+-----------+
| tab_name  |
+-----------+
+-----------+
```
in the log:
```
2026-04-23T06:57:47,726  WARN [206cd7f2-349d-4837-b992-151a856290e0 HiveServer2-Handler-Pool: Thread-911] drop.DropFunctionAnalyzer: Function testdb.myfunc has unavailable resources; proceeding with drop using metastore metadata only.
```

the exception appears in the log in both cases:
```
2026-04-23T06:55:40,376 ERROR [e3a4a121-cf9f-42da-84d3-78e7a3bcc501 HiveServer2-Handler-Pool: Thread-937] exec.FunctionRegistry: Unable to load resources for testdb.myfunc:java.lang.RuntimeException: java.io.FileNotFoundException: File does not exist: hdfs://127.0.0.1:65436/tmp/test-udf.jar
java.lang.RuntimeException: java.io.FileNotFoundException: File does not exist: hdfs://127.0.0.1:65436/tmp/test-udf.jar
	at org.apache.hadoop.hive.ql.session.SessionState.add_resources(SessionState.java:1693)
	at org.apache.hadoop.hive.ql.exec.FunctionUtils.addFunctionResources(FunctionUtils.java:86)
	at org.apache.hadoop.hive.ql.exec.Registry.registerToSessionRegistry(Registry.java:690)
	at org.apache.hadoop.hive.ql.exec.Registry.getQualifiedFunctionInfo(Registry.java:667)
	at org.apache.hadoop.hive.ql.exec.Registry.getFunctionInfo(Registry.java:358)
	at org.apache.hadoop.hive.ql.exec.FunctionRegistry.getFunctionInfo(FunctionRegistry.java:825)
	at org.apache.hadoop.hive.ql.ddl.function.drop.DropFunctionAnalyzer.analyzeInternal(DropFunctionAnalyzer.java:51)
	at org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer.analyze(BaseSemanticAnalyzer.java:358)
	at org.apache.hadoop.hive.ql.Compiler.analyze(Compiler.java:224)
	at org.apache.hadoop.hive.ql.Compiler.compile(Compiler.java:109)
	at org.apache.hadoop.hive.ql.Driver.compile(Driver.java:499)
	at org.apache.hadoop.hive.ql.Driver.compileInternal(Driver.java:451)
	at org.apache.hadoop.hive.ql.Driver.compileAndRespond(Driver.java:415)
	at org.apache.hadoop.hive.ql.Driver.compileAndRespond(Driver.java:409)
	at org.apache.hadoop.hive.ql.reexec.ReExecDriver.compileAndRespond(ReExecDriver.java:126)
	at org.apache.hive.service.cli.operation.SQLOperation.prepare(SQLOperation.java:205)
	at org.apache.hive.service.cli.operation.SQLOperation.runInternal(SQLOperation.java:268)
	at org.apache.hive.service.cli.operation.Operation.run(Operation.java:286)
	at org.apache.hive.service.cli.session.HiveSessionImpl.executeStatementInternal(HiveSessionImpl.java:558)
	at org.apache.hive.service.cli.session.HiveSessionImpl.executeStatementAsync(HiveSessionImpl.java:543)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.hive.service.cli.session.HiveSessionProxy.invoke(HiveSessionProxy.java:78)
	at org.apache.hive.service.cli.session.HiveSessionProxy$1.run(HiveSessionProxy.java:63)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:714)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:525)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1953)
	at org.apache.hive.service.cli.session.HiveSessionProxy.invoke(HiveSessionProxy.java:59)
	at jdk.proxy2/jdk.proxy2.$Proxy133.executeStatementAsync(Unknown Source)
	at org.apache.hive.service.cli.CLIService.executeStatementAsync(CLIService.java:311)
	at org.apache.hive.service.cli.thrift.ThriftCLIService.ExecuteStatement(ThriftCLIService.java:650)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$ExecuteStatement.getResult(TCLIService.java:1670)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$ExecuteStatement.getResult(TCLIService.java:1650)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
	at org.apache.hive.service.auth.TSetIpAddressProcessor.process(TSetIpAddressProcessor.java:56)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.io.FileNotFoundException: File does not exist: hdfs://127.0.0.1:65436/tmp/test-udf.jar
	at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1842)
	at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1835)
	at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
	at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1850)
	at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:431)
	at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:370)
	at org.apache.hadoop.fs.FileSystem.copyToLocalFile(FileSystem.java:2657)
	at org.apache.hadoop.fs.FileSystem.copyToLocalFile(FileSystem.java:2626)
	at org.apache.hadoop.fs.FileSystem.copyToLocalFile(FileSystem.java:2602)
	at org.apache.hadoop.hive.ql.util.ResourceDownloader.downloadResource(ResourceDownloader.java:105)
	at org.apache.hadoop.hive.ql.util.ResourceDownloader.resolveAndDownloadInternal(ResourceDownloader.java:90)
	at org.apache.hadoop.hive.ql.util.ResourceDownloader.resolveAndDownload(ResourceDownloader.java:75)
	at org.apache.hadoop.hive.ql.session.SessionState.resolveAndDownload(SessionState.java:1703)
	at org.apache.hadoop.hive.ql.session.SessionState.add_resources(SessionState.java:1658)
	... 39 more

```
