### PR TITLE
HIVE-29461: Iceberg: HIVE_METASTORE_WAREHOUSE_EXTERNAL is ignored when initializing HiveCatalog

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -78,6 +78,13 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
   public static final String LIST_ALL_TABLES = "list-all-tables";
   public static final String LIST_ALL_TABLES_DEFAULT = "false";
 
+  /**
+   * Catalog property for the external (unmanaged) warehouse location, propagated by
+   * {@link #initialize(String, Map)} to {@code hive.metastore.warehouse.external.dir}.
+   * Mirrors {@link CatalogProperties#WAREHOUSE_LOCATION} which targets the managed warehouse.
+   */
+  public static final String EXTERNAL_WAREHOUSE_LOCATION = "external-warehouse";
+
   public static final String HMS_TABLE_OWNER = "hive.metastore.table.owner";
   public static final String HMS_DB_OWNER = "hive.metastore.database.owner";
   public static final String HMS_DB_OWNER_TYPE = "hive.metastore.database.owner-type";
@@ -113,6 +120,11 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
     if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
       this.conf.set(HiveConf.ConfVars.METASTORE_WAREHOUSE.varname,
           LocationUtil.stripTrailingSlash(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
+    }
+
+    if (properties.containsKey(EXTERNAL_WAREHOUSE_LOCATION)) {
+      this.conf.set(HiveConf.ConfVars.HIVE_METASTORE_WAREHOUSE_EXTERNAL.varname,
+          LocationUtil.stripTrailingSlash(properties.get(EXTERNAL_WAREHOUSE_LOCATION)));
     }
 
     this.listAllTables = Boolean.parseBoolean(properties.getOrDefault(LIST_ALL_TABLES, LIST_ALL_TABLES_DEFAULT));

--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -284,7 +284,7 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
   }
 
   @Test
-  public void testInitializeCatalogWithExternalWarehouseProperty() {
+  void testInitializeCatalogWithExternalWarehouseProperty() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put("warehouse", "/user/hive/testwarehouse/");
     properties.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, "/user/hive/external/");

--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -284,6 +284,22 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
   }
 
   @Test
+  public void testInitializeCatalogWithExternalWarehouseProperty() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("warehouse", "/user/hive/testwarehouse/");
+    properties.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, "/user/hive/external/");
+    HiveCatalog hiveCatalog = new HiveCatalog();
+    hiveCatalog.initialize("hive", properties);
+
+    // Both warehouse properties should be propagated to the Hadoop configuration
+    // and trailing slashes should be stripped (matching the managed warehouse behavior).
+    assertThat(hiveCatalog.getConf().get("hive.metastore.warehouse.dir"))
+        .isEqualTo("/user/hive/testwarehouse");
+    assertThat(hiveCatalog.getConf().get("hive.metastore.warehouse.external.dir"))
+        .isEqualTo("/user/hive/external");
+  }
+
+  @Test
   public void testCreateTableTxnBuilder() throws Exception {
     Schema schema = getTestSchema();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/metasummary/IcebergSummaryHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/metasummary/IcebergSummaryHandler.java
@@ -64,7 +64,7 @@ public class IcebergSummaryHandler implements MetaSummaryHandler {
     LOG.info("Initializing iceberg summary handler with warehouse:{}，external warehouse:{}，uris:{}",
         mgdWarehouse, extWarehouse, uris);
     propertiesMap.put("warehouse", mgdWarehouse);
-    propertiesMap.put("externalwarehouse", extWarehouse);
+    propertiesMap.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, extWarehouse);
     propertiesMap.put("uri", uris);
     PrivilegedAction<HiveCatalog> action = () -> {
       HiveCatalog hiveCatalog = new HiveCatalog();

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/metasummary/IcebergSummaryHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/metasummary/IcebergSummaryHandler.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hive.metastore.metasummary.MetadataTableSummary;
 import org.apache.hadoop.hive.metastore.utils.StringUtils;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hive.HiveCatalog;
@@ -63,9 +64,15 @@ public class IcebergSummaryHandler implements MetaSummaryHandler {
     Map<String, String> propertiesMap = Maps.newHashMap();
     LOG.info("Initializing iceberg summary handler with warehouse:{}，external warehouse:{}，uris:{}",
         mgdWarehouse, extWarehouse, uris);
-    propertiesMap.put("warehouse", mgdWarehouse);
-    propertiesMap.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, extWarehouse);
-    propertiesMap.put("uri", uris);
+    if (!StringUtils.isEmpty(mgdWarehouse)) {
+      propertiesMap.put(CatalogProperties.WAREHOUSE_LOCATION, mgdWarehouse);
+    }
+    if (!StringUtils.isEmpty(extWarehouse)) {
+      propertiesMap.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, extWarehouse);
+    }
+    if (!StringUtils.isEmpty(uris)) {
+      propertiesMap.put(CatalogProperties.URI, uris);
+    }
     PrivilegedAction<HiveCatalog> action = () -> {
       HiveCatalog hiveCatalog = new HiveCatalog();
       hiveCatalog.setConf(configuration);

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -72,12 +72,12 @@ public class HMSCatalogFactory {
     final String configUri = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.THRIFT_URIS);
     // Clear THRIFT_URIS so HiveCatalog doesn't accidentally use Thrift connection
     // when REST Catalog is embedded in HMS (same JVM). HiveCatalog reads from Configuration
-    // as fallback, so clearing it ensures it uses embedded connection when "uri" is not set.
+    // as fallback, so clearing it ensures it uses embedded connection when CatalogProperties.URI is not set.
     MetastoreConf.setVar(configuration, MetastoreConf.ConfVars.THRIFT_URIS, "");
-    // Only set "uri" property if THRIFT_URIS was configured (standalone mode)
+    // Only set CatalogProperties.URI if THRIFT_URIS was configured (standalone mode)
     // This tells HiveCatalog to use Thrift connection to external HMS
     if (configUri != null && !configUri.isEmpty()) {
-      properties.put("uri", configUri);
+      properties.put(CatalogProperties.URI, configUri);
     }
     final String configWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE);
     if (configWarehouse != null) {

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.servlet.http.HttpServlet;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.ServletSecurity;
 import org.apache.hadoop.hive.metastore.ServletSecurity.AuthType;
@@ -71,20 +72,18 @@ public class HMSCatalogFactory {
     final Map<String, String> properties = new TreeMap<>();
     final String configUri = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.THRIFT_URIS);
     // Clear THRIFT_URIS so HiveCatalog doesn't accidentally use Thrift connection
-    // when REST Catalog is embedded in HMS (same JVM). HiveCatalog reads from Configuration
-    // as fallback, so clearing it ensures it uses embedded connection when CatalogProperties.URI is not set.
+    // when REST Catalog is embedded in HMS (same JVM).
     MetastoreConf.setVar(configuration, MetastoreConf.ConfVars.THRIFT_URIS, "");
-    // Only set CatalogProperties.URI if THRIFT_URIS was configured (standalone mode)
     // This tells HiveCatalog to use Thrift connection to external HMS
-    if (configUri != null && !configUri.isEmpty()) {
+    if (!StringUtils.isEmpty(configUri)) {
       properties.put(CatalogProperties.URI, configUri);
     }
     final String configWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE);
-    if (configWarehouse != null) {
+    if (!StringUtils.isEmpty(configWarehouse)) {
       properties.put(CatalogProperties.WAREHOUSE_LOCATION, configWarehouse);
     }
     final String configExtWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE_EXTERNAL);
-    if (configExtWarehouse != null) {
+    if (!StringUtils.isEmpty(configExtWarehouse)) {
       properties.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, configExtWarehouse);
     }
     if (configuration.get(SERVLET_ID_KEY) != null) {

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -85,9 +85,7 @@ public class HMSCatalogFactory {
     }
     final String configExtWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE_EXTERNAL);
     if (configExtWarehouse != null) {
-      properties.put("external-warehouse", configExtWarehouse);
-      // HiveCatalog reads this property directly from Configuration, not from properties map
-      configuration.set(MetastoreConf.ConfVars.WAREHOUSE_EXTERNAL.getHiveName(), configExtWarehouse);
+      properties.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, configExtWarehouse);
     }
     if (configuration.get(SERVLET_ID_KEY) != null) {
       // For the testing purpose. HiveCatalog caches a metastore client in a static field. As our tests can spin up

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -83,10 +83,6 @@ public class HMSCatalogFactory {
     if (configWarehouse != null) {
       properties.put("warehouse", configWarehouse);
     }
-    final String configExtWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE_EXTERNAL);
-    if (configExtWarehouse != null) {
-      properties.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, configExtWarehouse);
-    }
     if (configuration.get(SERVLET_ID_KEY) != null) {
       // For the testing purpose. HiveCatalog caches a metastore client in a static field. As our tests can spin up
       // multiple HMS instances, we need a unique cache key.

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -81,7 +81,11 @@ public class HMSCatalogFactory {
     }
     final String configWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE);
     if (configWarehouse != null) {
-      properties.put("warehouse", configWarehouse);
+      properties.put(CatalogProperties.WAREHOUSE_LOCATION, configWarehouse);
+    }
+    final String configExtWarehouse = MetastoreConf.getVar(configuration, MetastoreConf.ConfVars.WAREHOUSE_EXTERNAL);
+    if (configExtWarehouse != null) {
+      properties.put(HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION, configExtWarehouse);
     }
     if (configuration.get(SERVLET_ID_KEY) != null) {
       // For the testing purpose. HiveCatalog caches a metastore client in a static field. As our tests can spin up


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION` ("external-warehouse") as a canonical catalog property and propagate it from `HiveCatalog.initialize(name, properties)` to `hive.metastore.warehouse.external.dir`, mirroring the existing handling for `CatalogProperties.WAREHOUSE_LOCATION` (including `LocationUtil.stripTrailingSlash`).

The two in-tree callers are unified onto the new constant:
- `HMSCatalogFactory#createCatalog` drops its redundant `configuration.set(...)` workaround that was needed because the property was not being read from the properties map.
- `IcebergSummaryHandler#initialize` switches from the unhyphenated `"externalwarehouse"` key (which was effectively dead code — `HiveCatalog.initialize` never read it) to the canonical name.

### Why are the changes needed?

`HiveCatalog.initialize(name, properties)` propagated `CatalogProperties.URI` and `CatalogProperties.WAREHOUSE_LOCATION` to the Hadoop configuration but silently dropped any external-warehouse value, so `getExternalWarehouseLocation()` and `convertToDatabase()` failed with:

```
Warehouse location is not set: hive.metastore.warehouse.external.dir=null
```

whenever a caller reached `HiveCatalog` through the standard Iceberg `Catalog.initialize(name, properties)` API without separately mutating the `Configuration` first.

The two existing callers worked around the gap differently and used different property keys:

- `HMSCatalogFactory.java` (line 86-91 before this change) put `"external-warehouse"` in the properties map AND re-set the value on the `Configuration` before `initialize()`, with a comment that explicitly acknowledged the API gap: `// HiveCatalog reads this property directly from Configuration, not from properties map`.
- `IcebergSummaryHandler.java` (line 67 before this change) put `"externalwarehouse"` (no hyphen) in the properties map but did not perform the `Configuration.set` workaround — it only happened to work because the prior `setConf(configuration)` call carried the value through when `MetastoreConf.WAREHOUSE_EXTERNAL` was already set on the underlying Hadoop conf.

External integrations using the standard Iceberg `Catalog.initialize(name, properties)` API (e.g. Polaris) had no documented way to pass the external warehouse location and tripped the NPE. After this change the property is documented on `HiveCatalog`, propagated via `initialize()`, and the two key spellings are unified.

### Does this PR introduce _any_ user-facing change?

Yes — adds a new public catalog property `external-warehouse` (`HiveCatalog.EXTERNAL_WAREHOUSE_LOCATION`) that callers can pass into `HiveCatalog.initialize(name, properties)` to set the external warehouse location. Existing flows that set `hive.metastore.warehouse.external.dir` directly on the `Configuration` continue to work unchanged.

### How was this patch tested?

Added `testInitializeCatalogWithExternalWarehouseProperty` in `TestHiveCatalog`, mirroring the existing `testInitializeCatalogWithProperties`. The test verifies that both `WAREHOUSE_LOCATION` and the new `EXTERNAL_WAREHOUSE_LOCATION` propagate to their respective Hadoop conf keys with trailing-slash stripping.

Local Maven test runs were blocked on unrelated lock contention from concurrent builds in my environment (`maven-remote-resources-plugin: Could not acquire lock(s)`), so I'm relying on CI for full verification. Happy to address any failures.