### PR TITLE
[HIVE-29611] Bump log4j-core version up to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.25.3</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.2.0</mysql.version>


### PR DESCRIPTION
Apache Hive currently depends on Apache Log4j Core versions affected by CVE-2026-34480.

The vulnerability affects XmlLayout in Log4j Core up to version 2.25.3. Malformed XML output may be produced when log messages contain characters forbidden by XML 1.0 specification. Depending on the StAX implementation, this can result in:
- invalid XML logs rejected by downstream log processing systems
- silent log event loss
- exceptions during logging operations

Upstream fix is available in Log4j Core 2.25.4