### PR TITLE
HIVE-29593: Server-side Metrics Reporting for Iceberg operations

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1935,6 +1935,10 @@ public class MetastoreConf {
         "hive.metastore.iceberg.catalog.cache.expiry", -1,
         "HMS Iceberg Catalog cache expiry."
     ),
+    ICEBERG_CATALOG_METRICS_REPORTERS("metastore.iceberg.catalog.metrics.reporters",
+        "hive.metastore.iceberg.catalog.metrics.reporters", "org.apache.iceberg.rest.metrics.LoggingMetricsReporter",
+        "A comma separated list of custom Iceberg Metrics Reporting plugins."
+    ),
     HTTPSERVER_THREADPOOL_MIN("hive.metastore.httpserver.threadpool.min",
             "hive.metastore.httpserver.threadpool.min", 8,
             "HMS embedded HTTP server minimum number of threads."

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -2521,6 +2521,24 @@ public class MetastoreConf {
   }
 
   /**
+   * Get class instances based on a configuration value
+   * @param conf configuration file to retrieve it from
+   * @param var variable to retrieve
+   * @return instances of the classes
+   */
+  public static Class<?>[] getClasses(Configuration conf, ConfVars var) {
+    assert var.defaultVal.getClass() == String.class;
+    Class<?> defaultClass;
+    try {
+      defaultClass = Class.forName((String) var.defaultVal);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("The default class " + var.defaultVal + " does not exist");
+    }
+    String val = conf.get(var.varname);
+    return val == null ? conf.getClasses(var.hiveName, defaultClass) : conf.getClasses(var.varname, defaultClass);
+  }
+
+  /**
    * Set the class name in the configuration file
    * @param conf configuration file to set it in
    * @param var variable to set

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.ZooKeeperHiveHelper;
 import org.apache.hadoop.hive.metastore.utils.StringUtils;
@@ -2521,21 +2522,27 @@ public class MetastoreConf {
   }
 
   /**
-   * Get class instances based on a configuration value
+   * Get class instances based on a configuration value.
+   *
    * @param conf configuration file to retrieve it from
-   * @param var variable to retrieve
+   * @param confVar variable to retrieve
    * @return instances of the classes
    */
-  public static Class<?>[] getClasses(Configuration conf, ConfVars var) {
-    assert var.defaultVal.getClass() == String.class;
+  public static Class<?>[] getClasses(Configuration conf, ConfVars confVar) {
+    Preconditions.checkArgument(confVar.defaultVal.getClass() == String.class);
     Class<?> defaultClass;
     try {
-      defaultClass = Class.forName((String) var.defaultVal);
+      defaultClass = Class.forName((String) confVar.defaultVal);
     } catch (ClassNotFoundException e) {
-      throw new RuntimeException("The default class " + var.defaultVal + " does not exist");
+      throw new IllegalArgumentException(
+          String.format("Failed to load the the default value of %s: %s", confVar.defaultVal, confVar.varname),
+          e
+      );
     }
-    String val = conf.get(var.varname);
-    return val == null ? conf.getClasses(var.hiveName, defaultClass) : conf.getClasses(var.varname, defaultClass);
+    String val = conf.get(confVar.varname);
+    return val == null
+        ? conf.getClasses(confVar.hiveName, defaultClass)
+        : conf.getClasses(confVar.varname, defaultClass);
   }
 
   /**

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
@@ -20,6 +20,9 @@
 package org.apache.iceberg.rest;
 
 import com.google.common.base.Preconditions;
+
+import java.io.IOException;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +55,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
+import org.apache.iceberg.rest.metrics.IcebergMetricsReporter;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -99,17 +103,21 @@ public class HMSCatalogAdapter implements RESTClient {
           .put(CommitStateUnknownException.class, 500)
           .buildOrThrow();
 
+  private final String catalogName;
   private final Catalog catalog;
   private final SupportsNamespaces asNamespaceCatalog;
   private final ViewCatalog asViewCatalog;
+  private final List<IcebergMetricsReporter> metricsReporters;
+  private final Clock clock = Clock.systemUTC();
 
-
-  public HMSCatalogAdapter(Catalog catalog) {
+  public HMSCatalogAdapter(String catalogName, Catalog catalog, List<IcebergMetricsReporter> metricsReporters) {
     Preconditions.checkArgument(catalog instanceof SupportsNamespaces);
     Preconditions.checkArgument(catalog instanceof ViewCatalog);
+    this.catalogName = catalogName;
     this.catalog = catalog;
     this.asNamespaceCatalog = (SupportsNamespaces) catalog;
     this.asViewCatalog = (ViewCatalog) catalog;
+    this.metricsReporters = metricsReporters;
   }
 
   enum Route {
@@ -315,9 +323,11 @@ public class HMSCatalogAdapter implements RESTClient {
     return null;
   }
 
-  private RESTResponse reportMetrics(Object body) {
-    // nothing to do here other than checking that we're getting the correct request
-    castRequest(ReportMetricsRequest.class, body);
+  private RESTResponse reportMetrics(Map<String, String> vars, Object body) {
+    final var ident = identFromPathVars(vars);
+    final var report = castRequest(ReportMetricsRequest.class, body).report();
+    final var receivedAt = clock.instant();
+    metricsReporters.forEach(reporter -> reporter.report(catalogName, ident, report, receivedAt));
     return null;
   }
 
@@ -456,7 +466,7 @@ public class HMSCatalogAdapter implements RESTClient {
         return (T) renameTable(body);
 
       case REPORT_METRICS:
-        return (T) reportMetrics(body);
+        return (T) reportMetrics(vars, body);
 
       case COMMIT_TRANSACTION:
         return (T) commitTransaction(body);
@@ -574,8 +584,11 @@ public class HMSCatalogAdapter implements RESTClient {
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     // The caller is responsible for closing the underlying catalog backing this REST catalog.
+    for (IcebergMetricsReporter reporter : metricsReporters) {
+      reporter.close();
+    }
   }
 
   private static class BadResponseType extends RuntimeException {

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
@@ -76,12 +76,15 @@ import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Original @ <a href="https://github.com/apache/iceberg/blob/apache-iceberg-1.9.1/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java">RESTCatalogAdapter.java</a>
  * Adaptor class to translate REST requests into {@link Catalog} API calls.
  */
 public class HMSCatalogAdapter implements RESTClient {
+  private static final Logger LOG = LoggerFactory.getLogger(HMSCatalogAdapter.class);
   private static final Splitter SLASH = Splitter.on('/');
 
   private static final Map<Class<? extends Exception>, Integer> EXCEPTION_ERROR_CODES =
@@ -584,10 +587,14 @@ public class HMSCatalogAdapter implements RESTClient {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     // The caller is responsible for closing the underlying catalog backing this REST catalog.
     for (IcebergMetricsReporter reporter : metricsReporters) {
-      reporter.close();
+      try {
+        reporter.close();
+      } catch (IOException e) {
+        LOG.error("Failed to close metrics reporter: {}", reporter, e);
+      }
     }
   }
 

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
@@ -324,7 +324,7 @@ public class HMSCatalogAdapter implements RESTClient {
   }
 
   private RESTResponse reportMetrics(Map<String, String> vars, Object body) {
-    final var ident = identFromPathVars(vars);
+    final TableIdentifier ident = identFromPathVars(vars);
     final var report = castRequest(ReportMetricsRequest.class, body).report();
     final var receivedAt = clock.instant();
     metricsReporters.forEach(reporter -> reporter.report(catalogName, ident, report, receivedAt));

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -131,7 +131,7 @@ public class HMSCatalogFactory {
         final var constructor = clazz.getDeclaredConstructor(Configuration.class);
         return (IcebergMetricsReporter) constructor.newInstance(configuration);
       } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-        throw new IllegalArgumentException("Failed to instantiate IcebergMetricsReporter: {}" + clazz.getName(), e);
+        throw new IllegalArgumentException("Failed to instantiate IcebergMetricsReporter: " + clazz.getName(), e);
       }
     }).toList();
   }

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.rest.metrics.IcebergMetricsReporter;
-import org.apache.iceberg.rest.metrics.LoggingMetricsReporter;
 
 /**
  * Catalog &amp; servlet factory.
@@ -122,10 +121,7 @@ public class HMSCatalogFactory {
   }
 
   private List<IcebergMetricsReporter> createReporters() {
-    final var classes = configuration.getClasses(
-        ConfVars.ICEBERG_CATALOG_METRICS_REPORTERS.getVarname(),
-        LoggingMetricsReporter.class
-    );
+    final var classes = MetastoreConf.getClasses(configuration, ConfVars.ICEBERG_CATALOG_METRICS_REPORTERS);
     return Arrays.stream(classes).map(clazz -> {
       try {
         final var constructor = clazz.getDeclaredConstructor(Configuration.class);

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.rest;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +34,8 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.iceberg.rest.metrics.IcebergMetricsReporter;
+import org.apache.iceberg.rest.metrics.LoggingMetricsReporter;
 
 /**
  * Catalog &amp; servlet factory.
@@ -112,7 +116,24 @@ public class HMSCatalogFactory {
     // Iceberg REST client uses "catalog" by default
     List<String> scopes = Collections.singletonList("catalog");
     ServletSecurity security = new ServletSecurity(AuthType.fromString(authType), configuration, req -> scopes);
-    return security.proxy(new HMSCatalogServlet(new HMSCatalogAdapter(catalog)));
+    String catalogName = MetastoreConf.getVar(configuration, ConfVars.CATALOG_DEFAULT);
+    List<IcebergMetricsReporter> reporters = createReporters();
+    return security.proxy(new HMSCatalogServlet(new HMSCatalogAdapter(catalogName, catalog, reporters)));
+  }
+
+  private List<IcebergMetricsReporter> createReporters() {
+    final var classes = configuration.getClasses(
+        ConfVars.ICEBERG_CATALOG_METRICS_REPORTERS.getVarname(),
+        LoggingMetricsReporter.class
+    );
+    return Arrays.stream(classes).map(clazz -> {
+      try {
+        final var constructor = clazz.getDeclaredConstructor(Configuration.class);
+        return (IcebergMetricsReporter) constructor.newInstance(configuration);
+      } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        throw new IllegalArgumentException("Failed to instantiate IcebergMetricsReporter: {}" + clazz.getName(), e);
+      }
+    }).toList();
   }
 
   /**

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogServlet.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogServlet.java
@@ -100,6 +100,12 @@ public class HMSCatalogServlet extends HttpServlet {
     };
   }
 
+  @Override
+  public void destroy() {
+    super.destroy();
+    restCatalogAdapter.close();
+  }
+
   public static class ServletRequestContext {
     private HTTPMethod method;
     private String path;

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogServlet.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogServlet.java
@@ -147,8 +147,15 @@ public class HMSCatalogServlet extends HttpServlet {
       Route route = routeContext.first();
       Object requestBody = null;
       if (route.requestClass() != null) {
-        requestBody =
-            RESTObjectMapper.mapper().readValue(request.getReader(), route.requestClass());
+        try {
+          requestBody = RESTObjectMapper.mapper().readValue(request.getReader(), route.requestClass());
+        } catch (Exception e) {
+          return new ServletRequestContext(ErrorResponse.builder()
+              .responseCode(400)
+              .withType(e.getClass().getSimpleName())
+              .withMessage(e.getMessage())
+              .build());
+        }
       }
 
       Map<String, String> queryParams =

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/metrics/IcebergMetricsReporter.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/metrics/IcebergMetricsReporter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.rest.metrics;
+
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.metrics.MetricsReport;
+
+import java.io.Closeable;
+import java.time.Instant;
+
+/**
+ * An event reporter for Iceberg metrics.
+ */
+public interface IcebergMetricsReporter extends Closeable {
+  /**
+   * Report an event.
+   *
+   * @param catalog the catalog name
+   * @param identifier the table identifier
+   * @param report the event
+   * @param receivedAt the timestamp when the Iceberg REST Catalog received the event
+   */
+  void report(String catalog, TableIdentifier identifier, MetricsReport report, Instant receivedAt);
+}

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/metrics/LoggingMetricsReporter.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/metrics/LoggingMetricsReporter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.rest.metrics;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Instant;
+
+/**
+ * A metrics reporter that logs events.
+ */
+public class LoggingMetricsReporter implements IcebergMetricsReporter {
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingMetricsReporter.class);
+
+  public LoggingMetricsReporter(Configuration conf) {
+  }
+
+  @Override
+  public void report(String catalog, TableIdentifier identifier, MetricsReport report, Instant receivedAt) {
+    LOG.info("Event reported at {}: catalog={}, table={}, report={}", receivedAt, catalog, identifier, report);
+  }
+
+  @Override
+  public void close() {
+    LOG.info("Closing {}", getClass().getName());
+  }
+}

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/metrics/LoggingMetricsReporter.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/metrics/LoggingMetricsReporter.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.metrics.MetricsReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.time.Instant;
 
 /**

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/extension/RESTCatalogServer.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/extension/RESTCatalogServer.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.rest.extension;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
@@ -60,6 +61,9 @@ public class RESTCatalogServer {
 
     String uniqueTestKey = String.format("RESTCatalogServer_%s", UUID.randomUUID());
     warehouseDir = Path.of(MetaStoreTestUtils.getTestWarehouseDir(uniqueTestKey));
+    Files.createDirectories(warehouseDir);
+    System.setProperty("derby.stream.error.file",
+        warehouseDir.resolve("derby.log").toAbsolutePath().toString());
     String jdbcUrl = String.format("jdbc:derby:memory:%s;create=true",
         warehouseDir.resolve("metastore_db").toAbsolutePath());
     MetastoreConf.setVar(conf, ConfVars.CONNECT_URL_KEY, jdbcUrl);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Complete implementing `/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics`.

https://issues.apache.org/jira/browse/HIVE-29593

### Why are the changes needed?

The current endpoint is NOOP, meaning we can't leverage the reported metrics for further optimization.

### Does this PR introduce _any_ user-facing change?

No. By default, HMS administrators can see more logs.

### How was this patch tested?

1. Launch HMS.

```sh
$ docker run --rm -p 9001:9001 apache/hive:standalone-metastore-4.3.0-SNAPSHOT
```

2. Send events.

```sh
$ curl -i -X POST \
  "http://localhost:9001/iceberg/v1/namespaces/default/tables/test/metrics" \
  -H "Content-Type: application/json" \
  --data-binary @- <<'JSON'
{
  "report-type": "scan-report",
  "table-name": "default.test",
  "snapshot-id": 1000000000001,
  "filter": true,
  "schema-id": 0,
  "projected-field-ids": [1],
  "projected-field-names": ["id"],
  "metrics": {
    "total-planning-duration": {
      "count": 1,
      "time-unit": "nanoseconds",
      "total-duration": 2644235116
    },
    "result-data-files": {
      "unit": "count",
      "value": 3
    },
    "result-delete-files": {
      "unit": "count",
      "value": 0
    },
    "total-data-manifests": {
      "unit": "count",
      "value": 1
    },
    "total-delete-manifests": {
      "unit": "count",
      "value": 0
    },
    "scanned-data-manifests": {
      "unit": "count",
      "value": 1
    },
    "skipped-data-manifests": {
      "unit": "count",
      "value": 0
    },
    "total-file-size-bytes": {
      "unit": "bytes",
      "value": 1048576
    },
    "total-delete-file-size-bytes": {
      "unit": "bytes",
      "value": 0
    }
  },
  "metadata": {
    "source": "dummy-curl",
    "user": "test-user",
    "trace-id": "dummy-trace-001"
  }
}
JSON

$ curl -i -X POST \
  "http://localhost:9001/iceberg/v1/namespaces/default/tables/test/metrics" \
  -H "Content-Type: application/json" \
  --data-binary @- <<'JSON'
{
  "report-type": "commit-report",
  "table-name": "default.test",
  "snapshot-id": 1000000000002,
  "sequence-number": 1,
  "operation": "append",
  "metrics": {
    "total-duration": {
      "count": 1,
      "time-unit": "nanoseconds",
      "total-duration": 1234567890
    },
    "attempts": {
      "unit": "count",
      "value": 1
    },
    "added-data-files": {
      "unit": "count",
      "value": 1
    },
    "removed-data-files": {
      "unit": "count",
      "value": 0
    },
    "added-records": {
      "unit": "count",
      "value": 100
    },
    "added-files-size-bytes": {
      "unit": "bytes",
      "value": 4096
    }
  },
  "metadata": {
    "source": "dummy-curl",
    "user": "test-user",
    "trace-id": "dummy-trace-002"
  }
}
JSON
```

3. I can see the logs

```
2026-05-04T09:20:12,525  INFO [qtp1859459396-63] metrics.LoggingMetricsReporter: Event reported at 2026-05-04T09:20:12.524872717Z: catalog=hive, table=default.test, report=ScanReport{tableName=default.test, snapshotId=1000000000001, filter=true, schemaId=0, projectedFieldIds=[1], projectedFieldNames=[id], scanMetrics=ScanMetricsResult{totalPlanningDuration=TimerResult{timeUnit=NANOSECONDS, totalDuration=PT2.644235116S, count=1}, resultDataFiles=CounterResult{unit=COUNT, value=3}, resultDeleteFiles=CounterResult{unit=COUNT, value=0}, totalDataManifests=CounterResult{unit=COUNT, value=1}, totalDeleteManifests=CounterResult{unit=COUNT, value=0}, scannedDataManifests=CounterResult{unit=COUNT, value=1}, skippedDataManifests=CounterResult{unit=COUNT, value=0}, totalFileSizeInBytes=null, totalDeleteFileSizeInBytes=null, skippedDataFiles=null, skippedDeleteFiles=null, scannedDeleteManifests=null, skippedDeleteManifests=null, indexedDeleteFiles=null, equalityDeleteFiles=null, positionalDeleteFiles=null, dvs=null}, metadata={source=dummy-curl, user=test-user, trace-id=dummy-trace-001}}
...
2026-05-04T09:20:24,841  INFO [qtp1859459396-59] metrics.LoggingMetricsReporter: Event reported at 2026-05-04T09:20:24.841145417Z: catalog=hive, table=default.test, report=CommitReport{tableName=default.test, snapshotId=1000000000002, sequenceNumber=1, operation=append, commitMetrics=CommitMetricsResult{totalDuration=TimerResult{timeUnit=NANOSECONDS, totalDuration=PT1.23456789S, count=1}, attempts=CounterResult{unit=COUNT, value=1}, addedDataFiles=CounterResult{unit=COUNT, value=1}, removedDataFiles=CounterResult{unit=COUNT, value=0}, totalDataFiles=null, addedDeleteFiles=null, addedEqualityDeleteFiles=null, addedPositionalDeleteFiles=null, addedDVs=null, removedDeleteFiles=null, removedEqualityDeleteFiles=null, removedPositionalDeleteFiles=null, removedDVs=null, totalDeleteFiles=null, addedRecords=CounterResult{unit=COUNT, value=100}, removedRecords=null, totalRecords=null, addedFilesSizeInBytes=CounterResult{unit=BYTES, value=4096}, removedFilesSizeInBytes=null, totalFilesSizeInBytes=null, addedPositionalDeletes=null, removedPositionalDeletes=null, totalPositionalDeletes=null, addedEqualityDeletes=null, removedEqualityDeletes=null, totalEqualityDeletes=null, manifestsCreated=null, manifestsReplaced=null, manifestsKept=null, manifestEntriesProcessed=null}, metadata={source=dummy-curl, user=test-user, trace-id=dummy-trace-002}}
```

Precisely, the status code should be 204. It is an existing problem, and I'll address it later.
https://issues.apache.org/jira/browse/HIVE-29594