### PR TITLE
HIVE-29603: Support SSL cipher suites inclusion for HS2 HTTP mode and…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3858,6 +3858,8 @@ public class HiveConf extends Configuration {
         "SSL certificate keystore password for HiveServer2 WebUI."),
     HIVE_SERVER2_WEBUI_SSL_KEYSTORE_TYPE("hive.server2.webui.keystore.type", "",
         "SSL certificate keystore type for HiveServer2 WebUI."),
+    HIVE_SERVER2_WEBUI_SSL_INCLUDE_CIPHERSUITES("hive.server2.webui.include.ciphersuites", "",
+        "SSL a list of include cipher suite names separated by colon for HiveServer2 WebUI."),
     HIVE_SERVER2_WEBUI_SSL_EXCLUDE_CIPHERSUITES("hive.server2.webui.exclude.ciphersuites", "",
         "SSL a list of exclude cipher suite names or regular expressions separated by comma"
         + " for HiveServer2 WebUI."),
@@ -4375,6 +4377,8 @@ public class HiveConf extends Configuration {
         "SSL certificate keystore type."),
     HIVE_SERVER2_SSL_KEYMANAGERFACTORY_ALGORITHM("hive.server2.keymanagerfactory.algorithm", "",
         "SSL certificate keystore algorithm."),
+    HIVE_SERVER2_SSL_HTTP_INCLUDE_CIPHERSUITES("hive.server2.http.include.ciphersuites", "",
+        "SSL a list of include cipher suite names separated by colon for HiveServer2 http server."),
     HIVE_SERVER2_SSL_HTTP_EXCLUDE_CIPHERSUITES("hive.server2.http.exclude.ciphersuites", "",
         "SSL a list of exclude cipher suite names or regular expressions separated by comma "
         + "for HiveServer2 http server."),

--- a/common/src/java/org/apache/hive/http/HttpServer.java
+++ b/common/src/java/org/apache/hive/http/HttpServer.java
@@ -163,6 +163,7 @@ public class HttpServer {
     private String keyStorePath;
     private String keyStoreType;
     private String keyManagerFactoryAlgorithm;
+    private String includeCiphersuites;
     private String excludeCiphersuites;
     private String spnegoPrincipal;
     private String spnegoKeytab;
@@ -243,6 +244,11 @@ public class HttpServer {
 
     public Builder setKeyManagerFactoryAlgorithm(String keyManagerFactoryAlgorithm) {
       this.keyManagerFactoryAlgorithm = keyManagerFactoryAlgorithm;
+      return this;
+    }
+
+    public Builder setIncludeCiphersuites(String includeCiphersuites) {
+      this.includeCiphersuites = includeCiphersuites;
       return this;
     }
 
@@ -668,12 +674,18 @@ public class HttpServer {
       sslContextFactory.setKeyManagerFactoryAlgorithm(
           b.keyManagerFactoryAlgorithm == null || b.keyManagerFactoryAlgorithm.isEmpty()?
           KeyManagerFactory.getDefaultAlgorithm() : b.keyManagerFactoryAlgorithm);
+      if (b.includeCiphersuites != null && !b.includeCiphersuites.trim().isEmpty()) {
+        Set<String> includeCS = Sets.newHashSet(
+            Splitter.on(":").trimResults().omitEmptyStrings().split(b.includeCiphersuites));
+        if (!includeCS.isEmpty()) {
+          sslContextFactory.setIncludeCipherSuites(includeCS.toArray(new String[0]));
+        }
+      }
       if (b.excludeCiphersuites != null && !b.excludeCiphersuites.trim().isEmpty()) {
         Set<String> excludeCS = Sets.newHashSet(
-            Splitter.on(",").trimResults().omitEmptyStrings().split(b.excludeCiphersuites.trim()));
-        int eSize = excludeCS.size();
-        if (eSize > 0) {
-          sslContextFactory.setExcludeCipherSuites(excludeCS.toArray(new String[eSize]));
+            Splitter.on(",").trimResults().omitEmptyStrings().split(b.excludeCiphersuites));
+        if (!excludeCS.isEmpty()) {
+          sslContextFactory.setExcludeCipherSuites(excludeCS.toArray(new String[0]));
         }
       }
       Set<String> excludedSSLProtocols = Sets.newHashSet(

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
@@ -173,13 +173,21 @@ public class ThriftHttpCLIService extends ThriftCLIService {
         sslContextFactory.setKeyStorePassword(keyStorePassword);
         sslContextFactory.setKeyStoreType(keyStoreType);
         sslContextFactory.setKeyManagerFactoryAlgorithm(keyStoreAlgorithm);
-        String excludeCiphersuites = hiveConf.getVar(ConfVars.HIVE_SERVER2_SSL_HTTP_EXCLUDE_CIPHERSUITES).trim();
-        if (!excludeCiphersuites.trim().isEmpty()) {
+        String includeCiphersuites = hiveConf.getVar(ConfVars.HIVE_SERVER2_SSL_HTTP_INCLUDE_CIPHERSUITES);
+        if (includeCiphersuites != null && !includeCiphersuites.trim().isEmpty()) {
+          Set<String> includeCS = Sets.newHashSet(
+              Splitter.on(":").trimResults().omitEmptyStrings().split(includeCiphersuites));
+          if (!includeCS.isEmpty()) {
+            sslContextFactory.setIncludeCipherSuites(includeCS.toArray(new String[0]));
+          }
+        }
+
+        String excludeCiphersuites = hiveConf.getVar(ConfVars.HIVE_SERVER2_SSL_HTTP_EXCLUDE_CIPHERSUITES);
+        if (excludeCiphersuites != null && !excludeCiphersuites.trim().isEmpty()) {
           Set<String> excludeCS = Sets.newHashSet(
-                  Splitter.on(",").trimResults().omitEmptyStrings().split(excludeCiphersuites.trim()));
-          int eSize = excludeCS.size();
-          if (eSize > 0) {
-            sslContextFactory.setExcludeCipherSuites(excludeCS.toArray(new String[eSize]));
+              Splitter.on(",").trimResults().omitEmptyStrings().split(excludeCiphersuites));
+          if (!excludeCS.isEmpty()) {
+            sslContextFactory.setExcludeCipherSuites(excludeCS.toArray(new String[0]));
           }
         }
         connector = new ServerConnector(server, sslContextFactory, http);

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -489,6 +489,7 @@ public class HiveServer2 extends CompositeService {
       builder.setKeyStoreType(hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYSTORE_TYPE));
       builder.setKeyManagerFactoryAlgorithm(
           hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYMANAGERFACTORY_ALGORITHM));
+      builder.setIncludeCiphersuites(hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_INCLUDE_CIPHERSUITES));
       builder.setExcludeCiphersuites(hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_EXCLUDE_CIPHERSUITES));
       builder.setUseSSL(true);
     }


### PR DESCRIPTION
… Web UI

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR:
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add support for explicit inclusion of SSL cipher suites for HS2 HTTP mode and Web UI

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
While HiveServer2 currently supports explicitly including SSL cipher suites for binary mode, this functionality is missing for HTTP mode and the Web UI. Modern industry security standards prefer the explicit inclusion of secure cipher suites rather than relying on the traditional exclusion of vulnerable ones.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, users will now be able to specify the cipher suites to use for HS2 HTTP mode and web ui in addition to traditional exclusion method. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual Testing