### PR TITLE
HIVE-29595: HiveClientCache does not respect metastore.client.impl

### DIFF
--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestPassProperties.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestPassProperties.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 
 import org.apache.hadoop.conf.Configuration;
@@ -45,8 +44,11 @@ import org.apache.hive.hcatalog.data.DefaultHCatRecord;
 import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
 import org.apache.hive.hcatalog.data.schema.HCatSchema;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestPassProperties {
+  private static final Logger LOG = LoggerFactory.getLogger(TestPassProperties.class);
   private static final String TEST_DATA_DIR = System.getProperty("user.dir") +
       "/build/test/data/" + TestPassProperties.class.getCanonicalName();
   private static final String TEST_WAREHOUSE_DIR = TEST_DATA_DIR + "/warehouse";
@@ -111,10 +113,19 @@ public class TestPassProperties {
       new FileOutputCommitterContainer(job, null).cleanupJob(job);
     } catch (Exception e) {
       caughtException = true;
-      assertTrue(((InvocationTargetException)e.getCause().getCause().getCause()).getTargetException().getMessage().contains(
-          "Could not connect to meta store using any of the URIs provided"));
-      assertTrue(e.getCause().getMessage().contains(
-          "Unable to instantiate org.apache.hadoop.hive.metastore.HiveClientCache$CacheableHiveMetaStoreClient"));
+      LOG.info("Caught expected exception from bad metastore URI", e);
+      // Verify the root cause is a connection failure to the bad metastore URI
+      Throwable cause = e;
+      boolean foundConnectionError = false;
+      while (cause != null) {
+        if (cause.getMessage() != null &&
+            cause.getMessage().contains("Could not connect to meta store using any of the URIs provided")) {
+          foundConnectionError = true;
+          break;
+        }
+        cause = cause.getCause();
+      }
+      assertTrue("Expected connection error in exception chain", foundConnectionError);
     }
     assertTrue(caughtException);
   }

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveClientCache.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveClientCache.java
@@ -18,7 +18,12 @@
  */
 package org.apache.hadoop.hive.metastore;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -34,6 +39,7 @@ import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.annotation.NoReconnect;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.client.builder.HiveMetaStoreClientBuilder;
 import org.apache.hadoop.hive.shims.Utils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.common.util.ShutdownHookManager;
@@ -45,6 +51,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
@@ -83,8 +90,9 @@ public class HiveClientCache {
     return threadId.get();
   }
 
-  public static IMetaStoreClient getNonCachedHiveMetastoreClient(HiveConf hiveConf) throws MetaException {
-    return RetryingMetaStoreClient.getProxy(hiveConf, true);
+  public static IMetaStoreClient getNonCachedHiveMetastoreClient(final HiveConf hiveConf)
+      throws MetaException {
+    return new HiveMetaStoreClientBuilder(hiveConf).newClient(true).build();
   }
 
   public HiveClientCache(HiveConf hiveConf) {
@@ -267,7 +275,7 @@ public class HiveClientCache {
         cacheableHiveMetaStoreClient.acquire();
       }
     }
-    return cacheableHiveMetaStoreClient;
+    return (IMetaStoreClient) cacheableHiveMetaStoreClient;
   }
 
   /**
@@ -284,11 +292,12 @@ public class HiveClientCache {
         @Override
         public ICacheableMetaStoreClient call() throws MetaException {
           // This is called from HCat, so always allow embedded metastore (as was the default).
-          return
-              (ICacheableMetaStoreClient) RetryingMetaStoreClient.getProxy(cacheKey.getHiveConf(),
-                  new Class<?>[]{HiveConf.class, Integer.class, Boolean.class},
-                  new Object[]{cacheKey.getHiveConf(), timeout, true},
-                  CacheableHiveMetaStoreClient.class.getName());
+          IMetaStoreClient metaStoreClient = getNonCachedHiveMetastoreClient(cacheKey.getHiveConf());
+
+          return (ICacheableMetaStoreClient) Proxy.newProxyInstance(
+              HiveClientCache.class.getClassLoader(),
+              new Class[]{IMetaStoreClient.class, ICacheableMetaStoreClient.class},
+              new CacheableHiveMetaStoreClient(metaStoreClient));
         }
       });
     } catch (ExecutionException e) {
@@ -357,7 +366,7 @@ public class HiveClientCache {
   }
 
   @InterfaceAudience.Private
-  public interface ICacheableMetaStoreClient extends IMetaStoreClient {
+  public interface ICacheableMetaStoreClient extends Closeable {
     @NoReconnect
     void acquire();
 
@@ -385,17 +394,32 @@ public class HiveClientCache {
   }
 
   /**
-   * Add # of current users on HiveMetaStoreClient, so that the client can be cleaned when no one is using it.
+   * Wraps a pluggable IMetaStoreClient with caching lifecycle management via InvocationHandler proxy.
+   * This allows any IMetaStoreClient implementation (including Glue) to be used with the cache.
    */
-  static class CacheableHiveMetaStoreClient extends HiveMetaStoreClient implements ICacheableMetaStoreClient {
+  static class CacheableHiveMetaStoreClient implements InvocationHandler, ICacheableMetaStoreClient {
+    private static final ImmutableSet<Method> CLOSE_METHODS;
+    private static final String CLOSE_METHOD_NAME = "close";
 
     private final AtomicInteger users = new AtomicInteger(0);
+    private final IMetaStoreClient base;
     private volatile boolean expiredFromCache = false;
     private boolean isClosed = false;
 
-    CacheableHiveMetaStoreClient(final HiveConf conf, final Integer timeout, Boolean allowEmbedded)
-        throws MetaException {
-      super(conf, null, allowEmbedded);
+    static {
+      try {
+        CLOSE_METHODS = ImmutableSet.of(
+            AutoCloseable.class.getMethod(CLOSE_METHOD_NAME),
+            Closeable.class.getMethod(CLOSE_METHOD_NAME),
+            IMetaStoreClient.class.getMethod(CLOSE_METHOD_NAME),
+            ICacheableMetaStoreClient.class.getMethod(CLOSE_METHOD_NAME));
+      } catch (NoSuchMethodException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    CacheableHiveMetaStoreClient(final IMetaStoreClient base) {
+      this.base = base;
     }
 
     /**
@@ -456,7 +480,7 @@ public class HiveClientCache {
     public boolean isOpen() {
       try {
         // Look for an unlikely database name and see if either MetaException or TException is thrown
-        super.getDatabases("NonExistentDatabaseUsedForHealthCheck");
+        base.getDatabases("NonExistentDatabaseUsedForHealthCheck");
       } catch (TException e) {
         return false;
       }
@@ -495,7 +519,7 @@ public class HiveClientCache {
     public void tearDown() {
       try {
         if (!isClosed) {
-          super.close();
+          base.close();
         }
         isClosed = true;
       } catch (Exception e) {
@@ -524,6 +548,25 @@ public class HiveClientCache {
         this.tearDown();
       } finally {
         super.finalize();
+      }
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      try {
+        // Route methods declared on this class (ICacheableMetaStoreClient lifecycle:
+        // acquire, isOpen, tearDown, etc.) to this handler instance rather than
+        // delegating to the underlying metastore client.
+        if (method.getDeclaringClass().isAssignableFrom(getClass())) {
+          return method.invoke(this, args);
+        }
+        if (CLOSE_METHODS.contains(method)) {
+          close();
+          return null;
+        }
+        return method.invoke(base, args);
+      } catch (InvocationTargetException e) {
+        throw e.getCause();
       }
     }
   }


### PR DESCRIPTION
## Problem

[HIVE-12679](https://issues.apache.org/jira/browse/HIVE-12679) (fixed in 4.2.0) added support for pluggable `IMetaStoreClient` via `metastore.client.impl` in the main Hive path (`HiveMetaStoreClientBuilder`). However, `HiveClientCache` — used by HCatalog's `HCatInputFormat`/`HCatOutputFormat` — was not updated and still hardcodes `HiveMetaStoreClient`:

1. `getNonCachedHiveMetastoreClient()` calls `RetryingMetaStoreClient.getProxy(hiveConf, true)` which hardcodes `HiveMetaStoreClient.class.getName()`
2. `CacheableHiveMetaStoreClient extends HiveMetaStoreClient` — only works with the Thrift client

This means custom `IMetaStoreClient` implementations (e.g., AWS Glue Data Catalog) are ignored when accessing Hive tables through HCatalog, even though they work correctly through the main Hive path.

## Fix

1. **`getNonCachedHiveMetastoreClient()`** now uses `HiveMetaStoreClientBuilder` to create the client, which already reads `METASTORE_CLIENT_IMPL` and handles constructor differences between client implementations.

2. **`CacheableHiveMetaStoreClient`** refactored from `extends HiveMetaStoreClient` to `implements InvocationHandler`. It wraps any `IMetaStoreClient` via `Proxy.newProxyInstance`, delegating metastore calls to the underlying client while managing cache lifecycle (acquire/release/teardown).

3. **`ICacheableMetaStoreClient`** changed from `extends IMetaStoreClient` to `extends Closeable` since the proxy handles `IMetaStoreClient`.

4. **`invoke()`** routes `ICacheableMetaStoreClient` lifecycle methods (`acquire`, `isOpen`, `tearDown`) to the handler itself, delegates all `IMetaStoreClient` methods to the underlying client, and unwraps `InvocationTargetException` so callers see the real exception.

5. **Proxy interfaces** hardcoded to `{IMetaStoreClient.class, ICacheableMetaStoreClient.class}` — the proxy only needs these two.

## Testing

`mvn test -pl metastore -Dtest=TestHiveClientCache -Drat.skip=true` — 5/5 pass, 0 failures.

`TestPassProperties.testSequenceTableWriteReadMR` updated to walk the exception chain for the connection error message rather than assuming a specific exception nesting depth.

## Note to committers

JIRA ticket: [HIVE-29595](https://issues.apache.org/jira/browse/HIVE-29595). This is a follow-up to [HIVE-12679](https://issues.apache.org/jira/browse/HIVE-12679) which missed the HCatalog code path.