### PR TITLE
HIVE-29613: [Optimizer] Cross-product join falls back to single-reducer shuffle merge when small-side row estimate marginally exceeds hive.xprod.mapjoin.small.table.rows

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -1080,6 +1080,34 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
   }
 
   /**
+   * When estimated rows already exceed {@link ConfVars#XPROD_SMALL_TABLE_ROWS_THRESHOLD}, still allow
+   * cross-product map join if {@link #computeOnlineDataSize} fits within the unconditional map-join
+   * byte budget ({@link ConfVars#HIVE_CONVERT_JOIN_NOCONDITIONAL_TASK_THRESHOLD}). NDV-based cardinality
+   * can overshoot row counts on tiny tables while bytes remain broadcast-safe.
+   */
+  @VisibleForTesting
+  boolean crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(Statistics parentStats,
+      long xprodRowThreshold, long noconditionalMaxBytes) {
+    long onlineBytes = computeOnlineDataSize(parentStats);
+    if (onlineBytes <= 0) {
+      LOG.debug(
+          "Cross-product map join: row estimate {} exceeds {} but online size unavailable; not applying byte fallback",
+          parentStats.getNumRows(), xprodRowThreshold);
+      return false;
+    }
+    if (onlineBytes <= noconditionalMaxBytes) {
+      LOG.info(
+          "Cross-product map join: row estimate {} exceeds {} but online size {} within broadcast budget {}; allowing map join",
+          parentStats.getNumRows(), xprodRowThreshold, onlineBytes, noconditionalMaxBytes);
+      return true;
+    }
+    LOG.debug(
+        "Cross-product map join: row estimate {} exceeds {} and online size {} exceeds budget {}",
+        parentStats.getNumRows(), xprodRowThreshold, onlineBytes, noconditionalMaxBytes);
+    return false;
+  }
+
+  /**
    * Return result for getMapJoinConversion method.
    */
   public static class MapJoinConversion {
@@ -1299,14 +1327,21 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     boolean cartesianProductEdgeEnabled =
       HiveConf.getBoolVar(context.conf, HiveConf.ConfVars.TEZ_CARTESIAN_PRODUCT_EDGE_ENABLED);
     if (cartesianProductEdgeEnabled && !hasOuterJoin(joinOp) && isCrossProduct(joinOp)) {
+      final long xprodRowThreshold =
+          HiveConf.getIntVar(context.conf, HiveConf.ConfVars.XPROD_SMALL_TABLE_ROWS_THRESHOLD);
+      final long noconditionalBroadcastBudget =
+          HiveConf.getLongVar(context.conf, HiveConf.ConfVars.HIVE_CONVERT_JOIN_NOCONDITIONAL_TASK_THRESHOLD);
       for (int i = 0 ; i < joinOp.getParentOperators().size(); i ++) {
         if (i != bigTablePosition) {
           Statistics parentStats = joinOp.getParentOperators().get(i).getStatistics();
-          if (parentStats.getNumRows() >
-            HiveConf.getIntVar(context.conf, HiveConf.ConfVars.XPROD_SMALL_TABLE_ROWS_THRESHOLD)) {
-            // if any of smaller side is estimated to generate more than
-            // threshold rows we would disable mapjoin
-            return null;
+          if (parentStats.getNumRows() > xprodRowThreshold) {
+            // NDV-based filters often estimate a few rows on tiny lookups (e.g. 2 vs 1); row count
+            // alone can reject a safe broadcast. If estimated online size still fits the same
+            // unconditional map-join byte budget, allow conversion (same knob as noconditionaltask).
+            if (!crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(parentStats, xprodRowThreshold,
+                noconditionalBroadcastBudget)) {
+              return null;
+            }
           }
         }
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.optimizer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -36,6 +37,65 @@ import org.apache.hadoop.hive.ql.plan.Statistics;
 import org.junit.jupiter.api.Test;
 
 class TestConvertJoinMapJoin {
+
+  @Test
+  void crossProductByteFallback_allowsWhenOnlineSizeWithinBudget() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    Statistics stats = new Statistics(2L, 500L, 0L, 0L);
+    assertTrue(
+        converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 10_000_000L));
+  }
+
+  @Test
+  void crossProductByteFallback_rejectsWhenOnlineSizeExceedsBudget() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    Statistics stats = new Statistics(50_000L, 50_000_000L, 0L, 0L);
+    assertFalse(
+        converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 10_000_000L));
+  }
+
+  @Test
+  void crossProductByteFallback_rejectsWhenBudgetTooSmallForEstimatedSize() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    Statistics stats = new Statistics(2L, 500L, 0L, 0L);
+    assertFalse(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 1L));
+  }
+
+  /**
+   * NDV-driven filter selectivity can estimate a tiny lookup at ~2 rows / a few hundred bytes
+   * onlineDataSize when {@code hive.xprod.mapjoin.small.table.rows=1}. The row-only gate would
+   * reject the broadcast even though the build side is well below the noconditionaltask byte
+   * budget. The byte fallback must still admit map-join in that shape.
+   */
+  @Test
+  void crossProductByteFallback_twoRowsTinyOnlineSize() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    final long ndvDrivenRowEstimate = 2L;
+    final long tinyDataSizeBytes = 296L;
+    Statistics stats = new Statistics(ndvDrivenRowEstimate, tinyDataSizeBytes, 0L, 0L);
+    final long xprodRowThreshold = 1L;
+    final long noconditionalBudgetBytes = 10_000_000L;
+    assertTrue(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(
+        stats, xprodRowThreshold, noconditionalBudgetBytes));
+  }
+
+  /**
+   * Same small row estimate (2) as the previous case, but with bytes large enough that the build
+   * side exceeds the broadcast budget — the byte fallback must reject so the row-only cap still
+   * bites.
+   */
+  @Test
+  void crossProductByteFallback_rejectsTwoRowsWhenEstimatedPayloadExceedsBudget() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    Statistics stats = new Statistics(2L, 50_000_000L, 0L, 0L);
+    assertFalse(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(
+        stats, 1L, 10_000_000L));
+  }
 
   @Test
   void testComputeOnlineDataSizeGenericLargeDataSize() {

--- a/ql/src/test/results/clientpositive/llap/auto_join0.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join0.q.out
@@ -1,4 +1,4 @@
-Warning: Shuffle Join MERGEJOIN[24][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 3' is a cross product
+Warning: Map Join MAPJOIN[24][bigTable=?] in task 'Reducer 2' is a cross product
 PREHOOK: query: explain 
 select sum(hash(a.k1,a.v1,a.k2, a.v2))
 from (
@@ -34,10 +34,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (BROADCAST_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -72,38 +71,32 @@ STAGE PLANS:
                 expressions: KEY.reducesinkkey0 (type: string), KEY.reducesinkkey1 (type: string)
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: string), _col1 (type: string)
-        Reducer 3 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 27556 Data size: 9809936 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: hash(_col0,_col1,_col2,_col3) (type: int)
-                  outputColumnNames: _col0
+                Map Join Operator
+                  condition map:
+                       Inner Join 0 to 1
+                  keys:
+                    0 
+                    1 
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  input vertices:
+                    1 Reducer 4
                   Statistics: Num rows: 27556 Data size: 9809936 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    aggregations: sum(_col0)
-                    minReductionHashAggr: 0.99
-                    mode: hash
+                  Select Operator
+                    expressions: hash(_col0,_col1,_col2,_col3) (type: int)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
+                    Statistics: Num rows: 27556 Data size: 9809936 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: sum(_col0)
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: bigint)
-        Reducer 4 
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint)
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -118,7 +111,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -137,7 +130,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[24][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 3' is a cross product
+Warning: Map Join MAPJOIN[24][bigTable=?] in task 'Reducer 2' is a cross product
 PREHOOK: query: select sum(hash(a.k1,a.v1,a.k2, a.v2))
 from (
 SELECT src1.key as k1, src1.value as v1, 

--- a/ql/src/test/results/clientpositive/llap/auto_join23.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join23.q.out
@@ -1,4 +1,4 @@
-Warning: Shuffle Join MERGEJOIN[15][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[15][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain 
 SELECT  *  FROM src src1 JOIN src src2 WHERE src1.key < 10 and src2.key < 10 SORT BY src1.key, src1.value, src2.key, src2.value
 PREHOOK: type: QUERY
@@ -18,8 +18,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Map 1 <- Map 3 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -35,14 +35,24 @@ STAGE PLANS:
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string), _col1 (type: string)
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 
+                          1 
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Map 3
+                        Statistics: Num rows: 27556 Data size: 9809936 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string), _col1 (type: string), _col2 (type: string), _col3 (type: string)
+                          null sort order: zzzz
+                          sort order: ++++
+                          Statistics: Num rows: 27556 Data size: 9809936 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 4 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: src2
@@ -63,22 +73,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 27556 Data size: 9809936 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: string), _col1 (type: string), _col2 (type: string), _col3 (type: string)
-                  null sort order: zzzz
-                  sort order: ++++
-                  Statistics: Num rows: 27556 Data size: 9809936 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -99,7 +93,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[15][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[15][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: SELECT  *  FROM src src1 JOIN src src2 WHERE src1.key < 10 and src2.key < 10 SORT BY src1.key, src1.value, src2.key, src2.value
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src

--- a/ql/src/test/results/clientpositive/llap/cbo_rp_auto_join0.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_rp_auto_join0.q.out
@@ -1,4 +1,4 @@
-Warning: Shuffle Join MERGEJOIN[16][tables = [a:cbo_t1:cbo_t3, a:cbo_t2:cbo_t3]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[16][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain 
 select sum(hash(a.k1,a.v1,a.k2, a.v2))
 from (
@@ -34,8 +34,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Map 1 <- Map 3 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -51,14 +51,34 @@ STAGE PLANS:
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: key, value
                       Statistics: Num rows: 6 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 6 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: key (type: string), value (type: string)
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 
+                          1 
+                        outputColumnNames: key, value, key0, value0
+                        input vertices:
+                          1 Map 3
+                        Statistics: Num rows: 36 Data size: 12240 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: hash(key,value,key0,value0) (type: int)
+                          outputColumnNames: $f0
+                          Statistics: Num rows: 36 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                          Group By Operator
+                            aggregations: sum($f0)
+                            minReductionHashAggr: 0.9722222
+                            mode: hash
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            Reduce Output Operator
+                              null sort order: 
+                              sort order: 
+                              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                              value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 4 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: a:cbo_t2:cbo_t3
@@ -79,32 +99,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: key, value, key0, value0
-                Statistics: Num rows: 36 Data size: 12240 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: hash(key,value,key0,value0) (type: int)
-                  outputColumnNames: $f0
-                  Statistics: Num rows: 36 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    aggregations: sum($f0)
-                    minReductionHashAggr: 0.9722222
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: bigint)
-        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -126,7 +120,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[16][tables = [a:cbo_t1:cbo_t3, a:cbo_t2:cbo_t3]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[16][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain 
 select sum(hash(a.k1,a.v1,a.k2, a.v2))
 from (
@@ -162,8 +156,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Map 1 <- Map 3 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -179,14 +173,34 @@ STAGE PLANS:
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: key, value
                       Statistics: Num rows: 6 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 6 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: key (type: string), value (type: string)
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 
+                          1 
+                        outputColumnNames: key, value, key0, value0
+                        input vertices:
+                          1 Map 3
+                        Statistics: Num rows: 36 Data size: 12240 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: hash(key,value,key0,value0) (type: int)
+                          outputColumnNames: $f0
+                          Statistics: Num rows: 36 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                          Group By Operator
+                            aggregations: sum($f0)
+                            minReductionHashAggr: 0.9722222
+                            mode: hash
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            Reduce Output Operator
+                              null sort order: 
+                              sort order: 
+                              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                              value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 4 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: a:cbo_t2:cbo_t3
@@ -207,32 +221,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: key, value, key0, value0
-                Statistics: Num rows: 36 Data size: 12240 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: hash(key,value,key0,value0) (type: int)
-                  outputColumnNames: $f0
-                  Statistics: Num rows: 36 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    aggregations: sum($f0)
-                    minReductionHashAggr: 0.9722222
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: bigint)
-        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/cbo_rp_cross_product_check_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_rp_cross_product_check_2.q.out
@@ -40,7 +40,7 @@ POSTHOOK: Input: default@src
 POSTHOOK: Output: default@b_n14
 POSTHOOK: Lineage: b_n14.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
 POSTHOOK: Lineage: b_n14.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
-Warning: Shuffle Join MERGEJOIN[8][tables = [a_n18, b_n14]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[8][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain select * from A_n18 join B_n14
 PREHOOK: type: QUERY
 PREHOOK: Input: default@a_n18
@@ -60,7 +60,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -72,14 +72,26 @@ STAGE PLANS:
                     expressions: key (type: string), value (type: string)
                     outputColumnNames: key, value
                     Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: key (type: string), value (type: string)
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: key, value, key0, value0
+                      input vertices:
+                        1 Map 2
+                      Statistics: Num rows: 5000 Data size: 1770000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 5000 Data size: 1770000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: b_n14
@@ -95,24 +107,6 @@ STAGE PLANS:
                       value expressions: key (type: string), value (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: key, value, key0, value0
-                Statistics: Num rows: 5000 Data size: 1770000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 5000 Data size: 1770000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -120,7 +114,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[30][tables = [$hdt$_1, a_n18]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[30][bigTable=?] in task 'Map 3' is a cross product
 PREHOOK: query: explain select * from B_n14 d1 join B_n14 d2 on d1.key = d2.key join A_n18
 PREHOOK: type: QUERY
 PREHOOK: Input: default@a_n18
@@ -140,8 +134,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Map 3 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
+        Map 3 <- Map 1 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -166,7 +160,7 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: key, value, key0, value0
                         input vertices:
-                          1 Map 3
+                          1 Map 2
                         Statistics: Num rows: 20 Data size: 7040 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           null sort order: 
@@ -175,7 +169,7 @@ STAGE PLANS:
                           value expressions: key (type: string), value (type: string), key0 (type: string), value0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: d2
@@ -197,7 +191,7 @@ STAGE PLANS:
                         value expressions: value (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 4 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: a_n18
@@ -206,31 +200,25 @@ STAGE PLANS:
                     expressions: key (type: string), value (type: string)
                     outputColumnNames: key, value
                     Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: key (type: string), value (type: string)
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: key, value, key0, value0, key1, value1
+                      input vertices:
+                        0 Map 1
+                      Statistics: Num rows: 10000 Data size: 5300000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 10000 Data size: 5300000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: key, value, key0, value0, key1, value1
-                Statistics: Num rows: 10000 Data size: 5300000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 10000 Data size: 5300000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -238,7 +226,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[34][tables = [a_n18, ]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[34][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain select * from A_n18 join 
          (select d1.key 
           from B_n14 d1 join B_n14 d2 on d1.key = d2.key 
@@ -264,8 +252,145 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 3 <- Map 5 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Map 1 <- Reducer 3 (BROADCAST_EDGE)
+        Map 2 <- Map 4 (BROADCAST_EDGE)
+        Reducer 3 <- Map 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a_n18
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: key, value
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: key, value, key0
+                      input vertices:
+                        1 Reducer 3
+                      Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: od1:d1
+                  filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
+                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: key
+                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 key (type: string)
+                          1 key (type: string)
+                        outputColumnNames: key
+                        input vertices:
+                          1 Map 4
+                        Statistics: Num rows: 20 Data size: 1720 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: key (type: string)
+                          outputColumnNames: key
+                          Statistics: Num rows: 20 Data size: 1720 Basic stats: COMPLETE Column stats: COMPLETE
+                          Group By Operator
+                            keys: key (type: string)
+                            minReductionHashAggr: 0.75
+                            mode: hash
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                            Reduce Output Operator
+                              key expressions: _col0 (type: string)
+                              null sort order: z
+                              sort order: +
+                              Map-reduce partition columns: _col0 (type: string)
+                              Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: od1:d2
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: key
+                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: key (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: key (type: string)
+                        Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: key
+                Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: key (type: string)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Map Join MAPJOIN[17][bigTable=?] in task 'Map 3' is a cross product
+Warning: Map Join MAPJOIN[18][bigTable=?] in task 'Map 1' is a cross product
+PREHOOK: query: explain select * from A_n18 join (select d1.key from B_n14 d1 join B_n14 d2 where 1 = 1 group by d1.key) od1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@a_n18
+PREHOOK: Input: default@b_n14
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from A_n18 join (select d1.key from B_n14 d1 join B_n14 d2 where 1 = 1 group by d1.key) od1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@a_n18
+POSTHOOK: Input: default@b_n14
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Reducer 4 (BROADCAST_EDGE)
+        Map 3 <- Map 2 (BROADCAST_EDGE)
         Reducer 4 <- Map 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -278,11 +403,146 @@ STAGE PLANS:
                     expressions: key (type: string), value (type: string)
                     outputColumnNames: key, value
                     Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: key, value, key0
+                      input vertices:
+                        1 Reducer 4
+                      Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: od1:d1
+                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string)
+                    outputColumnNames: key
+                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       null sort order: 
                       sort order: 
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: key (type: string), value (type: string)
+                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: key (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: od1:d2
+                  Statistics: Num rows: 10 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 10 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: key
+                      input vertices:
+                        0 Map 2
+                      Statistics: Num rows: 100 Data size: 8600 Basic stats: COMPLETE Column stats: COMPLETE
+                      Select Operator
+                        expressions: key (type: string)
+                        outputColumnNames: key
+                        Statistics: Num rows: 100 Data size: 8600 Basic stats: COMPLETE Column stats: COMPLETE
+                        Group By Operator
+                          keys: key (type: string)
+                          minReductionHashAggr: 0.95
+                          mode: hash
+                          outputColumnNames: _col0
+                          Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            key expressions: _col0 (type: string)
+                            null sort order: z
+                            sort order: +
+                            Map-reduce partition columns: _col0 (type: string)
+                            Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: key
+                Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: key (type: string)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Map Join MAPJOIN[37][bigTable=?] in task 'Reducer 2' is a cross product
+PREHOOK: query: explain select * from 
+(select A_n18.key from A_n18 group by key) ss join 
+(select d1.key from B_n14 d1 join B_n14 d2 on d1.key = d2.key where 1 = 1 group by d1.key) od1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@a_n18
+PREHOOK: Input: default@b_n14
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from 
+(select A_n18.key from A_n18 group by key) ss join 
+(select d1.key from B_n14 d1 join B_n14 d2 on d1.key = d2.key where 1 = 1 group by d1.key) od1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@a_n18
+POSTHOOK: Input: default@b_n14
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 3 <- Map 5 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (BROADCAST_EDGE)
+        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ss:a_n18
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string)
+                    outputColumnNames: key
+                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: key (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 3 
@@ -290,7 +550,7 @@ STAGE PLANS:
                 TableScan
                   alias: od1:d1
                   filterExpr: key is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_36_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -349,296 +609,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: key, value, key0
-                Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: key
-                Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: key (type: string)
-
-  Stage: Stage-0
-    Fetch Operator
-      limit: -1
-      Processor Tree:
-        ListSink
-
-Warning: Shuffle Join MERGEJOIN[17][tables = [od1:d1, od1:d2]] in Stage 'Reducer 4' is a cross product
-Warning: Shuffle Join MERGEJOIN[18][tables = [a_n18, ]] in Stage 'Reducer 2' is a cross product
-PREHOOK: query: explain select * from A_n18 join (select d1.key from B_n14 d1 join B_n14 d2 where 1 = 1 group by d1.key) od1
-PREHOOK: type: QUERY
-PREHOOK: Input: default@a_n18
-PREHOOK: Input: default@b_n14
-#### A masked pattern was here ####
-POSTHOOK: query: explain select * from A_n18 join (select d1.key from B_n14 d1 join B_n14 d2 where 1 = 1 group by d1.key) od1
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@a_n18
-POSTHOOK: Input: default@b_n14
-#### A masked pattern was here ####
-STAGE DEPENDENCIES:
-  Stage-1 is a root stage
-  Stage-0 depends on stages: Stage-1
-
-STAGE PLANS:
-  Stage: Stage-1
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 4 <- Map 3 (XPROD_EDGE), Map 6 (XPROD_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: a_n18
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: key (type: string), value (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: od1:d1
-                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: key (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: od1:d2
-                  Statistics: Num rows: 10 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 10 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 10 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: key, value, key0
-                Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: key
-                Statistics: Num rows: 100 Data size: 8600 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: key (type: string)
-                  outputColumnNames: key
-                  Statistics: Num rows: 100 Data size: 8600 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    keys: key (type: string)
-                    minReductionHashAggr: 0.95
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: key
-                Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: key (type: string)
-
-  Stage: Stage-0
-    Fetch Operator
-      limit: -1
-      Processor Tree:
-        ListSink
-
-Warning: Shuffle Join MERGEJOIN[37][tables = [, ]] in Stage 'Reducer 3' is a cross product
-PREHOOK: query: explain select * from 
-(select A_n18.key from A_n18 group by key) ss join 
-(select d1.key from B_n14 d1 join B_n14 d2 on d1.key = d2.key where 1 = 1 group by d1.key) od1
-PREHOOK: type: QUERY
-PREHOOK: Input: default@a_n18
-PREHOOK: Input: default@b_n14
-#### A masked pattern was here ####
-POSTHOOK: query: explain select * from 
-(select A_n18.key from A_n18 group by key) ss join 
-(select d1.key from B_n14 d1 join B_n14 d2 on d1.key = d2.key where 1 = 1 group by d1.key) od1
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@a_n18
-POSTHOOK: Input: default@b_n14
-#### A masked pattern was here ####
-STAGE DEPENDENCIES:
-  Stage-1 is a root stage
-  Stage-0 depends on stages: Stage-1
-
-STAGE PLANS:
-  Stage: Stage-1
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Map 4 <- Map 6 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: ss:a_n18
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: od1:d1
-                  filterExpr: key is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_36_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
-                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: key
-                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 key (type: string)
-                          1 key (type: string)
-                        outputColumnNames: key
-                        input vertices:
-                          1 Map 6
-                        Statistics: Num rows: 20 Data size: 1720 Basic stats: COMPLETE Column stats: COMPLETE
-                        Select Operator
-                          expressions: key (type: string)
-                          outputColumnNames: key
-                          Statistics: Num rows: 20 Data size: 1720 Basic stats: COMPLETE Column stats: COMPLETE
-                          Group By Operator
-                            keys: key (type: string)
-                            minReductionHashAggr: 0.75
-                            mode: hash
-                            outputColumnNames: _col0
-                            Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                            Reduce Output Operator
-                              key expressions: _col0 (type: string)
-                              null sort order: z
-                              sort order: +
-                              Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: od1:d2
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: key
-                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: key (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: key (type: string)
-                        Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -646,30 +616,24 @@ STAGE PLANS:
                 mode: mergepartial
                 outputColumnNames: key
                 Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: key (type: string)
-        Reducer 3 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: key, key0
-                Statistics: Num rows: 1580 Data size: 273340 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
+                Map Join Operator
+                  condition map:
+                       Inner Join 0 to 1
+                  keys:
+                    0 
+                    1 
+                  outputColumnNames: key, key0
+                  input vertices:
+                    1 Reducer 4
                   Statistics: Num rows: 1580 Data size: 273340 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1580 Data size: 273340 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/cross_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/cross_join.q.out
@@ -235,7 +235,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Map 2' is a cross product
 PREHOOK: query: explain select src.key from src join src src2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -253,7 +253,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 2 <- Map 1 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -272,37 +272,32 @@ STAGE PLANS:
                       value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: src2
                   Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 500 Data size: 4000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 500 Data size: 4000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col0
+                      input vertices:
+                        0 Map 1
+                      Statistics: Num rows: 250000 Data size: 21750000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 250000 Data size: 21750000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0
-                Statistics: Num rows: 250000 Data size: 21750000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 250000 Data size: 21750000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -310,7 +305,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Map 2' is a cross product
 PREHOOK: query: explain select src.key from src cross join src src2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -328,7 +323,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 2 <- Map 1 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -347,37 +342,32 @@ STAGE PLANS:
                       value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: src2
                   Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 500 Data size: 4000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 500 Data size: 4000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col0
+                      input vertices:
+                        0 Map 1
+                      Statistics: Num rows: 250000 Data size: 21750000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 250000 Data size: 21750000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0
-                Statistics: Num rows: 250000 Data size: 21750000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 250000 Data size: 21750000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/cross_prod_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/cross_prod_4.q.out
@@ -12,7 +12,7 @@ POSTHOOK: Output: database:default
 POSTHOOK: Output: default@X_n1
 POSTHOOK: Lineage: x_n1.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
 POSTHOOK: Lineage: x_n1.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
-Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain select * from X_n1 as A, X_n1 as B
 PREHOOK: type: QUERY
 PREHOOK: Input: default@x_n1
@@ -30,7 +30,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -42,14 +42,26 @@ STAGE PLANS:
                     expressions: key (type: string), value (type: string)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: string), _col1 (type: string)
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      input vertices:
+                        1 Map 2
+                      Statistics: Num rows: 100 Data size: 35600 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 100 Data size: 35600 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: b
@@ -65,24 +77,6 @@ STAGE PLANS:
                       value expressions: _col0 (type: string), _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 100 Data size: 35600 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 100 Data size: 35600 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -90,7 +84,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[11][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[11][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: select * from X_n1 as A, X_n1 as B order by A.key, B.key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@x_n1

--- a/ql/src/test/results/clientpositive/llap/cross_product_check_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/cross_product_check_2.q.out
@@ -28,7 +28,7 @@ POSTHOOK: Output: database:default
 POSTHOOK: Output: default@B_n2
 POSTHOOK: Lineage: b_n2.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
 POSTHOOK: Lineage: b_n2.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
-Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain select * from A_n2 join B_n2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@a_n2
@@ -48,7 +48,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -60,14 +60,26 @@ STAGE PLANS:
                     expressions: key (type: string), value (type: string)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: string), _col1 (type: string)
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      input vertices:
+                        1 Map 2
+                      Statistics: Num rows: 5000 Data size: 1770000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 5000 Data size: 1770000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: b_n2
@@ -83,24 +95,6 @@ STAGE PLANS:
                       value expressions: _col0 (type: string), _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 5000 Data size: 1770000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 5000 Data size: 1770000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -108,7 +102,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[31][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[31][bigTable=?] in task 'Map 3' is a cross product
 PREHOOK: query: explain select * from B_n2 d1 join B_n2 d2 on d1.key = d2.key join A_n2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@a_n2
@@ -128,8 +122,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Map 3 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
+        Map 3 <- Map 1 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -154,7 +148,7 @@ STAGE PLANS:
                           1 _col0 (type: string)
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
-                          1 Map 3
+                          1 Map 2
                         Statistics: Num rows: 20 Data size: 7040 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           null sort order: 
@@ -163,7 +157,7 @@ STAGE PLANS:
                           value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: string), _col3 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: d2
@@ -185,7 +179,7 @@ STAGE PLANS:
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 4 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: a_n2
@@ -194,31 +188,25 @@ STAGE PLANS:
                     expressions: key (type: string), value (type: string)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: string), _col1 (type: string)
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                      input vertices:
+                        0 Map 1
+                      Statistics: Num rows: 10000 Data size: 5300000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 10000 Data size: 5300000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 10000 Data size: 5300000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 10000 Data size: 5300000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -226,7 +214,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[36][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[36][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain select * from A_n2 join 
          (select d1.key 
           from B_n2 d1 join B_n2 d2 on d1.key = d2.key 
@@ -252,8 +240,141 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 3 <- Map 5 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Map 1 <- Reducer 3 (BROADCAST_EDGE)
+        Map 2 <- Map 4 (BROADCAST_EDGE)
+        Reducer 3 <- Map 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a_n2
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col0, _col1, _col2
+                      input vertices:
+                        1 Reducer 3
+                      Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: d1
+                  filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_35_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.5
+                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: string)
+                          1 _col0 (type: string)
+                        outputColumnNames: _col0
+                        input vertices:
+                          1 Map 4
+                        Statistics: Num rows: 20 Data size: 1720 Basic stats: COMPLETE Column stats: COMPLETE
+                        Group By Operator
+                          keys: _col0 (type: string)
+                          minReductionHashAggr: 0.75
+                          mode: hash
+                          outputColumnNames: _col0
+                          Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            key expressions: _col0 (type: string)
+                            null sort order: z
+                            sort order: +
+                            Map-reduce partition columns: _col0 (type: string)
+                            Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: d2
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: string)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Map Join MAPJOIN[19][bigTable=?] in task 'Map 3' is a cross product
+Warning: Map Join MAPJOIN[20][bigTable=?] in task 'Map 1' is a cross product
+PREHOOK: query: explain select * from A_n2 join (select d1.key from B_n2 d1 join B_n2 d2 where 1 = 1 group by d1.key) od1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@a_n2
+PREHOOK: Input: default@b_n2
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from A_n2 join (select d1.key from B_n2 d1 join B_n2 d2 where 1 = 1 group by d1.key) od1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@a_n2
+POSTHOOK: Input: default@b_n2
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Reducer 4 (BROADCAST_EDGE)
+        Map 3 <- Map 2 (BROADCAST_EDGE)
         Reducer 4 <- Map 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -266,11 +387,142 @@ STAGE PLANS:
                     expressions: key (type: string), value (type: string)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col0, _col1, _col2
+                      input vertices:
+                        1 Reducer 4
+                      Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: d1
+                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       null sort order: 
                       sort order: 
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: string), _col1 (type: string)
+                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: d2
+                  Statistics: Num rows: 10 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 10 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col0
+                      input vertices:
+                        0 Map 2
+                      Statistics: Num rows: 100 Data size: 8600 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.95
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: string)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Map Join MAPJOIN[40][bigTable=?] in task 'Reducer 2' is a cross product
+PREHOOK: query: explain select * from 
+(select A_n2.key from A_n2 group by key) ss join 
+(select d1.key from B_n2 d1 join B_n2 d2 on d1.key = d2.key where 1 = 1 group by d1.key) od1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@a_n2
+PREHOOK: Input: default@b_n2
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from 
+(select A_n2.key from A_n2 group by key) ss join 
+(select d1.key from B_n2 d1 join B_n2 d2 on d1.key = d2.key where 1 = 1 group by d1.key) od1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@a_n2
+POSTHOOK: Input: default@b_n2
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 3 <- Map 5 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (BROADCAST_EDGE)
+        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a_n2
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string)
+                    outputColumnNames: key
+                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: key (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 3 
@@ -278,7 +530,7 @@ STAGE PLANS:
                 TableScan
                   alias: d1
                   filterExpr: key is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_35_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.5
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_39_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.5
                   Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -333,288 +585,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: string)
-
-  Stage: Stage-0
-    Fetch Operator
-      limit: -1
-      Processor Tree:
-        ListSink
-
-Warning: Shuffle Join MERGEJOIN[19][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
-Warning: Shuffle Join MERGEJOIN[20][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-PREHOOK: query: explain select * from A_n2 join (select d1.key from B_n2 d1 join B_n2 d2 where 1 = 1 group by d1.key) od1
-PREHOOK: type: QUERY
-PREHOOK: Input: default@a_n2
-PREHOOK: Input: default@b_n2
-#### A masked pattern was here ####
-POSTHOOK: query: explain select * from A_n2 join (select d1.key from B_n2 d1 join B_n2 d2 where 1 = 1 group by d1.key) od1
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@a_n2
-POSTHOOK: Input: default@b_n2
-#### A masked pattern was here ####
-STAGE DEPENDENCIES:
-  Stage-1 is a root stage
-  Stage-0 depends on stages: Stage-1
-
-STAGE PLANS:
-  Stage: Stage-1
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 4 <- Map 3 (XPROD_EDGE), Map 6 (XPROD_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: a_n2
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: d1
-                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: d2
-                  Statistics: Num rows: 10 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 10 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 10 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 2500 Data size: 660000 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0
-                Statistics: Num rows: 100 Data size: 8600 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  keys: _col0 (type: string)
-                  minReductionHashAggr: 0.95
-                  mode: hash
-                  outputColumnNames: _col0
-                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: string)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: string)
-                    Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: string)
-
-  Stage: Stage-0
-    Fetch Operator
-      limit: -1
-      Processor Tree:
-        ListSink
-
-Warning: Shuffle Join MERGEJOIN[40][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 3' is a cross product
-PREHOOK: query: explain select * from 
-(select A_n2.key from A_n2 group by key) ss join 
-(select d1.key from B_n2 d1 join B_n2 d2 on d1.key = d2.key where 1 = 1 group by d1.key) od1
-PREHOOK: type: QUERY
-PREHOOK: Input: default@a_n2
-PREHOOK: Input: default@b_n2
-#### A masked pattern was here ####
-POSTHOOK: query: explain select * from 
-(select A_n2.key from A_n2 group by key) ss join 
-(select d1.key from B_n2 d1 join B_n2 d2 on d1.key = d2.key where 1 = 1 group by d1.key) od1
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@a_n2
-POSTHOOK: Input: default@b_n2
-#### A masked pattern was here ####
-STAGE DEPENDENCIES:
-  Stage-1 is a root stage
-  Stage-0 depends on stages: Stage-1
-
-STAGE PLANS:
-  Stage: Stage-1
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Map 4 <- Map 6 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: a_n2
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: d1
-                  filterExpr: key is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_39_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.5
-                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 _col0 (type: string)
-                          1 _col0 (type: string)
-                        outputColumnNames: _col0
-                        input vertices:
-                          1 Map 6
-                        Statistics: Num rows: 20 Data size: 1720 Basic stats: COMPLETE Column stats: COMPLETE
-                        Group By Operator
-                          keys: _col0 (type: string)
-                          minReductionHashAggr: 0.75
-                          mode: hash
-                          outputColumnNames: _col0
-                          Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-                          Reduce Output Operator
-                            key expressions: _col0 (type: string)
-                            null sort order: z
-                            sort order: +
-                            Map-reduce partition columns: _col0 (type: string)
-                            Statistics: Num rows: 5 Data size: 430 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: d2
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -622,30 +592,24 @@ STAGE PLANS:
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: string)
-        Reducer 3 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1580 Data size: 273340 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
+                Map Join Operator
+                  condition map:
+                       Inner Join 0 to 1
+                  keys:
+                    0 
+                    1 
+                  outputColumnNames: _col0, _col1
+                  input vertices:
+                    1 Reducer 4
                   Statistics: Num rows: 1580 Data size: 273340 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1580 Data size: 273340 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/dynamic_partition_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_partition_pruning.q.out
@@ -5576,7 +5576,7 @@ POSTHOOK: Input: default@srcpart@ds=2008-04-08/hr=11
 POSTHOOK: Input: default@srcpart@ds=2008-04-09/hr=11
 #### A masked pattern was here ####
 1000
-Warning: Shuffle Join MERGEJOIN[22][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[22][bigTable=?] in task 'Reducer 3' is a cross product
 PREHOOK: query: EXPLAIN select count(*) from srcpart join (select ds as ds, ds as `date` from srcpart group by ds) s on (srcpart.ds = s.ds) where s.`date` = '2008-04-08'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@srcpart
@@ -5598,9 +5598,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (BROADCAST_EDGE)
+        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -5632,25 +5632,42 @@ STAGE PLANS:
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                Statistics: Num rows: 500000 Data size: 11124000 Basic stats: COMPLETE Column stats: NONE
-                Group By Operator
-                  aggregations: count()
-                  minReductionHashAggr: 0.99
-                  mode: hash
-                  outputColumnNames: _col0
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                    value expressions: _col0 (type: bigint)
+              Select Operator
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1000 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
         Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: boolean)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
+                  Map Join Operator
+                    condition map:
+                         Inner Join 0 to 1
+                    keys:
+                      0 
+                      1 
+                    input vertices:
+                      0 Reducer 2
+                    Statistics: Num rows: 500000 Data size: 11124000 Basic stats: COMPLETE Column stats: NONE
+                    Group By Operator
+                      aggregations: count()
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: bigint)
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
@@ -5665,20 +5682,6 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: boolean)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
 
   Stage: Stage-0
     Fetch Operator
@@ -5686,7 +5689,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[22][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[22][bigTable=?] in task 'Reducer 3' is a cross product
 PREHOOK: query: select count(*) from srcpart join (select ds as ds, ds as `date` from srcpart group by ds) s on (srcpart.ds = s.ds) where s.`date` = '2008-04-08'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@srcpart

--- a/ql/src/test/results/clientpositive/llap/dynamic_partition_pruning_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_partition_pruning_2.q.out
@@ -612,7 +612,7 @@ bar
 baz
 baz
 baz
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 2' is a cross product
 PREHOOK: query: EXPLAIN SELECT agg.amount
 FROM agg_01 agg,
 dim_shops d1
@@ -642,7 +642,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 2 <- Map 1 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -662,7 +662,7 @@ STAGE PLANS:
                       value expressions: _col0 (type: decimal(10,0))
             Execution mode: llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: d1
@@ -673,30 +673,25 @@ STAGE PLANS:
                     Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: NONE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 
+                          1 
+                        outputColumnNames: _col0
+                        input vertices:
+                          0 Map 1
+                        Statistics: Num rows: 9 Data size: 1053 Basic stats: COMPLETE Column stats: NONE
+                        File Output Operator
+                          compressed: false
+                          Statistics: Num rows: 9 Data size: 1053 Basic stats: COMPLETE Column stats: NONE
+                          table:
+                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0
-                Statistics: Num rows: 9 Data size: 1053 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 9 Data size: 1053 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -704,7 +699,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[15][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[15][bigTable=?] in task 'Map 2' is a cross product
 PREHOOK: query: SELECT agg.amount
 FROM agg_01 agg,
 dim_shops d1

--- a/ql/src/test/results/clientpositive/llap/explainuser_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/explainuser_1.q.out
@@ -271,7 +271,7 @@ POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@src_orc_merge_test_part_n1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@src_orc_merge_test_part_n1
-Warning: Shuffle Join MERGEJOIN[18][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[18][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain select sum(hash(a.k1,a.v1,a.k2, a.v2))
 from (
 select src1.key as k1, src1.value as v1, 
@@ -299,41 +299,39 @@ POSTHOOK: Input: default@src
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
-Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+Map 1 <- Map 3 (BROADCAST_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
     limit:-1
     Stage-1
-      Reducer 3 llap
+      Reducer 2 llap
       File Output Operator [FS_15]
         Group By Operator [GBY_13] (rows=1 width=8)
           Output:["_col0"],aggregations:["sum(VALUE._col0)"]
-        <-Reducer 2 [CUSTOM_SIMPLE_EDGE] llap
+        <-Map 1 [CUSTOM_SIMPLE_EDGE] llap
           PARTITION_ONLY_SHUFFLE [RS_12]
             Group By Operator [GBY_11] (rows=1 width=8)
               Output:["_col0"],aggregations:["sum(_col0)"]
               Select Operator [SEL_9] (rows=27556 width=356)
                 Output:["_col0"]
-                Merge Join Operator [MERGEJOIN_18] (rows=27556 width=356)
+                Map Join Operator [MAPJOIN_18] (rows=27556 width=356)
                   Conds:(Inner),Output:["_col0","_col1","_col2","_col3"]
-                <-Map 1 [XPROD_EDGE] llap
-                  XPROD_EDGE [RS_6]
-                    Select Operator [SEL_2] (rows=166 width=178)
-                      Output:["_col0","_col1"]
-                      Filter Operator [FIL_16] (rows=166 width=178)
-                        predicate:(UDFToDouble(key) < 10.0D)
-                        TableScan [TS_0] (rows=500 width=178)
-                          default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                <-Map 4 [XPROD_EDGE] llap
-                  XPROD_EDGE [RS_7]
+                <-Map 3 [BROADCAST_EDGE] llap
+                  BROADCAST [RS_7]
                     Select Operator [SEL_5] (rows=166 width=178)
                       Output:["_col0","_col1"]
                       Filter Operator [FIL_17] (rows=166 width=178)
                         predicate:(UDFToDouble(key) < 10.0D)
                         TableScan [TS_3] (rows=500 width=178)
                           default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                <-Select Operator [SEL_2] (rows=166 width=178)
+                    Output:["_col0","_col1"]
+                    Filter Operator [FIL_16] (rows=166 width=178)
+                      predicate:(UDFToDouble(key) < 10.0D)
+                      TableScan [TS_0] (rows=500 width=178)
+                        default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
 
 PREHOOK: query: explain select key, (c_int+1)+2 as x, sum(c_int) from cbo_t1 group by c_float, cbo_t1.c_int, key
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_1.q.out
@@ -1384,7 +1384,7 @@ POSTHOOK: Lineage: decimal_mapjoin.cdecimal1 EXPRESSION [(alltypesorc)alltypesor
 POSTHOOK: Lineage: decimal_mapjoin.cdecimal2 EXPRESSION [(alltypesorc)alltypesorc.FieldSchema(name:cdouble, type:double, comment:null), ]
 POSTHOOK: Lineage: decimal_mapjoin.cdouble SIMPLE [(alltypesorc)alltypesorc.FieldSchema(name:cdouble, type:double, comment:null), ]
 POSTHOOK: Lineage: decimal_mapjoin.cint SIMPLE [(alltypesorc)alltypesorc.FieldSchema(name:cint, type:int, comment:null), ]
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: EXPLAIN SELECT l.cint, r.cint, l.cdecimal1, r.cdecimal2
   FROM decimal_mapjoin l
   JOIN decimal_mapjoin r ON l.cint = r.cint
@@ -1408,7 +1408,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1424,14 +1424,30 @@ STAGE PLANS:
                       expressions: cdecimal1 (type: decimal(20,10))
                       outputColumnNames: _col0
                       Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: decimal(20,10))
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 
+                          1 
+                        outputColumnNames: _col0, _col1
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: 6981 (type: int), 6981 (type: int), _col0 (type: decimal(20,10)), _col1 (type: decimal(23,14))
+                          outputColumnNames: _col0, _col1, _col2, _col3
+                          Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: r
@@ -1451,28 +1467,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: decimal(23,14))
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: 6981 (type: int), 6981 (type: int), _col0 (type: decimal(20,10)), _col1 (type: decimal(23,14))
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -1480,7 +1474,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: SELECT l.cint, r.cint, l.cdecimal1, r.cdecimal2
   FROM decimal_mapjoin l
   JOIN decimal_mapjoin r ON l.cint = r.cint
@@ -1496,6 +1490,8 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@decimal_mapjoin
 #### A masked pattern was here ####
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1503,9 +1499,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1513,9 +1509,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1523,9 +1519,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1533,9 +1529,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	5831542.2692483780	NULL
+6981	6981	5831542.2692483780	-617.56077692307690
+6981	6981	5831542.2692483780	-617.56077692307690
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
@@ -1543,9 +1539,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
-6981	6981	5831542.2692483780	-617.56077692307690
-6981	6981	5831542.2692483780	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1553,9 +1549,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1563,9 +1559,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1573,9 +1569,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	-515.6210729730	NULL
+6981	6981	-515.6210729730	-617.56077692307690
+6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
@@ -1583,9 +1579,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
-6981	6981	-515.6210729730	-617.56077692307690
-6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
+6981	6981	-515.6210729730	-617.56077692307690
+6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
@@ -1593,9 +1589,7 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
-6981	6981	-515.6210729730	-617.56077692307690
-6981	6981	-515.6210729730	-617.56077692307690
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: EXPLAIN SELECT l.cint, r.cint, l.cdecimal1, r.cdecimal2
   FROM decimal_mapjoin l
   JOIN decimal_mapjoin r ON l.cint = r.cint
@@ -1619,7 +1613,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1635,14 +1629,30 @@ STAGE PLANS:
                       expressions: cdecimal1 (type: decimal(20,10))
                       outputColumnNames: _col0
                       Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: decimal(20,10))
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 
+                          1 
+                        outputColumnNames: _col0, _col1
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: 6981 (type: int), 6981 (type: int), _col0 (type: decimal(20,10)), _col1 (type: decimal(23,14))
+                          outputColumnNames: _col0, _col1, _col2, _col3
+                          Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: r
@@ -1662,28 +1672,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: decimal(23,14))
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: 6981 (type: int), 6981 (type: int), _col0 (type: decimal(20,10)), _col1 (type: decimal(23,14))
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -1691,7 +1679,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: SELECT l.cint, r.cint, l.cdecimal1, r.cdecimal2
   FROM decimal_mapjoin l
   JOIN decimal_mapjoin r ON l.cint = r.cint
@@ -1707,6 +1695,8 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@decimal_mapjoin
 #### A masked pattern was here ####
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1714,9 +1704,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1724,9 +1714,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1734,9 +1724,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1744,9 +1734,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	5831542.2692483780	NULL
+6981	6981	5831542.2692483780	-617.56077692307690
+6981	6981	5831542.2692483780	-617.56077692307690
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
@@ -1754,9 +1744,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
-6981	6981	5831542.2692483780	-617.56077692307690
-6981	6981	5831542.2692483780	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1764,9 +1754,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1774,9 +1764,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1784,9 +1774,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	-515.6210729730	NULL
+6981	6981	-515.6210729730	-617.56077692307690
+6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
@@ -1794,9 +1784,9 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
-6981	6981	-515.6210729730	-617.56077692307690
-6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
+6981	6981	-515.6210729730	-617.56077692307690
+6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
@@ -1804,8 +1794,6 @@ POSTHOOK: Input: default@decimal_mapjoin
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
-6981	6981	-515.6210729730	-617.56077692307690
-6981	6981	-515.6210729730	-617.56077692307690
 PREHOOK: query: DROP TABLE decimal_mapjoin
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@decimal_mapjoin

--- a/ql/src/test/results/clientpositive/llap/orc_llap.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_llap.q.out
@@ -127,7 +127,7 @@ POSTHOOK: Output: default@orc_llap_small
 POSTHOOK: Lineage: orc_llap_small.cint SIMPLE [(alltypesorc)alltypesorc.FieldSchema(name:cint, type:int, comment:null), ]
 POSTHOOK: Lineage: orc_llap_small.csmallint SIMPLE [(alltypesorc)alltypesorc.FieldSchema(name:csmallint, type:smallint, comment:null), ]
 POSTHOOK: Lineage: orc_llap_small.ctinyint SIMPLE [(alltypesorc)alltypesorc.FieldSchema(name:ctinyint, type:tinyint, comment:null), ]
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: explain
 select count(1) from orc_llap_small y join orc_llap_small x
 PREHOOK: type: QUERY
@@ -147,8 +147,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Map 1 <- Map 3 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -158,13 +158,29 @@ STAGE PLANS:
                   Statistics: Num rows: 15 Data size: 180 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 15 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 15 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      input vertices:
+                        1 Map 3
+                      Statistics: Num rows: 225 Data size: 1800 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        minReductionHashAggr: 0.99
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 4 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: x
@@ -178,27 +194,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                Statistics: Num rows: 225 Data size: 1800 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count()
-                  minReductionHashAggr: 0.99
-                  mode: hash
-                  outputColumnNames: _col0
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: bigint)
-        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -220,7 +215,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: select count(1) from orc_llap_small y join orc_llap_small x
 PREHOOK: type: QUERY
 PREHOOK: Input: default@orc_llap_small
@@ -705,7 +700,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@orc_llap
 #### A masked pattern was here ####
 -735462183586256
-Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[17][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: insert into table orc_llap
 select ctinyint + i, csmallint + i, cint + i, cbigint + i, cfloat + i, cdouble + i, cstring1, cstring2, ctimestamp1, ctimestamp2, cboolean1, cboolean2
 from alltypesorc cross join cross_numbers

--- a/ql/src/test/results/clientpositive/llap/vector_between_columns.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_between_columns.q.out
@@ -164,7 +164,7 @@ OVERWRITE INTO TABLE test_orc_ppd
 POSTHOOK: type: LOAD
 #### A masked pattern was here ####
 POSTHOOK: Output: default@test_orc_ppd
-Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Map 2' is a cross product
 PREHOOK: query: explain vectorization expression
 select tint.rnum, tsint.rnum, tint.cint, tsint.csint, (case when (tint.cint between tsint.csint and tsint.csint) then "Ok" else "NoOk" end) as between_col from tint , tsint
 PREHOOK: type: QUERY
@@ -191,7 +191,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 2 <- Map 1 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -229,7 +229,7 @@ STAGE PLANS:
                 allNative: true
                 usesVectorUDFAdaptor: false
                 vectorized: true
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: tsint
@@ -244,15 +244,40 @@ STAGE PLANS:
                         native: true
                         projectedOutputColumnNums: [0, 1, 1]
                     Statistics: Num rows: 6 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Reduce Sink Vectorization:
-                          className: VectorReduceSinkEmptyKeyOperator
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      Map Join Vectorization:
+                          className: VectorMapJoinInnerMultiKeyOperator
                           native: true
-                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                      Statistics: Num rows: 6 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: smallint), _col2 (type: int)
+                          nativeConditionsMet: hive.mapjoin.optimized.hashtable IS true, hive.vectorized.execution.mapjoin.native.enabled IS true, hive.execution.engine tez IN [tez] IS true, One MapJoin Condition IS true, No nullsafe IS true, Small table vectorizes IS true, Optimized Table and Supports Key Types IS true
+                          hashTableImplementationType: OPTIMIZED
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                      input vertices:
+                        0 Map 1
+                      Statistics: Num rows: 36 Data size: 708 Basic stats: COMPLETE Column stats: COMPLETE
+                      Select Operator
+                        expressions: _col0 (type: int), _col2 (type: int), _col1 (type: int), _col3 (type: smallint), if(_col4 BETWEEN _col1 AND _col1, 'Ok', 'NoOk') (type: string)
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                        Select Vectorization:
+                            className: VectorSelectOperator
+                            native: true
+                            projectedOutputColumnNums: [4, 0, 5, 1, 7]
+                            selectExpressions: IfExprStringScalarStringScalar(col 6:boolean, val Ok, val NoOk)(children: VectorUDFAdaptor(_col4 BETWEEN _col1 AND _col1) -> 6:boolean) -> 7:string
+                        Statistics: Num rows: 36 Data size: 3736 Basic stats: COMPLETE Column stats: COMPLETE
+                        File Output Operator
+                          compressed: false
+                          File Sink Vectorization:
+                              className: VectorFileSinkOperator
+                              native: false
+                          Statistics: Num rows: 36 Data size: 3736 Basic stats: COMPLETE Column stats: COMPLETE
+                          table:
+                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -261,34 +286,9 @@ STAGE PLANS:
                 inputFormatFeatureSupport: [DECIMAL_64]
                 featureSupportInUse: [DECIMAL_64]
                 inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
+                allNative: false
+                usesVectorUDFAdaptor: true
                 vectorized: true
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 36 Data size: 708 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), _col2 (type: int), _col1 (type: int), _col3 (type: smallint), if(_col4 BETWEEN _col1 AND _col1, 'Ok', 'NoOk') (type: string)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 36 Data size: 3736 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 36 Data size: 3736 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-            MergeJoin Vectorization:
-                enabled: false
-                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
 
   Stage: Stage-0
     Fetch Operator
@@ -296,7 +296,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[9][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Map 2' is a cross product
 PREHOOK: query: select tint.rnum, tsint.rnum, tint.cint, tsint.csint, (case when (tint.cint between tsint.csint and tsint.csint) then "Ok" else "NoOk" end) as between_col from tint , tsint
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tint
@@ -344,7 +344,7 @@ NULL	2	NULL	0	NoOk
 NULL	3	NULL	1	NoOk
 NULL	4	NULL	10	NoOk
 NULL	NULL	NULL	NULL	NoOk
-Warning: Shuffle Join MERGEJOIN[10][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[10][bigTable=?] in task 'Map 2' is a cross product
 PREHOOK: query: explain vectorization expression
 select tint.rnum, tsint.rnum, tint.cint, tsint.csint from tint , tsint where tint.cint between tsint.csint and tsint.csint
 PREHOOK: type: QUERY
@@ -371,7 +371,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 2 <- Map 1 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -409,7 +409,7 @@ STAGE PLANS:
                 allNative: true
                 usesVectorUDFAdaptor: false
                 vectorized: true
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: tsint
@@ -424,15 +424,46 @@ STAGE PLANS:
                         native: true
                         projectedOutputColumnNums: [0, 1, 1]
                     Statistics: Num rows: 6 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Reduce Sink Vectorization:
-                          className: VectorReduceSinkEmptyKeyOperator
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      Map Join Vectorization:
+                          className: VectorMapJoinInnerMultiKeyOperator
                           native: true
-                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                      Statistics: Num rows: 6 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: smallint), _col2 (type: int)
+                          nativeConditionsMet: hive.mapjoin.optimized.hashtable IS true, hive.vectorized.execution.mapjoin.native.enabled IS true, hive.execution.engine tez IN [tez] IS true, One MapJoin Condition IS true, No nullsafe IS true, Small table vectorizes IS true, Optimized Table and Supports Key Types IS true
+                          hashTableImplementationType: OPTIMIZED
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                      input vertices:
+                        0 Map 1
+                      Statistics: Num rows: 36 Data size: 708 Basic stats: COMPLETE Column stats: COMPLETE
+                      Filter Operator
+                        Filter Vectorization:
+                            className: VectorFilterOperator
+                            native: true
+                            predicateExpression: SelectColumnIsTrue(col 6:boolean)(children: VectorUDFAdaptor(_col4 BETWEEN _col1 AND _col1) -> 6:boolean)
+                        predicate: _col4 BETWEEN _col1 AND _col1 (type: boolean)
+                        Statistics: Num rows: 4 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: int), _col2 (type: int), _col1 (type: int), _col3 (type: smallint)
+                          outputColumnNames: _col0, _col1, _col2, _col3
+                          Select Vectorization:
+                              className: VectorSelectOperator
+                              native: true
+                              projectedOutputColumnNums: [4, 0, 5, 1]
+                          Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            File Sink Vectorization:
+                                className: VectorFileSinkOperator
+                                native: false
+                            Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -441,37 +472,9 @@ STAGE PLANS:
                 inputFormatFeatureSupport: [DECIMAL_64]
                 featureSupportInUse: [DECIMAL_64]
                 inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
+                allNative: false
+                usesVectorUDFAdaptor: true
                 vectorized: true
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 36 Data size: 708 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col4 BETWEEN _col1 AND _col1 (type: boolean)
-                  Statistics: Num rows: 4 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col0 (type: int), _col2 (type: int), _col1 (type: int), _col3 (type: smallint)
-                    outputColumnNames: _col0, _col1, _col2, _col3
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    File Output Operator
-                      compressed: false
-                      Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                      table:
-                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-            MergeJoin Vectorization:
-                enabled: false
-                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
 
   Stage: Stage-0
     Fetch Operator
@@ -479,7 +482,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[10][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[10][bigTable=?] in task 'Map 2' is a cross product
 PREHOOK: query: select tint.rnum, tsint.rnum, tint.cint, tsint.csint from tint , tsint where tint.cint between tsint.csint and tsint.csint
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tint

--- a/ql/src/test/results/clientpositive/llap/vector_include_no_sel.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_include_no_sel.q.out
@@ -162,7 +162,7 @@ POSTHOOK: Lineage: customer_demographics.cd_education_status SIMPLE [(customer_d
 POSTHOOK: Lineage: customer_demographics.cd_gender SIMPLE [(customer_demographics_txt)customer_demographics_txt.FieldSchema(name:cd_gender, type:string, comment:null), ]
 POSTHOOK: Lineage: customer_demographics.cd_marital_status SIMPLE [(customer_demographics_txt)customer_demographics_txt.FieldSchema(name:cd_marital_status, type:string, comment:null), ]
 POSTHOOK: Lineage: customer_demographics.cd_purchase_estimate SIMPLE [(customer_demographics_txt)customer_demographics_txt.FieldSchema(name:cd_purchase_estimate, type:int, comment:null), ]
-Warning: Shuffle Join MERGEJOIN[13][tables = [customer_demographics, store_sales_n1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=store_sales_n1] in task 'Map 2' is a cross product
 PREHOOK: query: explain vectorization expression
 select count(1) from customer_demographics,store_sales_n1
 where ((customer_demographics.cd_demo_sk = store_sales_n1.ss_cdemo_sk and customer_demographics.cd_marital_status = 'M') or
@@ -192,8 +192,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Map 2 <- Map 1 (BROADCAST_EDGE)
+        Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -224,23 +224,64 @@ STAGE PLANS:
                 allNative: false
                 usesVectorUDFAdaptor: false
                 vectorized: true
-        Map 4 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: store_sales_n1
                   Statistics: Num rows: 1000 Data size: 3796 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Reduce Sink Vectorization:
-                        className: VectorReduceSinkOperator
-                        native: false
-                        nativeConditionsMet: hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                        nativeConditionsNotMet: hive.vectorized.execution.reducesink.new.enabled IS false
-                    Statistics: Num rows: 1000 Data size: 3796 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: ss_cdemo_sk (type: int)
+                  Map Join Operator
+                    condition map:
+                         Inner Join 0 to 1
+                    keys:
+                      0 
+                      1 
+                    Map Join Vectorization:
+                        className: VectorMapJoinInnerMultiKeyOperator
+                        native: true
+                        nativeConditionsMet: hive.mapjoin.optimized.hashtable IS true, hive.vectorized.execution.mapjoin.native.enabled IS true, hive.execution.engine tez IN [tez] IS true, One MapJoin Condition IS true, No nullsafe IS true, Small table vectorizes IS true, Optimized Table and Supports Key Types IS true
+                        hashTableImplementationType: OPTIMIZED
+                    outputColumnNames: _col0, _col2, _col17
+                    input vertices:
+                      0 Map 1
+                    Statistics: Num rows: 200000 Data size: 18599796 Basic stats: COMPLETE Column stats: COMPLETE
+                    Filter Operator
+                      Filter Vectorization:
+                          className: VectorFilterOperator
+                          native: true
+                          predicateExpression: FilterExprOrExpr(children: FilterExprAndExpr(children: FilterLongColEqualLongColumn(col 25:int, col 4:int), FilterStringGroupColEqualStringScalar(col 26:string, val M)), FilterExprAndExpr(children: FilterLongColEqualLongColumn(col 25:int, col 4:int), FilterStringGroupColEqualStringScalar(col 26:string, val U)))
+                      predicate: (((_col0 = _col17) and (_col2 = 'M')) or ((_col0 = _col17) and (_col2 = 'U'))) (type: boolean)
+                      Statistics: Num rows: 40000 Data size: 3719964 Basic stats: COMPLETE Column stats: COMPLETE
+                      Select Operator
+                        Select Vectorization:
+                            className: VectorSelectOperator
+                            native: true
+                            projectedOutputColumnNums: []
+                        Statistics: Num rows: 40000 Data size: 3719964 Basic stats: COMPLETE Column stats: COMPLETE
+                        Group By Operator
+                          aggregations: count(1)
+                          Group By Vectorization:
+                              aggregators: VectorUDAFCount(ConstantVectorExpression(val 1) -> 27:int) -> bigint
+                              className: VectorGroupByOperator
+                              groupByMode: HASH
+                              native: false
+                              vectorProcessingMode: HASH
+                              projectedOutputColumnNums: [0]
+                          minReductionHashAggr: 0.99
+                          mode: hash
+                          outputColumnNames: _col0
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            null sort order: 
+                            sort order: 
+                            Reduce Sink Vectorization:
+                                className: VectorReduceSinkOperator
+                                native: false
+                                nativeConditionsMet: hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                                nativeConditionsNotMet: hive.vectorized.execution.reducesink.new.enabled IS false
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -252,36 +293,6 @@ STAGE PLANS:
                 allNative: false
                 usesVectorUDFAdaptor: false
                 vectorized: true
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col2, _col17
-                Statistics: Num rows: 200000 Data size: 18599796 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (((_col0 = _col17) and (_col2 = 'M')) or ((_col0 = _col17) and (_col2 = 'U'))) (type: boolean)
-                  Statistics: Num rows: 40000 Data size: 3719964 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 40000 Data size: 3719964 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count(1)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: bigint)
-            MergeJoin Vectorization:
-                enabled: false
-                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -320,7 +331,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[13][tables = [customer_demographics, store_sales_n1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=store_sales_n1] in task 'Map 2' is a cross product
 PREHOOK: query: select count(1) from customer_demographics,store_sales_n1
 where ((customer_demographics.cd_demo_sk = store_sales_n1.ss_cdemo_sk and customer_demographics.cd_marital_status = 'M') or
        (customer_demographics.cd_demo_sk = store_sales_n1.ss_cdemo_sk and customer_demographics.cd_marital_status = 'U'))

--- a/ql/src/test/results/clientpositive/llap/vector_join_nulls.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_join_nulls.q.out
@@ -26,7 +26,7 @@ POSTHOOK: Output: database:default
 POSTHOOK: Output: default@myinput1_n4
 POSTHOOK: Lineage: myinput1_n4.key SIMPLE [(myinput1_txt_n1)myinput1_txt_n1.FieldSchema(name:key, type:int, comment:null), ]
 POSTHOOK: Lineage: myinput1_n4.value SIMPLE [(myinput1_txt_n1)myinput1_txt_n1.FieldSchema(name:value, type:int, comment:null), ]
-Warning: Shuffle Join MERGEJOIN[14][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[14][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: SELECT sum(hash(a.key,a.value,b.key,b.value)) FROM myinput1_n4 a JOIN myinput1_n4 b
 PREHOOK: type: QUERY
 PREHOOK: Input: default@myinput1_n4

--- a/ql/src/test/results/clientpositive/llap/vectorized_dynamic_partition_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_dynamic_partition_pruning.q.out
@@ -6177,7 +6177,7 @@ POSTHOOK: Input: default@srcpart@ds=2008-04-08/hr=11
 POSTHOOK: Input: default@srcpart@ds=2008-04-09/hr=11
 #### A masked pattern was here ####
 1000
-Warning: Shuffle Join MERGEJOIN[22][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[22][bigTable=?] in task 'Reducer 3' is a cross product
 PREHOOK: query: EXPLAIN VECTORIZATION select count(*) from srcpart join (select ds as ds, ds as `date` from srcpart group by ds) s on (srcpart.ds = s.ds) where s.`date` = '2008-04-08'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@srcpart
@@ -6203,9 +6203,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (BROADCAST_EDGE)
+        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -6244,30 +6244,56 @@ STAGE PLANS:
                 usesVectorUDFAdaptor: false
                 vectorized: true
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
             Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                Statistics: Num rows: 500000 Data size: 11124000 Basic stats: COMPLETE Column stats: NONE
-                Group By Operator
-                  aggregations: count()
-                  minReductionHashAggr: 0.99
-                  mode: hash
-                  outputColumnNames: _col0
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                    value expressions: _col0 (type: bigint)
-            MergeJoin Vectorization:
-                enabled: false
-                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
+              Select Operator
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1000 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
         Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: boolean)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
+                  Map Join Operator
+                    condition map:
+                         Inner Join 0 to 1
+                    keys:
+                      0 
+                      1 
+                    input vertices:
+                      0 Reducer 2
+                    Statistics: Num rows: 500000 Data size: 11124000 Basic stats: COMPLETE Column stats: NONE
+                    Group By Operator
+                      aggregations: count()
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: bigint)
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
@@ -6288,26 +6314,6 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
-            Execution mode: vectorized, llap
-            Reduce Vectorization:
-                enabled: true
-                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: boolean)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
 
   Stage: Stage-0
     Fetch Operator
@@ -6315,7 +6321,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[22][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[22][bigTable=?] in task 'Reducer 3' is a cross product
 PREHOOK: query: select count(*) from srcpart join (select ds as ds, ds as `date` from srcpart group by ds) s on (srcpart.ds = s.ds) where s.`date` = '2008-04-08'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@srcpart

--- a/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_1.q.out
+++ b/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_1.q.out
@@ -1359,7 +1359,7 @@ POSTHOOK: Lineage: decimal_mapjoin.cdecimal1 EXPRESSION [(alltypesorc)alltypesor
 POSTHOOK: Lineage: decimal_mapjoin.cdecimal2 EXPRESSION [(alltypesorc)alltypesorc.FieldSchema(name:cdouble, type:double, comment:null), ]
 POSTHOOK: Lineage: decimal_mapjoin.cdouble SIMPLE [(alltypesorc)alltypesorc.FieldSchema(name:cdouble, type:double, comment:null), ]
 POSTHOOK: Lineage: decimal_mapjoin.cint SIMPLE [(alltypesorc)alltypesorc.FieldSchema(name:cint, type:int, comment:null), ]
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: EXPLAIN SELECT l.cint, r.cint, l.cdecimal1, r.cdecimal2
   FROM decimal_mapjoin l
   JOIN decimal_mapjoin r ON l.cint = r.cint
@@ -1383,7 +1383,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1399,13 +1399,29 @@ STAGE PLANS:
                       expressions: cdecimal1 (type: decimal(20,10))
                       outputColumnNames: _col0
                       Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: decimal(20,10))
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 
+                          1 
+                        outputColumnNames: _col0, _col1
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: 6981 (type: int), 6981 (type: int), _col0 (type: decimal(20,10)), _col1 (type: decimal(23,14))
+                          outputColumnNames: _col0, _col1, _col2, _col3
+                          Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: r
@@ -1424,27 +1440,6 @@ STAGE PLANS:
                         Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: decimal(23,14))
             Execution mode: vectorized
-        Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: 6981 (type: int), 6981 (type: int), _col0 (type: decimal(20,10)), _col1 (type: decimal(23,14))
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -1452,7 +1447,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: SELECT l.cint, r.cint, l.cdecimal1, r.cdecimal2
   FROM decimal_mapjoin l
   JOIN decimal_mapjoin r ON l.cint = r.cint
@@ -1468,6 +1463,8 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@decimal_mapjoin
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1475,9 +1472,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1485,9 +1482,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1495,9 +1492,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1505,9 +1502,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	5831542.2692483780	NULL
+6981	6981	5831542.2692483780	-617.56077692307690
+6981	6981	5831542.2692483780	-617.56077692307690
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
@@ -1515,9 +1512,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
-6981	6981	5831542.2692483780	-617.56077692307690
-6981	6981	5831542.2692483780	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1525,9 +1522,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1535,9 +1532,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1545,9 +1542,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	-515.6210729730	NULL
+6981	6981	-515.6210729730	-617.56077692307690
+6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
@@ -1555,9 +1552,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
-6981	6981	-515.6210729730	-617.56077692307690
-6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
+6981	6981	-515.6210729730	-617.56077692307690
+6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
@@ -1565,9 +1562,7 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
-6981	6981	-515.6210729730	-617.56077692307690
-6981	6981	-515.6210729730	-617.56077692307690
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: EXPLAIN SELECT l.cint, r.cint, l.cdecimal1, r.cdecimal2
   FROM decimal_mapjoin l
   JOIN decimal_mapjoin r ON l.cint = r.cint
@@ -1591,7 +1586,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 3 (XPROD_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1607,13 +1602,29 @@ STAGE PLANS:
                       expressions: cdecimal1 (type: decimal(20,10))
                       outputColumnNames: _col0
                       Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: decimal(20,10))
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 
+                          1 
+                        outputColumnNames: _col0, _col1
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: 6981 (type: int), 6981 (type: int), _col0 (type: decimal(20,10)), _col1 (type: decimal(23,14))
+                          outputColumnNames: _col0, _col1, _col2, _col3
+                          Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: vectorized
-        Map 3 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: r
@@ -1632,27 +1643,6 @@ STAGE PLANS:
                         Statistics: Num rows: 5 Data size: 551 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: decimal(23,14))
             Execution mode: vectorized
-        Reducer 2 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: 6981 (type: int), 6981 (type: int), _col0 (type: decimal(20,10)), _col1 (type: decimal(23,14))
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 25 Data size: 5535 Basic stats: COMPLETE Column stats: NONE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -1660,7 +1650,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Map Join MAPJOIN[13][bigTable=?] in task 'Map 1' is a cross product
 PREHOOK: query: SELECT l.cint, r.cint, l.cdecimal1, r.cdecimal2
   FROM decimal_mapjoin l
   JOIN decimal_mapjoin r ON l.cint = r.cint
@@ -1676,6 +1666,8 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@decimal_mapjoin
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1683,9 +1675,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1693,9 +1685,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1703,9 +1695,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1713,9 +1705,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	5831542.2692483780	NULL
+6981	6981	5831542.2692483780	-617.56077692307690
+6981	6981	5831542.2692483780	-617.56077692307690
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
@@ -1723,9 +1715,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
 6981	6981	5831542.2692483780	NULL
-6981	6981	5831542.2692483780	-617.56077692307690
-6981	6981	5831542.2692483780	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1733,9 +1725,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1743,9 +1735,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
+6981	6981	NULL	-617.56077692307690
+6981	6981	NULL	-617.56077692307690
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
@@ -1753,9 +1745,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
 6981	6981	NULL	NULL
-6981	6981	NULL	-617.56077692307690
-6981	6981	NULL	-617.56077692307690
 6981	6981	-515.6210729730	NULL
+6981	6981	-515.6210729730	-617.56077692307690
+6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
@@ -1763,9 +1755,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
-6981	6981	-515.6210729730	-617.56077692307690
-6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
+6981	6981	-515.6210729730	-617.56077692307690
+6981	6981	-515.6210729730	-617.56077692307690
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
@@ -1773,8 +1765,6 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
 6981	6981	-515.6210729730	NULL
-6981	6981	-515.6210729730	-617.56077692307690
-6981	6981	-515.6210729730	-617.56077692307690
 PREHOOK: query: DROP TABLE decimal_mapjoin
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@decimal_mapjoin


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Widen the cross-product gate in ConvertJoinMapJoin#getMapJoinConversion: when the smaller (broadcast-candidate) side's row count exceeds hive.xprod.mapjoin.small.table.rows but its onlineDataSize still fits hive.auto.convert.join.noconditionaltask.size, allow conversion to a broadcast map-join via a new helper crossProductBuildSideWithinBroadcastBudgetAfterRowCheck. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The current gate consults only the row count of the smaller (broadcast-candidate) side. NDV-driven filter selectivity routinely estimates tiny lookups at 2–3 rows even when their actual byte footprint is a few hundred bytes — well within the broadcast budget. The gate rejects these safe broadcasts, the join falls back to a MERGEJOIN with XPROD_EDGE inputs, and the keyless shuffle collapses onto a single reducer that materialises the entire Cartesian. See [HIVE-29613](https://issues.apache.org/jira/browse/HIVE-29613) for full analysis.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Query results are unchanged. Although, For cross-product joins where the small side overshoots the row threshold but still fits the broadcast byte budget, EXPLAIN now shows MAPJOIN with BROADCAST_EDGE instead of MERGEJOIN with XPROD_EDGE on a Reducer.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added Five new unit tests in TestConvertJoinMapJoin class