### PR TITLE
HIVE-29605: Upgrade datanucleus dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <datanucleus-api-jdo.version>6.0.3</datanucleus-api-jdo.version>
     <datanucleus-core.version>6.0.10</datanucleus-core.version>
     <datanucleus-jdo.version>3.2.0-release</datanucleus-jdo.version>
-    <datanucleus-rdbms.version>6.0.10</datanucleus-rdbms.version>
+    <datanucleus-rdbms.version>6.0.11</datanucleus-rdbms.version>
     <checkstyle.version>11.1.0</checkstyle.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-codec.version>1.15</commons-codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <avro.version>1.12.0</avro.version>
     <bcprov-jdk18on.version>1.82</bcprov-jdk18on.version>
     <calcite.version>1.33.0</calcite.version>
-    <datanucleus-api-jdo.version>6.0.3</datanucleus-api-jdo.version>
+    <datanucleus-api-jdo.version>6.0.5</datanucleus-api-jdo.version>
     <datanucleus-core.version>6.0.10</datanucleus-core.version>
     <datanucleus-jdo.version>3.2.0-release</datanucleus-jdo.version>
     <datanucleus-rdbms.version>6.0.11</datanucleus-rdbms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <bcprov-jdk18on.version>1.82</bcprov-jdk18on.version>
     <calcite.version>1.33.0</calcite.version>
     <datanucleus-api-jdo.version>6.0.5</datanucleus-api-jdo.version>
-    <datanucleus-core.version>6.0.10</datanucleus-core.version>
+    <datanucleus-core.version>6.0.11</datanucleus-core.version>
     <datanucleus-jdo.version>3.2.0-release</datanucleus-jdo.version>
     <datanucleus-rdbms.version>6.0.11</datanucleus-rdbms.version>
     <checkstyle.version>11.1.0</checkstyle.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -72,7 +72,7 @@
     <commons-dbcp2.version>2.14.0</commons-dbcp2.version>
     <datasketches.version>2.0.0</datasketches.version>
     <datanucleus-api-jdo.version>6.0.5</datanucleus-api-jdo.version>
-    <datanucleus-core.version>6.0.10</datanucleus-core.version>
+    <datanucleus-core.version>6.0.11</datanucleus-core.version>
     <datanucleus-jdo.version>3.2.0-release</datanucleus-jdo.version>
     <datanucleus-rdbms.version>6.0.11</datanucleus-rdbms.version>
     <derby.version>10.17.1.0</derby.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -74,7 +74,7 @@
     <datanucleus-api-jdo.version>6.0.3</datanucleus-api-jdo.version>
     <datanucleus-core.version>6.0.10</datanucleus-core.version>
     <datanucleus-jdo.version>3.2.0-release</datanucleus-jdo.version>
-    <datanucleus-rdbms.version>6.0.10</datanucleus-rdbms.version>
+    <datanucleus-rdbms.version>6.0.11</datanucleus-rdbms.version>
     <derby.version>10.17.1.0</derby.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -71,7 +71,7 @@
     <commons-lang3.version>3.17.0</commons-lang3.version>
     <commons-dbcp2.version>2.14.0</commons-dbcp2.version>
     <datasketches.version>2.0.0</datasketches.version>
-    <datanucleus-api-jdo.version>6.0.3</datanucleus-api-jdo.version>
+    <datanucleus-api-jdo.version>6.0.5</datanucleus-api-jdo.version>
     <datanucleus-core.version>6.0.10</datanucleus-core.version>
     <datanucleus-jdo.version>3.2.0-release</datanucleus-jdo.version>
     <datanucleus-rdbms.version>6.0.11</datanucleus-rdbms.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
datanucleus-rdbms dependency version upgrade 6.0.10 to 6.0.11


### Why are the changes needed?

1. To keep dependencies up to date. 
2. Additionally, we identified two Sonatype security findings affecting the current version of org.datanucleus:datanucleus-rdbms:6.0.10.
Both issues stem from embedded Apache Commons DBCP2 classes, which prevents consumers from mitigating the risk via dependency overrides.

sonatype‑2020‑1349 – Insufficiently Protected Credentials
Severity: High (Sonatype CVSS 7.5)
CWE: CWE‑522
Affected Versions: [2.2.0‑release, 6.0.10]
Root Cause: Embedded Commons DBCP2 v2.8.0
Impact:
toString() methods in several DBCP2 classes can expose database credentials in logs or error output.
Affected Classes (embedded):
DelegatingConnection
DriverConnectionFactory
DriverAdapterCPDS
PoolKey
UserPassKey

sonatype‑2020‑0460 – Information Exposure via JMX
Severity: Medium‑High (Sonatype CVSS 6.5)
CWE: CWE‑200
Affected Versions: [5.0.3, 6.0.10]
Root Cause: Embedded Commons DBCP2 v2.9.0
Impact:
When BasicDataSource is configured with jmxName, database passwords may be exposed via JMX access.
Affected Classes (embedded):
BasicDataSource
BasicDataSourceMXBean
 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

PFA dependency tree post upgrade:
[datanucleus.txt](https://github.com/user-attachments/files/27627569/datanucleus.txt)

