### PR TITLE
HIVE-29650: Upgrade ORC to 2.3.0

### DIFF
--- a/hplsql/pom.xml
+++ b/hplsql/pom.xml
@@ -107,6 +107,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>26.0.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/hplsql/pom.xml
+++ b/hplsql/pom.xml
@@ -109,7 +109,6 @@
     <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
-      <version>26.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
     <jettison.version>1.5.4</jettison.version>
     <jetty.version>9.4.57.v20241219</jetty.version>
     <jersey.version>1.19.4</jersey.version>
+    <jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
     <!-- HIVE-28992: only upgrade to newer than 3.25.0 if you tested the prompt -->
     <jline.version>3.25.0</jline.version>
     <jms.version>2.0.2</jms.version>
@@ -472,6 +473,11 @@
         <groupId>javolution</groupId>
         <artifactId>javolution</artifactId>
         <version>${javolution.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${jetbrains-annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jline</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <postgres.version>42.7.3</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <opencsv.version>5.9</opencsv.version>
-    <orc.version>2.1.2</orc.version>
+    <orc.version>2.3.0</orc.version>
     <otel.version>1.60.1</otel.version>
     <mockito-core.version>5.17.0</mockito-core.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -425,6 +425,11 @@
       <artifactId>groovy-all</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>26.0.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.jodd</groupId>
       <artifactId>jodd-util</artifactId>
       <version>${jodd.version}</version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -427,7 +427,6 @@
     <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
-      <version>26.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.jodd</groupId>

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestFixAcidKeyIndex.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestFixAcidKeyIndex.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
+import org.apache.orc.OrcConf;
 import org.apache.orc.OrcFile.WriterContext;
 import org.apache.orc.impl.OrcAcidUtils;
 import org.junit.Before;
@@ -86,6 +87,8 @@ public class TestFixAcidKeyIndex {
     FileSystem fs = path.getFileSystem(conf);
     fs.delete(path, true);
     TypeInfo typeInfo = TypeInfoUtils.getTypeInfoFromTypeString(typeStr);
+    OrcConf.STRIPE_SIZE_CHECKRATIO.setDouble(conf, 0);
+    OrcConf.STRIPE_ROW_COUNT.setLong(conf, 5000);
     Writer writer = OrcFile.createWriter(path,
         OrcFile.writerOptions(conf)
             .fileSystem(fs)

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -104,6 +104,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
 import org.apache.hadoop.hive.shims.CombineHiveKey;
@@ -2624,7 +2625,7 @@ public class TestInputOutputFormat {
     assertEquals("mock:/combinationAcid/p=0/base_0000010/bucket_00000",
         split.getPath().toString());
     assertEquals(0, split.getStart());
-    assertEquals(784, split.getLength());
+    assertEquals(791, split.getLength());
     split = (HiveInputFormat.HiveInputSplit) splits[1];
     assertEquals("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
         split.inputFormatClassName());
@@ -4172,21 +4173,19 @@ public class TestInputOutputFormat {
       // d
       ((BytesColumnVector) scv.fields[2]).setVal(r,
           Integer.toHexString(r).getBytes(StandardCharsets.UTF_8));
-      indexBuilder.addKey(OrcRecordUpdater.INSERT_OPERATION,
-          1, (int)(((LongColumnVector) batch.cols[2]).vector[0]), r);
     }
 
-    // Minimum 5000 rows per stripe.
+    // Match OrcRecordUpdater: addKey before rows are written. If addKey runs after addRowBatch,
+    // a mid-batch flush can snapshot the index with the previous statement id while the stripe
+    // already contains rows from the current batch.
     for (int idx = 0; idx < 8; ++idx) {
-      writer.addRowBatch(batch);
-      // bucket
-      batch.cols[2].isRepeating = true;
-      ((LongColumnVector) batch.cols[2]).vector[0] = BucketCodec.V1.encode(new AcidOutputFormat
-          .Options(conf).bucket(0).statementId(idx + 1));
-      for(long row_id : ((LongColumnVector) batch.cols[3]).vector) {
-        indexBuilder.addKey(OrcRecordUpdater.INSERT_OPERATION,
-            1, (int)(((LongColumnVector) batch.cols[2]).vector[0]), row_id);
+      final int bucketForBatch = (int) ((LongColumnVector) batch.cols[2]).vector[0];
+      for (long row_id : ((LongColumnVector) batch.cols[3]).vector) {
+        indexBuilder.addKey(OrcRecordUpdater.INSERT_OPERATION, 1, bucketForBatch, row_id);
       }
+      writer.addRowBatch(batch);
+      ((LongColumnVector) batch.cols[2]).vector[0] = BucketCodec.V1.encode(
+          new AcidOutputFormat.Options(conf).bucket(0).statementId(idx + 1));
     }
     writer.close();
     long fileLength = fs.getFileStatus(testFilePath).getLen();
@@ -4194,21 +4193,43 @@ public class TestInputOutputFormat {
     // Find the last stripe.
     List<StripeInformation> stripes;
     RecordIdentifier[] keyIndex;
-    try (Reader orcReader = OrcFile.createReader(fs, testFilePath)) {
+    try (Reader orcReader = OrcFile.createReader(fs, testFilePath);
+        RecordReader rr = orcReader.rows()) {
       stripes = orcReader.getStripes();
       keyIndex = OrcRecordUpdater.parseKeyIndex(orcReader);
+
+      StructObjectInspector soi = (StructObjectInspector) orcReader.getObjectInspector();
+      List<? extends StructField> structFields = soi.getAllStructFieldRefs();
+      StructField transactionField = structFields.get(1);
+      LongObjectInspector transactionOI =
+          (LongObjectInspector) transactionField.getFieldObjectInspector();
+      StructField bucketField = structFields.get(2);
+      IntObjectInspector bucketOI =
+          (IntObjectInspector) bucketField.getFieldObjectInspector();
+      StructField rowIdField = structFields.get(3);
+      LongObjectInspector rowIdOI =
+          (LongObjectInspector) rowIdField.getFieldObjectInspector();
+
+      Assert.assertEquals("Index length doesn't match number of stripes",
+          stripes.size(), keyIndex.length);
+      long rowsProcessed = 0;
+      for (int i = 0; i < stripes.size(); i++) {
+        rowsProcessed += stripes.get(i).getNumberOfRows();
+        rr.seekToRow(rowsProcessed - 1);
+        OrcStruct row = (OrcStruct) rr.next(null);
+        long lastTransaction =
+            transactionOI.get(soi.getStructFieldData(row, transactionField));
+        int lastBucket = bucketOI.get(soi.getStructFieldData(row, bucketField));
+        long lastRowId = rowIdOI.get(soi.getStructFieldData(row, rowIdField));
+        RecordIdentifier expected =
+            new RecordIdentifier(lastTransaction, lastBucket, lastRowId);
+        Assert.assertEquals("Index entry mismatch for stripe " + i, expected, keyIndex[i]);
+      }
     }
 
     StripeInformation lastStripe = stripes.get(stripes.size() - 1);
     long lastStripeOffset = lastStripe.getOffset();
     long lastStripeLength = lastStripe.getLength();
-
-    Assert.assertEquals("Index length doesn't match number of stripes",
-        stripes.size(), keyIndex.length);
-    Assert.assertEquals("1st Index entry mismatch",
-        new RecordIdentifier(1, 536870916, 999), keyIndex[0]);
-    Assert.assertEquals("2nd Index entry mismatch",
-        new RecordIdentifier(1, 536870920, 999), keyIndex[1]);
 
     // test with same schema with include
     conf.set(ValidTxnList.VALID_TXNS_KEY, "100:99:");

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcFileStripeMergeRecordReader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcFileStripeMergeRecordReader.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.FileSplit;
+import org.apache.orc.CompressionKind;
+import org.apache.orc.OrcConf;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,7 +39,9 @@ import org.junit.rules.TestName;
 
 public class TestOrcFileStripeMergeRecordReader {
 
-  private static final int TEST_STRIPE_SIZE = 5000;
+  private static final int MAX_ROWS_PER_STRIPE = 5000;
+
+  private static final long STRIPE_SIZE_BYTES = 128;
 
   private OrcFileKeyWrapper key;
   private OrcFileValueWrapper value;
@@ -51,11 +55,16 @@ public class TestOrcFileStripeMergeRecordReader {
   @Before
   public void setup() throws IOException {
     conf = new Configuration();
+    // ORC ≥2.x: orc.stripe.size.check.ratio triggers flushes when buffered tree bytes exceed ratio × orc.stripe.size
+    // Setting it to 0 disables it.
+    OrcConf.STRIPE_SIZE_CHECKRATIO.setDouble(conf, 0);
+    // Maximum number of rows a Stripe can hold in ORC file.
+    OrcConf.STRIPE_ROW_COUNT.setLong(conf, MAX_ROWS_PER_STRIPE);
     fs = FileSystem.getLocal(conf);
     key = new OrcFileKeyWrapper();
     value = new OrcFileValueWrapper();
     tmpPath  = prepareTmpPath();
-    createOrcFile(TEST_STRIPE_SIZE, TEST_STRIPE_SIZE + 1);
+    createOrcFile(MAX_ROWS_PER_STRIPE + 1);
   }
 
   @After
@@ -86,7 +95,7 @@ public class TestOrcFileStripeMergeRecordReader {
     // both stripes will be processed, first stripe has 5000 rows and second stripe has 1 row
     reader.next(key, value);
     Assert.assertEquals("InputPath", tmpPath, key.getInputPath());
-    Assert.assertEquals("NumberOfValues", TEST_STRIPE_SIZE,
+    Assert.assertEquals("NumberOfValues", MAX_ROWS_PER_STRIPE,
         value.getStripeStatistics().getColStats(0).getNumberOfValues());
     reader.next(key, value);
     Assert.assertEquals("InputPath", tmpPath, key.getInputPath());
@@ -96,7 +105,7 @@ public class TestOrcFileStripeMergeRecordReader {
     reader.close();
   }
 
-  private void createOrcFile(int stripSize, int numberOfRows) throws IOException {
+  private void createOrcFile(int numberOfRows) throws IOException {
     ObjectInspector inspector;
     synchronized (TestOrcFileStripeMergeRecordReader.class) {
       inspector = ObjectInspectorFactory.getReflectionObjectInspector
@@ -106,7 +115,7 @@ public class TestOrcFileStripeMergeRecordReader {
     Writer writer = OrcFile.createWriter(tmpPath,
         OrcFile.writerOptions(conf)
             .inspector(inspector)
-            .stripeSize(stripSize)
+            .stripeSize(STRIPE_SIZE_BYTES)
             .compress(CompressionKind.ZLIB)
             .bufferSize(5000)
             .rowIndexStride(1000));

--- a/ql/src/test/queries/clientpositive/orc_merge10.q
+++ b/ql/src/test/queries/clientpositive/orc_merge10.q
@@ -1,6 +1,7 @@
 --! qt:dataset:src
 --! qt:dataset:part
 --! qt:replace:/(File Version:)(.+)/$1#Masked#/
+--! qt:replace:/(File length:\s+)\S+(\s+bytes)/$1#Masked#$2/
 set hive.vectorized.execution.enabled=false;
 set hive.compute.query.using.stats=false;
 set hive.mapred.mode=nonstrict;

--- a/ql/src/test/results/clientpositive/llap/explainanalyze_acid_with_direct_insert.q.out
+++ b/ql/src/test/results/clientpositive/llap/explainanalyze_acid_with_direct_insert.q.out
@@ -825,17 +825,17 @@ STAGE PLANS:
                 TableScan
                   alias: analyze_part_table
                   filterExpr: (b = 1) (type: boolean)
-                  Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                       value expressions: 1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -845,10 +845,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -1795,17 +1795,17 @@ STAGE PLANS:
                 TableScan
                   alias: analyze_part_table
                   filterExpr: (b = 1) (type: boolean)
-                  Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                       value expressions: 1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -1815,10 +1815,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2/2 Data size: 6376 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 2/2 Data size: 6386 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_10.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_10.q.out
@@ -79,7 +79,7 @@ STAGE PLANS:
                 TableScan
                   alias: t1
                   filterExpr: (b = 1) (type: boolean)
-                  Statistics: Num rows: 69 Data size: #Masked# Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 70 Data size: #Masked# Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (b = 1) (type: boolean)
                     Statistics: Num rows: 1 Data size: #Masked# Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/orc_merge10.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_merge10.q.out
@@ -761,22 +761,22 @@ Stripe Statistics:
   Stripe 1:
     Column 0: count: 242 hasNull: false
     Column 1: count: 242 hasNull: false bytesOnDisk: 489 min: 0 max: 497 sum: 60770
-    Column 2: count: 242 hasNull: false bytesOnDisk: 910 min: val_0 max: val_97 sum: 1646
+    Column 2: count: 242 hasNull: false bytesOnDisk: 914 min: val_0 max: val_97 sum: 1646
 
 File Statistics:
   Column 0: count: 242 hasNull: false
   Column 1: count: 242 hasNull: false bytesOnDisk: 489 min: 0 max: 497 sum: 60770
-  Column 2: count: 242 hasNull: false bytesOnDisk: 910 min: val_0 max: val_97 sum: 1646
+  Column 2: count: 242 hasNull: false bytesOnDisk: 914 min: val_0 max: val_97 sum: 1646
 
 Stripes:
-  Stripe: offset: 3 data: 1399 rows: 242 tail: 73 index: 77
+  Stripe: offset: 3 data: 1403 rows: 242 tail: 73 index: 77
     Stream: column 0 section ROW_INDEX start: 3 length 12
     Stream: column 1 section ROW_INDEX start: 15 length 28
     Stream: column 2 section ROW_INDEX start: 43 length 37
     Stream: column 1 section DATA start: 80 length 489
     Stream: column 2 section DATA start: 569 length 247
-    Stream: column 2 section LENGTH start: 816 length 71
-    Stream: column 2 section DICTIONARY_DATA start: 887 length 592
+    Stream: column 2 section LENGTH start: 816 length 72
+    Stream: column 2 section DICTIONARY_DATA start: 888 length 595
     Encoding column 0: DIRECT
     Encoding column 1: DIRECT_V2
     Encoding column 2: DICTIONARY_V2[153]
@@ -787,7 +787,7 @@ Stripes:
     Row group indices for column 2:
       Entry 0: count: 242 hasNull: false min: val_0 max: val_97 sum: 1646 positions: 0,0,0
 
-File length: 1763 bytes
+File length: 1767 bytes
 File raw data size: #Masked#
 Padding length: 0 bytes
 Padding ratio: 0%
@@ -813,22 +813,22 @@ Stripe Statistics:
   Stripe 1:
     Column 0: count: 242 hasNull: false
     Column 1: count: 242 hasNull: false bytesOnDisk: 489 min: 0 max: 497 sum: 60770
-    Column 2: count: 242 hasNull: false bytesOnDisk: 910 min: val_0 max: val_97 sum: 1646
+    Column 2: count: 242 hasNull: false bytesOnDisk: 914 min: val_0 max: val_97 sum: 1646
 
 File Statistics:
   Column 0: count: 242 hasNull: false
   Column 1: count: 242 hasNull: false bytesOnDisk: 489 min: 0 max: 497 sum: 60770
-  Column 2: count: 242 hasNull: false bytesOnDisk: 910 min: val_0 max: val_97 sum: 1646
+  Column 2: count: 242 hasNull: false bytesOnDisk: 914 min: val_0 max: val_97 sum: 1646
 
 Stripes:
-  Stripe: offset: 3 data: 1399 rows: 242 tail: 73 index: 77
+  Stripe: offset: 3 data: 1403 rows: 242 tail: 73 index: 77
     Stream: column 0 section ROW_INDEX start: 3 length 12
     Stream: column 1 section ROW_INDEX start: 15 length 28
     Stream: column 2 section ROW_INDEX start: 43 length 37
     Stream: column 1 section DATA start: 80 length 489
     Stream: column 2 section DATA start: 569 length 247
-    Stream: column 2 section LENGTH start: 816 length 71
-    Stream: column 2 section DICTIONARY_DATA start: 887 length 592
+    Stream: column 2 section LENGTH start: 816 length 72
+    Stream: column 2 section DICTIONARY_DATA start: 888 length 595
     Encoding column 0: DIRECT
     Encoding column 1: DIRECT_V2
     Encoding column 2: DICTIONARY_V2[153]
@@ -839,7 +839,7 @@ Stripes:
     Row group indices for column 2:
       Entry 0: count: 242 hasNull: false min: val_0 max: val_97 sum: 1646 positions: 0,0,0
 
-File length: 1763 bytes
+File length: 1767 bytes
 File raw data size: #Masked#
 Padding length: 0 bytes
 Padding ratio: 0%

--- a/ql/src/test/results/clientpositive/llap/orc_merge10.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_merge10.q.out
@@ -761,22 +761,22 @@ Stripe Statistics:
   Stripe 1:
     Column 0: count: 242 hasNull: false
     Column 1: count: 242 hasNull: false bytesOnDisk: 489 min: 0 max: 497 sum: 60770
-    Column 2: count: 242 hasNull: false bytesOnDisk: 914 min: val_0 max: val_97 sum: 1646
+    Column 2: count: 242 hasNull: false bytesOnDisk: 913 min: val_0 max: val_97 sum: 1646
 
 File Statistics:
   Column 0: count: 242 hasNull: false
   Column 1: count: 242 hasNull: false bytesOnDisk: 489 min: 0 max: 497 sum: 60770
-  Column 2: count: 242 hasNull: false bytesOnDisk: 914 min: val_0 max: val_97 sum: 1646
+  Column 2: count: 242 hasNull: false bytesOnDisk: 913 min: val_0 max: val_97 sum: 1646
 
 Stripes:
-  Stripe: offset: 3 data: 1403 rows: 242 tail: 73 index: 77
+  Stripe: offset: 3 data: 1402 rows: 242 tail: 73 index: 77
     Stream: column 0 section ROW_INDEX start: 3 length 12
     Stream: column 1 section ROW_INDEX start: 15 length 28
     Stream: column 2 section ROW_INDEX start: 43 length 37
     Stream: column 1 section DATA start: 80 length 489
     Stream: column 2 section DATA start: 569 length 247
-    Stream: column 2 section LENGTH start: 816 length 72
-    Stream: column 2 section DICTIONARY_DATA start: 888 length 595
+    Stream: column 2 section LENGTH start: 816 length 71
+    Stream: column 2 section DICTIONARY_DATA start: 887 length 595
     Encoding column 0: DIRECT
     Encoding column 1: DIRECT_V2
     Encoding column 2: DICTIONARY_V2[153]
@@ -787,7 +787,7 @@ Stripes:
     Row group indices for column 2:
       Entry 0: count: 242 hasNull: false min: val_0 max: val_97 sum: 1646 positions: 0,0,0
 
-File length: 1767 bytes
+File length: #Masked# bytes
 File raw data size: #Masked#
 Padding length: 0 bytes
 Padding ratio: 0%
@@ -813,22 +813,22 @@ Stripe Statistics:
   Stripe 1:
     Column 0: count: 242 hasNull: false
     Column 1: count: 242 hasNull: false bytesOnDisk: 489 min: 0 max: 497 sum: 60770
-    Column 2: count: 242 hasNull: false bytesOnDisk: 914 min: val_0 max: val_97 sum: 1646
+    Column 2: count: 242 hasNull: false bytesOnDisk: 913 min: val_0 max: val_97 sum: 1646
 
 File Statistics:
   Column 0: count: 242 hasNull: false
   Column 1: count: 242 hasNull: false bytesOnDisk: 489 min: 0 max: 497 sum: 60770
-  Column 2: count: 242 hasNull: false bytesOnDisk: 914 min: val_0 max: val_97 sum: 1646
+  Column 2: count: 242 hasNull: false bytesOnDisk: 913 min: val_0 max: val_97 sum: 1646
 
 Stripes:
-  Stripe: offset: 3 data: 1403 rows: 242 tail: 73 index: 77
+  Stripe: offset: 3 data: 1402 rows: 242 tail: 73 index: 77
     Stream: column 0 section ROW_INDEX start: 3 length 12
     Stream: column 1 section ROW_INDEX start: 15 length 28
     Stream: column 2 section ROW_INDEX start: 43 length 37
     Stream: column 1 section DATA start: 80 length 489
     Stream: column 2 section DATA start: 569 length 247
-    Stream: column 2 section LENGTH start: 816 length 72
-    Stream: column 2 section DICTIONARY_DATA start: 888 length 595
+    Stream: column 2 section LENGTH start: 816 length 71
+    Stream: column 2 section DICTIONARY_DATA start: 887 length 595
     Encoding column 0: DIRECT
     Encoding column 1: DIRECT_V2
     Encoding column 2: DICTIONARY_V2[153]
@@ -839,7 +839,7 @@ Stripes:
     Row group indices for column 2:
       Entry 0: count: 242 hasNull: false min: val_0 max: val_97 sum: 1646 positions: 0,0,0
 
-File length: 1767 bytes
+File length: #Masked# bytes
 File raw data size: #Masked#
 Padding length: 0 bytes
 Padding ratio: 0%

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
@@ -64,9 +64,10 @@ import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.layered.TFramedTransport;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;

--- a/standalone-metastore/metastore-tools/pom.xml
+++ b/standalone-metastore/metastore-tools/pom.xml
@@ -30,7 +30,6 @@
     <errorprone.core.version>2.29.2</errorprone.core.version>
     <picocli.version>3.1.0</picocli.version>
     <commons-math3.version>3.6.1</commons-math3.version>
-    <jetbrain-annotation.version>16.0.2</jetbrain-annotation.version>
     <standalone.metastore.path.to.root>..</standalone.metastore.path.to.root>
   </properties>
   <!-- why the f*ck this pom.xml has a dependencyManagement block? -->
@@ -79,12 +78,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>1.7.30</version>
-      </dependency>
-      <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
-      <dependency>
-        <groupId>org.jetbrains</groupId>
-        <artifactId>annotations</artifactId>
-        <version>${jetbrain-annotation.version}</version>
       </dependency>
       <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jxr-plugin -->
       <dependency>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -106,6 +106,7 @@
     <io.grpc.version>1.72.0</io.grpc.version>
     <sqlline.version>1.9.0</sqlline.version>
     <netty.version>4.1.127.Final</netty.version>
+    <jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
     <!-- HIVE-28992: only upgrade to newer than 3.25.0 if you tested the prompt -->
     <jline.version>3.25.0</jline.version>
     <ST4.version>4.0.4</ST4.version>
@@ -373,6 +374,11 @@
             <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${jetbrains-annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jline</groupId>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -98,7 +98,7 @@
     <libthrift.version>0.16.0</libthrift.version>
     <log4j2.version>2.25.3</log4j2.version>
     <mockito-core.version>5.17.0</mockito-core.version>
-    <orc.version>2.1.2</orc.version>
+    <orc.version>2.3.0</orc.version>
     <protobuf.version>3.25.5</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>


### PR DESCRIPTION


### What changes were proposed in this pull request?

- Bump orc.version in root and standalone-metastore pom.xml.
- Add explicit org.jetbrains:annotations dependency (ORC 2.3 no longer pulls it transitively).
- Fix ORC-related unit tests for ORC 2.3 stripe/memory-check behavior (TestFixAcidKeyIndex, TestOrcFileStripeMergeRecordReader, TestInputOutputFormat).
- qtest golden files 

### Why are the changes needed?
https://issues.apache.org/jira/browse/HIVE-29585 
Starting with ORC 2.3.0, LZ4 compression is implemented natively in ORC rather than via Aircompressor. This matters because Aircompressor’s LZ4 path does not support direct buffers which can affect performance in zero-copy I/O paths (e.g. LLAP). Aircompressor is still supported as an alternative but ORC’s built-in LZ4 is now the default.

### Does this PR introduce _any_ user-facing change?
ORC 2.3.0 ships a native LZ4 codec. Hive previously relied on Aircompressor for LZ4, which lacks direct-buffer support and can limit efficiency in direct-buffer read/write scenarios. The upgrade moves to ORC’s native implementation by default. Aircompressor remains configurable for compatibility.

### How was this patch tested?
Unit Tests, Qtests

