### PR TITLE
HIVE-29479: Improve histogram-based selectivity estimation for two-sided range predicates

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -69,6 +69,8 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
 
   protected static final Logger LOG = LoggerFactory.getLogger(FilterSelectivityEstimator.class);
 
+  private static final double DEFAULT_COMPARISON_SELECTIVITY = 1.0 / 3.0;
+
   private final RelNode childRel;
   private final double childCardinality;
   private final RelMetadataQuery mq;
@@ -411,8 +413,6 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
     return lower > upper ? Range.closedOpen(0f, 0f) : Range.range(lower, BoundType.CLOSED, upper, upperType);
   }
 
-  private static final Double DEFAULT_COMPARISON_SELECTIVITY = ((double) 1 / (double) 3);
-
   private double computeComparisonPredicateSelectivity(RexCall call, SqlKind op) {
     double defaultSelectivity = DEFAULT_COMPARISON_SELECTIVITY;
     if (!(childRel instanceof HiveTableScan)) {
@@ -463,7 +463,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
    * Returns the default selectivity if the histogram is not available.
    */
   private double computeRangePredicateSelectivity(Supplier<Double> defaultSelectivity, RexNode operand,
-      Range<Float> boundaries, boolean inverseBool /* true only for NOT_BETWEEN */ ) {
+      Range<Float> boundaries, boolean inverseBool /* true only for NOT_BETWEEN */) {
     if (!(childRel instanceof HiveTableScan)) {
       return defaultSelectivity.get();
     }
@@ -612,7 +612,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
   /**
    * Similar to {@link SearchTransformer}, but computing the selectivity of the expression.
    */
-  private class SearchSelectivityHelper<C extends Comparable<C>> {
+  private final class SearchSelectivityHelper<C extends Comparable<C>> {
     private final RexNode ref;
     private final Sarg<C> sarg;
     private final RelDataType operandType;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -627,84 +627,78 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
 
     private double compute() {
       final List<RexNode> inLiterals = new ArrayList<>();
-      final List<Double> rangesSelectivityList = new ArrayList<>();
-      // accumulate the selectivity of all ranges
+      final List<Double> rangeSelectivities = new ArrayList<>();
       for (Range<C> range : sarg.rangeSet.asRanges()) {
         if (!range.hasLowerBound() && !range.hasUpperBound()) {
           return 1.0; // "all" range
         }
-
-        final BoundType lowerBoundType;
-        final BoundType upperBoundType;
-        final Optional<Float> lowerLiteral;
-        final Optional<Float> upperLiteral;
-        final Supplier<Double> defaultSelectivity;
-        if (range.hasLowerBound() && range.hasUpperBound()) {
-          C lower = range.lowerEndpoint();
-          C upper = range.upperEndpoint();
-          lowerBoundType = range.lowerBoundType();
-          upperBoundType = range.upperBoundType();
-          if (lower.equals(upper) && lowerBoundType == BoundType.CLOSED && upperBoundType == BoundType.CLOSED) {
-            // range represents a single value: save it for later
-            inLiterals.add(makeLiteral(lower));
-            continue;
-          }
-          RexNode lowerRexLiteral = makeLiteral(lower);
-          RexNode upperRexLiteral = makeLiteral(upper);
-          lowerLiteral = extractLiteral(lowerRexLiteral);
-          upperLiteral = extractLiteral(upperRexLiteral);
-          defaultSelectivity = () -> computeFunctionSelectivity(List.of(ref, lowerRexLiteral, upperRexLiteral));
-        } else if (range.hasLowerBound()) {
-          lowerLiteral = extractLiteral(makeLiteral(range.lowerEndpoint()));
-          lowerBoundType = range.lowerBoundType();
-          upperLiteral = Optional.of(Float.POSITIVE_INFINITY);
-          upperBoundType = BoundType.CLOSED;
-          defaultSelectivity = () -> DEFAULT_COMPARISON_SELECTIVITY;
-        } else { // i.e. range.hasUpperBound()
-          upperLiteral = extractLiteral(makeLiteral(range.upperEndpoint()));
-          upperBoundType = range.upperBoundType();
-          lowerLiteral = Optional.of(Float.NEGATIVE_INFINITY);
-          lowerBoundType = BoundType.CLOSED;
-          defaultSelectivity = () -> DEFAULT_COMPARISON_SELECTIVITY;
-        }
-
-        double currentRangeSelectivity = lowerLiteral.isEmpty() || upperLiteral.isEmpty()
-            ? defaultSelectivity.get()
-            : computeRangePredicateSelectivity(defaultSelectivity, ref,
-                Range.range(lowerLiteral.get(), lowerBoundType, upperLiteral.get(), upperBoundType));
-        rangesSelectivityList.add(currentRangeSelectivity);
+        processRangeSelectivity(range, rangeSelectivities, inLiterals);
       }
 
-      final List<Double> searchSelectivityList = new ArrayList<>();
-      if (!rangesSelectivityList.isEmpty() && rangesSelectivityList.stream().noneMatch(Objects::isNull)) {
+      final List<Double> searchSelectivities = new ArrayList<>();
+      if (!rangeSelectivities.isEmpty() && rangeSelectivities.stream().noneMatch(Objects::isNull)) {
         // Aggregate all ranges selectivity, respecting the max value of 1
-        double rangesSelectivity = Math.min(1.0, rangesSelectivityList.stream().mapToDouble(Double::doubleValue).sum());
-        if (rangesSelectivity == 1.0) {
+        double total = Math.min(1.0, rangeSelectivities.stream().mapToDouble(Double::doubleValue).sum());
+        if (total == 1.0) {
           return 1.0;
         }
-        searchSelectivityList.add(rangesSelectivity);
+        searchSelectivities.add(total);
       } else {
-        searchSelectivityList.addAll(rangesSelectivityList);
+        searchSelectivities.addAll(rangeSelectivities);
       }
 
       if (!inLiterals.isEmpty()) {
         if (inLiterals.size() == 1) {
-          searchSelectivityList.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, inLiterals.get(0))
+          searchSelectivities.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, inLiterals.get(0))
               .accept(FilterSelectivityEstimator.this));
         } else {
           List<RexNode> operands = new ArrayList<>(inLiterals.size() + 1);
           operands.add(ref);
           operands.addAll(inLiterals);
-          searchSelectivityList.add(rexBuilder.makeCall(HiveIn.INSTANCE, operands).accept(FilterSelectivityEstimator.this));
+          searchSelectivities.add(rexBuilder.makeCall(HiveIn.INSTANCE, operands).accept(FilterSelectivityEstimator.this));
         }
       }
 
       if (sarg.nullAs == RexUnknownAs.TRUE) {
-        searchSelectivityList.add(
+        searchSelectivities.add(
             rexBuilder.makeCall(SqlStdOperatorTable.IS_NULL, ref).accept(FilterSelectivityEstimator.this));
       }
 
-      return searchSelectivityList.size() == 1 ? searchSelectivityList.get(0) : computeDisjunctionSelectivity(searchSelectivityList);
+      return searchSelectivities.size() == 1 ? searchSelectivities.get(0) : computeDisjunctionSelectivity(searchSelectivities);
+    }
+
+    private void processRangeSelectivity(Range<C> range, List<Double> rangeSelectivities, List<RexNode> inLiterals) {
+      final boolean hasLower = range.hasLowerBound();
+      final boolean hasUpper = range.hasUpperBound();
+
+      final BoundType lowerBoundType = hasLower ? range.lowerBoundType() : BoundType.CLOSED;
+      final BoundType upperBoundType = hasUpper ? range.upperBoundType() : BoundType.CLOSED;
+
+      final RexNode lowerRex = hasLower ? makeLiteral(range.lowerEndpoint()) : null;
+      final RexNode upperRex = hasUpper ? makeLiteral(range.upperEndpoint()) : null;
+
+      // map missing bounds to infinity
+      final Optional<Float> lowerLiteral = hasLower ? extractLiteral(lowerRex) : Optional.of(Float.NEGATIVE_INFINITY);
+      final Optional<Float> upperLiteral = hasUpper ? extractLiteral(upperRex) : Optional.of(Float.POSITIVE_INFINITY);
+
+      // check for single value ranges
+      if (hasLower && hasUpper && lowerBoundType == BoundType.CLOSED && upperBoundType == BoundType.CLOSED
+          && lowerLiteral.equals(upperLiteral)) {
+        inLiterals.add(lowerRex);
+        return;
+      }
+
+      // map the range to a selectivity
+      final Supplier<Double> defaultSelectivity =
+          hasLower && hasUpper ? () -> computeFunctionSelectivity(List.of(ref, lowerRex, upperRex))
+              : () -> DEFAULT_COMPARISON_SELECTIVITY;
+
+      if (lowerLiteral.isEmpty() || upperLiteral.isEmpty()) {
+        rangeSelectivities.add(defaultSelectivity.get());
+      } else {
+        rangeSelectivities.add(computeRangePredicateSelectivity(defaultSelectivity, ref,
+            Range.range(lowerLiteral.get(), lowerBoundType, upperLiteral.get(), upperBoundType)));
+      }
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -56,7 +56,6 @@ import org.apache.datasketches.quantilescommon.QuantileSearchCriteria;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveCalciteUtil;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveConfPlannerContext;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
-import org.apache.hadoop.hive.ql.optimizer.calcite.SearchTransformer;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveIn;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveTableScan;
 import org.apache.hadoop.hive.ql.plan.ColStatistics;
@@ -71,7 +70,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
   private static final double DEFAULT_COMPARISON_SELECTIVITY = 1.0 / 3.0;
 
   private final RelNode childRel;
-  private final double childCardinality;
+  private final double  childCardinality;
   private final RelMetadataQuery mq;
   private final RexBuilder rexBuilder;
 
@@ -118,10 +117,9 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
       selectivity = computeConjunctionSelectivity(call);
       break;
     }
-    case SEARCH: {
+    case SEARCH:
       selectivity = computeSearchSelectivity(call);
       break;
-    }
     case OR: {
       selectivity = computeDisjunctionSelectivity(call);
       break;
@@ -638,8 +636,10 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
           return 1.0; // "all" range
         }
 
-        final BoundType lowerBoundType, upperBoundType;
-        final Optional<Float> lowerLiteral, upperLiteral;
+        final BoundType lowerBoundType;
+        final BoundType upperBoundType;
+        final Optional<Float> lowerLiteral;
+        final Optional<Float> upperLiteral;
         final Supplier<Double> defaultSelectivity;
         if (range.hasLowerBound() && range.hasUpperBound()) {
           C lower = range.lowerEndpoint();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
@@ -44,9 +45,12 @@ import org.apache.calcite.rex.RexUnknownAs;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.RangeSets;
+import org.apache.calcite.util.Sarg;
 import org.apache.datasketches.kll.KllFloatsSketch;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.quantilescommon.QuantileSearchCriteria;
@@ -66,7 +70,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
   protected static final Logger LOG = LoggerFactory.getLogger(FilterSelectivityEstimator.class);
 
   private final RelNode childRel;
-  private final double  childCardinality;
+  private final double childCardinality;
   private final RelMetadataQuery mq;
   private final RexBuilder rexBuilder;
 
@@ -113,8 +117,6 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
       selectivity = computeConjunctionSelectivity(call);
       break;
     }
-    case SEARCH:
-      return new SearchTransformer<>(rexBuilder, call, RexUnknownAs.FALSE).transform().accept(this);
     case OR: {
       selectivity = computeDisjunctionSelectivity(call);
       break;
@@ -159,12 +161,16 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
     case GREATER_THAN_OR_EQUAL:
     case LESS_THAN:
     case GREATER_THAN: {
-      selectivity = computeRangePredicateSelectivity(call, call.getKind());
+      selectivity = computeComparisonPredicateSelectivity(call, call.getKind());
       break;
     }
 
     case BETWEEN:
       selectivity = computeBetweenPredicateSelectivity(call);
+      break;
+
+    case SEARCH:
+      selectivity = computeSearchSelectivity(call);
       break;
 
     default:
@@ -226,7 +232,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
    * @return true if the expression is a removable cast, false otherwise
    */
   private boolean isRemovableCast(RexNode exp, HiveTableScan tableScan) {
-    if(SqlKind.CAST != exp.getKind()) {
+    if (SqlKind.CAST != exp.getKind()) {
       return false;
     }
     RexCall cast = (RexCall) exp;
@@ -405,8 +411,10 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
     return lower > upper ? Range.closedOpen(0f, 0f) : Range.range(lower, BoundType.CLOSED, upper, upperType);
   }
 
-  private double computeRangePredicateSelectivity(RexCall call, SqlKind op) {
-    double defaultSelectivity = ((double) 1 / (double) 3);
+  private static final Double DEFAULT_COMPARISON_SELECTIVITY = ((double) 1 / (double) 3);
+
+  private double computeComparisonPredicateSelectivity(RexCall call, SqlKind op) {
+    double defaultSelectivity = DEFAULT_COMPARISON_SELECTIVITY;
     if (!(childRel instanceof HiveTableScan)) {
       return defaultSelectivity;
     }
@@ -440,34 +448,56 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
     boundaryValues[boundaryIdx] = value;
     inclusive[boundaryIdx] = openBound ? BoundType.OPEN : BoundType.CLOSED;
     Range<Float> boundaries = Range.range(boundaryValues[0], inclusive[0], boundaryValues[1], inclusive[1]);
-
-    // extract the column index from the other operator
-    final HiveTableScan scan = (HiveTableScan) childRel;
     int inputRefOpIndex = 1 - literalOpIdx;
     RexNode node = operands.get(inputRefOpIndex);
-    if (isRemovableCast(node, scan)) {
-      Range<Float> typeRange = getRangeOfType(node.getType());
-      boundaries = adjustRangeToType(boundaries, node.getType(), typeRange);
+    return computeRangePredicateSelectivity(() -> defaultSelectivity, node, boundaries);
+  }
 
-      node = RexUtil.removeCast(node);
+  private double computeRangePredicateSelectivity(Supplier<Double> defaultSelectivity, RexNode operand,
+      Range<Float> boundaries) {
+    return computeRangePredicateSelectivity(defaultSelectivity, operand, boundaries, false);
+  }
+
+  /**
+   * Computes the selectivity of an operand in a certain range trying to leverage the histogram information.
+   * Returns the default selectivity if the histogram is not available.
+   */
+  private double computeRangePredicateSelectivity(Supplier<Double> defaultSelectivity, RexNode operand,
+      Range<Float> boundaries, boolean inverseBool /* true only for NOT_BETWEEN */ ) {
+    if (!(childRel instanceof HiveTableScan)) {
+      return defaultSelectivity.get();
+    }
+
+    final HiveTableScan scan = (HiveTableScan) childRel;
+    Range<Float> typeRange = inverseBool ? Range.closed(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY) : null;
+    if (isRemovableCast(operand, scan)) {
+      typeRange = getRangeOfType(operand.getType());
+      boundaries = adjustRangeToType(boundaries, operand.getType(), typeRange);
+      operand = RexUtil.removeCast(operand);
     }
 
     int inputRefIndex = -1;
-    if (node.getKind().equals(SqlKind.INPUT_REF)) {
-      inputRefIndex = ((RexInputRef) node).getIndex();
+    if (operand.getKind().equals(SqlKind.INPUT_REF)) {
+      inputRefIndex = ((RexInputRef) operand).getIndex();
     }
 
     if (inputRefIndex < 0) {
-      return defaultSelectivity;
+      return defaultSelectivity.get();
     }
 
     final List<ColStatistics> colStats = scan.getColStat(Collections.singletonList(inputRefIndex));
     if (colStats.isEmpty() || !isHistogramAvailable(colStats.get(0))) {
-      return defaultSelectivity;
+      return defaultSelectivity.get();
     }
 
     final KllFloatsSketch kll = KllFloatsSketch.heapify(Memory.wrap(colStats.get(0).getHistogram()));
     double rawSelectivity = rangedSelectivity(kll, boundaries);
+    if (inverseBool) {
+      // when inverseBool == true, this is a NOT_BETWEEN and selectivity must be inverted
+      // if there's a cast, the inversion is with respect to its codomain (range of the values of the cast)
+      double typeRangeSelectivity = rangedSelectivity(kll, typeRange);
+      rawSelectivity = typeRangeSelectivity - rawSelectivity;
+    }
     return scaleSelectivityToNullableValues(kll, rawSelectivity, scan);
   }
 
@@ -511,7 +541,6 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
     Optional<Float> rightLiteral = extractLiteral(operands.get(3));
 
     if (hasLiteralBool && leftLiteral.isPresent() && rightLiteral.isPresent()) {
-      final HiveTableScan scan = (HiveTableScan) childRel;
       float leftValue = leftLiteral.get();
       float rightValue = rightLiteral.get();
 
@@ -522,36 +551,9 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
       }
 
       Range<Float> rangeBoundaries = makeRange(leftValue, rightValue, BoundType.CLOSED);
-      Range<Float> typeBoundaries = inverseBool ? Range.closed(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY) : null;
-
       RexNode expr = operands.get(1); // expr to be checked by the BETWEEN
-      if (isRemovableCast(expr, scan)) {
-        typeBoundaries = getRangeOfType(expr.getType());
-        rangeBoundaries = adjustRangeToType(rangeBoundaries, expr.getType(), typeBoundaries);
-        expr = RexUtil.removeCast(expr);
-      }
-
-      int inputRefIndex = -1;
-      if (expr.getKind().equals(SqlKind.INPUT_REF)) {
-        inputRefIndex = ((RexInputRef) expr).getIndex();
-      }
-
-      if (inputRefIndex < 0) {
-        return computeFunctionSelectivity(call);
-      }
-
-      final List<ColStatistics> colStats = scan.getColStat(Collections.singletonList(inputRefIndex));
-      if (!colStats.isEmpty() && isHistogramAvailable(colStats.get(0))) {
-        final KllFloatsSketch kll = KllFloatsSketch.heapify(Memory.wrap(colStats.get(0).getHistogram()));
-        double rawSelectivity = rangedSelectivity(kll, rangeBoundaries);
-        if (inverseBool) {
-          // when inverseBool == true, this is a NOT_BETWEEN and selectivity must be inverted
-          // if there's a cast, the inversion is with respect to its codomain (range of the values of the cast)
-          double typeRangeSelectivity = rangedSelectivity(kll, typeBoundaries);
-          rawSelectivity = typeRangeSelectivity - rawSelectivity;
-        }
-        return scaleSelectivityToNullableValues(kll, rawSelectivity, scan);
-      }
+      return computeRangePredicateSelectivity(() -> computeFunctionSelectivity(call), expr, rangeBoundaries,
+          inverseBool);
     }
     return computeFunctionSelectivity(call);
   }
@@ -603,6 +605,151 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
     return Optional.of(value);
   }
 
+  private double computeSearchSelectivity(RexCall search) {
+    return new SearchSelectivityHelper<>(search).compute();
+  }
+
+  /**
+   * Similar to {@link SearchTransformer}, but computing the selectivity of the expression.
+   */
+  private class SearchSelectivityHelper<C extends Comparable<C>> {
+    private final RexNode ref;
+    private final Sarg<C> sarg;
+    private final RelDataType operandType;
+
+    private SearchSelectivityHelper(RexCall search) {
+      ref = search.getOperands().get(0);
+      RexLiteral literal = (RexLiteral) search.operands.get(1);
+      sarg = Objects.requireNonNull(literal.getValueAs(Sarg.class), "Sarg");
+      operandType = literal.getType();
+    }
+
+    private RexNode makeLiteral(C value) {
+      return rexBuilder.makeLiteral(value, operandType, true, true);
+    }
+
+    private double compute() {
+      final List<Double> selectivityList = new ArrayList<>();
+      final List<RexNode> inLiterals = new ArrayList<>();
+
+      if (sarg.nullAs == RexUnknownAs.TRUE) {
+        selectivityList.add(
+            rexBuilder.makeCall(SqlStdOperatorTable.IS_NULL, ref).accept(FilterSelectivityEstimator.this));
+      }
+
+      RangeSets.forEach(sarg.rangeSet, new RangeSets.Consumer<C>() {
+        @Override
+        public void all() {
+          selectivityList.add(1.0);
+        }
+
+        @Override
+        public void singleton(C value) {
+          inLiterals.add(rexBuilder.makeLiteral(value, operandType, true, true));
+        }
+
+        @Override
+        public void atLeast(C lower) {
+          Optional<Float> lowerLiteral = extractLiteral(makeLiteral(lower));
+          if (lowerLiteral.isEmpty()) {
+            selectivityList.add(DEFAULT_COMPARISON_SELECTIVITY);
+          } else {
+            processRange(() -> DEFAULT_COMPARISON_SELECTIVITY,
+                Range.range(lowerLiteral.get(), BoundType.CLOSED, Float.POSITIVE_INFINITY, BoundType.CLOSED));
+          }
+        }
+
+        @Override
+        public void atMost(C upper) {
+          Optional<Float> upperLiteral = extractLiteral(makeLiteral(upper));
+          if (upperLiteral.isEmpty()) {
+            selectivityList.add(DEFAULT_COMPARISON_SELECTIVITY);
+          } else {
+            processRange(() -> DEFAULT_COMPARISON_SELECTIVITY,
+                Range.range(Float.NEGATIVE_INFINITY, BoundType.CLOSED, upperLiteral.get(), BoundType.CLOSED));
+          }
+        }
+
+        @Override
+        public void greaterThan(C lower) {
+          Optional<Float> lowerLiteral = extractLiteral(makeLiteral(lower));
+          if (lowerLiteral.isEmpty()) {
+            selectivityList.add(DEFAULT_COMPARISON_SELECTIVITY);
+          } else {
+            processRange(() -> DEFAULT_COMPARISON_SELECTIVITY,
+                Range.range(lowerLiteral.get(), BoundType.OPEN, Float.POSITIVE_INFINITY, BoundType.CLOSED));
+          }
+        }
+
+        @Override
+        public void lessThan(C upper) {
+          Optional<Float> upperLiteral = extractLiteral(makeLiteral(upper));
+          if (upperLiteral.isEmpty()) {
+            selectivityList.add(DEFAULT_COMPARISON_SELECTIVITY);
+          } else {
+            processRange(() -> DEFAULT_COMPARISON_SELECTIVITY,
+                Range.range(Float.NEGATIVE_INFINITY, BoundType.CLOSED, upperLiteral.get(), BoundType.OPEN));
+          }
+        }
+
+        @Override
+        public void closed(C lower, C upper) {
+          processRange(lower, BoundType.CLOSED, upper, BoundType.CLOSED);
+        }
+
+        @Override
+        public void closedOpen(C lower, C upper) {
+          processRange(lower, BoundType.CLOSED, upper, BoundType.OPEN);
+        }
+
+        @Override
+        public void openClosed(C lower, C upper) {
+          processRange(lower, BoundType.OPEN, upper, BoundType.CLOSED);
+        }
+
+        @Override
+        public void open(C lower, C upper) {
+          processRange(lower, BoundType.OPEN, upper, BoundType.OPEN);
+        }
+
+        private void processRange(C lower, BoundType lowerBoundType, C upper, BoundType upperBoundType) {
+          RexNode lowerRexLiteral = makeLiteral(lower);
+          RexNode upperRexLiteral = makeLiteral(upper);
+          Supplier<Double> defaultSelectivity =
+              () -> computeFunctionSelectivity(List.of(ref, lowerRexLiteral, upperRexLiteral));
+          Optional<Float> lowerLiteral = extractLiteral(lowerRexLiteral);
+          Optional<Float> upperLiteral = extractLiteral(upperRexLiteral);
+          if (lowerLiteral.isEmpty() || upperLiteral.isEmpty()) {
+            selectivityList.add(defaultSelectivity.get());
+          } else {
+            processRange(defaultSelectivity,
+                Range.range(lowerLiteral.get(), lowerBoundType, upperLiteral.get(), upperBoundType));
+          }
+        }
+
+        private void processRange(Supplier<Double> defaultSelectivity, Range<Float> boundaries) {
+          selectivityList.add(computeRangePredicateSelectivity(defaultSelectivity, ref, boundaries));
+        }
+      });
+
+      switch (inLiterals.size()) {
+      case 0:
+        break;
+      case 1:
+        selectivityList.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, inLiterals.get(0))
+            .accept(FilterSelectivityEstimator.this));
+        break;
+      default:
+        List<RexNode> operands = new ArrayList<>(inLiterals.size() + 1);
+        operands.add(ref);
+        operands.addAll(inLiterals);
+        selectivityList.add(rexBuilder.makeCall(HiveIn.INSTANCE, operands).accept(FilterSelectivityEstimator.this));
+      }
+
+      return computeDisjunctionSelectivity(selectivityList);
+    }
+  }
+
   /**
    * NDV of "f1(x, y, z) != f2(p, q, r)" ->
    * "(maxNDV(x,y,z,p,q,r) - 1)/maxNDV(x,y,z,p,q,r)".
@@ -633,7 +780,11 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
    * @return
    */
   private Double computeFunctionSelectivity(RexCall call) {
-    Double tmpNDV = getMaxNDV(call);
+    return computeFunctionSelectivity(call.getOperands());
+  }
+
+  private Double computeFunctionSelectivity(List<RexNode> operands) {
+    Double tmpNDV = getMaxNDV(operands);
     if (tmpNDV == null) {
       // Could not be computed
       return null;
@@ -653,12 +804,20 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
    * @return
    */
   private Double computeDisjunctionSelectivity(RexCall call) {
+    List<Double> selectivityList = new ArrayList<>(call.getOperands().size());
+    for (RexNode dje : call.getOperands()) {
+      selectivityList.add(dje.accept(this));
+    }
+    return computeDisjunctionSelectivity(selectivityList);
+  }
+
+  private double computeDisjunctionSelectivity(List<Double> selectivityList) {
     Double tmpCardinality;
     Double tmpSelectivity;
     double selectivity = 1;
 
-    for (RexNode dje : call.getOperands()) {
-      tmpSelectivity = dje.accept(this);
+    for (Double sel : selectivityList) {
+      tmpSelectivity = sel;
       if (tmpSelectivity == null) {
         tmpSelectivity = 0.99;
       }
@@ -729,10 +888,14 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
   }
 
   private Double getMaxNDV(RexCall call) {
+    return getMaxNDV(call.getOperands());
+  }
+
+  private Double getMaxNDV(List<RexNode> operands) {
     Double tmpNDV;
     double maxNDV = 1.0;
     InputReferencedVisitor irv;
-    for (RexNode op : call.getOperands()) {
+    for (RexNode op : operands) {
       if (op instanceof RexInputRef) {
         tmpNDV = HiveRelMdDistinctRowCount.getDistinctRowCount(this.childRel, mq,
             ((RexInputRef) op).getIndex());

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -49,7 +49,6 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.apache.calcite.util.RangeSets;
 import org.apache.calcite.util.Sarg;
 import org.apache.datasketches.kll.KllFloatsSketch;
 import org.apache.datasketches.memory.Memory;
@@ -119,6 +118,10 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
       selectivity = computeConjunctionSelectivity(call);
       break;
     }
+    case SEARCH: {
+      selectivity = computeSearchSelectivity(call);
+      break;
+    }
     case OR: {
       selectivity = computeDisjunctionSelectivity(call);
       break;
@@ -169,10 +172,6 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
 
     case BETWEEN:
       selectivity = computeBetweenPredicateSelectivity(call);
-      break;
-
-    case SEARCH:
-      selectivity = computeSearchSelectivity(call);
       break;
 
     default:
@@ -234,7 +233,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
    * @return true if the expression is a removable cast, false otherwise
    */
   private boolean isRemovableCast(RexNode exp, HiveTableScan tableScan) {
-    if (SqlKind.CAST != exp.getKind()) {
+    if(SqlKind.CAST != exp.getKind()) {
       return false;
     }
     RexCall cast = (RexCall) exp;
@@ -610,7 +609,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
   }
 
   /**
-   * Similar to {@link SearchTransformer}, but computing the selectivity of the expression.
+   * Auxiliary class to compute the selectivity of a SEARCH expression.
    */
   private final class SearchSelectivityHelper<C extends Comparable<C>> {
     private final RexNode ref;
@@ -632,118 +631,68 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
       final List<Double> selectivityList = new ArrayList<>();
       final List<RexNode> inLiterals = new ArrayList<>();
 
+      double rangesSelectivity = 0d;
+      // accumulate the selectivity of all ranges
+      for (Range<C> range : sarg.rangeSet.asRanges()) {
+        if (!range.hasLowerBound() && !range.hasUpperBound()) {
+          return 1.0; // "all" range
+        }
+
+        final BoundType lowerBoundType, upperBoundType;
+        final Optional<Float> lowerLiteral, upperLiteral;
+        final Supplier<Double> defaultSelectivity;
+        if (range.hasLowerBound() && range.hasUpperBound()) {
+          C lower = range.lowerEndpoint();
+          C upper = range.upperEndpoint();
+          lowerBoundType = range.lowerBoundType();
+          upperBoundType = range.upperBoundType();
+          if (lower.equals(upper) && lowerBoundType == BoundType.CLOSED && upperBoundType == BoundType.CLOSED) {
+            // range represents a single value: save it for later
+            inLiterals.add(makeLiteral(lower));
+            continue;
+          }
+          RexNode lowerRexLiteral = makeLiteral(lower);
+          RexNode upperRexLiteral = makeLiteral(upper);
+          lowerLiteral = extractLiteral(lowerRexLiteral);
+          upperLiteral = extractLiteral(upperRexLiteral);
+          defaultSelectivity = () -> computeFunctionSelectivity(List.of(ref, lowerRexLiteral, upperRexLiteral));
+        } else if (range.hasLowerBound()) {
+          lowerLiteral = extractLiteral(makeLiteral(range.lowerEndpoint()));
+          lowerBoundType = range.lowerBoundType();
+          upperLiteral = Optional.of(Float.POSITIVE_INFINITY);
+          upperBoundType = BoundType.CLOSED;
+          defaultSelectivity = () -> DEFAULT_COMPARISON_SELECTIVITY;
+        } else { // i.e. range.hasUpperBound()
+          upperLiteral = extractLiteral(makeLiteral(range.upperEndpoint()));
+          upperBoundType = range.upperBoundType();
+          lowerLiteral = Optional.of(Float.NEGATIVE_INFINITY);
+          lowerBoundType = BoundType.CLOSED;
+          defaultSelectivity = () -> DEFAULT_COMPARISON_SELECTIVITY;
+        }
+
+        double currentRangeSelectivity = lowerLiteral.isEmpty() || upperLiteral.isEmpty()
+            ? defaultSelectivity.get()
+            : computeRangePredicateSelectivity(defaultSelectivity, ref,
+                Range.range(lowerLiteral.get(), lowerBoundType, upperLiteral.get(), upperBoundType));
+        rangesSelectivity = Math.min(1.0, rangesSelectivity + currentRangeSelectivity);
+      }
+      selectivityList.add(rangesSelectivity);
+
+      if (!inLiterals.isEmpty()) {
+        if (inLiterals.size() == 1) {
+          selectivityList.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, inLiterals.get(0))
+              .accept(FilterSelectivityEstimator.this));
+        } else {
+          List<RexNode> operands = new ArrayList<>(inLiterals.size() + 1);
+          operands.add(ref);
+          operands.addAll(inLiterals);
+          selectivityList.add(rexBuilder.makeCall(HiveIn.INSTANCE, operands).accept(FilterSelectivityEstimator.this));
+        }
+      }
+
       if (sarg.nullAs == RexUnknownAs.TRUE) {
         selectivityList.add(
             rexBuilder.makeCall(SqlStdOperatorTable.IS_NULL, ref).accept(FilterSelectivityEstimator.this));
-      }
-
-      RangeSets.forEach(sarg.rangeSet, new RangeSets.Consumer<C>() {
-        @Override
-        public void all() {
-          selectivityList.add(1.0);
-        }
-
-        @Override
-        public void singleton(C value) {
-          inLiterals.add(rexBuilder.makeLiteral(value, operandType, true, true));
-        }
-
-        @Override
-        public void atLeast(C lower) {
-          Optional<Float> lowerLiteral = extractLiteral(makeLiteral(lower));
-          if (lowerLiteral.isEmpty()) {
-            selectivityList.add(DEFAULT_COMPARISON_SELECTIVITY);
-          } else {
-            processRange(() -> DEFAULT_COMPARISON_SELECTIVITY,
-                Range.range(lowerLiteral.get(), BoundType.CLOSED, Float.POSITIVE_INFINITY, BoundType.CLOSED));
-          }
-        }
-
-        @Override
-        public void atMost(C upper) {
-          Optional<Float> upperLiteral = extractLiteral(makeLiteral(upper));
-          if (upperLiteral.isEmpty()) {
-            selectivityList.add(DEFAULT_COMPARISON_SELECTIVITY);
-          } else {
-            processRange(() -> DEFAULT_COMPARISON_SELECTIVITY,
-                Range.range(Float.NEGATIVE_INFINITY, BoundType.CLOSED, upperLiteral.get(), BoundType.CLOSED));
-          }
-        }
-
-        @Override
-        public void greaterThan(C lower) {
-          Optional<Float> lowerLiteral = extractLiteral(makeLiteral(lower));
-          if (lowerLiteral.isEmpty()) {
-            selectivityList.add(DEFAULT_COMPARISON_SELECTIVITY);
-          } else {
-            processRange(() -> DEFAULT_COMPARISON_SELECTIVITY,
-                Range.range(lowerLiteral.get(), BoundType.OPEN, Float.POSITIVE_INFINITY, BoundType.CLOSED));
-          }
-        }
-
-        @Override
-        public void lessThan(C upper) {
-          Optional<Float> upperLiteral = extractLiteral(makeLiteral(upper));
-          if (upperLiteral.isEmpty()) {
-            selectivityList.add(DEFAULT_COMPARISON_SELECTIVITY);
-          } else {
-            processRange(() -> DEFAULT_COMPARISON_SELECTIVITY,
-                Range.range(Float.NEGATIVE_INFINITY, BoundType.CLOSED, upperLiteral.get(), BoundType.OPEN));
-          }
-        }
-
-        @Override
-        public void closed(C lower, C upper) {
-          processRange(lower, BoundType.CLOSED, upper, BoundType.CLOSED);
-        }
-
-        @Override
-        public void closedOpen(C lower, C upper) {
-          processRange(lower, BoundType.CLOSED, upper, BoundType.OPEN);
-        }
-
-        @Override
-        public void openClosed(C lower, C upper) {
-          processRange(lower, BoundType.OPEN, upper, BoundType.CLOSED);
-        }
-
-        @Override
-        public void open(C lower, C upper) {
-          processRange(lower, BoundType.OPEN, upper, BoundType.OPEN);
-        }
-
-        private void processRange(C lower, BoundType lowerBoundType, C upper, BoundType upperBoundType) {
-          RexNode lowerRexLiteral = makeLiteral(lower);
-          RexNode upperRexLiteral = makeLiteral(upper);
-          Supplier<Double> defaultSelectivity =
-              () -> computeFunctionSelectivity(List.of(ref, lowerRexLiteral, upperRexLiteral));
-          Optional<Float> lowerLiteral = extractLiteral(lowerRexLiteral);
-          Optional<Float> upperLiteral = extractLiteral(upperRexLiteral);
-          if (lowerLiteral.isEmpty() || upperLiteral.isEmpty()) {
-            selectivityList.add(defaultSelectivity.get());
-          } else {
-            processRange(defaultSelectivity,
-                Range.range(lowerLiteral.get(), lowerBoundType, upperLiteral.get(), upperBoundType));
-          }
-        }
-
-        private void processRange(Supplier<Double> defaultSelectivity, Range<Float> boundaries) {
-          selectivityList.add(computeRangePredicateSelectivity(defaultSelectivity, ref, boundaries));
-        }
-      });
-
-      switch (inLiterals.size()) {
-      case 0:
-        break;
-      case 1:
-        selectivityList.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, inLiterals.get(0))
-            .accept(FilterSelectivityEstimator.this));
-        break;
-      default:
-        List<RexNode> operands = new ArrayList<>(inLiterals.size() + 1);
-        operands.add(ref);
-        operands.addAll(inLiterals);
-        selectivityList.add(rexBuilder.makeCall(HiveIn.INSTANCE, operands).accept(FilterSelectivityEstimator.this));
       }
 
       return selectivityList.size() == 1 ? selectivityList.get(0) : computeDisjunctionSelectivity(selectivityList);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -450,7 +450,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
     return computeRangePredicateSelectivity(() -> defaultSelectivity, node, boundaries);
   }
 
-  private double computeRangePredicateSelectivity(Supplier<Double> defaultSelectivity, RexNode operand,
+  private Double computeRangePredicateSelectivity(Supplier<Double> defaultSelectivity, RexNode operand,
       Range<Float> boundaries) {
     return computeRangePredicateSelectivity(defaultSelectivity, operand, boundaries, false);
   }
@@ -459,7 +459,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
    * Computes the selectivity of an operand in a certain range trying to leverage the histogram information.
    * Returns the default selectivity if the histogram is not available.
    */
-  private double computeRangePredicateSelectivity(Supplier<Double> defaultSelectivity, RexNode operand,
+  private Double computeRangePredicateSelectivity(Supplier<Double> defaultSelectivity, RexNode operand,
       Range<Float> boundaries, boolean inverseBool /* true only for NOT_BETWEEN */) {
     if (!(childRel instanceof HiveTableScan)) {
       return defaultSelectivity.get();
@@ -626,10 +626,8 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
     }
 
     private double compute() {
-      final List<Double> selectivityList = new ArrayList<>();
       final List<RexNode> inLiterals = new ArrayList<>();
-
-      double rangesSelectivity = 0d;
+      final List<Double> rangesSelectivityList = new ArrayList<>();
       // accumulate the selectivity of all ranges
       for (Range<C> range : sarg.rangeSet.asRanges()) {
         if (!range.hasLowerBound() && !range.hasUpperBound()) {
@@ -674,28 +672,39 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
             ? defaultSelectivity.get()
             : computeRangePredicateSelectivity(defaultSelectivity, ref,
                 Range.range(lowerLiteral.get(), lowerBoundType, upperLiteral.get(), upperBoundType));
-        rangesSelectivity = Math.min(1.0, rangesSelectivity + currentRangeSelectivity);
+        rangesSelectivityList.add(currentRangeSelectivity);
       }
-      selectivityList.add(rangesSelectivity);
+
+      final List<Double> searchSelectivityList = new ArrayList<>();
+      if (!rangesSelectivityList.isEmpty() && rangesSelectivityList.stream().noneMatch(Objects::isNull)) {
+        // Aggregate all ranges selectivity, respecting the max value of 1
+        double rangesSelectivity = Math.min(1.0, rangesSelectivityList.stream().mapToDouble(Double::doubleValue).sum());
+        if (rangesSelectivity == 1.0) {
+          return 1.0;
+        }
+        searchSelectivityList.add(rangesSelectivity);
+      } else {
+        searchSelectivityList.addAll(rangesSelectivityList);
+      }
 
       if (!inLiterals.isEmpty()) {
         if (inLiterals.size() == 1) {
-          selectivityList.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, inLiterals.get(0))
+          searchSelectivityList.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, inLiterals.get(0))
               .accept(FilterSelectivityEstimator.this));
         } else {
           List<RexNode> operands = new ArrayList<>(inLiterals.size() + 1);
           operands.add(ref);
           operands.addAll(inLiterals);
-          selectivityList.add(rexBuilder.makeCall(HiveIn.INSTANCE, operands).accept(FilterSelectivityEstimator.this));
+          searchSelectivityList.add(rexBuilder.makeCall(HiveIn.INSTANCE, operands).accept(FilterSelectivityEstimator.this));
         }
       }
 
       if (sarg.nullAs == RexUnknownAs.TRUE) {
-        selectivityList.add(
+        searchSelectivityList.add(
             rexBuilder.makeCall(SqlStdOperatorTable.IS_NULL, ref).accept(FilterSelectivityEstimator.this));
       }
 
-      return selectivityList.size() == 1 ? selectivityList.get(0) : computeDisjunctionSelectivity(selectivityList);
+      return searchSelectivityList.size() == 1 ? searchSelectivityList.get(0) : computeDisjunctionSelectivity(searchSelectivityList);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -746,7 +746,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
         selectivityList.add(rexBuilder.makeCall(HiveIn.INSTANCE, operands).accept(FilterSelectivityEstimator.this));
       }
 
-      return computeDisjunctionSelectivity(selectivityList);
+      return selectivityList.size() == 1 ? selectivityList.get(0) : computeDisjunctionSelectivity(selectivityList);
     }
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
@@ -466,9 +467,27 @@ public class TestFilterSelectivityEstimator {
   }
 
   @Test
+  public void testComputeRangePredicateSelectivityBetweenWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeBetween(inputRef0, int1, int3);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6923076923076923, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
   public void testComputeRangePredicateSelectivityBetweenFromMinToMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
     RexNode filter = REX_BUILDER.makeCall(HiveBetween.INSTANCE, boolFalse, inputRef0, int1, int7);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityBetweenFromMinToMaxWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeBetween(inputRef0, int1, int7);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -482,9 +501,27 @@ public class TestFilterSelectivityEstimator {
   }
 
   @Test
+  public void testComputeRangePredicateSelectivityBetweenFromLowerThanMinToHigherThanMaxWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeBetween(inputRef0, int0, int8);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
   public void testComputeRangePredicateSelectivityBetweenLeftLowerThanMin() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
     RexNode filter = REX_BUILDER.makeCall(HiveBetween.INSTANCE, boolFalse, inputRef0, int0, int3);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6923076923076923, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityBetweenLeftLowerThanMinWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeBetween(inputRef0, int0, int3);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0.6923076923076923, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -498,9 +535,27 @@ public class TestFilterSelectivityEstimator {
   }
 
   @Test
+  public void testComputeRangePredicateSelectivityBetweenRightLowerThanMinWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeBetween(inputRef0, intMinus1, int0);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
   public void testComputeRangePredicateSelectivityBetweenLeftHigherThanMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
     RexNode filter = REX_BUILDER.makeCall(HiveBetween.INSTANCE, boolFalse, inputRef0, int10, int11);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityBetweenLeftHigherThanMaxWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeBetween(inputRef0, int10, int11);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -518,6 +573,17 @@ public class TestFilterSelectivityEstimator {
     verify(tableMock, never()).getColStat(any());
     doReturn(10.0).when(mq).getDistinctRowCount(scan, ImmutableBitSet.of(0), REX_BUILDER.makeLiteral(true));
     RexNode filter = REX_BUILDER.makeCall(HiveBetween.INSTANCE, boolFalse, inputRef0, int3, int3);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    // this is what FilterSelectivityEstimator returns for a generic "function" based on NDV values, in this case 1 / 10
+    Assert.assertEquals(0.1, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityBetweenLeftEqualsRightWithSearch() {
+    verify(tableMock, never()).getColStat(any());
+    doReturn(10.0).when(mq).getDistinctRowCount(scan, ImmutableBitSet.of(0), REX_BUILDER.makeLiteral(true));
+    RexNode filter = REX_BUILDER.makeBetween(inputRef0, int3, int3);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     // this is what FilterSelectivityEstimator returns for a generic "function" based on NDV values, in this case 1 / 10
     Assert.assertEquals(0.1, estimator.estimateSelectivity(filter), DELTA);
@@ -930,7 +996,6 @@ public class TestFilterSelectivityEstimator {
     float invExpectedSelectivity = (universe - expectedEntries) / total;
     Assert.assertEquals(invMessage, invExpectedSelectivity, estimator.estimateSelectivity(invBetween), DELTA);
   }
-
 
   private RexNode cast(String fieldname, SqlTypeName typeName) {
     return cast(fieldname, type(typeName));

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
@@ -540,7 +540,7 @@ public class TestFilterSelectivityEstimator {
     filter = simplify(filter);
     Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
-    Assert.assertEquals(0.6153846153846154, estimator.estimateSelectivity(filter), DELTA);
+    Assert.assertEquals(0.6923076923076923, estimator.estimateSelectivity(filter), DELTA);
   }
 
   @Test
@@ -552,7 +552,7 @@ public class TestFilterSelectivityEstimator {
     filter = simplify(filter);
     Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
-    Assert.assertEquals(0.23076923076923073, estimator.estimateSelectivity(filter), DELTA);
+    Assert.assertEquals(0.30769230769230765, estimator.estimateSelectivity(filter), DELTA);
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
@@ -65,7 +65,9 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.calcite.sql.type.SqlTypeName.BIGINT;
 import static org.apache.calcite.sql.type.SqlTypeName.INTEGER;
@@ -145,6 +147,7 @@ public class TestFilterSelectivityEstimator {
   private static RexNode int11;
   private static RelDataType tableType;
   private static RexNode inputRef0;
+  private static RexNode inputRef10;
   private static RexNode boolFalse;
   private static RexNode boolTrue;
 
@@ -188,6 +191,7 @@ public class TestFilterSelectivityEstimator {
     b.add("f_bigint", TYPE_FACTORY.createSqlType(BIGINT));
     b.add("f_timestamp", SqlTypeName.TIMESTAMP);
     b.add("f_date", SqlTypeName.DATE).build();
+    b.add("f_numeric_nullable", TYPE_FACTORY.createTypeWithNullability(decimalType(38, 25), true));
     tableType = b.build();
 
     RelOptPlanner planner = CalcitePlanner.createPlanner(new HiveConf());
@@ -208,6 +212,11 @@ public class TestFilterSelectivityEstimator {
     currentValuesSize = VALUES.length;
     doReturn(tableType).when(tableMock).getRowType();
     when(tableMock.getRowCount()).thenAnswer(a -> (double) currentValuesSize);
+    Set<Float> set = new HashSet<>();
+    for (float f : VALUES) {
+      set.add(f);
+    }
+    double distinctRowCount = set.size();
 
     RelBuilder relBuilder = HiveRelFactories.HIVE_BUILDER.create(relOptCluster, schemaMock);
     HiveTableScan tableScan =
@@ -215,7 +224,10 @@ public class TestFilterSelectivityEstimator {
             false, false);
     scan = relBuilder.push(tableScan).build();
     when(mq.getRowCount(scan)).thenAnswer(a -> (double) currentValuesSize);
+    when(mq.getDistinctRowCount(scan, ImmutableBitSet.of(0), REX_BUILDER.makeLiteral(true))).thenAnswer(
+        a -> distinctRowCount);
     inputRef0 = REX_BUILDER.makeInputRef(scan, 0);
+    inputRef10 = REX_BUILDER.makeInputRef(scan, 10);
     currentInputRef = inputRef0;
 
     stats = new ColStatistics();
@@ -544,6 +556,49 @@ public class TestFilterSelectivityEstimator {
   }
 
   @Test
+  public void testComputeRangeOrPointPredicateSelectivityWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.OR,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS, inputRef0, int6),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+            REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef0, int1),
+            REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, inputRef0, int3)));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6703296703296704, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangeOrPointsPredicateSelectivityWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.OR,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS, inputRef0, int6),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS, inputRef0, int7),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+            REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef0, int1),
+            REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, inputRef0, int3)));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.7252747252747254, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangeOrIsNullPredicateSelectivityWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(10));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.OR,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.IS_NULL, inputRef10),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+          REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef10, int1),
+          REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, inputRef10, int3)));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6153846153846154, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
   public void testComputeRangePredicateSelectivityBetween() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
     RexNode filter = REX_BUILDER.makeCall(HiveBetween.INSTANCE, boolFalse, inputRef0, int1, int3);
@@ -703,7 +758,7 @@ public class TestFilterSelectivityEstimator {
     verify(tableMock, never()).getColStat(any());
     RexNode filter = REX_BUILDER.makeCall(HiveBetween.INSTANCE, boolTrue, inputRef0, int3, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
-    Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
+    Assert.assertEquals(0.8571428571428571, estimator.estimateSelectivity(filter), DELTA);
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.optimizer.calcite.stats;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
@@ -30,6 +31,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexSimplify;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -456,6 +458,58 @@ public class TestFilterSelectivityEstimator {
     RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, inputRef0, int10);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  private RexNode simplify(RexNode e) {
+    return new RexSimplify(REX_BUILDER, RelOptPredicateList.EMPTY, RexUtil.EXECUTOR).simplify(e);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityOpenOpenWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef0, int1),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN, inputRef0, int4));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6153846153846154, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityClosedOpenWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, inputRef0, int2),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN, inputRef0, int4));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6153846153846154, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityOpenClosedWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef0, int1),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, inputRef0, int3));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6153846153846154, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityClosedClosedWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, inputRef0, int2),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, inputRef0, int3));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6153846153846154, estimator.estimateSelectivity(filter), DELTA);
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
@@ -138,6 +138,7 @@ public class TestFilterSelectivityEstimator {
   private static RexNode int3;
   private static RexNode int4;
   private static RexNode int5;
+  private static RexNode int6;
   private static RexNode int7;
   private static RexNode int8;
   private static RexNode int10;
@@ -169,6 +170,7 @@ public class TestFilterSelectivityEstimator {
     int3 = REX_BUILDER.makeLiteral(3, integerType, true);
     int4 = REX_BUILDER.makeLiteral(4, integerType, true);
     int5 = REX_BUILDER.makeLiteral(5, integerType, true);
+    int6 = REX_BUILDER.makeLiteral(6, integerType, true);
     int7 = REX_BUILDER.makeLiteral(7, integerType, true);
     int8 = REX_BUILDER.makeLiteral(8, integerType, true);
     int10 = REX_BUILDER.makeLiteral(10, integerType, true);
@@ -212,6 +214,7 @@ public class TestFilterSelectivityEstimator {
         new HiveTableScan(relOptCluster, relOptCluster.traitSetOf(HiveRelNode.CONVENTION), tableMock, "table", null,
             false, false);
     scan = relBuilder.push(tableScan).build();
+    when(mq.getRowCount(scan)).thenAnswer(a -> (double) currentValuesSize);
     inputRef0 = REX_BUILDER.makeInputRef(scan, 0);
     currentInputRef = inputRef0;
 
@@ -510,6 +513,34 @@ public class TestFilterSelectivityEstimator {
     Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0.6153846153846154, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeSeveralRangesPredicateSelectivityWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.OR,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+            REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef0, int1),
+            REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN, inputRef0, int4)),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.AND,
+            REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef0, int6),
+            REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN, inputRef0, int10)));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.6153846153846154, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeSeveralSingleSideRangesPredicateSelectivityWithSearch() {
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.OR,
+        REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN, inputRef0, int2),
+        REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef0, int4));
+    filter = simplify(filter);
+    Assert.assertEquals(SqlKind.SEARCH, filter.getKind());
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.23076923076923073, estimator.estimateSelectivity(filter), DELTA);
   }
 
   @Test

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_7.q.out
@@ -571,37 +571,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-        Reducer 3 <- Map 9 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Map 10 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 7 <- Union 6 (SIMPLE_EDGE)
+        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Union 5 (SIMPLE_EDGE)
+        Reducer 9 <- Map 10 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: dependents_n4
-                  filterExpr: name is not null (type: boolean)
-                  Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: name is not null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: empid (type: int), name (type: varchar(256))
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: varchar(256))
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: varchar(256))
-                        Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 10 
             Map Operator Tree:
                 TableScan
                   alias: emps_n8
@@ -621,6 +599,27 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: float)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 10 
+            Map Operator Tree:
+                TableScan
+                  alias: locations_n4
+                  filterExpr: name is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: name is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: name (type: varchar(256))
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: varchar(256))
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: varchar(256))
+                        Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 11 
@@ -648,7 +647,7 @@ STAGE PLANS:
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: depts_n6
@@ -662,33 +661,34 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: varchar(256))
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 8 
+            Map Operator Tree:
+                TableScan
+                  alias: dependents_n4
+                  filterExpr: name is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: name is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: empid (type: int), name (type: varchar(256))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
                         key expressions: _col1 (type: varchar(256))
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: varchar(256))
-                        Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: locations_n4
-                  filterExpr: name is not null (type: boolean)
-                  Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: name is not null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: name (type: varchar(256))
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: varchar(256))
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: varchar(256))
-                        Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 12 
@@ -725,17 +725,17 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col1 (type: varchar(256))
-                  1 _col1 (type: varchar(256))
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col1, _col3
+                Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col1 (type: varchar(256))
+                  key expressions: _col3 (type: varchar(256))
                   null sort order: z
                   sort order: +
-                  Map-reduce partition columns: _col1 (type: varchar(256))
-                  Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col2 (type: int)
+                  Map-reduce partition columns: _col3 (type: varchar(256))
+                  Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: float)
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -743,31 +743,13 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col1 (type: varchar(256))
-                  1 _col0 (type: varchar(256))
-                outputColumnNames: _col0, _col2
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col2 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col2 (type: int)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int)
-        Reducer 4 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col2 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col6
+                  0 _col3 (type: varchar(256))
+                  1 _col1 (type: varchar(256))
+                outputColumnNames: _col1, _col4
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
-                  aggregations: count(_col6)
-                  keys: _col0 (type: int)
+                  aggregations: count(_col1)
+                  keys: _col4 (type: int)
                   minReductionHashAggr: 0.4
                   mode: hash
                   outputColumnNames: _col0, _col1
@@ -779,7 +761,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -802,7 +784,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -822,8 +804,26 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Union 6 
-            Vertex: Union 6
+        Reducer 9 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: varchar(256))
+                  1 _col0 (type: varchar(256))
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: varchar(256))
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: varchar(256))
+                  Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int)
+        Union 5 
+            Vertex: Union 5
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_7.q.out
@@ -276,22 +276,23 @@ STAGE PLANS:
         Map 10 
             Map Operator Tree:
                 TableScan
-                  alias: emps_n8
-                  filterExpr: ((deptno > 10) and (deptno <= 11)) (type: boolean)
-                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  alias: depts_n6
+                  filterExpr: ((deptno > 10) and (deptno <= 11) and name is not null) (type: boolean)
+                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((deptno > 10) and (deptno <= 11)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((deptno > 10) and (deptno <= 11) and name is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: deptno (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: deptno (type: int), name (type: varchar(256))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: varchar(256))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 11 
@@ -341,23 +342,22 @@ STAGE PLANS:
         Map 8 
             Map Operator Tree:
                 TableScan
-                  alias: depts_n6
-                  filterExpr: ((deptno > 10) and (deptno <= 11) and name is not null) (type: boolean)
-                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                  alias: emps_n8
+                  filterExpr: ((deptno > 10) and (deptno <= 11)) (type: boolean)
+                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((deptno > 10) and (deptno <= 11) and name is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((deptno > 10) and (deptno <= 11)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: deptno (type: int), name (type: varchar(256))
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: deptno (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: varchar(256))
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
@@ -386,11 +386,11 @@ STAGE PLANS:
                      Inner Join 0 to 1
                 keys:
                   0 _col1 (type: varchar(256))
-                  1 _col1 (type: varchar(256))
-                outputColumnNames: _col0, _col3
+                  1 _col2 (type: varchar(256))
+                outputColumnNames: _col0, _col4
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
-                  keys: _col0 (type: int), _col3 (type: int)
+                  keys: _col0 (type: int), _col4 (type: int)
                   minReductionHashAggr: 0.4
                   mode: hash
                   outputColumnNames: _col0, _col1
@@ -445,15 +445,15 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1
+                outputColumnNames: _col1, _col2
                 Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col1 (type: varchar(256))
+                  key expressions: _col2 (type: varchar(256))
                   null sort order: z
                   sort order: +
-                  Map-reduce partition columns: _col1 (type: varchar(256))
+                  Map-reduce partition columns: _col2 (type: varchar(256))
                   Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int)
+                  value expressions: _col1 (type: int)
         Union 5 
             Vertex: Union 5
 
@@ -571,12 +571,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 5 (CONTAINS)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
-        Reducer 6 <- Union 5 (SIMPLE_EDGE)
-        Reducer 9 <- Map 10 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 3 <- Map 9 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 10 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 7 <- Union 6 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -604,23 +604,23 @@ STAGE PLANS:
         Map 10 
             Map Operator Tree:
                 TableScan
-                  alias: depts_n6
-                  filterExpr: ((((deptno > 10) and (deptno <= 11)) or ((deptno >= 19) and (deptno < 20))) and name is not null) (type: boolean)
-                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                  alias: emps_n8
+                  filterExpr: (((deptno > 10) and (deptno <= 11)) or ((deptno >= 19) and (deptno < 20))) (type: boolean)
+                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((((deptno > 10) and (deptno <= 11)) or ((deptno >= 19) and (deptno < 20))) and name is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (((deptno > 10) and (deptno <= 11)) or ((deptno >= 19) and (deptno < 20))) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: deptno (type: int), name (type: varchar(256))
+                      expressions: deptno (type: int), salary (type: float)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: varchar(256))
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 11 
@@ -648,7 +648,29 @@ STAGE PLANS:
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
+        Map 8 
+            Map Operator Tree:
+                TableScan
+                  alias: depts_n6
+                  filterExpr: ((((deptno > 10) and (deptno <= 11)) or ((deptno >= 19) and (deptno < 20))) and name is not null) (type: boolean)
+                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((((deptno > 10) and (deptno <= 11)) or ((deptno >= 19) and (deptno < 20))) and name is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: deptno (type: int), name (type: varchar(256))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: varchar(256))
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: varchar(256))
+                        Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 9 
             Map Operator Tree:
                 TableScan
                   alias: locations_n4
@@ -667,28 +689,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: varchar(256))
                         Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: emps_n8
-                  filterExpr: (((deptno > 10) and (deptno <= 11)) or ((deptno >= 19) and (deptno < 20))) (type: boolean)
-                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (((deptno > 10) and (deptno <= 11)) or ((deptno >= 19) and (deptno < 20))) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: deptno (type: int), salary (type: float)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 12 
@@ -726,16 +726,16 @@ STAGE PLANS:
                      Inner Join 0 to 1
                 keys:
                   0 _col1 (type: varchar(256))
-                  1 _col0 (type: varchar(256))
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                  1 _col1 (type: varchar(256))
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col1 (type: varchar(256))
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col1 (type: varchar(256))
-                  Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int)
+                  Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col2 (type: int)
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -744,11 +744,29 @@ STAGE PLANS:
                      Inner Join 0 to 1
                 keys:
                   0 _col1 (type: varchar(256))
-                  1 _col3 (type: varchar(256))
-                outputColumnNames: _col0, _col4
+                  1 _col0 (type: varchar(256))
+                outputColumnNames: _col0, _col2
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int)
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col6
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Group By Operator
-                  aggregations: count(_col4)
+                  aggregations: count(_col6)
                   keys: _col0 (type: int)
                   minReductionHashAggr: 0.4
                   mode: hash
@@ -761,7 +779,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 4 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -784,7 +802,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 6 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -804,26 +822,8 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 9 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col1, _col3
-                Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col3 (type: varchar(256))
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col3 (type: varchar(256))
-                  Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: float)
-        Union 5 
-            Vertex: Union 5
+        Union 6 
+            Vertex: Union 6
 
   Stage: Stage-0
     Fetch Operator
@@ -934,6 +934,27 @@ STAGE PLANS:
         Map 1 
             Map Operator Tree:
                 TableScan
+                  alias: emps_n8
+                  filterExpr: ((deptno > 0) and (deptno < 10)) (type: boolean)
+                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((deptno > 0) and (deptno < 10)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: deptno (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 5 
+            Map Operator Tree:
+                TableScan
                   alias: depts_n6
                   filterExpr: ((deptno > 0) and (deptno < 10) and name is not null) (type: boolean)
                   Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
@@ -951,27 +972,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: varchar(256))
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: emps_n8
-                  filterExpr: ((deptno > 0) and (deptno < 10)) (type: boolean)
-                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((deptno > 0) and (deptno < 10)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: deptno (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 6 
@@ -1023,13 +1023,13 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col1
+                outputColumnNames: _col2
                 Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col1 (type: varchar(256))
+                  key expressions: _col2 (type: varchar(256))
                   null sort order: z
                   sort order: +
-                  Map-reduce partition columns: _col1 (type: varchar(256))
+                  Map-reduce partition columns: _col2 (type: varchar(256))
                   Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 3 
             Execution mode: llap
@@ -1038,7 +1038,7 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col1 (type: varchar(256))
+                  0 _col2 (type: varchar(256))
                   1 _col1 (type: varchar(256))
                 outputColumnNames: _col3
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE


### PR DESCRIPTION
See HIVE-29479.

### What changes were proposed in this pull request?
This PR adapts FilterSelectivityEstimator so that histogram statistics are used for all types of range predicates (so far it was only done for single-sided range predicates and bounded ranges).


### Why are the changes needed?
This PR allows the CBO planner to use histogram statistics for all types of range predicates.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit tests added.
