### PR TITLE
HIVE-29536: Stabilize rebalance compaction tests

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
@@ -52,6 +52,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -188,7 +189,8 @@ public abstract class CompactorOnTezTest {
   protected HiveHookEvents.HiveHookEventProto getRelatedTezEvent(String dbTableName) throws Exception {
     int retryCount = 3;
     while (retryCount-- > 0) {
-      List<ProtoMessageReader<HiveHookEvents.HiveHookEventProto>> readers = TestHiveProtoLoggingHook.getTestReader(conf, tmpFolder);
+      List<ProtoMessageReader<HiveHookEvents.HiveHookEventProto>>
+          readers = TestHiveProtoLoggingHook.getTestReader(conf, tmpFolder);
       for (ProtoMessageReader<HiveHookEvents.HiveHookEventProto> reader : readers) {
         do {
           HiveHookEvents.HiveHookEventProto event;
@@ -566,7 +568,7 @@ public abstract class CompactorOnTezTest {
       static RowInfo fromRawString(String row) throws JsonProcessingException {
         // Example row data to parse: "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":10}\t5\t4",
 
-        String[] parts = row.split("\t", 3);
+        String[] parts = row.split("\t");
 
         JsonNode json = MAPPER.readTree(parts[0]);
 
@@ -574,10 +576,8 @@ public abstract class CompactorOnTezTest {
             json.get("writeid").asLong(),
             json.get("bucketid").asLong(),
             json.get("rowid").asLong(),
-            new TestRebalanceCompactor.RowData(
-                parts[1], // colA
-                Long.parseLong(parts[2])  // colB
-            )
+
+            new TestRebalanceCompactor.RowData(Arrays.copyOfRange(parts, 1, parts.length))
         );
       }
     }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.txn.compactor;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hive.cli.CliSessionState;
 import org.apache.hadoop.hive.conf.Constants;
@@ -48,6 +51,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -58,8 +62,8 @@ import java.util.regex.Pattern;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_COMPACTOR_CLEANER_RETENTION_TIME;
 import static org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtil.executeStatementOnDriverAndReturnResults;
-import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.dropTables;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
 
 /**
  * Superclass for Test[Crud|Mm]CompactorOnTez, for setup and helper classes.
@@ -541,8 +545,41 @@ public abstract class CompactorOnTezTest {
           "select ROW__ID, * from " + tblName + " where ROW__ID.bucketid = " + bucketId + " order by ROW__ID, a, b", driver);
     }
 
+    protected List<RowInfo> getStructuredBucketData(String tblName, String bucketId) throws Exception {
+      List<String> getBucketData = getBucketData(tblName, bucketId);
+
+      List<RowInfo> result = new ArrayList<>(getBucketData.size());
+      for (String row : getBucketData) {
+        result.add(RowInfo.fromRawString(row));
+      }
+
+      return result;
+    }
+
     protected void dropTable(String tblName) throws Exception {
       executeStatementOnDriver("drop table " + tblName, driver);
+    }
+
+    protected record RowInfo(long writeId, long bucketId, long rowId, TestRebalanceCompactor.RowData rowData) {
+      private static final ObjectMapper MAPPER = new ObjectMapper();
+
+      static RowInfo fromRawString(String row) throws JsonProcessingException {
+        // Example row data to parse: "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":10}\t5\t4",
+
+        String[] parts = row.split("\t", 3);
+
+        JsonNode json = MAPPER.readTree(parts[0]);
+
+        return new RowInfo(
+            json.get("writeid").asLong(),
+            json.get("bucketid").asLong(),
+            json.get("rowid").asLong(),
+            new TestRebalanceCompactor.RowData(
+                parts[1], // colA
+                Long.parseLong(parts[2])  // colB
+            )
+        );
+      }
     }
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -17,6 +17,17 @@
  */
 package org.apache.hadoop.hive.ql.txn.compactor;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileStatus;
@@ -38,9 +49,9 @@ import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
 import org.apache.hadoop.hive.metastore.api.ShowCompactResponseElement;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.txn.entities.CompactionInfo;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
-import org.apache.hadoop.hive.metastore.txn.entities.CompactionInfo;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
@@ -51,7 +62,6 @@ import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
-import org.apache.hive.common.util.ReflectionUtil;
 import org.apache.hive.streaming.HiveStreamingConnection;
 import org.apache.hive.streaming.StreamingConnection;
 import org.apache.hive.streaming.StrictDelimitedInputWriter;
@@ -65,26 +75,14 @@ import org.apache.orc.impl.RecordReaderImpl;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hive.common.util.ReflectionUtil;
 
 import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hive.ql.TxnCommandsBaseForTests.runWorker;
-import static org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtil.executeStatementOnDriverAndReturnResults;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.execSelectAndDumpData;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
+import static org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtil.executeStatementOnDriverAndReturnResults;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactorBase.dropTables;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -167,15 +165,15 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     } catch (CommandProcessorException e) {
       String errorMessage = ErrorMsg.COMPACTION_REFUSED.format(dbName, tableName, "",
           "Compaction is already scheduled with state='ready for cleaning' and id=" + resp.getId());
-      assertEquals(errorMessage, e.getCauseMessage());
-      assertEquals(ErrorMsg.COMPACTION_REFUSED.getErrorCode(), e.getErrorCode());
+      Assert.assertEquals(errorMessage, e.getCauseMessage());
+      Assert.assertEquals(ErrorMsg.COMPACTION_REFUSED.getErrorCode(), e.getErrorCode());
     }
 
     //Check if the first compaction is in 'ready for cleaning'
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    assertEquals(1, compacts.size());
-    assertEquals("ready for cleaning", compacts.get(0).getState());
+    Assert.assertEquals(1, compacts.size());
+    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
   }
 
   @Test
@@ -213,15 +211,15 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     } catch (CommandProcessorException e) {
       String errorMessage = ErrorMsg.COMPACTION_REFUSED.format(dbName, tableName, " partition(pt=test)",
           "Compaction is already scheduled with state='ready for cleaning' and id=" + resp.getId());
-      assertEquals(errorMessage, e.getCauseMessage());
-      assertEquals(ErrorMsg.COMPACTION_REFUSED.getErrorCode(), e.getErrorCode());
+      Assert.assertEquals(errorMessage, e.getCauseMessage());
+      Assert.assertEquals(ErrorMsg.COMPACTION_REFUSED.getErrorCode(), e.getErrorCode());
     }
 
     //Check if the first compaction is in 'ready for cleaning'
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    assertEquals(1, compacts.size());
-    assertEquals("ready for cleaning", compacts.get(0).getState());
+    Assert.assertEquals(1, compacts.size());
+    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
   }
 
   @Test
@@ -270,7 +268,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check captured compaction request and if the type for the table was MAJOR
     ArgumentCaptor<CompactionRequest> requests = ArgumentCaptor.forClass(CompactionRequest.class);
     verify(mockedHandler).compact(requests.capture());
-    assertTrue(requests.getAllValues().stream().anyMatch(r -> r.getTablename().equals(tableName) && r.getType().equals(CompactionType.MAJOR)));
+    Assert.assertTrue(requests.getAllValues().stream().anyMatch(r -> r.getTablename().equals(tableName) && r.getType().equals(CompactionType.MAJOR)));
 
     //Try to do a minor compaction directly
     CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MINOR);
@@ -284,11 +282,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     if (2 != compacts.size()) {
       Assert.fail("Expecting 2 rows and found " + compacts.size() + " files " + compacts);
     }
-    assertEquals("refused", compacts.get(0).getState());
-    assertTrue(compacts.get(0).getErrorMessage()
+    Assert.assertEquals("refused", compacts.get(0).getState());
+    Assert.assertTrue(compacts.get(0).getErrorMessage()
             .startsWith("Query based Minor compaction is not possible for full acid tables having raw format (non-acid) data in them."));
-    assertEquals("did not initiate", compacts.get(1).getState());
-    assertTrue(compacts.get(1).getErrorMessage()
+    Assert.assertEquals("did not initiate", compacts.get(1).getState());
+    Assert.assertTrue(compacts.get(1).getErrorMessage()
             .startsWith("Caught exception while trying to determine if we should compact "));
   }
 
@@ -339,7 +337,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check captured compaction request and if the type for the table was MAJOR
     ArgumentCaptor<CompactionRequest> requests = ArgumentCaptor.forClass(CompactionRequest.class);
     verify(mockedHandler).compact(requests.capture());
-    assertTrue(requests.getAllValues().stream().anyMatch(r -> r.getTablename().equals(testTableName) && r.getType().equals(CompactionType.MAJOR)));
+    Assert.assertTrue(requests.getAllValues().stream().anyMatch(r -> r.getTablename().equals(testTableName) && r.getType().equals(CompactionType.MAJOR)));
 
     //Try to do a minor compaction directly
     CompactionRequest rqst = new CompactionRequest(dbName, testTableName, CompactionType.MINOR);
@@ -353,10 +351,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     if (2 != compacts.size()) {
       Assert.fail("Expecting 2 rows and found " + compacts.size() + " files " + compacts);
     }
-    assertEquals("refused", compacts.get(0).getState());
-    assertTrue(compacts.get(0).getErrorMessage().startsWith("Query based Minor compaction is not possible for full acid tables having raw format (non-acid) data in them."));
-    assertEquals("did not initiate", compacts.get(1).getState());
-    assertTrue(compacts.get(1).getErrorMessage().startsWith("Caught exception while trying to determine if we should compact"));
+    Assert.assertEquals("refused", compacts.get(0).getState());
+    Assert.assertTrue(compacts.get(0).getErrorMessage().startsWith("Query based Minor compaction is not possible for full acid tables having raw format (non-acid) data in them."));
+    Assert.assertEquals("did not initiate", compacts.get(1).getState());
+    Assert.assertTrue(compacts.get(1).getErrorMessage().startsWith("Caught exception while trying to determine if we should compact"));
   }
 
   /**
@@ -394,8 +392,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     //Check basic stats are collected
     Map<String, String> parameters = Hive.get().getTable(tblName).getParameters();
-    assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
-    assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
+    Assert.assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
+    Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
 
     //Do a major compaction
     CompactorTestUtil.runCompaction(conf, dbName, tblName, CompactionType.MAJOR, true);
@@ -405,12 +403,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     if (1 != compacts.size()) {
       Assert.fail("Expecting 1 file and found " + compacts.size() + " files " + compacts);
     }
-    assertEquals("ready for cleaning", compacts.get(0).getState());
+    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
 
     //Check basic stats are updated
     parameters = Hive.get().getTable(tblName).getParameters();
-    assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
-    assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
+    Assert.assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
+    Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
   }
 
   @Test
@@ -432,12 +430,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas (delta_0000001_0000001_0000, delta_0000002_0000002_0000) are present
-    assertEquals("Delta directories does not match before compaction",
+    Assert.assertEquals("Delta directories does not match before compaction",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000",
             "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify that delete delta (delete_delta_0000003_0000003_0000) is present
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
 
@@ -455,7 +453,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":4}\t6\t3",
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":5}\t6\t4"));
     // Check bucket contents
-    assertEquals("pre-compaction bucket 0", expectedRsBucket0,
+    Assert.assertEquals("pre-compaction bucket 0", expectedRsBucket0,
         testDataProvider.getBucketData(tblName, "536870912"));
 
     conf.setVar(HiveConf.ConfVars.PRE_EXEC_HOOKS, HiveProtoLoggingHook.class.getName());
@@ -467,16 +465,16 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     verifySuccessfulCompaction(1);
     // Should contain only one base directory now
     String expectedBase = "base_0000005_v0000008";
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList(expectedBase),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Check base dir contents
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, null, expectedBase));
     // Check bucket contents
-    assertEquals("post-compaction bucket 0", expectedRsBucket0,
+    Assert.assertEquals("post-compaction bucket 0", expectedRsBucket0,
         testDataProvider.getBucketData(tblName, "536870912"));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
@@ -487,7 +485,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     HiveHookEvents.HiveHookEventProto event = getRelatedTezEvent(dbTableName);
     Assert.assertNotNull(event);
-    assertEquals(event.getQueue(), CUSTOM_COMPACTION_QUEUE);
+    Assert.assertEquals(event.getQueue(), CUSTOM_COMPACTION_QUEUE);
   }
 
   /**
@@ -510,7 +508,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas are present
-    assertEquals("Delta directories does not match before compaction",
+    Assert.assertEquals("Delta directories does not match before compaction",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000",
             "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
@@ -523,12 +521,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     verifySuccessfulCompaction(1);
     // Should contain only one base directory now
     String expectedBase = "base_0000005_v0000007";
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList(expectedBase),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Check base dir contents
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, null, expectedBase));
     // Check bucket file contents
@@ -562,11 +560,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas (delta_0000001_0000001_0000, delta_0000002_0000002_0000) are present
-    assertEquals("Delta directories does not match before compaction",
+    Assert.assertEquals("Delta directories does not match before compaction",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify that delete delta (delete_delta_0000003_0000003_0000) is present
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     List<String> expectedRsBucket0 = new ArrayList<>(Arrays.asList(
@@ -587,9 +585,9 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     List<String> preCompactionRsBucket0 = testDataProvider.getBucketData(tblName, "536870912");
     List<String> preCompactionRsBucket1 = testDataProvider.getBucketData(tblName, "536936448");
     List<String> preCompactionRsBucket2 = testDataProvider.getBucketData(tblName, "537001984");
-    assertEquals("pre-compaction bucket 0", expectedRsBucket0, preCompactionRsBucket0);
-    assertEquals("pre-compaction bucket 1", expectedRsBucket1, preCompactionRsBucket1);
-    assertEquals("pre-compaction bucket 2", expectedRsBucket2, preCompactionRsBucket2);
+    Assert.assertEquals("pre-compaction bucket 0", expectedRsBucket0, preCompactionRsBucket0);
+    Assert.assertEquals("pre-compaction bucket 1", expectedRsBucket1, preCompactionRsBucket1);
+    Assert.assertEquals("pre-compaction bucket 2", expectedRsBucket2, preCompactionRsBucket2);
 
     // Run major compaction and cleaner
     CompactorTestUtil.runCompaction(conf, dbName, tblName, CompactionType.MAJOR, true);
@@ -597,20 +595,20 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     verifySuccessfulCompaction(1);
     // Should contain only one base directory now
     String expectedBase = "base_0000003_v0000008";
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList(expectedBase),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Check files in base
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001", "bucket_00002");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, null, "base_0000003_v0000008"));
     // Check buckets contents
-    assertEquals("post-compaction bucket 0", expectedRsBucket0, testDataProvider.getBucketData(tblName,
+    Assert.assertEquals("post-compaction bucket 0", expectedRsBucket0, testDataProvider.getBucketData(tblName,
       "536870912"));
-    assertEquals("post-compaction bucket 1", expectedRsBucket1, testDataProvider.getBucketData(tblName,
+    Assert.assertEquals("post-compaction bucket 1", expectedRsBucket1, testDataProvider.getBucketData(tblName,
       "536936448"));
-    assertEquals("post-compaction bucket 2", expectedRsBucket2, testDataProvider.getBucketData(tblName,
+    Assert.assertEquals("post-compaction bucket 2", expectedRsBucket2, testDataProvider.getBucketData(tblName,
       "537001984"));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
@@ -641,11 +639,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Path yesterdayPath = new Path(tablePath, partitionYesterday);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday));
     // Verify delete delta
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday));
@@ -663,7 +661,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":1}\t6\t2\ttoday",
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":2}\t6\t3\ttoday",
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":3}\t6\t4\ttoday"));
-    assertEquals("pre-compaction bucket 0", expectedRsBucket0,
+    Assert.assertEquals("pre-compaction bucket 0", expectedRsBucket0,
         testDataProvider.getBucketData(tblName, "536870912"));
 
     // Run major compaction and cleaner for all 3 partitions
@@ -673,28 +671,28 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // 3 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction( 3);
     // Should contain only one base directory now
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionToday));
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000010"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionTomorrow));
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000012"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionYesterday));
     // Check base dir contents
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, "base_0000005_v0000008"));
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionTomorrow, "base_0000005_v0000010"));
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionYesterday, "base_0000005_v0000012"));
     // Check buckets contents
-    assertEquals("post-compaction bucket 0", expectedRsBucket0,
+    Assert.assertEquals("post-compaction bucket 0", expectedRsBucket0,
         testDataProvider.getBucketData(tblName, "536870912"));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(todayPath, "base_0000005_v0000008"), 0);
@@ -723,11 +721,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String partitionToday = "ds=today";
     String partitionTomorrow = "ds=tomorrow";
     String partitionYesterday = "ds=yesterday";
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday));
     // Verify delete delta
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday));
@@ -749,8 +747,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":2}\t6\t3\ttoday",
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":3}\t6\t4\ttoday");
     List<String> rsBucket1 = dataProvider.getBucketData(tableName, "536936448");
-    assertEquals(expectedRsBucket0, rsBucket0);
-    assertEquals(expectedRsBucket1, rsBucket1);
+    Assert.assertEquals(expectedRsBucket0, rsBucket0);
+    Assert.assertEquals(expectedRsBucket1, rsBucket1);
 
     // Run a compaction
     CompactorTestUtil
@@ -767,37 +765,37 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String expectedBaseYesterday = "base_0000005_v0000014";
     List<String> baseDeltasInToday =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionToday);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList(expectedBaseToday), baseDeltasInToday);
     List<String> baseDeltasInTomorrow =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionTomorrow);
 
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList(expectedBaseTomorrow), baseDeltasInTomorrow);
     List<String> baseDeltasInYesterday =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionYesterday);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList(expectedBaseYesterday), baseDeltasInYesterday);
     // Verify contents of bases
-    assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00000", "bucket_00001"),
+    Assert.assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00000", "bucket_00001"),
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, expectedBaseToday));
-    assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00001"),
+    Assert.assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00001"),
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionTomorrow, expectedBaseTomorrow));
-    assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00000", "bucket_00001"),
+    Assert.assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00000", "bucket_00001"),
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionYesterday, expectedBaseYesterday));
     // Verify contents of bucket files.
     // Bucket 0
     rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    assertEquals(expectedRsBucket0, rsBucket0);
+    Assert.assertEquals(expectedRsBucket0, rsBucket0);
     // Bucket 1
     rsBucket1 = dataProvider.getBucketData(tableName, "536936448");
-    assertEquals(expectedRsBucket1, rsBucket1);
+    Assert.assertEquals(expectedRsBucket1, rsBucket1);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
     String tablePath = table.getSd().getLocation();
     checkBucketIdAndRowIdInAcidFile(fs, new Path(new Path(tablePath, partitionToday), expectedBaseToday), 0);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(new Path(tablePath, partitionToday), expectedBaseToday), 1);
@@ -825,11 +823,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Get all data before compaction is run
     List<String> expectedData = dataProvider.getAllData(tableName);
     // Verify deltas
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Run a compaction
@@ -841,17 +839,17 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals("Delete delta directories does not match after compaction",
+    Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"), actualDeleteDeltasAfterComp);
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Collections.singletonList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
     // Verify contents of bucket files.
     // Bucket 0
@@ -869,10 +867,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":4}\t6\t3",
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":5}\t6\t4");
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    assertEquals(expectedRsBucket0, rsBucket0);
+    Assert.assertEquals(expectedRsBucket0, rsBucket0);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -961,10 +959,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     List<String> expectedFileNames = dataProvider.getDataWithInputFileNames(null, tableName);
 
     // Verify deltas
-    assertEquals("Delta directories does not match", expectedDeltas,
+    Assert.assertEquals("Delta directories does not match", expectedDeltas,
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    assertEquals("Delete directories does not match", expectedDeleteDeltas,
+    Assert.assertEquals("Delete directories does not match", expectedDeleteDeltas,
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
 
     List<String> expectedBucketFiles =
@@ -979,40 +977,40 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     List<ShowCompactResponseElement> compacts =
         TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    assertEquals("Completed compaction queue must contain one element", 1, compacts.size());
-    assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
+    Assert.assertEquals("Completed compaction queue must contain one element", 1, compacts.size());
+    Assert.assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
 
     // Verify delta and delete delta directories after compaction
     if (CompactionType.MAJOR == compactionType) {
       List<String> actualBasesAfterComp =
           CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
-      assertEquals("Base directory does not match after compaction",
+      Assert.assertEquals("Base directory does not match after compaction",
           Collections.singletonList(expectedCompactedDeltaDirName), actualBasesAfterComp);
       // Verify bucket files in delta and delete delta dirs
-      assertEquals("Bucket names are not matching after compaction in the base folder",
+      Assert.assertEquals("Bucket names are not matching after compaction in the base folder",
           expectedBucketFiles, CompactorTestUtil.getBucketFileNames(fs, table, null, actualBasesAfterComp.get(0)));
     } else {
       List<String> actualDeltasAfterComp =
           CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-      assertEquals("Delta directories does not match after compaction",
+      Assert.assertEquals("Delta directories does not match after compaction",
           Collections.singletonList(expectedCompactedDeltaDirName), actualDeltasAfterComp);
       List<String> actualDeleteDeltasAfterComp =
           CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-      assertEquals("Delete delta directories does not match after compaction",
+      Assert.assertEquals("Delete delta directories does not match after compaction",
           Collections.singletonList("delete_" + expectedCompactedDeltaDirName), actualDeleteDeltasAfterComp);
       // Verify bucket files in delta and delete delta dirs
-      assertEquals("Bucket names are not matching after compaction in the delete deltas",
+      Assert.assertEquals("Bucket names are not matching after compaction in the delete deltas",
           expectedDeleteBucketFiles,
           CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
-      assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+      Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
           CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
     }
 
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
     List<String> actualFileNames = dataProvider.getDataWithInputFileNames(null, tableName);
-    assertTrue(dataProvider.compareFileNames(expectedFileNames, actualFileNames));
+    Assert.assertTrue(dataProvider.compareFileNames(expectedFileNames, actualFileNames));
     dataProvider.dropTable(tableName);
   }
 
@@ -1035,7 +1033,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     expectedDeltas.add("delta_0000006_0000006_0000");
     expectedDeltas.add("delta_0000007_0000007_0000");
     expectedDeltas.add("delta_0000008_0000008_0000");
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         expectedDeltas,
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
@@ -1044,7 +1042,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     expectedDeleteDeltas.add("delete_delta_0000003_0000003_0000");
     expectedDeleteDeltas.add("delete_delta_0000004_0000004_0000");
     expectedDeleteDeltas.add("delete_delta_0000005_0000005_0000");
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         expectedDeleteDeltas,
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
 
@@ -1059,28 +1057,28 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     List<ShowCompactResponseElement> compacts =
         TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    assertEquals("Completed compaction queue must contain one element", 1, compacts.size());
-    assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
+    Assert.assertEquals("Completed compaction queue must contain one element", 1, compacts.size());
+    Assert.assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000008_v0000011"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals("Delete delta directories does not match after compaction",
+    Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000008_v0000011"), actualDeleteDeltasAfterComp);
     // Verify bucket files in delta dirs
     List<String> actualData = dataProvider.getAllData(tableName);
 
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
 
-    assertEquals("Bucket names in delete delta are not matching after compaction", expectedDeleteBucketFiles,
+    Assert.assertEquals("Bucket names in delete delta are not matching after compaction", expectedDeleteBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
     // Verify all contents
    // List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MAJOR, true);
     // Clean up resources
@@ -1089,19 +1087,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     compacts =
         TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    assertEquals("Completed compaction queue must contain one element", 2, compacts.size());
-    assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
+    Assert.assertEquals("Completed compaction queue must contain one element", 2, compacts.size());
+    Assert.assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
     // Verify delta directories after compaction
     List<String> actualBasesAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
-    assertEquals("Base directory does not match after compaction",
+    Assert.assertEquals("Base directory does not match after compaction",
         Collections.singletonList("base_0000008_v0000014"), actualBasesAfterComp);
     // Verify bucket files in delta dirs
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualBasesAfterComp.get(0)));
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
     dataProvider.dropTable(tableName);
   }
 
@@ -1121,11 +1119,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Get all data before compaction is run
     List<String> expectedData = dataProvider.getAllData(tableName);
     // Verify deltas
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Run a compaction
@@ -1137,17 +1135,17 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals("Delete delta directories does not match after compaction",
+    Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"), actualDeleteDeltasAfterComp);
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
     // Verify contents of bucket files.
     // Bucket 0
@@ -1155,7 +1153,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":1}\t3\t3",
         "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":2}\t3\t4");
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    assertEquals(expectedRsBucket0, rsBucket0);
+    Assert.assertEquals(expectedRsBucket0, rsBucket0);
     // Bucket 1
     List<String> expectedRs1Bucket = Arrays.asList(
         "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":1}\t2\t3",
@@ -1169,10 +1167,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":4}\t6\t3",
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":5}\t6\t4");
     List<String> rsBucket1 = dataProvider.getBucketData(tableName, "536936448");
-    assertEquals(expectedRs1Bucket, rsBucket1);
+    Assert.assertEquals(expectedRs1Bucket, rsBucket1);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1201,11 +1199,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String partitionToday = "ds=today";
     String partitionTomorrow = "ds=tomorrow";
     String partitionYesterday = "ds=yesterday";
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday));
     // Verify delete delta
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday));
@@ -1220,19 +1218,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction in each partition
     List<String> actualDeltasAfterCompPartToday =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"), actualDeltasAfterCompPartToday);
     List<String> actualDeleteDeltasAfterCompPartToday =
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday);
-    assertEquals("Delete delta directories does not match after compaction",
+    Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"), actualDeleteDeltasAfterCompPartToday);
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Collections.singletonList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, actualDeltasAfterCompPartToday.get(0)));
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, actualDeleteDeltasAfterCompPartToday.get(0)));
 
@@ -1252,11 +1250,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":2}\t6\t3\ttoday",
             "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":3}\t6\t4\ttoday");
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    assertEquals(expectedRsBucket0, rsBucket0);
+    Assert.assertEquals(expectedRsBucket0, rsBucket0);
 
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1285,11 +1283,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String partitionToday = "ds=today";
     String partitionTomorrow = "ds=tomorrow";
     String partitionYesterday = "ds=yesterday";
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday));
     // Verify delete delta
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday));
@@ -1304,19 +1302,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction in each partition
     List<String> actualDeltasAfterCompPartToday =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"), actualDeltasAfterCompPartToday);
     List<String> actualDeleteDeltasAfterCompPartToday =
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday);
-    assertEquals("Delete delta directories does not match after compaction",
+    Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"), actualDeleteDeltasAfterCompPartToday);
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, actualDeltasAfterCompPartToday.get(0)));
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, actualDeleteDeltasAfterCompPartToday.get(0)));
     // Verify contents of bucket files.
@@ -1325,7 +1323,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t3\t3\ttoday",
         "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t3\t4\tyesterday");
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    assertEquals(expectedRsBucket0, rsBucket0);
+    Assert.assertEquals(expectedRsBucket0, rsBucket0);
     // Bucket 1
     List<String> expectedRsBucket1 = Arrays.asList("{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t2\t3\tyesterday",
         "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t2\t4\ttoday",
@@ -1338,10 +1336,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":2}\t6\t3\ttoday",
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":3}\t6\t4\ttoday");
     List<String> rsBucket1 = dataProvider.getBucketData(tableName, "536936448");
-    assertEquals(expectedRsBucket1, rsBucket1);
+    Assert.assertEquals(expectedRsBucket1, rsBucket1);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1370,10 +1368,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify deltas
     List<String> deltaNames = CompactorTestUtil
         .getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals(10, deltaNames.size());
+    Assert.assertEquals(10, deltaNames.size());
     List<String> deleteDeltaName =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals(5, deleteDeltaName.size());
+    Assert.assertEquals(5, deleteDeltaName.size());
     // Run a compaction
     CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MINOR, true);
     // Clean up resources
@@ -1382,22 +1380,23 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals(Collections.singletonList("delta_0000001_0000015_v0000018"), actualDeltasAfterComp);
+    Assert.assertEquals(Collections.singletonList("delta_0000001_0000015_v0000018"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals(Collections.singletonList("delete_delta_0000001_0000015_v0000018"), actualDeleteDeltasAfterComp);
+    Assert
+        .assertEquals(Collections.singletonList("delete_delta_0000001_0000015_v0000018"), actualDeleteDeltasAfterComp);
     // Verify bucket file in delta dir
     List<String> expectedBucketFile = Collections.singletonList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFile,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFile,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFile,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFile,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
     // Verify contents of bucket file
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    assertEquals(5, rsBucket0.size());
+    Assert.assertEquals(5, rsBucket0.size());
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1445,11 +1444,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000015_v0000021"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals("Delete delta directories does not match after compaction",
+    Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000015_v0000021"), actualDeleteDeltasAfterComp);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
@@ -1482,7 +1481,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
       Table table = metaStoreClient.getTable(dbName, tableName);
       FileSystem fs = FileSystem.get(conf);
-      assertEquals("Delta names does not match", Arrays
+      Assert.assertEquals("Delta names does not match", Arrays
           .asList("delta_0000001_0000002", "delta_0000001_0000005_v0000008", "delta_0000003_0000004",
               "delta_0000005_0000006"), CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
       CompactorTestUtil.checkExpectedTxnsPresent(null,
@@ -1512,7 +1511,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
     Table table = metaStoreClient.getTable(dbName, tableName);
     FileSystem fs = FileSystem.get(conf);
-    assertEquals("Delta names does not match",
+    Assert.assertEquals("Delta names does not match",
         Arrays.asList("delta_0000001_0000002", "delta_0000001_0000006_v0000008", "delta_0000003_0000004"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
     CompactorTestUtil.checkExpectedTxnsPresent(null,
@@ -1542,7 +1541,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
     Table table = metaStoreClient.getTable(dbName, tableName);
     FileSystem fs = FileSystem.get(conf);
-    assertEquals("Delta names does not match",
+    Assert.assertEquals("Delta names does not match",
         Arrays.asList("delta_0000001_0000002", "delta_0000001_0000006_v0000008", "delta_0000005_0000006"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
     CompactorTestUtil.checkExpectedTxnsPresent(null,
@@ -1580,7 +1579,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
     Table table = metaStoreClient.getTable(dbName, tableName);
     FileSystem fs = FileSystem.get(conf);
-    assertEquals("Delta names does not match", Collections.singletonList("delta_0000001_0000003_v0000005"),
+    Assert.assertEquals("Delta names does not match", Collections.singletonList("delta_0000001_0000003_v0000005"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
     CompactorTestUtil.checkExpectedTxnsPresent(null,
         new Path[] {new Path(table.getSd().getLocation(), "delta_0000001_0000003_v0000005")}, "a,b", "int:string", 0,
@@ -1610,15 +1609,15 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(1);
     // Verify delta directories after compaction
-    assertEquals("Delta directories does not match after minor compaction",
+    Assert.assertEquals("Delta directories does not match after minor compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
-    assertEquals("Delete delta directories does not match after minor compaction",
+    Assert.assertEquals("Delete delta directories does not match after minor compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
     // Insert another round of test data
     dataProvider.insertTestData(tableName, false);
     expectedData = dataProvider.getAllData(tableName);
@@ -1630,12 +1629,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // 2 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(2);
     // Verify base directory after compaction
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000010_v0000017"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
   }
 
   @Test
@@ -1661,12 +1660,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(1);
     // Verify base directory after compaction
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
     // Insert another round of test data
     dataProvider.insertTestData(tableName, false);
     expectedData = dataProvider.getAllData(tableName);
@@ -1678,18 +1677,18 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // 2 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(2);
     // Verify base directory after compaction
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
-    assertEquals("Delta directories do not match after major compaction",
+    Assert.assertEquals("Delta directories do not match after major compaction",
         Collections.singletonList("delta_0000006_0000010_v0000017"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
-    assertEquals("Delete delta directories does not match after minor compaction",
+    Assert.assertEquals("Delete delta directories does not match after minor compaction",
         Collections.singletonList("delete_delta_0000006_0000010_v0000017"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
   }
 
   @Test
@@ -1713,14 +1712,14 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
       Table table = metaStoreClient.getTable(dbName, tableName);
       FileSystem fs = FileSystem.get(conf);
-      assertEquals("Delta names does not match", Arrays
+      Assert.assertEquals("Delta names does not match", Arrays
           .asList("delta_0000001_0000002", "delta_0000001_0000005_v0000008", "delta_0000003_0000004",
               "delta_0000005_0000006"), CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
       CompactorTestUtil.checkExpectedTxnsPresent(null,
           new Path[] {new Path(table.getSd().getLocation(), "delta_0000001_0000005_v0000008")}, "a,b", "int:string",
           0, 1L, 4L, null, 1);
       //Assert that we have no delete deltas if there are no input delete events.
-      assertEquals(0,
+      Assert.assertEquals(0,
           CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null).size());
     } finally {
       if (connection != null) {
@@ -1764,8 +1763,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Bucket 1, partition 'today'
     List<String> rsBucket1PtnToday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  " + tblName
         + " where ROW__ID.bucketid = 536936448 and ds='today' order by a,b", driver);
-    assertEquals("pre-compaction read", expectedRsBucket0PtnToday, rsBucket0PtnToday);
-    assertEquals("pre-compaction read", expectedRsBucket1PtnToday, rsBucket1PtnToday);
+    Assert.assertEquals("pre-compaction read", expectedRsBucket0PtnToday, rsBucket0PtnToday);
+    Assert.assertEquals("pre-compaction read", expectedRsBucket1PtnToday, rsBucket1PtnToday);
 
     //  Run major compaction and cleaner
     CompactorTestUtil
@@ -1775,11 +1774,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Bucket 0, partition 'today'
     List<String> rsCompactBucket0PtnToday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  "
         + tblName + " where ROW__ID.bucketid = 536870912 and ds='today' order by a,b", driver);
-    assertEquals("compacted read", expectedRsBucket0PtnToday, rsCompactBucket0PtnToday);
+    Assert.assertEquals("compacted read", expectedRsBucket0PtnToday, rsCompactBucket0PtnToday);
     // Bucket 1, partition 'today'
     List<String> rsCompactBucket1PtnToday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  "
         + tblName + " where ROW__ID.bucketid = 536936448 and ds='today' order by a,b", driver);
-    assertEquals("compacted read", expectedRsBucket1PtnToday, rsCompactBucket1PtnToday);
+    Assert.assertEquals("compacted read", expectedRsBucket1PtnToday, rsCompactBucket1PtnToday);
     // Clean up
     dropTables(driver, tblName);
   }
@@ -1823,11 +1822,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Partition 'today'
     List<String> rsCompactPtnToday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  " + tblName
         + " where ds='today'", driver);
-    assertEquals("compacted read", expectedRsPtnToday, rsCompactPtnToday);
+    Assert.assertEquals("compacted read", expectedRsPtnToday, rsCompactPtnToday);
     // Partition 'yesterday'
     List<String> rsCompactPtnYesterday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  " + tblName
         + " where ds='yesterday'", driver);
-    assertEquals("compacted read", expectedRsPtnYesterday, rsCompactPtnYesterday);
+    Assert.assertEquals("compacted read", expectedRsPtnYesterday, rsCompactPtnYesterday);
     // Clean up
     dropTables(driver, tblName);
   }
@@ -1869,11 +1868,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000003_v0000005"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals("Delete delta directories does not match after compaction",
+    Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.emptyList(), actualDeleteDeltasAfterComp);
   }
 
@@ -1910,11 +1909,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals("Delta directories does not match after compaction",
+    Assert.assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000004_0000004_0000"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals("Delete delta directories does not match after compaction",
+    Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000002_0000003_v0000005"), actualDeleteDeltasAfterComp);
   }
 
@@ -1945,11 +1944,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     executeStatementOnDriver("insert into " + tableName + " values ('75', 'value75'),('99', 'value99')", driver);
 
     // Verify deltas
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000004_0000004_0000", "delta_0000005_0000005_0000", "delta_0000006_0000006_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000002_0000002_0000", "delete_delta_0000003_0000003_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Get all data before compaction is run
@@ -1963,16 +1962,16 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(1);
     // Verify deltas
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
         Collections.singletonList("delta_0000002_0000006_v0000009"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    assertEquals("Delete directories does not match",
+    Assert.assertEquals("Delete directories does not match",
         Collections.singletonList("delete_delta_0000002_0000006_v0000009"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     // Run a compaction
     CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MAJOR, true);
@@ -1982,19 +1981,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     verifySuccessfulCompaction(2);
     // Should contain only one base directory now
     String expectedBase = "base_0000006_v0000012";
-    assertEquals("Base directory does not match after major compaction",
+    Assert.assertEquals("Base directory does not match after major compaction",
         Collections.singletonList(expectedBase),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Check base dir contents
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, expectedBase));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 1);
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     // Clean up
     dataProvider.dropTable(tableName);
@@ -2034,12 +2033,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
-    assertEquals("Base directory does not match after compaction",
+    Assert.assertEquals("Base directory does not match after compaction",
         Collections.singletonList("base_0000003_v0000006"), actualDeltasAfterComp);
 
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Collections.singletonList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
 
     // Verify contents of bucket files.
@@ -2052,10 +2051,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     "{\"writeid\":3,\"bucketid\":536870913,\"rowid\":3}\t7\tnewestvalue_7",
     "{\"writeid\":3,\"bucketid\":536870914,\"rowid\":0}\t8\tvalue_8");
     List<String> rsBucket0 = executeStatementOnDriverAndReturnResults("select ROW__ID, * from " + tableName, driver);
-    assertEquals(expectedRsBucket0, rsBucket0);
+    Assert.assertEquals(expectedRsBucket0, rsBucket0);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
     // Clean up
     dataProvider.dropTable(tableName);
     msClient.close();
@@ -2105,19 +2104,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta and delete delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals("Delta directory does not match after compaction",
+    Assert.assertEquals("Delta directory does not match after compaction",
         Collections.singletonList("delta_0000001_0000004_v0000009"), actualDeltasAfterComp);
 
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    assertEquals("Delete delta directory does not match after compaction",
+    Assert.assertEquals("Delete delta directory does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000004_v0000009"), actualDeleteDeltasAfterComp);
 
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Collections.singletonList("bucket_00000");
-    assertEquals("Bucket name in delta directory is not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket name in delta directory is not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
-    assertEquals("Bucket name in delete delta directory is not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket name in delete delta directory is not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
 
     // Verify contents of bucket files.
@@ -2139,10 +2138,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     "{\"writeid\":4,\"bucketid\":536870914,\"rowid\":0}\t15\tvalue_15");
     List<String> rsBucket0 =
         executeStatementOnDriverAndReturnResults("select ROW__ID, * from " + tableName + " order by id", driver);
-    assertEquals(expectedRsBucket0, rsBucket0);
+    Assert.assertEquals(expectedRsBucket0, rsBucket0);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
     // Clean up
     dataProvider.dropTable(tableName);
     msClient.close();
@@ -2191,12 +2190,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify directories after compaction
     PathFilter pathFilter = compactionType == CompactionType.MAJOR ? AcidUtils.baseFileFilter :
         AcidUtils.deltaFileFilter;
-    assertEquals("Result directory does not match after " + compactionType.name()
+    Assert.assertEquals("Result directory does not match after " + compactionType.name()
             + " compaction", Collections.singletonList(resultDirName),
         CompactorTestUtil.getBaseOrDeltaNames(fs, pathFilter, table, null));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(dbName, tableName, false);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
   }
 
   @Test public void testVectorizationOff() throws Exception {
@@ -2225,7 +2224,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       // check that bucket property in each row matches the bucket in the file name
       long[] bucketIdVector = ((LongColumnVector) batch.cols[2]).vector;
       for (int i = 0; i < batch.count(); i++) {
-        assertEquals(bucketId, decodeBucketProperty(bucketIdVector[i]));
+        Assert.assertEquals(bucketId, decodeBucketProperty(bucketIdVector[i]));
       }
       // check that writeIds, then rowIds are sorted in ascending order
       long[] writeIdVector = ((LongColumnVector) batch.cols[1]).vector;
@@ -2236,10 +2235,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         long currentWriteId = writeIdVector[i];
         long currentRowId = rowIdVector[i];
         if (writeId == writeIdVector[i]) {
-          assertTrue(rowId <= currentRowId);
+          Assert.assertTrue(rowId <= currentRowId);
           rowId = currentRowId;
         } else {
-          assertTrue(writeId < currentWriteId);
+          Assert.assertTrue(writeId < currentWriteId);
           writeId = currentWriteId;
           rowId = 0;
         }
@@ -2255,7 +2254,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       boolean bloomFilter = rows.readStripeFooter(stripe).getStreamsList().stream().anyMatch(
           s -> s.getKind() == OrcProto.Stream.Kind.BLOOM_FILTER_UTF8
               || s.getKind() == OrcProto.Stream.Kind.BLOOM_FILTER);
-      assertTrue("Bloom filter is missing", bloomFilter);
+      Assert.assertTrue("Bloom filter is missing", bloomFilter);
     }
   }
 
@@ -2293,12 +2292,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     // Check for default case.
     qc.runCompactionQueries(hiveConf, null, ciMock, null, emptyQueries, emptyQueries, emptyQueries, null);
-    assertEquals("all", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
+    Assert.assertEquals("all", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
 
     // Check for case where  hive.llap.io.etl.skip.format is explicitly set to none - as to always use cache.
     hiveConf.setVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT, "none");
     qc.runCompactionQueries(hiveConf, null, ciMock, null, emptyQueries, emptyQueries, emptyQueries, null);
-    assertEquals("none", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
+    Assert.assertEquals("none", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
   }
 
   @Test
@@ -2324,10 +2323,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     FileStatus[] fileStatuses = fs.listStatus(new Path(table.getSd().getLocation()));
     // There should be only dir
-    assertEquals(1, fileStatuses.length);
+    Assert.assertEquals(1, fileStatuses.length);
     Path basePath = fileStatuses[0].getPath();
     // And it's a base
-    assertTrue(AcidUtils.baseFileFilter.accept(basePath));
+    Assert.assertTrue(AcidUtils.baseFileFilter.accept(basePath));
     RemoteIterator<LocatedFileStatus> filesInBase = fs.listFiles(basePath, true);
     // It has no files in it
     Assert.assertFalse(filesInBase.hasNext());
@@ -2356,7 +2355,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     // Some sanity checks
     List<String> result = execSelectAndDumpData("select * from " + tblName, driver, tblName);
-    assertEquals(4, result.size());
+    Assert.assertEquals(4, result.size());
 
     // Convert the table to acid
     executeStatementOnDriver("alter table " + tblName + " SET TBLPROPERTIES ('transactional'='true')", driver);
@@ -2375,21 +2374,21 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     // Partition lvl1
     FileStatus[] fileStatuses = fs.listStatus(tablePath);
-    assertEquals(1, fileStatuses.length);
+    Assert.assertEquals(1, fileStatuses.length);
     String partitionName1 = fileStatuses[0].getPath().getName();
-    assertEquals("p=p1", partitionName1);
+    Assert.assertEquals("p=p1", partitionName1);
 
     // Partition lvl2
     fileStatuses = fs.listStatus(new Path(table.getSd().getLocation() + "/" + partitionName1));
-    assertEquals(1, fileStatuses.length);
+    Assert.assertEquals(1, fileStatuses.length);
     String partitionName2 = fileStatuses[0].getPath().getName();
-    assertEquals("q=q1", partitionName2);
+    Assert.assertEquals("q=q1", partitionName2);
 
     // 1 base should be here
     fileStatuses = fs.listStatus(new Path(table.getSd().getLocation() + "/" + partitionName1 + "/" + partitionName2));
-    assertEquals(1, fileStatuses.length);
+    Assert.assertEquals(1, fileStatuses.length);
     String baseName = fileStatuses[0].getPath().getName();
-    assertEquals("base_10000000_v0000002", baseName);
+    Assert.assertEquals("base_10000000_v0000002", baseName);
   }
 
   @Test
@@ -2417,7 +2416,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas (delta_0000001_0000001_0000, delta_0000002_0000002_0000) are present
-    assertEquals("Delta directories does not match before compaction",
+    Assert.assertEquals("Delta directories does not match before compaction",
             Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000"),
             CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
 
@@ -2434,8 +2433,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check if the compaction succeed
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
-    assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
+    Assert.assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
+    Assert.assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
             "succeeded", compacts.get(0).getState());
     // Should contain only one base directory now
     FileStatus[] status = fs.listStatus(new Path(table.getSd().getLocation()));
@@ -2443,18 +2442,18 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     for(FileStatus file: status) {
       inputFileCount++;
     }
-    assertEquals("Expecting 1 file and found "+ inputFileCount, 1, inputFileCount);
+    Assert.assertEquals("Expecting 1 file and found "+ inputFileCount, 1, inputFileCount);
 
     // Check bucket file name
     List<String> baseDir = CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
             CompactorTestUtil
                     .getBucketFileNames(fs, table, null, baseDir.get(0)));
 
     // Verify all contents
     List<String> actualData = testDP.getAllData(tblName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
   }
 
   @Test
@@ -2497,8 +2496,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check if the compaction succeeds
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
-    assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
+    Assert.assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
+    Assert.assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
             "succeeded", compacts.get(0).getState());
 
     IMetaStoreClient msClient = new HiveMetaStoreClient(conf);
@@ -2507,19 +2506,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] fileStatus = fs.listStatus(new Path(table.getSd().getLocation()));
     for(FileStatus file: fileStatus) {
-      assertTrue(file.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
+      Assert.assertTrue(file.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
     }
 
     // Verify all contents
     List<String> actualData = testDP.getAllData(tblName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     HiveHookEvents.HiveHookEventProto event = getRelatedTezEvent(dbTableName);
     Assert.assertNotNull(event);
 
     for (org.apache.hadoop.hive.ql.hooks.proto.HiveHookEvents.MapFieldEntry mapFieldEntry: event.getOtherInfoList()) {
       if (mapFieldEntry.getKey().equalsIgnoreCase("CONF")) {
-        assertTrue(mapFieldEntry.getValue().contains("\"tez.task.resource.memory.mb\":\"8000\""));
+        Assert.assertTrue(mapFieldEntry.getValue().contains("\"tez.task.resource.memory.mb\":\"8000\""));
       }
     }
   }
@@ -2563,8 +2562,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check if the compaction succeeds
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
-    assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
+    Assert.assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
+    Assert.assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
             "succeeded", compacts.get(0).getState());
 
     IMetaStoreClient msClient = new HiveMetaStoreClient(conf);
@@ -2573,19 +2572,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] fileStatus = fs.listStatus(new Path(table.getSd().getLocation()));
     for(FileStatus file: fileStatus) {
-      assertTrue(file.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
+      Assert.assertTrue(file.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
     }
 
     // Verify all contents
     List<String> actualData = testDP.getAllData(tblName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
 
     HiveHookEvents.HiveHookEventProto event = getRelatedTezEvent(dbTableName);
     Assert.assertNotNull(event);
 
     for (org.apache.hadoop.hive.ql.hooks.proto.HiveHookEvents.MapFieldEntry mapFieldEntry: event.getOtherInfoList()) {
       if (mapFieldEntry.getKey().equalsIgnoreCase("CONF")) {
-        assertTrue(mapFieldEntry.getValue().contains("\"tez.task.resource.memory.mb\":\"5000\""));
+        Assert.assertTrue(mapFieldEntry.getValue().contains("\"tez.task.resource.memory.mb\":\"5000\""));
       }
     }
   }
@@ -2615,7 +2614,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas (delta_0000001_0000001_0000, delta_0000002_0000002_0000) are present
-    assertEquals("Delta directories does not match before compaction",
+    Assert.assertEquals("Delta directories does not match before compaction",
             Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000"),
             CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
 
@@ -2632,8 +2631,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check if the compaction succeed
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
-    assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
+    Assert.assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
+    Assert.assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
             "succeeded", compacts.get(0).getState());
     // Should contain only one base directory now
     FileStatus[] status = fs.listStatus(new Path(table.getSd().getLocation()));
@@ -2641,18 +2640,18 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     for(FileStatus file: status) {
       inputFileCount++;
     }
-    assertEquals("Expecting 1 file and found "+ inputFileCount, 1, inputFileCount);
+    Assert.assertEquals("Expecting 1 file and found "+ inputFileCount, 1, inputFileCount);
 
     // Check bucket file name
     List<String> baseDir = CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
             CompactorTestUtil
                     .getBucketFileNames(fs, table, null, baseDir.get(0)));
 
     // Verify all contents
     List<String> actualData = testDP.getAllData(tblName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
   }
 
   @Test
@@ -2707,8 +2706,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             .findFirst()
             .orElseThrow(() -> new RuntimeException("Could not get Partition"))
             .getParameters();
-    assertEquals("The number of files is differing from the expected", "6", parameters.get("numFiles"));
-    assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
+    Assert.assertEquals("The number of files is differing from the expected", "6", parameters.get("numFiles"));
+    Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
 
     //Do a minor compaction
     CompactionRequest rqst = new CompactionRequest(dbName, tblName, compactionType);
@@ -2722,7 +2721,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     if (1 != compacts.size()) {
       Assert.fail("Expecting 1 compaction and found " + compacts.size() + " compactions " + compacts);
     }
-    assertEquals("succeeded", compacts.get(0).getState());
+    Assert.assertEquals("succeeded", compacts.get(0).getState());
 
     partitions = Hive.get().getPartitions(hiveTable);
     parameters = partitions
@@ -2732,11 +2731,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             .orElseThrow(() -> new RuntimeException("Could not get Partition"))
             .getParameters();
     if (compactionType == CompactionType.MINOR) {
-      assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
+      Assert.assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
     } else {
-      assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
+      Assert.assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
     }
-    assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
+    Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
     dropTables(driver, tblName);
   }
 
@@ -2979,10 +2978,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Get all data before compaction is run
     List<String> expectedData = dataProvider.getAllData(tableName);
     // Verify deltas
-    assertEquals("Delta directories does not match",
+    Assert.assertEquals("Delta directories does not match",
             deltaDirNames, CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionName));
     // Verify delete delta
-    assertTrue(CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table,
+    Assert.assertTrue(CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table,
             partitionName).isEmpty());
     // Run a compaction which uses only merge compactor / query-based compaction
     CompactorFactory compactorFactory = spy(CompactorFactory.getInstance());
@@ -2990,28 +2989,28 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     AtomicReference<Compactor> secondary = new AtomicReference<>();
     doAnswer(invocationOnMock -> {
       Object result = invocationOnMock.callRealMethod();
-      assertTrue(result instanceof CompactorPipeline);
+      Assert.assertTrue(result instanceof CompactorPipeline);
       // Use reflection to fetch inner compactors
       CompactorPipeline compactorPipeline = (CompactorPipeline) result;
       Field field = compactorPipeline.getClass().getDeclaredField("compactor");
       field.setAccessible(true);
       Compactor compactor = (Compactor) field.get(compactorPipeline);
-      assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
+      Assert.assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
       CompactorPipeline.FallbackCompactor fallbackCompactor = spy((CompactorPipeline.FallbackCompactor) compactor);
       field.set(compactorPipeline, fallbackCompactor);
       field = fallbackCompactor.getClass().getDeclaredField("primaryCompactor");
       field.setAccessible(true);
       Compactor compactor1 = (Compactor) field.get(fallbackCompactor);
-      assertTrue(compactor1 instanceof MergeCompactor);
+      Assert.assertTrue(compactor1 instanceof MergeCompactor);
       compactor1 = spy(compactor1);
       field.set(fallbackCompactor, compactor1);
       field = fallbackCompactor.getClass().getDeclaredField("secondaryCompactor");
       field.setAccessible(true);
       Compactor compactor2 = (Compactor) field.get(fallbackCompactor);
       if (compactionType == CompactionType.MAJOR) {
-        assertTrue(compactor2 instanceof MajorQueryCompactor);
+        Assert.assertTrue(compactor2 instanceof MajorQueryCompactor);
       } else {
-        assertTrue(compactor2 instanceof MinorQueryCompactor);
+        Assert.assertTrue(compactor2 instanceof MinorQueryCompactor);
       }
       compactor2 = spy(compactor2);
       field.set(fallbackCompactor, compactor2);
@@ -3047,20 +3046,20 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     List<ShowCompactResponseElement> compacts =
             TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    compacts.forEach(c -> assertEquals("succeeded", c.getState()));
+    compacts.forEach(c -> Assert.assertEquals("succeeded", c.getState()));
     // Verify directories after compaction
     List<String> actualDirAfterComp =
             CompactorTestUtil.getBaseOrDeltaNames(fs, compactionType == CompactionType.MAJOR ? AcidUtils.baseFileFilter :
                     AcidUtils.deltaFileFilter, table, partitionName);
-    assertEquals("Base directory does not match after compaction", compactDirNames, actualDirAfterComp);
-    assertTrue(CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table,
+    Assert.assertEquals("Base directory does not match after compaction", compactDirNames, actualDirAfterComp);
+    Assert.assertTrue(CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table,
             partitionName).isEmpty());
     // Verify bucket files in delta dirs
-    assertEquals("Bucket names are not matching after compaction", bucketName,
+    Assert.assertEquals("Bucket names are not matching after compaction", bucketName,
             CompactorTestUtil.getBucketFileNames(fs, table, partitionName, actualDirAfterComp.get(0)));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    assertEquals(expectedData, actualData);
+    Assert.assertEquals(expectedData, actualData);
     // Clean up
     if (dropTable) {
       dataProvider.dropTable(tableName);
@@ -3093,25 +3092,25 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     AtomicReference<Compactor> secondary = new AtomicReference<>();
     doAnswer(invocationOnMock -> {
       Object result = invocationOnMock.callRealMethod();
-      assertTrue(result instanceof CompactorPipeline);
+      Assert.assertTrue(result instanceof CompactorPipeline);
       // Use reflection to fetch inner compactors
       CompactorPipeline compactorPipeline = (CompactorPipeline) result;
       Field field = compactorPipeline.getClass().getDeclaredField("compactor");
       field.setAccessible(true);
       Compactor compactor = (Compactor) field.get(compactorPipeline);
-      assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
+      Assert.assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
       CompactorPipeline.FallbackCompactor fallbackCompactor = spy((CompactorPipeline.FallbackCompactor) compactor);
       field.set(compactorPipeline, fallbackCompactor);
       field = fallbackCompactor.getClass().getDeclaredField("primaryCompactor");
       field.setAccessible(true);
       Compactor compactor1 = (Compactor) field.get(fallbackCompactor);
-      assertTrue(compactor1 instanceof MergeCompactor);
+      Assert.assertTrue(compactor1 instanceof MergeCompactor);
       compactor1 = spy(compactor1);
       field.set(fallbackCompactor, compactor1);
       field = fallbackCompactor.getClass().getDeclaredField("secondaryCompactor");
       field.setAccessible(true);
       Compactor compactor2 = (Compactor) field.get(fallbackCompactor);
-      assertTrue(compactor2 instanceof MmMajorQueryCompactor);
+      Assert.assertTrue(compactor2 instanceof MmMajorQueryCompactor);
       compactor2 = spy(compactor2);
       field.set(fallbackCompactor, compactor2);
       primary.set(compactor1);
@@ -3156,25 +3155,25 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     AtomicReference<Compactor> secondary = new AtomicReference<>();
     doAnswer(invocationOnMock -> {
       Object result = invocationOnMock.callRealMethod();
-      assertTrue(result instanceof CompactorPipeline);
+      Assert.assertTrue(result instanceof CompactorPipeline);
       // Use reflection to fetch inner compactors
       CompactorPipeline compactorPipeline = (CompactorPipeline) result;
       Field field = compactorPipeline.getClass().getDeclaredField("compactor");
       field.setAccessible(true);
       Compactor compactor = (Compactor) field.get(compactorPipeline);
-      assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
+      Assert.assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
       CompactorPipeline.FallbackCompactor fallbackCompactor = spy((CompactorPipeline.FallbackCompactor) compactor);
       field.set(compactorPipeline, fallbackCompactor);
       field = fallbackCompactor.getClass().getDeclaredField("primaryCompactor");
       field.setAccessible(true);
       Compactor compactor1 = (Compactor) field.get(fallbackCompactor);
-      assertTrue(compactor1 instanceof MergeCompactor);
+      Assert.assertTrue(compactor1 instanceof MergeCompactor);
       compactor1 = spy(compactor1);
       field.set(fallbackCompactor, compactor1);
       field = fallbackCompactor.getClass().getDeclaredField("secondaryCompactor");
       field.setAccessible(true);
       Compactor compactor2 = (Compactor) field.get(fallbackCompactor);
-      assertTrue(compactor2 instanceof MajorQueryCompactor);
+      Assert.assertTrue(compactor2 instanceof MajorQueryCompactor);
       compactor2 = spy(compactor2);
       field.set(fallbackCompactor, compactor2);
       primary.set(compactor1);
@@ -3211,7 +3210,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     org.apache.hadoop.hive.ql.metadata.Table table = Hive.get().getTable(DB, TABLE1);
 
-    assertEquals(3, StatsSetupConst.getColumnsHavingStats(table.getParameters()).size());
+    Assert.assertEquals(3, StatsSetupConst.getColumnsHavingStats(table.getParameters()).size());
   }
 
   @Test
@@ -3231,7 +3230,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     org.apache.hadoop.hive.ql.metadata.Table table = Hive.get().getTable(DB, TABLE1);
     Partition partition = Hive.get().getPartition(table, new HashMap<String, String>() {{ put("p", "p1"); }});
 
-    assertEquals(3, StatsSetupConst.getColumnsHavingStats(partition.getParameters()).size());
+    Assert.assertEquals(3, StatsSetupConst.getColumnsHavingStats(partition.getParameters()).size());
   }
 
   @Test
@@ -3270,10 +3269,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     verifySuccessfulCompaction(1);
     List<String> resultData = testDataProvider.getAllData(tableName);
-    assertEquals(expectedData, resultData);
+    Assert.assertEquals(expectedData, resultData);
     List<String> deltas = CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals(2, deltas.size());
-    assertEquals("Delta directory names are not matching after compaction",
+    Assert.assertEquals(2, deltas.size());
+    Assert.assertEquals("Delta directory names are not matching after compaction",
         Arrays.asList("delta_0000002_0000004_v0000007", "delta_0000005_0000005"), deltas);
     for (String delta: deltas) {
       // Check if none of the delta directories are empty
@@ -3314,10 +3313,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     verifySuccessfulCompaction(1);
     List<String> resultData = testDataProvider.getAllData(tableName);
-    assertEquals(expectedData, resultData);
+    Assert.assertEquals(expectedData, resultData);
     List<String> deltas = CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    assertEquals(2, deltas.size());
-    assertEquals("Delta directory names are not matching after compaction",
+    Assert.assertEquals(2, deltas.size());
+    Assert.assertEquals("Delta directory names are not matching after compaction",
         Arrays.asList("delta_0000001_0000003_v0000006", "delta_0000004_0000004"), deltas);
     for (String delta: deltas) {
       // Check if none of the delta directories are empty

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -17,19 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.txn.compactor;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileStatus;
@@ -51,23 +38,20 @@ import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
 import org.apache.hadoop.hive.metastore.api.ShowCompactResponseElement;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.metastore.txn.entities.CompactionInfo;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
-import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.metastore.txn.entities.CompactionInfo;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.hooks.HiveProtoLoggingHook;
 import org.apache.hadoop.hive.ql.hooks.proto.HiveHookEvents;
-import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
-import org.apache.hadoop.hive.ql.io.BucketCodec;
-import org.apache.hadoop.hive.ql.lockmgr.LockException;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
+import org.apache.hive.common.util.ReflectionUtil;
 import org.apache.hive.streaming.HiveStreamingConnection;
 import org.apache.hive.streaming.StreamingConnection;
 import org.apache.hive.streaming.StrictDelimitedInputWriter;
@@ -81,499 +65,40 @@ import org.apache.orc.impl.RecordReaderImpl;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.apache.hive.common.util.ReflectionUtil;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hive.ql.TxnCommandsBaseForTests.runWorker;
+import static org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtil.executeStatementOnDriverAndReturnResults;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.execSelectAndDumpData;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
-import static org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtil.executeStatementOnDriverAndReturnResults;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactorBase.dropTables;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("deprecation")
 public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
   private static final String DB = "default";
   private static final String TABLE1 = "t1";
-
-  @Test
-  public void testRebalanceCompactionWithParallelDeleteAsSecondOptimisticLock() throws Exception {
-    testRebalanceCompactionWithParallelDeleteAsSecond(true);
-  }
-
-  @Test
-  public void testRebalanceCompactionWithParallelDeleteAsSecondPessimisticLock() throws Exception {
-    testRebalanceCompactionWithParallelDeleteAsSecond(false);
-  }
-
-  private void testRebalanceCompactionWithParallelDeleteAsSecond(boolean optimisticLock) throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
-    conf.setBoolVar(HiveConf.ConfVars.TXN_WRITE_X_LOCK, optimisticLock);
-
-    //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "400");
-    conf.set("tez.grouping.max-size", "5000");
-    driver = new Driver(conf);
-
-    final String tableName = "rebalance_test";
-    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
-
-    //Try to do a rebalancing compaction
-    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' ORDER BY b DESC", driver);
-
-    CountDownLatch startDelete = new CountDownLatch(1);
-    CountDownLatch endDelete = new CountDownLatch(1);
-    CompactorFactory factory = Mockito.spy(CompactorFactory.getInstance());
-    doAnswer(invocation -> {
-      Object result = invocation.callRealMethod();
-      startDelete.countDown();
-      Thread.sleep(1000);
-      return result;
-    }).when(factory).getCompactorPipeline(any(), any(), any(), any());
-
-    Worker worker = new Worker(factory);
-    worker.setConf(conf);
-    worker.init(new AtomicBoolean(true));
-    worker.start();
-
-    if (!startDelete.await(10, TimeUnit.SECONDS)) {
-      throw new RuntimeException("Waiting for the compaction to start timed out!");
-    }
-
-    boolean aborted = false;
-    try {
-      executeStatementOnDriver("DELETE FROM " + tableName + " WHERE b = 12", driver);
-    } catch (CommandProcessorException e) {
-      if (optimisticLock) {
-        Assert.fail("In case of TXN_WRITE_X_LOCK = true, the transaction must be retried instead of being aborted.");
-      }
-      aborted = true;
-      Assert.assertEquals(LockException.class, e.getCause().getClass());
-      Assert.assertEquals( "Transaction manager has aborted the transaction txnid:19.  Reason: Aborting [txnid:19,19] due to a write conflict on default/rebalance_test committed by [txnid:18,19] d/u", e.getCauseMessage());
-      // Delete the record, so the rest of the test can be the same in both cases
-      executeStatementOnDriver("DELETE FROM " + tableName + " WHERE b = 12", driver);
-    } finally {
-      if(!optimisticLock && !aborted) {
-        Assert.fail("In case of TXN_WRITE_X_LOCK = false, the transaction must be aborted instead of being retried.");
-      }
-    }
-    endDelete.countDown();
-
-    worker.join();
-
-    driver.close();
-    driver = new Driver(conf);
-
-    List<String> result = execSelectAndDumpData("select * from " + tableName + " WHERE b = 12", driver,
-        "Dumping data for " + tableName + " after load:");
-    Assert.assertEquals(0, result.size());
-
-    //Check if the compaction succeed
-    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
-
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":0}\t17\t17",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":1}\t16\t16",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":2}\t15\t15",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":3}\t14\t14",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":4}\t13\t13",
-        },
-        {
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":6}\t6\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":7}\t3\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":9}\t2\t4",
-        },
-        {
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":10}\t5\t4",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":11}\t2\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":12}\t3\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":13}\t6\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":14}\t4\t3",
-        },
-        {
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":15}\t5\t3",
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":16}\t6\t2",
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t5\t2",
-        },
-    };
-    verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002", "bucket_00003"}, "base_0000007_v0000018");
-  }
-
-  @Test
-  public void testRebalanceCompactionOfNotPartitionedImplicitlyBucketedTableWithOrder() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
-
-    //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "400");
-    conf.set("tez.grouping.max-size", "5000");
-    driver = new Driver(conf);
-
-    final String tableName = "rebalance_test";
-    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
-
-    //Try to do a rebalancing compaction
-    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' ORDER BY b DESC", driver);
-    runWorker(conf);
-
-    driver.close();
-    driver = new Driver(conf);
-
-    //Check if the compaction succeed
-    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
-
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":0}\t17\t17",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":1}\t16\t16",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":2}\t15\t15",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":3}\t14\t14",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":4}\t13\t13",
-        },
-        {
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":5}\t12\t12",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":6}\t6\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":7}\t3\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":9}\t2\t4",
-        },
-        {
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":10}\t5\t4",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":11}\t2\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":12}\t3\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":13}\t6\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":14}\t4\t3",
-        },
-        {
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":15}\t5\t3",
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":16}\t6\t2",
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t5\t2",
-        },
-    };
-    verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002","bucket_00003"}, "base_0000007_v0000018");
-  }
-
-  @Test
-  public void testRebalanceCompactionOfNotPartitionedImplicitlyBucketedTable() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
-
-    //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "400");
-    conf.set("tez.grouping.max-size", "5000");
-    driver = new Driver(conf);
-
-    final String tableName = "rebalance_test";
-    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
-
-    //Try to do a rebalancing compaction
-    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance'", driver);
-    runWorker(conf);
-
-    //Check if the compaction succeed
-    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
-
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t5\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t6\t2",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t6\t3",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t5\t2",
-        },
-        {
-
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":5}\t5\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t4\t3",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":10}\t2\t3",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":11}\t3\t4",
-            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12",
-            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13",
-            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14",
-        },
-        {
-            "{\"writeid\":5,\"bucketid\":537067520,\"rowid\":15}\t15\t15",
-            "{\"writeid\":6,\"bucketid\":537067520,\"rowid\":16}\t16\t16",
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
-        },
-    };
-    verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002","bucket_00003"}, "base_0000007_v0000018");
-  }
-
-  @Test
-  public void testRebalanceCompactionOfPartitionedImplicitlyBucketedTable() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
-
-    //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "1");
-    driver = new Driver(conf);
-
-    final String stageTableName = "stage_rebalance_test";
-    final String tableName = "rebalance_test";
-    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
-
-    TestDataProvider testDataProvider = new TestDataProvider();
-    testDataProvider.createFullAcidTable(stageTableName, true, false);
-    executeStatementOnDriver("insert into " + stageTableName +" values " +
-            "('1',1,'yesterday'), ('1',2,'yesterday'), ('1',3, 'yesterday'), ('1',4, 'yesterday'), " +
-            "('2',1,'today'), ('2',2,'today'), ('2',3,'today'), ('2',4, 'today'), " +
-            "('3',1,'tomorrow'), ('3',2,'tomorrow'), ('3',3,'tomorrow'), ('3',4,'tomorrow')",
-        driver);
-
-    dropTables(driver, tableName);
-    executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
-        "PARTITIONED BY (ds string) STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
-    executeStatementOnDriver("INSERT OVERWRITE TABLE " + tableName + " partition (ds='tomorrow') select a, b from " + stageTableName, driver);
-
-    //do some single inserts to have more data in the first bucket.
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('12',12,'tomorrow')", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('13',13,'tomorrow')", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('14',14,'tomorrow')", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('15',15,'tomorrow')", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('16',16,'tomorrow')", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17,'tomorrow')", driver);
-
-    // Verify buckets and their content before rebalance in partition ds=tomorrow
-    Table table = msClient.getTable("default", tableName);
-    FileSystem fs = FileSystem.get(conf);
-    Assert.assertEquals("Test setup does not match the expected: different buckets",
-        Arrays.asList("bucket_00000_0", "bucket_00001_0", "bucket_00002_0"),
-        CompactorTestUtil.getBucketFileNames(fs, table, "ds=tomorrow", "base_0000001"));
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t2\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t2\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t2\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t2\t4\ttomorrow",
-            "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t12\t12\ttomorrow",
-            "{\"writeid\":3,\"bucketid\":536870912,\"rowid\":0}\t13\t13\ttomorrow",
-            "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":0}\t14\t14\ttomorrow",
-            "{\"writeid\":5,\"bucketid\":536870912,\"rowid\":0}\t15\t15\ttomorrow",
-            "{\"writeid\":6,\"bucketid\":536870912,\"rowid\":0}\t16\t16\ttomorrow",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":0}\t17\t17\ttomorrow",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t3\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":1}\t3\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":2}\t3\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":3}\t3\t4\ttomorrow",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":0}\t1\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":1}\t1\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":2}\t1\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":3}\t1\t4\ttomorrow",
-        },
-    };
-    for(int i = 0; i < 3; i++) {
-      Assert.assertEquals("rebalanced bucket " + i, Arrays.asList(expectedBuckets[i]),
-          testDataProvider.getBucketData(tableName, BucketCodec.V1.encode(options.bucket(i)) + ""));
-    }
-
-    //Try to do a rebalancing compaction
-    executeStatementOnDriver("ALTER TABLE " + tableName + " PARTITION (ds='tomorrow') COMPACT 'rebalance'", driver);
-    runWorker(conf);
-
-    //Check if the compaction succeed
-    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
-
-    expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t2\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t2\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t2\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t2\t4\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t3\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":5}\t3\t2\ttomorrow",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t3\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t4\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t1\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t1\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":10}\t1\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":11}\t1\t4\ttomorrow",
-        },
-        {
-            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12\ttomorrow",
-            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13\ttomorrow",
-            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14\ttomorrow",
-            "{\"writeid\":5,\"bucketid\":537001984,\"rowid\":15}\t15\t15\ttomorrow",
-            "{\"writeid\":6,\"bucketid\":537001984,\"rowid\":16}\t16\t16\ttomorrow",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":17}\t17\t17\ttomorrow",
-        },
-    };
-    verifyRebalance(testDataProvider, tableName, "ds=tomorrow", expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002"}, "base_0000007_v0000014");
-  }
-
-  @Test
-  public void testRebalanceCompactionOfNotPartitionedExplicitlyBucketedTable() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
-
-    final String tableName = "rebalance_test";
-    dropTables(driver, tableName);
-    executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
-        "CLUSTERED BY(a) INTO 4 BUCKETS STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('11',11),('22',22),('33',33),('44',44)", driver);
-
-    //Try to do a rebalancing compaction
-    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance'", driver);
-    runWorker(conf);
-
-    //Check if the compaction is refused
-    List<ShowCompactResponseElement> compacts = verifyCompaction(1, TxnStore.REFUSED_RESPONSE);
-    Assert.assertEquals("Expecting error message 'Cannot execute rebalancing compaction on bucketed tables.' and found:" + compacts.get(0).getState(),
-        "Cannot execute rebalancing compaction on bucketed tables.", compacts.get(0).getErrorMessage());
-  }
-
-  @Test
-  public void testRebalanceCompactionNotPartitionedExplicitBucketNumbers() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
-
-    //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "400");
-    conf.set("tez.grouping.max-size", "5000");
-    driver = new Driver(conf);
-
-    final String tableName = "rebalance_test";
-    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
-
-    //Try to do a rebalancing compaction
-    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' CLUSTERED INTO 4 BUCKETS", driver);
-    runWorker(conf);
-
-    verifyCompaction(1,  TxnStore.CLEANING_RESPONSE);
-
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t5\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t6\t2",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t6\t3",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t5\t2",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":5}\t5\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t4\t3",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":10}\t2\t3",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":11}\t3\t4",
-            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12",
-            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13",
-            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14",
-        },
-        {
-            "{\"writeid\":5,\"bucketid\":537067520,\"rowid\":15}\t15\t15",
-            "{\"writeid\":6,\"bucketid\":537067520,\"rowid\":16}\t16\t16",
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
-        },
-    };
-    verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002", "bucket_00003"}, "base_0000007_v0000018");
-  }
-
-  private TestDataProvider prepareRebalanceTestData(String tableName) throws Exception {
-    final String stageTableName = "stage_" + tableName;
-
-    TestDataProvider testDataProvider = new TestDataProvider();
-    testDataProvider.createFullAcidTable(stageTableName, true, false);
-    testDataProvider.insertTestData(stageTableName, true);
-
-    dropTables(driver, tableName);
-    executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
-        "STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
-    executeStatementOnDriver("INSERT OVERWRITE TABLE " + tableName + " select a, b from " + stageTableName, driver);
-
-    //do some single inserts to have more data in the first bucket.
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('12',12)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('13',13)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('14',14)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('15',15)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('16',16)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17)", driver);
-
-    // Verify buckets and their content before rebalance
-    Table table = msClient.getTable("default", tableName);
-    FileSystem fs = FileSystem.get(conf);
-    Assert.assertEquals("Test setup does not match the expected: different buckets",
-        Arrays.asList("bucket_00000_0", "bucket_00001_0", "bucket_00002_0","bucket_00003_0"),
-        CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000001"));
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t5\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t6\t2",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t6\t3",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
-            "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t12\t12",
-            "{\"writeid\":3,\"bucketid\":536870912,\"rowid\":0}\t13\t13",
-            "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":0}\t14\t14",
-            "{\"writeid\":5,\"bucketid\":536870912,\"rowid\":0}\t15\t15",
-            "{\"writeid\":6,\"bucketid\":536870912,\"rowid\":0}\t16\t16",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":0}\t17\t17",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t5\t2",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":1}\t5\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":2}\t2\t4",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":0}\t3\t3",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":1}\t4\t4",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":2}\t4\t3",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":537067520,\"rowid\":0}\t2\t3",
-            "{\"writeid\":1,\"bucketid\":537067520,\"rowid\":1}\t3\t4",
-        },
-    };
-    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
-    for(int i = 0; i < 3; i++) {
-      Assert.assertEquals("unbalanced bucket " + i, Arrays.asList(expectedBuckets[i]),
-          testDataProvider.getBucketData(tableName, BucketCodec.V1.encode(options.bucket(i)) + ""));
-    }
-    return testDataProvider;
-  }
-
-  private void verifyRebalance(TestDataProvider testDataProvider, String tableName, String partitionName,
-                               String[][] expectedBucketContent, String[] bucketNames, String folderName) throws Exception {
-    // Verify buckets and their content after rebalance
-    Table table = msClient.getTable("default", tableName);
-    FileSystem fs = FileSystem.get(conf);
-    Assert.assertEquals("Buckets does not match after compaction", Arrays.asList(bucketNames),
-        CompactorTestUtil.getBucketFileNames(fs, table, partitionName, folderName));
-    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
-    for (int i = 0; i < expectedBucketContent.length; i++) {
-      Assert.assertEquals("rebalanced bucket " + i, Arrays.asList(expectedBucketContent[i]),
-          testDataProvider.getBucketData(tableName, BucketCodec.V1.encode(options.bucket(i)) + ""));
-    }
-  }
 
   @Test
   public void testCompactionShouldNotFailOnPartitionsWithBooleanField() throws Exception {
@@ -642,15 +167,15 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     } catch (CommandProcessorException e) {
       String errorMessage = ErrorMsg.COMPACTION_REFUSED.format(dbName, tableName, "",
           "Compaction is already scheduled with state='ready for cleaning' and id=" + resp.getId());
-      Assert.assertEquals(errorMessage, e.getCauseMessage());
-      Assert.assertEquals(ErrorMsg.COMPACTION_REFUSED.getErrorCode(), e.getErrorCode());
+      assertEquals(errorMessage, e.getCauseMessage());
+      assertEquals(ErrorMsg.COMPACTION_REFUSED.getErrorCode(), e.getErrorCode());
     }
 
     //Check if the first compaction is in 'ready for cleaning'
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
   }
 
   @Test
@@ -688,15 +213,15 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     } catch (CommandProcessorException e) {
       String errorMessage = ErrorMsg.COMPACTION_REFUSED.format(dbName, tableName, " partition(pt=test)",
           "Compaction is already scheduled with state='ready for cleaning' and id=" + resp.getId());
-      Assert.assertEquals(errorMessage, e.getCauseMessage());
-      Assert.assertEquals(ErrorMsg.COMPACTION_REFUSED.getErrorCode(), e.getErrorCode());
+      assertEquals(errorMessage, e.getCauseMessage());
+      assertEquals(ErrorMsg.COMPACTION_REFUSED.getErrorCode(), e.getErrorCode());
     }
 
     //Check if the first compaction is in 'ready for cleaning'
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
   }
 
   @Test
@@ -745,7 +270,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check captured compaction request and if the type for the table was MAJOR
     ArgumentCaptor<CompactionRequest> requests = ArgumentCaptor.forClass(CompactionRequest.class);
     verify(mockedHandler).compact(requests.capture());
-    Assert.assertTrue(requests.getAllValues().stream().anyMatch(r -> r.getTablename().equals(tableName) && r.getType().equals(CompactionType.MAJOR)));
+    assertTrue(requests.getAllValues().stream().anyMatch(r -> r.getTablename().equals(tableName) && r.getType().equals(CompactionType.MAJOR)));
 
     //Try to do a minor compaction directly
     CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MINOR);
@@ -759,11 +284,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     if (2 != compacts.size()) {
       Assert.fail("Expecting 2 rows and found " + compacts.size() + " files " + compacts);
     }
-    Assert.assertEquals("refused", compacts.get(0).getState());
-    Assert.assertTrue(compacts.get(0).getErrorMessage()
+    assertEquals("refused", compacts.get(0).getState());
+    assertTrue(compacts.get(0).getErrorMessage()
             .startsWith("Query based Minor compaction is not possible for full acid tables having raw format (non-acid) data in them."));
-    Assert.assertEquals("did not initiate", compacts.get(1).getState());
-    Assert.assertTrue(compacts.get(1).getErrorMessage()
+    assertEquals("did not initiate", compacts.get(1).getState());
+    assertTrue(compacts.get(1).getErrorMessage()
             .startsWith("Caught exception while trying to determine if we should compact "));
   }
 
@@ -814,7 +339,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check captured compaction request and if the type for the table was MAJOR
     ArgumentCaptor<CompactionRequest> requests = ArgumentCaptor.forClass(CompactionRequest.class);
     verify(mockedHandler).compact(requests.capture());
-    Assert.assertTrue(requests.getAllValues().stream().anyMatch(r -> r.getTablename().equals(testTableName) && r.getType().equals(CompactionType.MAJOR)));
+    assertTrue(requests.getAllValues().stream().anyMatch(r -> r.getTablename().equals(testTableName) && r.getType().equals(CompactionType.MAJOR)));
 
     //Try to do a minor compaction directly
     CompactionRequest rqst = new CompactionRequest(dbName, testTableName, CompactionType.MINOR);
@@ -828,10 +353,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     if (2 != compacts.size()) {
       Assert.fail("Expecting 2 rows and found " + compacts.size() + " files " + compacts);
     }
-    Assert.assertEquals("refused", compacts.get(0).getState());
-    Assert.assertTrue(compacts.get(0).getErrorMessage().startsWith("Query based Minor compaction is not possible for full acid tables having raw format (non-acid) data in them."));
-    Assert.assertEquals("did not initiate", compacts.get(1).getState());
-    Assert.assertTrue(compacts.get(1).getErrorMessage().startsWith("Caught exception while trying to determine if we should compact"));
+    assertEquals("refused", compacts.get(0).getState());
+    assertTrue(compacts.get(0).getErrorMessage().startsWith("Query based Minor compaction is not possible for full acid tables having raw format (non-acid) data in them."));
+    assertEquals("did not initiate", compacts.get(1).getState());
+    assertTrue(compacts.get(1).getErrorMessage().startsWith("Caught exception while trying to determine if we should compact"));
   }
 
   /**
@@ -869,8 +394,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     //Check basic stats are collected
     Map<String, String> parameters = Hive.get().getTable(tblName).getParameters();
-    Assert.assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
-    Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
+    assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
+    assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
 
     //Do a major compaction
     CompactorTestUtil.runCompaction(conf, dbName, tblName, CompactionType.MAJOR, true);
@@ -880,12 +405,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     if (1 != compacts.size()) {
       Assert.fail("Expecting 1 file and found " + compacts.size() + " files " + compacts);
     }
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     //Check basic stats are updated
     parameters = Hive.get().getTable(tblName).getParameters();
-    Assert.assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
-    Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
+    assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
+    assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
   }
 
   @Test
@@ -907,12 +432,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas (delta_0000001_0000001_0000, delta_0000002_0000002_0000) are present
-    Assert.assertEquals("Delta directories does not match before compaction",
+    assertEquals("Delta directories does not match before compaction",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000",
             "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify that delete delta (delete_delta_0000003_0000003_0000) is present
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
 
@@ -930,7 +455,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":4}\t6\t3",
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":5}\t6\t4"));
     // Check bucket contents
-    Assert.assertEquals("pre-compaction bucket 0", expectedRsBucket0,
+    assertEquals("pre-compaction bucket 0", expectedRsBucket0,
         testDataProvider.getBucketData(tblName, "536870912"));
 
     conf.setVar(HiveConf.ConfVars.PRE_EXEC_HOOKS, HiveProtoLoggingHook.class.getName());
@@ -942,16 +467,16 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     verifySuccessfulCompaction(1);
     // Should contain only one base directory now
     String expectedBase = "base_0000005_v0000008";
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList(expectedBase),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Check base dir contents
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, null, expectedBase));
     // Check bucket contents
-    Assert.assertEquals("post-compaction bucket 0", expectedRsBucket0,
+    assertEquals("post-compaction bucket 0", expectedRsBucket0,
         testDataProvider.getBucketData(tblName, "536870912"));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
@@ -962,7 +487,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     HiveHookEvents.HiveHookEventProto event = getRelatedTezEvent(dbTableName);
     Assert.assertNotNull(event);
-    Assert.assertEquals(event.getQueue(), CUSTOM_COMPACTION_QUEUE);
+    assertEquals(event.getQueue(), CUSTOM_COMPACTION_QUEUE);
   }
 
   /**
@@ -985,7 +510,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas are present
-    Assert.assertEquals("Delta directories does not match before compaction",
+    assertEquals("Delta directories does not match before compaction",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000",
             "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
@@ -998,12 +523,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     verifySuccessfulCompaction(1);
     // Should contain only one base directory now
     String expectedBase = "base_0000005_v0000007";
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList(expectedBase),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Check base dir contents
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, null, expectedBase));
     // Check bucket file contents
@@ -1037,11 +562,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas (delta_0000001_0000001_0000, delta_0000002_0000002_0000) are present
-    Assert.assertEquals("Delta directories does not match before compaction",
+    assertEquals("Delta directories does not match before compaction",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify that delete delta (delete_delta_0000003_0000003_0000) is present
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     List<String> expectedRsBucket0 = new ArrayList<>(Arrays.asList(
@@ -1062,9 +587,9 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     List<String> preCompactionRsBucket0 = testDataProvider.getBucketData(tblName, "536870912");
     List<String> preCompactionRsBucket1 = testDataProvider.getBucketData(tblName, "536936448");
     List<String> preCompactionRsBucket2 = testDataProvider.getBucketData(tblName, "537001984");
-    Assert.assertEquals("pre-compaction bucket 0", expectedRsBucket0, preCompactionRsBucket0);
-    Assert.assertEquals("pre-compaction bucket 1", expectedRsBucket1, preCompactionRsBucket1);
-    Assert.assertEquals("pre-compaction bucket 2", expectedRsBucket2, preCompactionRsBucket2);
+    assertEquals("pre-compaction bucket 0", expectedRsBucket0, preCompactionRsBucket0);
+    assertEquals("pre-compaction bucket 1", expectedRsBucket1, preCompactionRsBucket1);
+    assertEquals("pre-compaction bucket 2", expectedRsBucket2, preCompactionRsBucket2);
 
     // Run major compaction and cleaner
     CompactorTestUtil.runCompaction(conf, dbName, tblName, CompactionType.MAJOR, true);
@@ -1072,20 +597,20 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     verifySuccessfulCompaction(1);
     // Should contain only one base directory now
     String expectedBase = "base_0000003_v0000008";
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList(expectedBase),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Check files in base
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001", "bucket_00002");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, null, "base_0000003_v0000008"));
     // Check buckets contents
-    Assert.assertEquals("post-compaction bucket 0", expectedRsBucket0, testDataProvider.getBucketData(tblName,
+    assertEquals("post-compaction bucket 0", expectedRsBucket0, testDataProvider.getBucketData(tblName,
       "536870912"));
-    Assert.assertEquals("post-compaction bucket 1", expectedRsBucket1, testDataProvider.getBucketData(tblName,
+    assertEquals("post-compaction bucket 1", expectedRsBucket1, testDataProvider.getBucketData(tblName,
       "536936448"));
-    Assert.assertEquals("post-compaction bucket 2", expectedRsBucket2, testDataProvider.getBucketData(tblName,
+    assertEquals("post-compaction bucket 2", expectedRsBucket2, testDataProvider.getBucketData(tblName,
       "537001984"));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
@@ -1116,11 +641,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Path yesterdayPath = new Path(tablePath, partitionYesterday);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday));
@@ -1138,7 +663,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":1}\t6\t2\ttoday",
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":2}\t6\t3\ttoday",
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":3}\t6\t4\ttoday"));
-    Assert.assertEquals("pre-compaction bucket 0", expectedRsBucket0,
+    assertEquals("pre-compaction bucket 0", expectedRsBucket0,
         testDataProvider.getBucketData(tblName, "536870912"));
 
     // Run major compaction and cleaner for all 3 partitions
@@ -1148,28 +673,28 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // 3 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction( 3);
     // Should contain only one base directory now
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionToday));
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000010"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionTomorrow));
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000012"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionYesterday));
     // Check base dir contents
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, "base_0000005_v0000008"));
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionTomorrow, "base_0000005_v0000010"));
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionYesterday, "base_0000005_v0000012"));
     // Check buckets contents
-    Assert.assertEquals("post-compaction bucket 0", expectedRsBucket0,
+    assertEquals("post-compaction bucket 0", expectedRsBucket0,
         testDataProvider.getBucketData(tblName, "536870912"));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(todayPath, "base_0000005_v0000008"), 0);
@@ -1198,11 +723,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String partitionToday = "ds=today";
     String partitionTomorrow = "ds=tomorrow";
     String partitionYesterday = "ds=yesterday";
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday));
@@ -1224,8 +749,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":2}\t6\t3\ttoday",
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":3}\t6\t4\ttoday");
     List<String> rsBucket1 = dataProvider.getBucketData(tableName, "536936448");
-    Assert.assertEquals(expectedRsBucket0, rsBucket0);
-    Assert.assertEquals(expectedRsBucket1, rsBucket1);
+    assertEquals(expectedRsBucket0, rsBucket0);
+    assertEquals(expectedRsBucket1, rsBucket1);
 
     // Run a compaction
     CompactorTestUtil
@@ -1242,37 +767,37 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String expectedBaseYesterday = "base_0000005_v0000014";
     List<String> baseDeltasInToday =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionToday);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList(expectedBaseToday), baseDeltasInToday);
     List<String> baseDeltasInTomorrow =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionTomorrow);
 
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList(expectedBaseTomorrow), baseDeltasInTomorrow);
     List<String> baseDeltasInYesterday =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, partitionYesterday);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList(expectedBaseYesterday), baseDeltasInYesterday);
     // Verify contents of bases
-    Assert.assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00000", "bucket_00001"),
+    assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00000", "bucket_00001"),
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, expectedBaseToday));
-    Assert.assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00001"),
+    assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00001"),
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionTomorrow, expectedBaseTomorrow));
-    Assert.assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00000", "bucket_00001"),
+    assertEquals("Bucket names are not matching after compaction", Arrays.asList("bucket_00000", "bucket_00001"),
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionYesterday, expectedBaseYesterday));
     // Verify contents of bucket files.
     // Bucket 0
     rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    Assert.assertEquals(expectedRsBucket0, rsBucket0);
+    assertEquals(expectedRsBucket0, rsBucket0);
     // Bucket 1
     rsBucket1 = dataProvider.getBucketData(tableName, "536936448");
-    Assert.assertEquals(expectedRsBucket1, rsBucket1);
+    assertEquals(expectedRsBucket1, rsBucket1);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
     String tablePath = table.getSd().getLocation();
     checkBucketIdAndRowIdInAcidFile(fs, new Path(new Path(tablePath, partitionToday), expectedBaseToday), 0);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(new Path(tablePath, partitionToday), expectedBaseToday), 1);
@@ -1300,11 +825,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Get all data before compaction is run
     List<String> expectedData = dataProvider.getAllData(tableName);
     // Verify deltas
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Run a compaction
@@ -1316,17 +841,17 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert.assertEquals("Delete delta directories does not match after compaction",
+    assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"), actualDeleteDeltasAfterComp);
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Collections.singletonList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
     // Verify contents of bucket files.
     // Bucket 0
@@ -1344,10 +869,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":4}\t6\t3",
         "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":5}\t6\t4");
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    Assert.assertEquals(expectedRsBucket0, rsBucket0);
+    assertEquals(expectedRsBucket0, rsBucket0);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1436,10 +961,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     List<String> expectedFileNames = dataProvider.getDataWithInputFileNames(null, tableName);
 
     // Verify deltas
-    Assert.assertEquals("Delta directories does not match", expectedDeltas,
+    assertEquals("Delta directories does not match", expectedDeltas,
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match", expectedDeleteDeltas,
+    assertEquals("Delete directories does not match", expectedDeleteDeltas,
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
 
     List<String> expectedBucketFiles =
@@ -1454,40 +979,40 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     List<ShowCompactResponseElement> compacts =
         TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    Assert.assertEquals("Completed compaction queue must contain one element", 1, compacts.size());
-    Assert.assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
+    assertEquals("Completed compaction queue must contain one element", 1, compacts.size());
+    assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
 
     // Verify delta and delete delta directories after compaction
     if (CompactionType.MAJOR == compactionType) {
       List<String> actualBasesAfterComp =
           CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
-      Assert.assertEquals("Base directory does not match after compaction",
+      assertEquals("Base directory does not match after compaction",
           Collections.singletonList(expectedCompactedDeltaDirName), actualBasesAfterComp);
       // Verify bucket files in delta and delete delta dirs
-      Assert.assertEquals("Bucket names are not matching after compaction in the base folder",
+      assertEquals("Bucket names are not matching after compaction in the base folder",
           expectedBucketFiles, CompactorTestUtil.getBucketFileNames(fs, table, null, actualBasesAfterComp.get(0)));
     } else {
       List<String> actualDeltasAfterComp =
           CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-      Assert.assertEquals("Delta directories does not match after compaction",
+      assertEquals("Delta directories does not match after compaction",
           Collections.singletonList(expectedCompactedDeltaDirName), actualDeltasAfterComp);
       List<String> actualDeleteDeltasAfterComp =
           CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-      Assert.assertEquals("Delete delta directories does not match after compaction",
+      assertEquals("Delete delta directories does not match after compaction",
           Collections.singletonList("delete_" + expectedCompactedDeltaDirName), actualDeleteDeltasAfterComp);
       // Verify bucket files in delta and delete delta dirs
-      Assert.assertEquals("Bucket names are not matching after compaction in the delete deltas",
+      assertEquals("Bucket names are not matching after compaction in the delete deltas",
           expectedDeleteBucketFiles,
           CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
-      Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+      assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
           CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
     }
 
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
     List<String> actualFileNames = dataProvider.getDataWithInputFileNames(null, tableName);
-    Assert.assertTrue(dataProvider.compareFileNames(expectedFileNames, actualFileNames));
+    assertTrue(dataProvider.compareFileNames(expectedFileNames, actualFileNames));
     dataProvider.dropTable(tableName);
   }
 
@@ -1510,7 +1035,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     expectedDeltas.add("delta_0000006_0000006_0000");
     expectedDeltas.add("delta_0000007_0000007_0000");
     expectedDeltas.add("delta_0000008_0000008_0000");
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         expectedDeltas,
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
@@ -1519,7 +1044,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     expectedDeleteDeltas.add("delete_delta_0000003_0000003_0000");
     expectedDeleteDeltas.add("delete_delta_0000004_0000004_0000");
     expectedDeleteDeltas.add("delete_delta_0000005_0000005_0000");
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         expectedDeleteDeltas,
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
 
@@ -1534,28 +1059,28 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     List<ShowCompactResponseElement> compacts =
         TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    Assert.assertEquals("Completed compaction queue must contain one element", 1, compacts.size());
-    Assert.assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
+    assertEquals("Completed compaction queue must contain one element", 1, compacts.size());
+    assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000008_v0000011"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert.assertEquals("Delete delta directories does not match after compaction",
+    assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000008_v0000011"), actualDeleteDeltasAfterComp);
     // Verify bucket files in delta dirs
     List<String> actualData = dataProvider.getAllData(tableName);
 
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
 
-    Assert.assertEquals("Bucket names in delete delta are not matching after compaction", expectedDeleteBucketFiles,
+    assertEquals("Bucket names in delete delta are not matching after compaction", expectedDeleteBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
     // Verify all contents
    // List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MAJOR, true);
     // Clean up resources
@@ -1564,19 +1089,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     compacts =
         TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    Assert.assertEquals("Completed compaction queue must contain one element", 2, compacts.size());
-    Assert.assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
+    assertEquals("Completed compaction queue must contain one element", 2, compacts.size());
+    assertEquals("Compaction state is not succeeded", "succeeded", compacts.get(0).getState());
     // Verify delta directories after compaction
     List<String> actualBasesAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
-    Assert.assertEquals("Base directory does not match after compaction",
+    assertEquals("Base directory does not match after compaction",
         Collections.singletonList("base_0000008_v0000014"), actualBasesAfterComp);
     // Verify bucket files in delta dirs
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualBasesAfterComp.get(0)));
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
     dataProvider.dropTable(tableName);
   }
 
@@ -1596,11 +1121,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Get all data before compaction is run
     List<String> expectedData = dataProvider.getAllData(tableName);
     // Verify deltas
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Run a compaction
@@ -1612,17 +1137,17 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert.assertEquals("Delete delta directories does not match after compaction",
+    assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"), actualDeleteDeltasAfterComp);
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
     // Verify contents of bucket files.
     // Bucket 0
@@ -1630,7 +1155,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":1}\t3\t3",
         "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":2}\t3\t4");
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    Assert.assertEquals(expectedRsBucket0, rsBucket0);
+    assertEquals(expectedRsBucket0, rsBucket0);
     // Bucket 1
     List<String> expectedRs1Bucket = Arrays.asList(
         "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":1}\t2\t3",
@@ -1644,10 +1169,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":4}\t6\t3",
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":5}\t6\t4");
     List<String> rsBucket1 = dataProvider.getBucketData(tableName, "536936448");
-    Assert.assertEquals(expectedRs1Bucket, rsBucket1);
+    assertEquals(expectedRs1Bucket, rsBucket1);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1676,11 +1201,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String partitionToday = "ds=today";
     String partitionTomorrow = "ds=tomorrow";
     String partitionYesterday = "ds=yesterday";
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday));
@@ -1695,19 +1220,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction in each partition
     List<String> actualDeltasAfterCompPartToday =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"), actualDeltasAfterCompPartToday);
     List<String> actualDeleteDeltasAfterCompPartToday =
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday);
-    Assert.assertEquals("Delete delta directories does not match after compaction",
+    assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"), actualDeleteDeltasAfterCompPartToday);
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Collections.singletonList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, actualDeltasAfterCompPartToday.get(0)));
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, actualDeleteDeltasAfterCompPartToday.get(0)));
 
@@ -1727,11 +1252,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":2}\t6\t3\ttoday",
             "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":3}\t6\t4\ttoday");
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    Assert.assertEquals(expectedRsBucket0, rsBucket0);
+    assertEquals(expectedRsBucket0, rsBucket0);
 
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1760,11 +1285,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String partitionToday = "ds=today";
     String partitionTomorrow = "ds=tomorrow";
     String partitionYesterday = "ds=yesterday";
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000", "delta_0000004_0000004_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000003_0000003_0000", "delete_delta_0000005_0000005_0000"),
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday));
@@ -1779,19 +1304,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction in each partition
     List<String> actualDeltasAfterCompPartToday =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionToday);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"), actualDeltasAfterCompPartToday);
     List<String> actualDeleteDeltasAfterCompPartToday =
         CompactorTestUtil
             .getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, partitionToday);
-    Assert.assertEquals("Delete delta directories does not match after compaction",
+    assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"), actualDeleteDeltasAfterCompPartToday);
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, actualDeltasAfterCompPartToday.get(0)));
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil
             .getBucketFileNames(fs, table, partitionToday, actualDeleteDeltasAfterCompPartToday.get(0)));
     // Verify contents of bucket files.
@@ -1800,7 +1325,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t3\t3\ttoday",
         "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t3\t4\tyesterday");
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    Assert.assertEquals(expectedRsBucket0, rsBucket0);
+    assertEquals(expectedRsBucket0, rsBucket0);
     // Bucket 1
     List<String> expectedRsBucket1 = Arrays.asList("{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t2\t3\tyesterday",
         "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t2\t4\ttoday",
@@ -1813,10 +1338,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":2}\t6\t3\ttoday",
         "{\"writeid\":4,\"bucketid\":536936448,\"rowid\":3}\t6\t4\ttoday");
     List<String> rsBucket1 = dataProvider.getBucketData(tableName, "536936448");
-    Assert.assertEquals(expectedRsBucket1, rsBucket1);
+    assertEquals(expectedRsBucket1, rsBucket1);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1845,10 +1370,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify deltas
     List<String> deltaNames = CompactorTestUtil
         .getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals(10, deltaNames.size());
+    assertEquals(10, deltaNames.size());
     List<String> deleteDeltaName =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert.assertEquals(5, deleteDeltaName.size());
+    assertEquals(5, deleteDeltaName.size());
     // Run a compaction
     CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MINOR, true);
     // Clean up resources
@@ -1857,23 +1382,22 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals(Collections.singletonList("delta_0000001_0000015_v0000018"), actualDeltasAfterComp);
+    assertEquals(Collections.singletonList("delta_0000001_0000015_v0000018"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert
-        .assertEquals(Collections.singletonList("delete_delta_0000001_0000015_v0000018"), actualDeleteDeltasAfterComp);
+    assertEquals(Collections.singletonList("delete_delta_0000001_0000015_v0000018"), actualDeleteDeltasAfterComp);
     // Verify bucket file in delta dir
     List<String> expectedBucketFile = Collections.singletonList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFile,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFile,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFile,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFile,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
     // Verify contents of bucket file
     List<String> rsBucket0 = dataProvider.getBucketData(tableName, "536870912");
-    Assert.assertEquals(5, rsBucket0.size());
+    assertEquals(5, rsBucket0.size());
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
         conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
@@ -1921,11 +1445,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000015_v0000021"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert.assertEquals("Delete delta directories does not match after compaction",
+    assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000015_v0000021"), actualDeleteDeltasAfterComp);
 
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
@@ -1958,7 +1482,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
       Table table = metaStoreClient.getTable(dbName, tableName);
       FileSystem fs = FileSystem.get(conf);
-      Assert.assertEquals("Delta names does not match", Arrays
+      assertEquals("Delta names does not match", Arrays
           .asList("delta_0000001_0000002", "delta_0000001_0000005_v0000008", "delta_0000003_0000004",
               "delta_0000005_0000006"), CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
       CompactorTestUtil.checkExpectedTxnsPresent(null,
@@ -1988,7 +1512,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
     Table table = metaStoreClient.getTable(dbName, tableName);
     FileSystem fs = FileSystem.get(conf);
-    Assert.assertEquals("Delta names does not match",
+    assertEquals("Delta names does not match",
         Arrays.asList("delta_0000001_0000002", "delta_0000001_0000006_v0000008", "delta_0000003_0000004"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
     CompactorTestUtil.checkExpectedTxnsPresent(null,
@@ -2018,7 +1542,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
     Table table = metaStoreClient.getTable(dbName, tableName);
     FileSystem fs = FileSystem.get(conf);
-    Assert.assertEquals("Delta names does not match",
+    assertEquals("Delta names does not match",
         Arrays.asList("delta_0000001_0000002", "delta_0000001_0000006_v0000008", "delta_0000005_0000006"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
     CompactorTestUtil.checkExpectedTxnsPresent(null,
@@ -2056,7 +1580,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
     Table table = metaStoreClient.getTable(dbName, tableName);
     FileSystem fs = FileSystem.get(conf);
-    Assert.assertEquals("Delta names does not match", Collections.singletonList("delta_0000001_0000003_v0000005"),
+    assertEquals("Delta names does not match", Collections.singletonList("delta_0000001_0000003_v0000005"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
     CompactorTestUtil.checkExpectedTxnsPresent(null,
         new Path[] {new Path(table.getSd().getLocation(), "delta_0000001_0000003_v0000005")}, "a,b", "int:string", 0,
@@ -2086,15 +1610,15 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(1);
     // Verify delta directories after compaction
-    Assert.assertEquals("Delta directories does not match after minor compaction",
+    assertEquals("Delta directories does not match after minor compaction",
         Collections.singletonList("delta_0000001_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
-    Assert.assertEquals("Delete delta directories does not match after minor compaction",
+    assertEquals("Delete delta directories does not match after minor compaction",
         Collections.singletonList("delete_delta_0000001_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
     // Insert another round of test data
     dataProvider.insertTestData(tableName, false);
     expectedData = dataProvider.getAllData(tableName);
@@ -2106,12 +1630,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // 2 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(2);
     // Verify base directory after compaction
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000010_v0000017"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
   }
 
   @Test
@@ -2137,12 +1661,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(1);
     // Verify base directory after compaction
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
     // Insert another round of test data
     dataProvider.insertTestData(tableName, false);
     expectedData = dataProvider.getAllData(tableName);
@@ -2154,18 +1678,18 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // 2 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(2);
     // Verify base directory after compaction
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList("base_0000005_v0000008"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
-    Assert.assertEquals("Delta directories do not match after major compaction",
+    assertEquals("Delta directories do not match after major compaction",
         Collections.singletonList("delta_0000006_0000010_v0000017"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
-    Assert.assertEquals("Delete delta directories does not match after minor compaction",
+    assertEquals("Delete delta directories does not match after minor compaction",
         Collections.singletonList("delete_delta_0000006_0000010_v0000017"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
   }
 
   @Test
@@ -2189,14 +1713,14 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
       Table table = metaStoreClient.getTable(dbName, tableName);
       FileSystem fs = FileSystem.get(conf);
-      Assert.assertEquals("Delta names does not match", Arrays
+      assertEquals("Delta names does not match", Arrays
           .asList("delta_0000001_0000002", "delta_0000001_0000005_v0000008", "delta_0000003_0000004",
               "delta_0000005_0000006"), CompactorTestUtil.getBaseOrDeltaNames(fs, null, table, null));
       CompactorTestUtil.checkExpectedTxnsPresent(null,
           new Path[] {new Path(table.getSd().getLocation(), "delta_0000001_0000005_v0000008")}, "a,b", "int:string",
           0, 1L, 4L, null, 1);
       //Assert that we have no delete deltas if there are no input delete events.
-      Assert.assertEquals(0,
+      assertEquals(0,
           CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null).size());
     } finally {
       if (connection != null) {
@@ -2240,8 +1764,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Bucket 1, partition 'today'
     List<String> rsBucket1PtnToday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  " + tblName
         + " where ROW__ID.bucketid = 536936448 and ds='today' order by a,b", driver);
-    Assert.assertEquals("pre-compaction read", expectedRsBucket0PtnToday, rsBucket0PtnToday);
-    Assert.assertEquals("pre-compaction read", expectedRsBucket1PtnToday, rsBucket1PtnToday);
+    assertEquals("pre-compaction read", expectedRsBucket0PtnToday, rsBucket0PtnToday);
+    assertEquals("pre-compaction read", expectedRsBucket1PtnToday, rsBucket1PtnToday);
 
     //  Run major compaction and cleaner
     CompactorTestUtil
@@ -2251,11 +1775,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Bucket 0, partition 'today'
     List<String> rsCompactBucket0PtnToday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  "
         + tblName + " where ROW__ID.bucketid = 536870912 and ds='today' order by a,b", driver);
-    Assert.assertEquals("compacted read", expectedRsBucket0PtnToday, rsCompactBucket0PtnToday);
+    assertEquals("compacted read", expectedRsBucket0PtnToday, rsCompactBucket0PtnToday);
     // Bucket 1, partition 'today'
     List<String> rsCompactBucket1PtnToday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  "
         + tblName + " where ROW__ID.bucketid = 536936448 and ds='today' order by a,b", driver);
-    Assert.assertEquals("compacted read", expectedRsBucket1PtnToday, rsCompactBucket1PtnToday);
+    assertEquals("compacted read", expectedRsBucket1PtnToday, rsCompactBucket1PtnToday);
     // Clean up
     dropTables(driver, tblName);
   }
@@ -2299,11 +1823,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Partition 'today'
     List<String> rsCompactPtnToday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  " + tblName
         + " where ds='today'", driver);
-    Assert.assertEquals("compacted read", expectedRsPtnToday, rsCompactPtnToday);
+    assertEquals("compacted read", expectedRsPtnToday, rsCompactPtnToday);
     // Partition 'yesterday'
     List<String> rsCompactPtnYesterday = executeStatementOnDriverAndReturnResults("select ROW__ID, * from  " + tblName
         + " where ds='yesterday'", driver);
-    Assert.assertEquals("compacted read", expectedRsPtnYesterday, rsCompactPtnYesterday);
+    assertEquals("compacted read", expectedRsPtnYesterday, rsCompactPtnYesterday);
     // Clean up
     dropTables(driver, tblName);
   }
@@ -2345,11 +1869,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000001_0000003_v0000005"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert.assertEquals("Delete delta directories does not match after compaction",
+    assertEquals("Delete delta directories does not match after compaction",
         Collections.emptyList(), actualDeleteDeltasAfterComp);
   }
 
@@ -2386,11 +1910,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals("Delta directories does not match after compaction",
+    assertEquals("Delta directories does not match after compaction",
         Collections.singletonList("delta_0000004_0000004_0000"), actualDeltasAfterComp);
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert.assertEquals("Delete delta directories does not match after compaction",
+    assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000002_0000003_v0000005"), actualDeleteDeltasAfterComp);
   }
 
@@ -2421,11 +1945,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     executeStatementOnDriver("insert into " + tableName + " values ('75', 'value75'),('99', 'value99')", driver);
 
     // Verify deltas
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         Arrays.asList("delta_0000004_0000004_0000", "delta_0000005_0000005_0000", "delta_0000006_0000006_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Arrays.asList("delete_delta_0000002_0000002_0000", "delete_delta_0000003_0000003_0000"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Get all data before compaction is run
@@ -2439,16 +1963,16 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     verifySuccessfulCompaction(1);
     // Verify deltas
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
         Collections.singletonList("delta_0000002_0000006_v0000009"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     // Verify delete delta
-    Assert.assertEquals("Delete directories does not match",
+    assertEquals("Delete directories does not match",
         Collections.singletonList("delete_delta_0000002_0000006_v0000009"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     // Run a compaction
     CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MAJOR, true);
@@ -2458,19 +1982,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     verifySuccessfulCompaction(2);
     // Should contain only one base directory now
     String expectedBase = "base_0000006_v0000012";
-    Assert.assertEquals("Base directory does not match after major compaction",
+    assertEquals("Base directory does not match after major compaction",
         Collections.singletonList(expectedBase),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     // Check base dir contents
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, expectedBase));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 1);
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     // Clean up
     dataProvider.dropTable(tableName);
@@ -2510,12 +2034,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
-    Assert.assertEquals("Base directory does not match after compaction",
+    assertEquals("Base directory does not match after compaction",
         Collections.singletonList("base_0000003_v0000006"), actualDeltasAfterComp);
 
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Collections.singletonList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
 
     // Verify contents of bucket files.
@@ -2528,10 +2052,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     "{\"writeid\":3,\"bucketid\":536870913,\"rowid\":3}\t7\tnewestvalue_7",
     "{\"writeid\":3,\"bucketid\":536870914,\"rowid\":0}\t8\tvalue_8");
     List<String> rsBucket0 = executeStatementOnDriverAndReturnResults("select ROW__ID, * from " + tableName, driver);
-    Assert.assertEquals(expectedRsBucket0, rsBucket0);
+    assertEquals(expectedRsBucket0, rsBucket0);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
     // Clean up
     dataProvider.dropTable(tableName);
     msClient.close();
@@ -2581,19 +2105,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify delta and delete delta directories after compaction
     List<String> actualDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals("Delta directory does not match after compaction",
+    assertEquals("Delta directory does not match after compaction",
         Collections.singletonList("delta_0000001_0000004_v0000009"), actualDeltasAfterComp);
 
     List<String> actualDeleteDeltasAfterComp =
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
-    Assert.assertEquals("Delete delta directory does not match after compaction",
+    assertEquals("Delete delta directory does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000004_v0000009"), actualDeleteDeltasAfterComp);
 
     // Verify bucket files in delta dirs
     List<String> expectedBucketFiles = Collections.singletonList("bucket_00000");
-    Assert.assertEquals("Bucket name in delta directory is not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket name in delta directory is not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeltasAfterComp.get(0)));
-    Assert.assertEquals("Bucket name in delete delta directory is not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket name in delete delta directory is not matching after compaction", expectedBucketFiles,
         CompactorTestUtil.getBucketFileNames(fs, table, null, actualDeleteDeltasAfterComp.get(0)));
 
     // Verify contents of bucket files.
@@ -2615,10 +2139,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     "{\"writeid\":4,\"bucketid\":536870914,\"rowid\":0}\t15\tvalue_15");
     List<String> rsBucket0 =
         executeStatementOnDriverAndReturnResults("select ROW__ID, * from " + tableName + " order by id", driver);
-    Assert.assertEquals(expectedRsBucket0, rsBucket0);
+    assertEquals(expectedRsBucket0, rsBucket0);
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
     // Clean up
     dataProvider.dropTable(tableName);
     msClient.close();
@@ -2667,12 +2191,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify directories after compaction
     PathFilter pathFilter = compactionType == CompactionType.MAJOR ? AcidUtils.baseFileFilter :
         AcidUtils.deltaFileFilter;
-    Assert.assertEquals("Result directory does not match after " + compactionType.name()
+    assertEquals("Result directory does not match after " + compactionType.name()
             + " compaction", Collections.singletonList(resultDirName),
         CompactorTestUtil.getBaseOrDeltaNames(fs, pathFilter, table, null));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(dbName, tableName, false);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
   }
 
   @Test public void testVectorizationOff() throws Exception {
@@ -2701,7 +2225,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       // check that bucket property in each row matches the bucket in the file name
       long[] bucketIdVector = ((LongColumnVector) batch.cols[2]).vector;
       for (int i = 0; i < batch.count(); i++) {
-        Assert.assertEquals(bucketId, decodeBucketProperty(bucketIdVector[i]));
+        assertEquals(bucketId, decodeBucketProperty(bucketIdVector[i]));
       }
       // check that writeIds, then rowIds are sorted in ascending order
       long[] writeIdVector = ((LongColumnVector) batch.cols[1]).vector;
@@ -2712,10 +2236,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         long currentWriteId = writeIdVector[i];
         long currentRowId = rowIdVector[i];
         if (writeId == writeIdVector[i]) {
-          Assert.assertTrue(rowId <= currentRowId);
+          assertTrue(rowId <= currentRowId);
           rowId = currentRowId;
         } else {
-          Assert.assertTrue(writeId < currentWriteId);
+          assertTrue(writeId < currentWriteId);
           writeId = currentWriteId;
           rowId = 0;
         }
@@ -2731,7 +2255,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       boolean bloomFilter = rows.readStripeFooter(stripe).getStreamsList().stream().anyMatch(
           s -> s.getKind() == OrcProto.Stream.Kind.BLOOM_FILTER_UTF8
               || s.getKind() == OrcProto.Stream.Kind.BLOOM_FILTER);
-      Assert.assertTrue("Bloom filter is missing", bloomFilter);
+      assertTrue("Bloom filter is missing", bloomFilter);
     }
   }
 
@@ -2769,12 +2293,12 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     // Check for default case.
     qc.runCompactionQueries(hiveConf, null, ciMock, null, emptyQueries, emptyQueries, emptyQueries, null);
-    Assert.assertEquals("all", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
+    assertEquals("all", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
 
     // Check for case where  hive.llap.io.etl.skip.format is explicitly set to none - as to always use cache.
     hiveConf.setVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT, "none");
     qc.runCompactionQueries(hiveConf, null, ciMock, null, emptyQueries, emptyQueries, emptyQueries, null);
-    Assert.assertEquals("none", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
+    assertEquals("none", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
   }
 
   @Test
@@ -2800,10 +2324,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     FileStatus[] fileStatuses = fs.listStatus(new Path(table.getSd().getLocation()));
     // There should be only dir
-    Assert.assertEquals(1, fileStatuses.length);
+    assertEquals(1, fileStatuses.length);
     Path basePath = fileStatuses[0].getPath();
     // And it's a base
-    Assert.assertTrue(AcidUtils.baseFileFilter.accept(basePath));
+    assertTrue(AcidUtils.baseFileFilter.accept(basePath));
     RemoteIterator<LocatedFileStatus> filesInBase = fs.listFiles(basePath, true);
     // It has no files in it
     Assert.assertFalse(filesInBase.hasNext());
@@ -2832,7 +2356,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     // Some sanity checks
     List<String> result = execSelectAndDumpData("select * from " + tblName, driver, tblName);
-    Assert.assertEquals(4, result.size());
+    assertEquals(4, result.size());
 
     // Convert the table to acid
     executeStatementOnDriver("alter table " + tblName + " SET TBLPROPERTIES ('transactional'='true')", driver);
@@ -2851,21 +2375,21 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     // Partition lvl1
     FileStatus[] fileStatuses = fs.listStatus(tablePath);
-    Assert.assertEquals(1, fileStatuses.length);
+    assertEquals(1, fileStatuses.length);
     String partitionName1 = fileStatuses[0].getPath().getName();
-    Assert.assertEquals("p=p1", partitionName1);
+    assertEquals("p=p1", partitionName1);
 
     // Partition lvl2
     fileStatuses = fs.listStatus(new Path(table.getSd().getLocation() + "/" + partitionName1));
-    Assert.assertEquals(1, fileStatuses.length);
+    assertEquals(1, fileStatuses.length);
     String partitionName2 = fileStatuses[0].getPath().getName();
-    Assert.assertEquals("q=q1", partitionName2);
+    assertEquals("q=q1", partitionName2);
 
     // 1 base should be here
     fileStatuses = fs.listStatus(new Path(table.getSd().getLocation() + "/" + partitionName1 + "/" + partitionName2));
-    Assert.assertEquals(1, fileStatuses.length);
+    assertEquals(1, fileStatuses.length);
     String baseName = fileStatuses[0].getPath().getName();
-    Assert.assertEquals("base_10000000_v0000002", baseName);
+    assertEquals("base_10000000_v0000002", baseName);
   }
 
   @Test
@@ -2893,7 +2417,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas (delta_0000001_0000001_0000, delta_0000002_0000002_0000) are present
-    Assert.assertEquals("Delta directories does not match before compaction",
+    assertEquals("Delta directories does not match before compaction",
             Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000"),
             CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
 
@@ -2910,8 +2434,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check if the compaction succeed
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
-    Assert.assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
+    assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
+    assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
             "succeeded", compacts.get(0).getState());
     // Should contain only one base directory now
     FileStatus[] status = fs.listStatus(new Path(table.getSd().getLocation()));
@@ -2919,18 +2443,18 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     for(FileStatus file: status) {
       inputFileCount++;
     }
-    Assert.assertEquals("Expecting 1 file and found "+ inputFileCount, 1, inputFileCount);
+    assertEquals("Expecting 1 file and found "+ inputFileCount, 1, inputFileCount);
 
     // Check bucket file name
     List<String> baseDir = CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
             CompactorTestUtil
                     .getBucketFileNames(fs, table, null, baseDir.get(0)));
 
     // Verify all contents
     List<String> actualData = testDP.getAllData(tblName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
   }
 
   @Test
@@ -2973,8 +2497,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check if the compaction succeeds
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
-    Assert.assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
+    assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
+    assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
             "succeeded", compacts.get(0).getState());
 
     IMetaStoreClient msClient = new HiveMetaStoreClient(conf);
@@ -2983,19 +2507,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] fileStatus = fs.listStatus(new Path(table.getSd().getLocation()));
     for(FileStatus file: fileStatus) {
-      Assert.assertTrue(file.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
+      assertTrue(file.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
     }
 
     // Verify all contents
     List<String> actualData = testDP.getAllData(tblName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     HiveHookEvents.HiveHookEventProto event = getRelatedTezEvent(dbTableName);
     Assert.assertNotNull(event);
 
     for (org.apache.hadoop.hive.ql.hooks.proto.HiveHookEvents.MapFieldEntry mapFieldEntry: event.getOtherInfoList()) {
       if (mapFieldEntry.getKey().equalsIgnoreCase("CONF")) {
-        Assert.assertTrue(mapFieldEntry.getValue().contains("\"tez.task.resource.memory.mb\":\"8000\""));
+        assertTrue(mapFieldEntry.getValue().contains("\"tez.task.resource.memory.mb\":\"8000\""));
       }
     }
   }
@@ -3039,8 +2563,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check if the compaction succeeds
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
-    Assert.assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
+    assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
+    assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
             "succeeded", compacts.get(0).getState());
 
     IMetaStoreClient msClient = new HiveMetaStoreClient(conf);
@@ -3049,19 +2573,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] fileStatus = fs.listStatus(new Path(table.getSd().getLocation()));
     for(FileStatus file: fileStatus) {
-      Assert.assertTrue(file.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
+      assertTrue(file.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
     }
 
     // Verify all contents
     List<String> actualData = testDP.getAllData(tblName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
 
     HiveHookEvents.HiveHookEventProto event = getRelatedTezEvent(dbTableName);
     Assert.assertNotNull(event);
 
     for (org.apache.hadoop.hive.ql.hooks.proto.HiveHookEvents.MapFieldEntry mapFieldEntry: event.getOtherInfoList()) {
       if (mapFieldEntry.getKey().equalsIgnoreCase("CONF")) {
-        Assert.assertTrue(mapFieldEntry.getValue().contains("\"tez.task.resource.memory.mb\":\"5000\""));
+        assertTrue(mapFieldEntry.getValue().contains("\"tez.task.resource.memory.mb\":\"5000\""));
       }
     }
   }
@@ -3091,7 +2615,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable(dbName, tblName);
     FileSystem fs = FileSystem.get(conf);
     // Verify deltas (delta_0000001_0000001_0000, delta_0000002_0000002_0000) are present
-    Assert.assertEquals("Delta directories does not match before compaction",
+    assertEquals("Delta directories does not match before compaction",
             Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000"),
             CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
 
@@ -3108,8 +2632,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     //Check if the compaction succeed
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
-    Assert.assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
+    assertEquals("Expecting 1 rows and found " + compacts.size(), 1, compacts.size());
+    assertEquals("Expecting compaction state 'succeeded' and found:" + compacts.get(0).getState(),
             "succeeded", compacts.get(0).getState());
     // Should contain only one base directory now
     FileStatus[] status = fs.listStatus(new Path(table.getSd().getLocation()));
@@ -3117,18 +2641,18 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     for(FileStatus file: status) {
       inputFileCount++;
     }
-    Assert.assertEquals("Expecting 1 file and found "+ inputFileCount, 1, inputFileCount);
+    assertEquals("Expecting 1 file and found "+ inputFileCount, 1, inputFileCount);
 
     // Check bucket file name
     List<String> baseDir = CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null);
     List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
-    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+    assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
             CompactorTestUtil
                     .getBucketFileNames(fs, table, null, baseDir.get(0)));
 
     // Verify all contents
     List<String> actualData = testDP.getAllData(tblName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
   }
 
   @Test
@@ -3183,8 +2707,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             .findFirst()
             .orElseThrow(() -> new RuntimeException("Could not get Partition"))
             .getParameters();
-    Assert.assertEquals("The number of files is differing from the expected", "6", parameters.get("numFiles"));
-    Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
+    assertEquals("The number of files is differing from the expected", "6", parameters.get("numFiles"));
+    assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
 
     //Do a minor compaction
     CompactionRequest rqst = new CompactionRequest(dbName, tblName, compactionType);
@@ -3198,7 +2722,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     if (1 != compacts.size()) {
       Assert.fail("Expecting 1 compaction and found " + compacts.size() + " compactions " + compacts);
     }
-    Assert.assertEquals("succeeded", compacts.get(0).getState());
+    assertEquals("succeeded", compacts.get(0).getState());
 
     partitions = Hive.get().getPartitions(hiveTable);
     parameters = partitions
@@ -3208,11 +2732,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             .orElseThrow(() -> new RuntimeException("Could not get Partition"))
             .getParameters();
     if (compactionType == CompactionType.MINOR) {
-      Assert.assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
+      assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
     } else {
-      Assert.assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
+      assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
     }
-    Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
+    assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
     dropTables(driver, tblName);
   }
 
@@ -3455,10 +2979,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Get all data before compaction is run
     List<String> expectedData = dataProvider.getAllData(tableName);
     // Verify deltas
-    Assert.assertEquals("Delta directories does not match",
+    assertEquals("Delta directories does not match",
             deltaDirNames, CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, partitionName));
     // Verify delete delta
-    Assert.assertTrue(CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table,
+    assertTrue(CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table,
             partitionName).isEmpty());
     // Run a compaction which uses only merge compactor / query-based compaction
     CompactorFactory compactorFactory = spy(CompactorFactory.getInstance());
@@ -3466,28 +2990,28 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     AtomicReference<Compactor> secondary = new AtomicReference<>();
     doAnswer(invocationOnMock -> {
       Object result = invocationOnMock.callRealMethod();
-      Assert.assertTrue(result instanceof CompactorPipeline);
+      assertTrue(result instanceof CompactorPipeline);
       // Use reflection to fetch inner compactors
       CompactorPipeline compactorPipeline = (CompactorPipeline) result;
       Field field = compactorPipeline.getClass().getDeclaredField("compactor");
       field.setAccessible(true);
       Compactor compactor = (Compactor) field.get(compactorPipeline);
-      Assert.assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
+      assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
       CompactorPipeline.FallbackCompactor fallbackCompactor = spy((CompactorPipeline.FallbackCompactor) compactor);
       field.set(compactorPipeline, fallbackCompactor);
       field = fallbackCompactor.getClass().getDeclaredField("primaryCompactor");
       field.setAccessible(true);
       Compactor compactor1 = (Compactor) field.get(fallbackCompactor);
-      Assert.assertTrue(compactor1 instanceof MergeCompactor);
+      assertTrue(compactor1 instanceof MergeCompactor);
       compactor1 = spy(compactor1);
       field.set(fallbackCompactor, compactor1);
       field = fallbackCompactor.getClass().getDeclaredField("secondaryCompactor");
       field.setAccessible(true);
       Compactor compactor2 = (Compactor) field.get(fallbackCompactor);
       if (compactionType == CompactionType.MAJOR) {
-        Assert.assertTrue(compactor2 instanceof MajorQueryCompactor);
+        assertTrue(compactor2 instanceof MajorQueryCompactor);
       } else {
-        Assert.assertTrue(compactor2 instanceof MinorQueryCompactor);
+        assertTrue(compactor2 instanceof MinorQueryCompactor);
       }
       compactor2 = spy(compactor2);
       field.set(fallbackCompactor, compactor2);
@@ -3523,20 +3047,20 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Only 1 compaction should be in the response queue with succeeded state
     List<ShowCompactResponseElement> compacts =
             TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    compacts.forEach(c -> Assert.assertEquals("succeeded", c.getState()));
+    compacts.forEach(c -> assertEquals("succeeded", c.getState()));
     // Verify directories after compaction
     List<String> actualDirAfterComp =
             CompactorTestUtil.getBaseOrDeltaNames(fs, compactionType == CompactionType.MAJOR ? AcidUtils.baseFileFilter :
                     AcidUtils.deltaFileFilter, table, partitionName);
-    Assert.assertEquals("Base directory does not match after compaction", compactDirNames, actualDirAfterComp);
-    Assert.assertTrue(CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table,
+    assertEquals("Base directory does not match after compaction", compactDirNames, actualDirAfterComp);
+    assertTrue(CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table,
             partitionName).isEmpty());
     // Verify bucket files in delta dirs
-    Assert.assertEquals("Bucket names are not matching after compaction", bucketName,
+    assertEquals("Bucket names are not matching after compaction", bucketName,
             CompactorTestUtil.getBucketFileNames(fs, table, partitionName, actualDirAfterComp.get(0)));
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, actualData);
+    assertEquals(expectedData, actualData);
     // Clean up
     if (dropTable) {
       dataProvider.dropTable(tableName);
@@ -3569,25 +3093,25 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     AtomicReference<Compactor> secondary = new AtomicReference<>();
     doAnswer(invocationOnMock -> {
       Object result = invocationOnMock.callRealMethod();
-      Assert.assertTrue(result instanceof CompactorPipeline);
+      assertTrue(result instanceof CompactorPipeline);
       // Use reflection to fetch inner compactors
       CompactorPipeline compactorPipeline = (CompactorPipeline) result;
       Field field = compactorPipeline.getClass().getDeclaredField("compactor");
       field.setAccessible(true);
       Compactor compactor = (Compactor) field.get(compactorPipeline);
-      Assert.assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
+      assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
       CompactorPipeline.FallbackCompactor fallbackCompactor = spy((CompactorPipeline.FallbackCompactor) compactor);
       field.set(compactorPipeline, fallbackCompactor);
       field = fallbackCompactor.getClass().getDeclaredField("primaryCompactor");
       field.setAccessible(true);
       Compactor compactor1 = (Compactor) field.get(fallbackCompactor);
-      Assert.assertTrue(compactor1 instanceof MergeCompactor);
+      assertTrue(compactor1 instanceof MergeCompactor);
       compactor1 = spy(compactor1);
       field.set(fallbackCompactor, compactor1);
       field = fallbackCompactor.getClass().getDeclaredField("secondaryCompactor");
       field.setAccessible(true);
       Compactor compactor2 = (Compactor) field.get(fallbackCompactor);
-      Assert.assertTrue(compactor2 instanceof MmMajorQueryCompactor);
+      assertTrue(compactor2 instanceof MmMajorQueryCompactor);
       compactor2 = spy(compactor2);
       field.set(fallbackCompactor, compactor2);
       primary.set(compactor1);
@@ -3632,25 +3156,25 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     AtomicReference<Compactor> secondary = new AtomicReference<>();
     doAnswer(invocationOnMock -> {
       Object result = invocationOnMock.callRealMethod();
-      Assert.assertTrue(result instanceof CompactorPipeline);
+      assertTrue(result instanceof CompactorPipeline);
       // Use reflection to fetch inner compactors
       CompactorPipeline compactorPipeline = (CompactorPipeline) result;
       Field field = compactorPipeline.getClass().getDeclaredField("compactor");
       field.setAccessible(true);
       Compactor compactor = (Compactor) field.get(compactorPipeline);
-      Assert.assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
+      assertTrue(compactor instanceof CompactorPipeline.FallbackCompactor);
       CompactorPipeline.FallbackCompactor fallbackCompactor = spy((CompactorPipeline.FallbackCompactor) compactor);
       field.set(compactorPipeline, fallbackCompactor);
       field = fallbackCompactor.getClass().getDeclaredField("primaryCompactor");
       field.setAccessible(true);
       Compactor compactor1 = (Compactor) field.get(fallbackCompactor);
-      Assert.assertTrue(compactor1 instanceof MergeCompactor);
+      assertTrue(compactor1 instanceof MergeCompactor);
       compactor1 = spy(compactor1);
       field.set(fallbackCompactor, compactor1);
       field = fallbackCompactor.getClass().getDeclaredField("secondaryCompactor");
       field.setAccessible(true);
       Compactor compactor2 = (Compactor) field.get(fallbackCompactor);
-      Assert.assertTrue(compactor2 instanceof MajorQueryCompactor);
+      assertTrue(compactor2 instanceof MajorQueryCompactor);
       compactor2 = spy(compactor2);
       field.set(fallbackCompactor, compactor2);
       primary.set(compactor1);
@@ -3687,7 +3211,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     org.apache.hadoop.hive.ql.metadata.Table table = Hive.get().getTable(DB, TABLE1);
 
-    Assert.assertEquals(3, StatsSetupConst.getColumnsHavingStats(table.getParameters()).size());
+    assertEquals(3, StatsSetupConst.getColumnsHavingStats(table.getParameters()).size());
   }
 
   @Test
@@ -3707,7 +3231,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     org.apache.hadoop.hive.ql.metadata.Table table = Hive.get().getTable(DB, TABLE1);
     Partition partition = Hive.get().getPartition(table, new HashMap<String, String>() {{ put("p", "p1"); }});
 
-    Assert.assertEquals(3, StatsSetupConst.getColumnsHavingStats(partition.getParameters()).size());
+    assertEquals(3, StatsSetupConst.getColumnsHavingStats(partition.getParameters()).size());
   }
 
   @Test
@@ -3746,10 +3270,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     verifySuccessfulCompaction(1);
     List<String> resultData = testDataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, resultData);
+    assertEquals(expectedData, resultData);
     List<String> deltas = CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals(2, deltas.size());
-    Assert.assertEquals("Delta directory names are not matching after compaction",
+    assertEquals(2, deltas.size());
+    assertEquals("Delta directory names are not matching after compaction",
         Arrays.asList("delta_0000002_0000004_v0000007", "delta_0000005_0000005"), deltas);
     for (String delta: deltas) {
       // Check if none of the delta directories are empty
@@ -3790,10 +3314,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
     verifySuccessfulCompaction(1);
     List<String> resultData = testDataProvider.getAllData(tableName);
-    Assert.assertEquals(expectedData, resultData);
+    assertEquals(expectedData, resultData);
     List<String> deltas = CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
-    Assert.assertEquals(2, deltas.size());
-    Assert.assertEquals("Delta directory names are not matching after compaction",
+    assertEquals(2, deltas.size());
+    assertEquals("Delta directory names are not matching after compaction",
         Arrays.asList("delta_0000001_0000003_v0000006", "delta_0000004_0000004"), deltas);
     for (String delta: deltas) {
       // Check if none of the delta directories are empty

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
@@ -1,0 +1,654 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.txn.compactor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.ShowCompactResponseElement;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.txn.TxnStore;
+import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.io.BucketCodec;
+import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.hadoop.hive.ql.ErrorMsg.TXN_ABORTED;
+import static org.apache.hadoop.hive.ql.TxnCommandsBaseForTests.runWorker;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactorBase.dropTables;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactorBase.execSelectAndDumpData;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactorBase.executeStatementOnDriver;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+public class TestRebalanceCompactor extends CompactorOnTezTest {
+
+  @Test
+  public void testRebalanceCompactionWithParallelDeleteAsSecondOptimisticLock() throws Exception {
+    testRebalanceCompactionWithParallelDeleteAsSecond(true);
+  }
+
+  @Test
+  public void testRebalanceCompactionWithParallelDeleteAsSecondPessimisticLock() throws Exception {
+    testRebalanceCompactionWithParallelDeleteAsSecond(false);
+  }
+
+  @Test
+  public void testRebalanceCompactionOfNotPartitionedImplicitlyBucketedTableWithOrder() throws Exception {
+    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+
+    //set grouping size to have 3 buckets, and re-create driver with the new config
+    conf.set("tez.grouping.min-size", "400");
+    conf.set("tez.grouping.max-size", "5000");
+    driver = new Driver(conf);
+
+    final String tableName = "rebalance_test";
+    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
+
+    //Try to do a rebalancing compaction
+    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' ORDER BY b DESC", driver);
+    runWorker(conf);
+
+    driver.close();
+    driver = new Driver(conf);
+
+    //Check if the compaction succeed
+    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
+
+    // Populate expected data
+    Set<RowData> expectedData = new HashSet<>();
+
+    expectedData.add(new RowData("17", 17L));
+    expectedData.add(new RowData("16", 16L));
+    expectedData.add(new RowData("15", 15L));
+    expectedData.add(new RowData("14", 14L));
+    expectedData.add(new RowData("13", 13L));
+    expectedData.add(new RowData("12", 12L));
+
+    // Adding the '4' group
+    expectedData.addAll(List.of(
+        new RowData("6", 4L),
+        new RowData("3", 4L),
+        new RowData("4", 4L),
+        new RowData("2", 4L),
+        new RowData("5", 4L)
+    ));
+
+    // Adding the '3' group
+    expectedData.addAll(List.of(
+        new RowData("2", 3L),
+        new RowData("3", 3L),
+        new RowData("6", 3L),
+        new RowData("4", 3L),
+        new RowData("5", 3L)
+    ));
+
+    // Adding the '2' group
+    expectedData.add(new RowData("6", 2L));
+    expectedData.add(new RowData("5", 2L));
+
+    verifyDataAfterCompaction(tableName, expectedData, testDataProvider);
+  }
+
+  @Test
+  public void testRebalanceCompactionOfNotPartitionedImplicitlyBucketedTable() throws Exception {
+    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+
+    //set grouping size to have 3 buckets, and re-create driver with the new config
+    conf.set("tez.grouping.min-size", "400");
+    conf.set("tez.grouping.max-size", "5000");
+    driver = new Driver(conf);
+
+    final String tableName = "rebalance_test";
+    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
+
+    //Try to do a rebalancing compaction
+    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance'", driver);
+    runWorker(conf);
+
+    //Check if the compaction succeed
+    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
+
+    String[][] expectedBuckets = new String[][] {
+        {
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t5\t4",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t6\t2",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t6\t3",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t5\t2",
+        },
+        {
+
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":5}\t5\t3",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t3",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t4\t3",
+        },
+        {
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":10}\t2\t3",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":11}\t3\t4",
+            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12",
+            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13",
+            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14",
+        },
+        {
+            "{\"writeid\":5,\"bucketid\":537067520,\"rowid\":15}\t15\t15",
+            "{\"writeid\":6,\"bucketid\":537067520,\"rowid\":16}\t16\t16",
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
+        },
+    };
+    verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
+        new String[] {"bucket_00000", "bucket_00001", "bucket_00002","bucket_00003"});
+  }
+
+  @Test
+  public void testRebalanceCompactionOfPartitionedImplicitlyBucketedTable() throws Exception {
+    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+
+    //set grouping size to have 3 buckets, and re-create driver with the new config
+    conf.set("tez.grouping.min-size", "1");
+    driver = new Driver(conf);
+
+    final String stageTableName = "stage_rebalance_test";
+    final String tableName = "rebalance_test";
+    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
+
+    TestDataProvider testDataProvider = new TestDataProvider();
+    testDataProvider.createFullAcidTable(stageTableName, true, false);
+    executeStatementOnDriver("insert into " + stageTableName +" values " +
+            "('1',1,'yesterday'), ('1',2,'yesterday'), ('1',3, 'yesterday'), ('1',4, 'yesterday'), " +
+            "('2',1,'today'), ('2',2,'today'), ('2',3,'today'), ('2',4, 'today'), " +
+            "('3',1,'tomorrow'), ('3',2,'tomorrow'), ('3',3,'tomorrow'), ('3',4,'tomorrow')",
+        driver);
+
+    dropTables(driver, tableName);
+    executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
+        "PARTITIONED BY (ds string) STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
+    executeStatementOnDriver("INSERT OVERWRITE TABLE " + tableName + " partition (ds='tomorrow') select a, b from " + stageTableName, driver);
+
+    //do some single inserts to have more data in the first bucket.
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('12',12,'tomorrow')", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('13',13,'tomorrow')", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('14',14,'tomorrow')", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('15',15,'tomorrow')", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('16',16,'tomorrow')", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17,'tomorrow')", driver);
+
+    // Verify buckets and their content before rebalance in partition ds=tomorrow
+    Table table = msClient.getTable("default", tableName);
+    FileSystem fs = FileSystem.get(conf);
+    assertEquals("Test setup does not match the expected: different buckets",
+        Arrays.asList("bucket_00000_0", "bucket_00001_0", "bucket_00002_0"),
+        CompactorTestUtil.getBucketFileNames(fs, table, "ds=tomorrow", "base_0000001"));
+    String[][] expectedBuckets = new String[][] {
+        {
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t2\t1\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t2\t2\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t2\t3\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t2\t4\ttomorrow",
+            "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t12\t12\ttomorrow",
+            "{\"writeid\":3,\"bucketid\":536870912,\"rowid\":0}\t13\t13\ttomorrow",
+            "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":0}\t14\t14\ttomorrow",
+            "{\"writeid\":5,\"bucketid\":536870912,\"rowid\":0}\t15\t15\ttomorrow",
+            "{\"writeid\":6,\"bucketid\":536870912,\"rowid\":0}\t16\t16\ttomorrow",
+            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":0}\t17\t17\ttomorrow",
+        },
+        {
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t3\t1\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":1}\t3\t2\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":2}\t3\t3\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":3}\t3\t4\ttomorrow",
+        },
+        {
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":0}\t1\t1\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":1}\t1\t2\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":2}\t1\t3\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":3}\t1\t4\ttomorrow",
+        },
+    };
+    for(int i = 0; i < 3; i++) {
+      assertEquals("rebalanced bucket " + i, Arrays.asList(expectedBuckets[i]),
+          testDataProvider.getBucketData(tableName, BucketCodec.V1.encode(options.bucket(i)) + ""));
+    }
+
+    //Try to do a rebalancing compaction
+    executeStatementOnDriver("ALTER TABLE " + tableName + " PARTITION (ds='tomorrow') COMPACT 'rebalance'", driver);
+    runWorker(conf);
+
+    //Check if the compaction succeed
+    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
+
+    expectedBuckets = new String[][] {
+        {
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t2\t1\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t2\t2\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t2\t3\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t2\t4\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t3\t1\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":5}\t3\t2\ttomorrow",
+        },
+        {
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t3\t3\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t4\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t1\t1\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t1\t2\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":10}\t1\t3\ttomorrow",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":11}\t1\t4\ttomorrow",
+        },
+        {
+            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12\ttomorrow",
+            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13\ttomorrow",
+            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14\ttomorrow",
+            "{\"writeid\":5,\"bucketid\":537001984,\"rowid\":15}\t15\t15\ttomorrow",
+            "{\"writeid\":6,\"bucketid\":537001984,\"rowid\":16}\t16\t16\ttomorrow",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":17}\t17\t17\ttomorrow",
+        },
+    };
+    verifyRebalance(testDataProvider, tableName, "ds=tomorrow", expectedBuckets,
+        new String[] {"bucket_00000", "bucket_00001", "bucket_00002"});
+  }
+
+  @Test
+  public void testRebalanceCompactionOfNotPartitionedExplicitlyBucketedTable() throws Exception {
+    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+
+    final String tableName = "rebalance_test";
+    dropTables(driver, tableName);
+    executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
+        "CLUSTERED BY(a) INTO 4 BUCKETS STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('11',11),('22',22),('33',33),('44',44)", driver);
+
+    //Try to do a rebalancing compaction
+    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance'", driver);
+    runWorker(conf);
+
+    //Check if the compaction is refused
+    List<ShowCompactResponseElement> compacts = verifyCompaction(1, TxnStore.REFUSED_RESPONSE);
+    assertEquals("Expecting error message 'Cannot execute rebalancing compaction on bucketed tables.' and found:" + compacts.get(0).getState(),
+        "Cannot execute rebalancing compaction on bucketed tables.", compacts.get(0).getErrorMessage());
+  }
+
+  @Test
+  public void testRebalanceCompactionNotPartitionedExplicitBucketNumbers() throws Exception {
+    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+
+    //set grouping size to have 3 buckets, and re-create driver with the new config
+    conf.set("tez.grouping.min-size", "400");
+    conf.set("tez.grouping.max-size", "5000");
+    driver = new Driver(conf);
+
+    final String tableName = "rebalance_test";
+    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
+
+    //Try to do a rebalancing compaction
+    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' CLUSTERED INTO 4 BUCKETS", driver);
+    runWorker(conf);
+
+    verifyCompaction(1,  TxnStore.CLEANING_RESPONSE);
+
+    String[][] expectedBuckets = new String[][] {
+        {
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t5\t4",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t6\t2",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t6\t3",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
+            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t5\t2",
+        },
+        {
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":5}\t5\t3",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t3",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t4\t3",
+        },
+        {
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":10}\t2\t3",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":11}\t3\t4",
+            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12",
+            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13",
+            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14",
+        },
+        {
+            "{\"writeid\":5,\"bucketid\":537067520,\"rowid\":15}\t15\t15",
+            "{\"writeid\":6,\"bucketid\":537067520,\"rowid\":16}\t16\t16",
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
+        },
+    };
+    verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
+        new String[] {"bucket_00000", "bucket_00001", "bucket_00002", "bucket_00003"});
+  }
+
+  private void testRebalanceCompactionWithParallelDeleteAsSecond(boolean optimisticLock) throws Exception {
+    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+    conf.setBoolVar(HiveConf.ConfVars.TXN_WRITE_X_LOCK, optimisticLock);
+
+    //set grouping size to have 3 buckets, and re-create driver with the new config
+    conf.set("tez.grouping.min-size", "400");
+    conf.set("tez.grouping.max-size", "5000");
+    driver = new Driver(conf);
+
+    final String tableName = "rebalance_test";
+    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
+
+    //Try to do a rebalancing compaction
+    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' ORDER BY b DESC", driver);
+
+    CountDownLatch startDelete = new CountDownLatch(1);
+    CountDownLatch endDelete = new CountDownLatch(1);
+    CompactorFactory factory = Mockito.spy(CompactorFactory.getInstance());
+    doAnswer(invocation -> {
+      Object result = invocation.callRealMethod();
+      startDelete.countDown();
+      Thread.sleep(1000);
+      return result;
+    }).when(factory).getCompactorPipeline(any(), any(), any(), any());
+
+    Worker worker = new Worker(factory);
+    worker.setConf(conf);
+    worker.init(new AtomicBoolean(true));
+    worker.start();
+
+    if (!startDelete.await(10, TimeUnit.SECONDS)) {
+      throw new RuntimeException("Waiting for the compaction to start timed out!");
+    }
+
+    boolean aborted = false;
+    try {
+      executeStatementOnDriver("DELETE FROM " + tableName + " WHERE b = 12", driver);
+    } catch (CommandProcessorException e) {
+      if (optimisticLock) {
+        Assert.fail("In case of TXN_WRITE_X_LOCK = true, the transaction must be retried instead of being aborted.");
+      }
+      aborted = true;
+      Assert.assertEquals(12, e.getResponseCode());
+      Assert.assertEquals(TXN_ABORTED.getErrorCode(), e.getErrorCode());
+
+      // Delete the record, so the rest of the test can be the same in both cases
+      executeStatementOnDriver("DELETE FROM " + tableName + " WHERE b = 12", driver);
+    } finally {
+      if(!optimisticLock && !aborted) {
+        Assert.fail("In case of TXN_WRITE_X_LOCK = false, the transaction must be aborted instead of being retried.");
+      }
+    }
+    endDelete.countDown();
+
+    worker.join();
+
+    driver.close();
+    driver = new Driver(conf);
+
+    List<String> result = execSelectAndDumpData("select * from " + tableName + " WHERE b = 12", driver,
+        "Dumping data for " + tableName + " after load:");
+    assertEquals(0, result.size());
+
+    //Check if the compaction succeed
+    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
+
+    // Populate expected data
+    Set<RowData> expectedData = new HashSet<>();
+
+    expectedData.add(new RowData("17", 17L));
+    expectedData.add(new RowData("16", 16L));
+    expectedData.add(new RowData("15", 15L));
+    expectedData.add(new RowData("14", 14L));
+    expectedData.add(new RowData("13", 13L));
+
+    // Adding the '4' group
+    expectedData.addAll(List.of(
+        new RowData("6", 4L),
+        new RowData("3", 4L),
+        new RowData("4", 4L),
+        new RowData("2", 4L),
+        new RowData("5", 4L)
+    ));
+
+    // Adding the '3' group
+    expectedData.addAll(List.of(
+        new RowData("2", 3L),
+        new RowData("3", 3L),
+        new RowData("6", 3L),
+        new RowData("4", 3L),
+        new RowData("5", 3L)
+    ));
+
+    // Adding the '2' group
+    expectedData.add(new RowData("6", 2L));
+    expectedData.add(new RowData("5", 2L));
+
+    verifyDataAfterCompaction(tableName, expectedData, testDataProvider);
+  }
+
+  record RowData(String colA, Long colB) {}
+
+  record RowInfo(long writeId, long bucketId, long rowId, RowData rowData) {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    static RowInfo fromRawString(String row) throws JsonProcessingException {
+      // Example row data to parse: "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":10}\t5\t4",
+
+      String[] parts = row.split("\t", 3);
+
+      JsonNode json = MAPPER.readTree(parts[0]);
+
+      return new RowInfo(
+          json.get("writeid").asLong(),
+          json.get("bucketid").asLong(),
+          json.get("rowid").asLong(),
+          new RowData(
+              parts[1], // colA
+              Long.parseLong(parts[2])  // colB
+          )
+      );
+    }
+  }
+
+  private void verifyDataAfterCompaction(String tableName, Set<RowData> expectedData, TestDataProvider testDataProvider)
+      throws Exception {
+    FileSystem fs = FileSystem.get(conf);
+    Table table = msClient.getTable("default", tableName);
+    List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000001");
+
+    int bucketCount = bucketFilenames.size();
+    assertTrue(bucketCount > 0);
+
+    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
+
+    /*
+      Validate the data after the test case
+        - the table is balanced (or if not, only numberOfDeletedRows amount of rows are missing
+        - there is only one writeId
+        - buckets has unique bucketId and the bucketId doesn't change inside a bucket
+        - data is sorted by column b (so the order of column a is not predictable)
+        - all the required value present
+     */
+
+    int optimalRecordsInBucket = expectedData.size() / bucketCount;
+    int maximumRecordCountInABucket = optimalRecordsInBucket + bucketCount - 1;
+
+    long previousValueForColB = Long.MAX_VALUE;
+
+    for (int i = 0; i < bucketCount; i++) {
+      List<String> bucket = testDataProvider.getBucketData(table.getTableName(), BucketCodec.V1.encode(options.bucket(i)) + "");
+
+      int bucketSize = bucket.size();
+      assertTrue(bucketSize <= maximumRecordCountInABucket);
+
+      long bucketId = -1L;
+      long writeId = -1L;
+
+      for (String row : bucket) {
+        RowInfo rowInfo = RowInfo.fromRawString(row);
+
+        // Check if writeId doesn't change
+        if (writeId == -1L) {
+          // we are at the first element
+          writeId = rowInfo.writeId;
+        } else {
+          assertTrue(rowInfo.writeId == writeId);
+        }
+
+        // Check if bucketId doesn't change inside the bucket
+        if (bucketId == -1) {
+          // we are at the first element of the bucket
+          bucketId = rowInfo.bucketId;
+        } else {
+          assertEquals(bucketId, rowInfo.bucketId);
+        }
+
+        // Check if the data is sorted by colB desc
+        RowData rowData = rowInfo.rowData;
+        assertTrue(rowData.colB <= previousValueForColB);
+        previousValueForColB = rowData.colB;
+
+        // Check if all the necessary data persist
+        assertTrue(expectedData.contains(rowData));
+        expectedData.remove(rowData);
+      }
+    }
+
+    // check if we got all the expected values
+    assertEquals(0, expectedData.size()); // we have found all the elements in a proper order
+  }
+
+  private TestDataProvider prepareRebalanceTestData(String tableName) throws Exception {
+    final String stageTableName = "stage_" + tableName;
+
+    TestDataProvider testDataProvider = new TestDataProvider();
+    testDataProvider.createFullAcidTable(stageTableName, true, false);
+    testDataProvider.insertTestData(stageTableName, true);
+
+    dropTables(driver, tableName);
+    executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
+        "STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
+    executeStatementOnDriver("INSERT OVERWRITE TABLE " + tableName + " select a, b from " + stageTableName, driver);
+
+    //do some single inserts to have more data in the first bucket.
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('12',12)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('13',13)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('14',14)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('15',15)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('16',16)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17)", driver);
+
+    /*
+     check if the test data is unbalanced
+     balanced if all the buckets contains between n / bucket count and n / bucket count + bucket count rows
+     where n is the number of rows in the table.
+     In our test case, we inserted 6 extra rows into the first bucket so we can say it is properly unbalanced
+     if the first bucket has 6 more elements than the second one.
+    */
+    Assert.assertFalse(isBalanced(tableName, testDataProvider));
+
+    // Please note, as the test tests rebalance compaction, not insert overwrite, it is not necessary to test if
+    // we have the exact same data after preparing the test data as we had at the source table.
+    return testDataProvider;
+  }
+
+  private boolean isBalanced(String tableName, TestDataProvider testDataProvider ) throws Exception {
+    FileSystem fs = FileSystem.get(conf);
+    Table table = msClient.getTable("default", tableName);
+
+    // Assert that we have multiple buckets
+    List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000001");
+    assertTrue(bucketFilenames.size() > 1);
+
+    int bucketCount = bucketFilenames.size();
+
+    if (bucketCount == 1) {
+      // nothing to rebalance with a single bucket
+      return true;
+    }
+
+    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
+    List<String>[] bucketData = new ArrayList[bucketCount];
+    for (int i = 0; i < bucketCount; i++) {
+      bucketData[i] = testDataProvider.getBucketData(table.getTableName(), BucketCodec.V1.encode(options.bucket(i)) + "");
+    }
+
+    int allRecordCount = Arrays.stream(bucketData)
+        .map(bucket -> bucket.size())
+        .reduce(0, Integer::sum);
+
+    int optimalRecordsInBucket = allRecordCount / bucketCount;
+    int maximumRecordCountInABucket = optimalRecordsInBucket + bucketCount - 1;
+
+    for (int i = 0; i < bucketCount; i++) {
+      if (bucketData[i].size() > maximumRecordCountInABucket || bucketData[i].size() < optimalRecordsInBucket) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private void verifyRebalance(TestDataProvider testDataProvider, String tableName, String partitionName,
+      String[][] expectedBucketContent, String[] bucketNames) throws Exception {
+    // Verify buckets and their content after rebalance
+    Table table = msClient.getTable("default", tableName);
+    FileSystem fs = FileSystem.get(conf);
+    assertEquals("Buckets does not match after compaction", Arrays.asList(bucketNames),
+        CompactorTestUtil.getBucketFileNames(fs, table, partitionName, findTheBaseFolder(table, partitionName, fs)));
+    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
+    for (int i = 0; i < expectedBucketContent.length; i++) {
+      assertEquals("rebalanced bucket " + i, Arrays.asList(expectedBucketContent[i]),
+          testDataProvider.getBucketData(tableName, BucketCodec.V1.encode(options.bucket(i)) + ""));
+    }
+  }
+
+  private String findTheBaseFolder(Table table, String partitionName, FileSystem fs) throws IOException {
+    Path searchPath = partitionName == null ? new Path(table.getSd().getLocation(), "base_*_v*") : new Path(
+        new Path(table.getSd().getLocation()), new Path(partitionName,  "base_*_v*"));
+
+    return Arrays.stream(fs.globStatus(searchPath, AcidUtils.baseFileFilter)).map(FileStatus::getPath).map(Path::getName)
+        .sorted()
+        .findFirst().get();
+  }
+}

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
@@ -17,9 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.txn.compactor;
 
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.ShowCompactResponseElement;
@@ -27,20 +25,13 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
-import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.BucketCodec;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -89,39 +80,39 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
 
     // Populate expected data
-    Set<RowData> expectedData = new HashSet<>();
+    List<RowData> expectedData = new ArrayList<>();
 
     expectedData.addAll(List.of(
-        new RowData("17", 17L),
-        new RowData("16", 16L),
-        new RowData("15", 15L),
-        new RowData("14", 14L),
-        new RowData("13", 13L),
-        new RowData("12", 12L)
+        new RowData("17", "17"),
+        new RowData("16", "16"),
+        new RowData("15", "15"),
+        new RowData("14", "14"),
+        new RowData("13", "13"),
+        new RowData("12", "12")
     ));
 
     // Adding the '4' group
     expectedData.addAll(List.of(
-        new RowData("6", 4L),
-        new RowData("3", 4L),
-        new RowData("4", 4L),
-        new RowData("2", 4L),
-        new RowData("5", 4L)
+        new RowData("6", "4"),
+        new RowData("3", "4"),
+        new RowData("4", "4"),
+        new RowData("2", "4"),
+        new RowData("5", "4")
     ));
 
     // Adding the '3' group
     expectedData.addAll(List.of(
-        new RowData("2", 3L),
-        new RowData("3", 3L),
-        new RowData("6", 3L),
-        new RowData("4", 3L),
-        new RowData("5", 3L)
+        new RowData("2", "3"),
+        new RowData("3", "3"),
+        new RowData("6", "3"),
+        new RowData("4", "3"),
+        new RowData("5", "3")
     ));
 
     // Adding the '2' group
     expectedData.addAll(List.of(
-        new RowData("6", 2L),
-        new RowData("5", 2L)
+        new RowData("6", "2"),
+        new RowData("5", "2")
     ));
 
     verifyDataAfterCompaction(expectedData, testDataProvider);
@@ -152,37 +143,40 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     // Check if the compaction succeed
     verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
 
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t5\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t6\t2",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t6\t3",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t5\t2",
-        },
-        {
+    // Populate expected data
+    List<RowData> expectedData = new ArrayList<>();
 
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":5}\t5\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t4\t3",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":10}\t2\t3",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":11}\t3\t4",
-            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12",
-            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13",
-            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14",
-        },
-        {
-            "{\"writeid\":5,\"bucketid\":537067520,\"rowid\":15}\t15\t15",
-            "{\"writeid\":6,\"bucketid\":537067520,\"rowid\":16}\t16\t16",
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
-        },
-    };
-    verifyRebalance(testDataProvider, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002","bucket_00003"});
+    expectedData.addAll(List.of(
+        new RowData("5", "4"),
+        new RowData("6", "2"),
+        new RowData("6", "3"),
+        new RowData("6", "4"),
+        new RowData("5", "2")
+    ));
+
+    expectedData.addAll(List.of(
+        new RowData("5", "3"),
+        new RowData("2", "4"),
+        new RowData("3", "3"),
+        new RowData("4", "4"),
+        new RowData("4", "3")
+    ));
+
+    expectedData.addAll(List.of(
+        new RowData("2", "3"),
+        new RowData("3", "4"),
+        new RowData("12", "12"),
+        new RowData("13", "13"),
+        new RowData("14", "14")
+    ));
+
+    expectedData.addAll(List.of(
+        new RowData("15", "15"),
+        new RowData("16", "16"),
+        new RowData("17", "17")
+    ));
+
+    verifyDataAfterCompaction(expectedData, testDataProvider, null, false);
   }
 
   @Test
@@ -195,7 +189,6 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
 
     final String stageTableName = "stage_rebalance_test";
     final String tableName = "rebalance_test";
-    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
 
     TestDataProvider testDataProvider = new TestDataProvider();
     testDataProvider.createFullAcidTable(stageTableName, true, false);
@@ -221,42 +214,12 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17,'tomorrow')", driver);
 
     // Verify buckets and their content before rebalance in partition ds=tomorrow
-    GetTableRequest getTableRequest = new GetTableRequest("default", tableName);
-    Table table = msClient.getTable(getTableRequest);
-    FileSystem fs = FileSystem.get(conf);
-    assertEquals("Test setup does not match the expected: different buckets",
-        Arrays.asList("bucket_00000_0", "bucket_00001_0", "bucket_00002_0"),
-        CompactorTestUtil.getBucketFileNames(fs, table, "ds=tomorrow", "base_0000001"));
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t2\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t2\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t2\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t2\t4\ttomorrow",
-            "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t12\t12\ttomorrow",
-            "{\"writeid\":3,\"bucketid\":536870912,\"rowid\":0}\t13\t13\ttomorrow",
-            "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":0}\t14\t14\ttomorrow",
-            "{\"writeid\":5,\"bucketid\":536870912,\"rowid\":0}\t15\t15\ttomorrow",
-            "{\"writeid\":6,\"bucketid\":536870912,\"rowid\":0}\t16\t16\ttomorrow",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":0}\t17\t17\ttomorrow",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t3\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":1}\t3\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":2}\t3\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":3}\t3\t4\ttomorrow",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":0}\t1\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":1}\t1\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":2}\t1\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":3}\t1\t4\ttomorrow",
-        },
-    };
-    for(int i = 0; i < 3; i++) {
-      assertEquals("rebalanced bucket " + i, Arrays.asList(expectedBuckets[i]),
-          testDataProvider.getBucketData(tableName, BucketCodec.V1.encode(options.bucket(i)) + ""));
-    }
+    // Make sure we have all the records persisted
+    List<String> allRecords = execSelectAndDumpData(
+        "SELECT * FROM " + tableName, driver, "Dumping data from test table, " + tableName);
+    Assert.assertEquals(18, allRecords.size());
+
+    Assert.assertFalse(isBalanced(testDataProvider, "ds=tomorrow"));
 
     //Try to do a rebalancing compaction
     executeStatementOnDriver("ALTER TABLE " + tableName + " PARTITION (ds='tomorrow') COMPACT 'rebalance'", driver);
@@ -265,34 +228,36 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     //Check if the compaction succeed
     verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
 
-    expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t2\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t2\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t2\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t2\t4\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t3\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":5}\t3\t2\ttomorrow",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t3\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t4\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t1\t1\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t1\t2\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":10}\t1\t3\ttomorrow",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":11}\t1\t4\ttomorrow",
-        },
-        {
-            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12\ttomorrow",
-            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13\ttomorrow",
-            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14\ttomorrow",
-            "{\"writeid\":5,\"bucketid\":537001984,\"rowid\":15}\t15\t15\ttomorrow",
-            "{\"writeid\":6,\"bucketid\":537001984,\"rowid\":16}\t16\t16\ttomorrow",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":17}\t17\t17\ttomorrow",
-        },
-    };
-    verifyRebalance(testDataProvider, "ds=tomorrow", expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002"});
+    List<RowData> expectedData = new ArrayList<>();
+
+    expectedData.addAll(List.of(
+      new RowData("2", "1", "tomorrow"),
+      new RowData("2", "2", "tomorrow"),
+      new RowData("2", "3", "tomorrow"),
+      new RowData("2", "4", "tomorrow"),
+      new RowData("3", "1", "tomorrow"),
+      new RowData("3", "2", "tomorrow")
+    ));
+
+    expectedData.addAll(List.of(
+        new RowData("3", "3", "tomorrow"),
+        new RowData("3", "4", "tomorrow"),
+        new RowData("1", "1", "tomorrow"),
+        new RowData("1", "2", "tomorrow"),
+        new RowData("1", "3", "tomorrow"),
+        new RowData("1", "4", "tomorrow")
+    ));
+
+    expectedData.addAll(List.of(
+        new RowData("12", "12", "tomorrow"),
+        new RowData("13", "13", "tomorrow"),
+        new RowData("14", "14", "tomorrow"),
+        new RowData("15", "15", "tomorrow"),
+        new RowData("16", "16", "tomorrow"),
+        new RowData("17", "17", "tomorrow")
+    ));
+
+    verifyDataAfterCompaction(expectedData, testDataProvider, "ds=tomorrow", false);
   }
 
   @Test
@@ -337,36 +302,38 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
 
     verifyCompaction(1,  TxnStore.CLEANING_RESPONSE);
 
-    String[][] expectedBuckets = new String[][] {
-        {
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":0}\t5\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":1}\t6\t2",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t6\t3",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t5\t2",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":5}\t5\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t4\t3",
-        },
-        {
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":10}\t2\t3",
-            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":11}\t3\t4",
-            "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12",
-            "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13",
-            "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14",
-        },
-        {
-            "{\"writeid\":5,\"bucketid\":537067520,\"rowid\":15}\t15\t15",
-            "{\"writeid\":6,\"bucketid\":537067520,\"rowid\":16}\t16\t16",
-            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
-        },
-    };
-    verifyRebalance(testDataProvider, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002", "bucket_00003"});
+    List<RowData> expectedData = new ArrayList<>();
+    expectedData.addAll(List.of(
+        new RowData("5", "4"),
+        new RowData("6", "2"),
+        new RowData("6", "3"),
+        new RowData("6", "4"),
+        new RowData("5", "2")
+    ));
+
+    expectedData.addAll(List.of(
+        new RowData("5", "3"),
+        new RowData("2", "4"),
+        new RowData("3", "3"),
+        new RowData("4", "4"),
+        new RowData("4", "3")
+    ));
+
+    expectedData.addAll(List.of(
+        new RowData("2", "3"),
+        new RowData("3", "4"),
+        new RowData("12", "12"),
+        new RowData("13", "13"),
+        new RowData("14", "14")
+    ));
+
+    expectedData.addAll(List.of(
+        new RowData("15", "15"),
+        new RowData("16", "16"),
+        new RowData("17", "17")
+    ));
+
+    verifyDataAfterCompaction(expectedData, testDataProvider, null, false);
   }
 
   @SuppressWarnings("java:S2925")
@@ -437,65 +404,96 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
 
     // Populate expected data
-    Set<RowData> expectedData = new HashSet<>();
+    List<RowData> expectedData = new ArrayList<>();
 
     expectedData.addAll(List.of(
-        new RowData("17", 17L),
-        new RowData("16", 16L),
-        new RowData("15", 15L),
-        new RowData("14", 14L),
-        new RowData("13", 13L)
+        new RowData("17", "17"),
+        new RowData("16", "16"),
+        new RowData("15", "15"),
+        new RowData("14", "14"),
+        new RowData("13", "13")
     ));
 
     // Adding the '4' group
     expectedData.addAll(List.of(
-        new RowData("6", 4L),
-        new RowData("3", 4L),
-        new RowData("4", 4L),
-        new RowData("2", 4L),
-        new RowData("5", 4L)
+        new RowData("6", "4"),
+        new RowData("3", "4"),
+        new RowData("4", "4"),
+        new RowData("2", "4"),
+        new RowData("5", "4")
     ));
 
     // Adding the '3' group
     expectedData.addAll(List.of(
-        new RowData("2", 3L),
-        new RowData("3", 3L),
-        new RowData("6", 3L),
-        new RowData("4", 3L),
-        new RowData("5", 3L)
+        new RowData("2", "3"),
+        new RowData("3", "3"),
+        new RowData("6", "3"),
+        new RowData("4", "3"),
+        new RowData("5", "3")
     ));
 
     // Adding the '2' group
     expectedData.addAll(List.of(
-        new RowData("6", 2L),
-        new RowData("5", 2L)
+        new RowData("6", "2"),
+        new RowData("5", "2")
     ));
 
     verifyDataAfterCompaction(expectedData, testDataProvider);
   }
 
-  record RowData(String colA, Long colB) {}
+  record RowData(String... columns) {
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof RowData(String[] otherColumns)) {
+        return Arrays.equals(otherColumns, this.columns);
+      }
+
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(columns);
+    }
+  }
 
   /**
    * Validate the data after rebalance compaction
    * - the table is balanced (or if not, only numberOfDeletedRows amount of rows are missing
    * - there is only one writeId
    * - buckets has unique bucketId and the bucketId doesn't change inside a bucket
-   * - data is sorted by column b (so the order of column a is not predictable)
+   * - all the required value present
+   * - rowId must be strictly monotonic
+   *
+   * @param expectedData     Expected row data
+   * @param testDataProvider Test data provider
+   * @throws Exception Any exception that occurs during the execution
+   */
+  private void verifyDataAfterCompaction(List<RowData> expectedData, TestDataProvider testDataProvider)
+      throws Exception {
+    verifyDataAfterCompaction(expectedData, testDataProvider, (String) null, true);
+  }
+  /**
+   * Validate the data after rebalance compaction
+   * - the table is balanced (or if not, only numberOfDeletedRows amount of rows are missing
+   * - writeId must be strictly monotonic
+   * - buckets has unique bucketId and the bucketId doesn't change inside a bucket
+   * - if we expect the output sorted, data is sorted by column b (so the order of column a is not predictable)
    * - all the required value present
    * - rowId must be strictly monotonic
    *
    * @param expectedData      Expected row data
    * @param testDataProvider  Test data provider
+   * @param sorted            True if the data must be sorted
    * @throws Exception        Any exception that occurs during the execution
    */
-  private void verifyDataAfterCompaction(Set<RowData> expectedData, TestDataProvider testDataProvider)
+  private void verifyDataAfterCompaction(List<RowData> expectedData, TestDataProvider testDataProvider, String partition, boolean sorted)
       throws Exception {
     FileSystem fs = FileSystem.get(conf);
     GetTableRequest getTableRequest = new GetTableRequest("default", "rebalance_test");
     Table table = msClient.getTable(getTableRequest);
     List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(
-        fs, table, null, "base_0000001");
+        fs, table, partition, "base_0000001");
 
     int bucketCount = bucketFilenames.size();
     assertTrue(bucketCount > 0);
@@ -514,7 +512,8 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
       assertTrue(bucketSize <= upperBound);
 
       long bucketId = -1L;
-      long writeId = -1L;
+
+      long previousWriteId = -1L;
 
       for (TestDataProvider.RowInfo rowInfo : bucket) {
 
@@ -524,12 +523,13 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
           rowInfo.rowId() > previousRowId);
         previousRowId = rowInfo.rowId();
 
-        // Check if writeId doesn't change
-        if (writeId == -1L) {
+        // Check if writeId is strictly monotonic
+        if (previousWriteId == -1L) {
           // we are at the first element
-          writeId = rowInfo.writeId();
+          previousWriteId = rowInfo.writeId();
         } else {
-          assertEquals(writeId, rowInfo.writeId());
+          assertTrue(previousWriteId <= rowInfo.writeId());
+          previousWriteId = rowInfo.writeId();
         }
 
         // Check if bucketId doesn't change inside the bucket
@@ -540,14 +540,17 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
           assertEquals(bucketId, rowInfo.bucketId());
         }
 
-        // Check if the data is sorted by colB desc
-        RowData rowData = rowInfo.rowData();
-        assertTrue(rowData.colB <= previousValueForColB);
-        previousValueForColB = rowData.colB;
-
         // Check if all the necessary data persist
+        RowData rowData = rowInfo.rowData();
         assertTrue(expectedData.contains(rowData));
         expectedData.remove(rowData);
+
+        // Check if the data is sorted by colB desc
+        if (sorted) {
+          long colB = Long.parseLong(rowData.columns()[1]);
+          assertTrue(colB <= previousValueForColB);
+          previousValueForColB = colB;
+        }
       }
     }
 
@@ -580,27 +583,27 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
         "SELECT * FROM " + "rebalance_test", driver, "Dumping data from test table, " + "rebalance_test");
     Assert.assertEquals(18, allRecords.size());
 
-    /*
-     check if the test data is unbalanced
-     Balanced if all the buckets contain between n / bucket count and n / bucket count + bucket count rows,
-     where n is the number of rows in the table.
-     In our test case, we inserted 6 extra rows into the first bucket so, we can say it is properly unbalanced
-     if the first bucket has 6 more elements than the second one.
-    */
-    Assert.assertFalse(isBalanced(testDataProvider));
+    Assert.assertFalse(isBalanced(testDataProvider, null));
 
     // Please note, as the test tests rebalance compaction, not insert overwrite, it is not necessary to test if
     // we have the exact same data after preparing the test data as we had at the source table.
     return testDataProvider;
   }
 
-  private boolean isBalanced(TestDataProvider testDataProvider) throws Exception {
+  /**
+   * checks if the test data is unbalanced
+   * Balanced if all the buckets contain between n / bucket count and n / bucket count + bucket count rows,
+   * where n is the number of rows in the table.
+   * In our test case, we inserted 6 extra rows into the first bucket so, we can say it is properly unbalanced
+   * if the first bucket has 6 more elements than the second one.
+   **/
+  private boolean isBalanced(TestDataProvider testDataProvider, String partition) throws Exception {
     FileSystem fs = FileSystem.get(conf);
     GetTableRequest getTableRequest = new GetTableRequest("default", "rebalance_test");
     Table table = msClient.getTable(getTableRequest);
 
     // Assert that we have multiple buckets
-    List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000001");
+    List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(fs, table, partition, "base_0000001");
     assertTrue(bucketFilenames.size() > 1);
 
     int bucketCount = bucketFilenames.size();
@@ -626,32 +629,5 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     }
 
     return true;
-  }
-
-  private void verifyRebalance(TestDataProvider testDataProvider, String partitionName,
-      String[][] expectedBucketContent, String[] bucketNames) throws Exception {
-    // Verify buckets and their content after rebalance
-    GetTableRequest getTableRequest = new GetTableRequest("default", "rebalance_test");
-    Table table = msClient.getTable(getTableRequest);
-    FileSystem fs = FileSystem.get(conf);
-    assertEquals("Buckets does not match after compaction", Arrays.asList(bucketNames),
-        CompactorTestUtil.getBucketFileNames(fs, table, partitionName, findTheBaseFolder(table, partitionName, fs)));
-    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
-    for (int i = 0; i < expectedBucketContent.length; i++) {
-      assertEquals("rebalanced bucket " + i, Arrays.asList(expectedBucketContent[i]),
-          testDataProvider.getBucketData("rebalance_test", BucketCodec.V1.encode(options.bucket(i)) + ""));
-    }
-  }
-
-  private String findTheBaseFolder(Table table, String partitionName, FileSystem fs) throws IOException {
-    Path searchPath = partitionName == null ? new Path(table.getSd().getLocation(), "base_*_v*") : new Path(
-        new Path(table.getSd().getLocation()), new Path(partitionName,  "base_*_v*"));
-
-    return Arrays.stream(
-        fs.globStatus(searchPath, AcidUtils.baseFileFilter))
-        .map(FileStatus::getPath)
-        .map(Path::getName)
-        .sorted()
-        .findFirst().orElse(null);
   }
 }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
@@ -31,7 +31,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -458,7 +461,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
   }
 
   /**
-   * Validate the data after rebalance compaction
+   * Validate the data after rebalance compaction.
    * - the table is balanced (or if not, only numberOfDeletedRows amount of rows are missing
    * - there is only one writeId
    * - buckets has unique bucketId and the bucketId doesn't change inside a bucket
@@ -474,7 +477,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     verifyDataAfterCompaction(expectedData, testDataProvider, (String) null, true);
   }
   /**
-   * Validate the data after rebalance compaction
+   * Validate the data after rebalance compaction.
    * - the table is balanced (or if not, only numberOfDeletedRows amount of rows are missing
    * - writeId must be strictly monotonic
    * - buckets has unique bucketId and the bucketId doesn't change inside a bucket
@@ -487,8 +490,10 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
    * @param sorted            True if the data must be sorted
    * @throws Exception        Any exception that occurs during the execution
    */
-  private void verifyDataAfterCompaction(List<RowData> expectedData, TestDataProvider testDataProvider, String partition, boolean sorted)
-      throws Exception {
+  private void verifyDataAfterCompaction(
+      List<RowData> expectedData, TestDataProvider testDataProvider, String partition, boolean sorted
+  ) throws Exception {
+
     FileSystem fs = FileSystem.get(conf);
     GetTableRequest getTableRequest = new GetTableRequest("default", "rebalance_test");
     Table table = msClient.getTable(getTableRequest);
@@ -506,7 +511,10 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     long previousRowId = Long.MIN_VALUE;
 
     for (int i = 0; i < bucketCount; i++) {
-      List<TestDataProvider.RowInfo> bucket = testDataProvider.getStructuredBucketData(table.getTableName(), BucketCodec.V1.encode(options.bucket(i)) + "");
+      List<TestDataProvider.RowInfo> bucket =
+          testDataProvider.getStructuredBucketData(
+              table.getTableName(), BucketCodec.V1.encode(options.bucket(i)) + ""
+          );
 
       int bucketSize = bucket.size();
       assertTrue(bucketSize <= upperBound);
@@ -519,8 +527,10 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
 
         // RowId must be strictly monotonic
         assertTrue(
-          String.format("RowId must be strictly monotonic rule failed. Previous RowId: %d, Bucket: %s,  ", previousRowId, rowInfo),
-          rowInfo.rowId() > previousRowId);
+            String.format(
+                "RowId must be strictly monotonic rule failed. Previous RowId: %d, Bucket: %s,  ",
+                previousRowId, rowInfo),
+            rowInfo.rowId() > previousRowId);
         previousRowId = rowInfo.rowId();
 
         // Check if writeId is strictly monotonic
@@ -568,7 +578,8 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     dropTables(driver, "rebalance_test");
     executeStatementOnDriver("CREATE TABLE " + "rebalance_test" + "(a string, b int) " +
         "STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
-    executeStatementOnDriver("INSERT OVERWRITE TABLE " + "rebalance_test" + " select a, b from " + stageTableName, driver);
+    executeStatementOnDriver(
+        "INSERT OVERWRITE TABLE " + "rebalance_test" + " select a, b from " + stageTableName, driver);
 
     //do some single inserts to have more data in the first bucket.
     executeStatementOnDriver("INSERT INTO TABLE " + "rebalance_test" + " values ('12',12)", driver);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.ShowCompactResponseElement;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
@@ -39,6 +40,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -206,7 +208,9 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     dropTables(driver, tableName);
     executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
         "PARTITIONED BY (ds string) STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
-    executeStatementOnDriver("INSERT OVERWRITE TABLE " + tableName + " partition (ds='tomorrow') select a, b from " + stageTableName, driver);
+    executeStatementOnDriver(
+        "INSERT OVERWRITE TABLE " + tableName + " partition (ds='tomorrow') select a, b from " + stageTableName, driver
+    );
 
     //do some single inserts to have more data in the first bucket.
     executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('12',12,'tomorrow')", driver);
@@ -217,7 +221,8 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17,'tomorrow')", driver);
 
     // Verify buckets and their content before rebalance in partition ds=tomorrow
-    Table table = msClient.getTable("default", tableName);
+    GetTableRequest getTableRequest = new GetTableRequest("default", tableName);
+    Table table = msClient.getTable(getTableRequest);
     FileSystem fs = FileSystem.get(conf);
     assertEquals("Test setup does not match the expected: different buckets",
         Arrays.asList("bucket_00000_0", "bucket_00001_0", "bucket_00002_0"),
@@ -300,7 +305,9 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     dropTables(driver, tableName);
     executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
         "CLUSTERED BY(a) INTO 4 BUCKETS STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('11',11),('22',22),('33',33),('44',44)", driver);
+    executeStatementOnDriver(
+        "INSERT INTO TABLE " + tableName + " values ('11',11),('22',22),('33',33),('44',44)", driver
+    );
 
     //Try to do a rebalancing compaction
     executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance'", driver);
@@ -308,7 +315,9 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
 
     //Check if the compaction is refused
     List<ShowCompactResponseElement> compacts = verifyCompaction(1, TxnStore.REFUSED_RESPONSE);
-    assertEquals("Expecting error message 'Cannot execute rebalancing compaction on bucketed tables.' and found:" + compacts.get(0).getState(),
+    assertEquals(
+        "Expecting error message 'Cannot execute rebalancing compaction on bucketed tables.' and found:" +
+              compacts.get(0).getState(),
         "Cannot execute rebalancing compaction on bucketed tables.", compacts.get(0).getErrorMessage());
   }
 
@@ -364,6 +373,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
         new String[] {"bucket_00000", "bucket_00001", "bucket_00002", "bucket_00003"});
   }
 
+  @SuppressWarnings("java:S2925")
   private void testRebalanceCompactionWithParallelDeleteAsSecond(boolean optimisticLock) throws Exception {
     conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
     conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
@@ -493,8 +503,10 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
   private void verifyDataAfterCompaction(String tableName, Set<RowData> expectedData, TestDataProvider testDataProvider)
       throws Exception {
     FileSystem fs = FileSystem.get(conf);
-    Table table = msClient.getTable("default", tableName);
-    List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000001");
+    GetTableRequest getTableRequest = new GetTableRequest("default", tableName);
+    Table table = msClient.getTable(getTableRequest);
+    List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(
+        fs, table, null, "base_0000001");
 
     int bucketCount = bucketFilenames.size();
     assertTrue(bucketCount > 0);
@@ -532,7 +544,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
           // we are at the first element
           writeId = rowInfo.writeId;
         } else {
-          assertTrue(rowInfo.writeId == writeId);
+          assertEquals(writeId, rowInfo.writeId);
         }
 
         // Check if bucketId doesn't change inside the bucket
@@ -579,7 +591,8 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17)", driver);
 
     // Make sure we have all the records persisted
-    List<String> allRecords = execSelectAndDumpData("SELECT * FROM " + tableName, driver, "Dumping data from test table, " + tableName);
+    List<String> allRecords = execSelectAndDumpData(
+        "SELECT * FROM " + tableName, driver, "Dumping data from test table, " + tableName);
     Assert.assertEquals(18, allRecords.size());
 
     /*
@@ -596,9 +609,10 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     return testDataProvider;
   }
 
-  private boolean isBalanced(String tableName, TestDataProvider testDataProvider ) throws Exception {
+  private boolean isBalanced(String tableName, TestDataProvider testDataProvider) throws Exception {
     FileSystem fs = FileSystem.get(conf);
-    Table table = msClient.getTable("default", tableName);
+    GetTableRequest getTableRequest = new GetTableRequest("default", tableName);
+    Table table = msClient.getTable(getTableRequest);
 
     // Assert that we have multiple buckets
     List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000001");
@@ -614,11 +628,12 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
     List<String>[] bucketData = new ArrayList[bucketCount];
     for (int i = 0; i < bucketCount; i++) {
-      bucketData[i] = testDataProvider.getBucketData(table.getTableName(), BucketCodec.V1.encode(options.bucket(i)) + "");
+      bucketData[i] = testDataProvider.getBucketData(
+          table.getTableName(), BucketCodec.V1.encode(options.bucket(i)) + "");
     }
 
     int allRecordCount = Arrays.stream(bucketData)
-        .map(bucket -> bucket.size())
+        .map(Collection::size)
         .reduce(0, Integer::sum);
 
     int optimalRecordsInBucket = allRecordCount / bucketCount;
@@ -636,7 +651,8 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
   private void verifyRebalance(TestDataProvider testDataProvider, String tableName, String partitionName,
       String[][] expectedBucketContent, String[] bucketNames) throws Exception {
     // Verify buckets and their content after rebalance
-    Table table = msClient.getTable("default", tableName);
+    GetTableRequest getTableRequest = new GetTableRequest("default", tableName);
+    Table table = msClient.getTable(getTableRequest);
     FileSystem fs = FileSystem.get(conf);
     assertEquals("Buckets does not match after compaction", Arrays.asList(bucketNames),
         CompactorTestUtil.getBucketFileNames(fs, table, partitionName, findTheBaseFolder(table, partitionName, fs)));
@@ -651,7 +667,10 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     Path searchPath = partitionName == null ? new Path(table.getSd().getLocation(), "base_*_v*") : new Path(
         new Path(table.getSd().getLocation()), new Path(partitionName,  "base_*_v*"));
 
-    return Arrays.stream(fs.globStatus(searchPath, AcidUtils.baseFileFilter)).map(FileStatus::getPath).map(Path::getName)
+    return Arrays.stream(
+        fs.globStatus(searchPath, AcidUtils.baseFileFilter))
+        .map(FileStatus::getPath)
+        .map(Path::getName)
         .sorted()
         .findFirst().get();
   }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
@@ -578,11 +578,15 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('16',16)", driver);
     executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17)", driver);
 
+    // Make sure we have all the records persisted
+    List<String> allRecords = execSelectAndDumpData("SELECT * FROM " + tableName, driver, "Dumping data from test table, " + tableName);
+    Assert.assertEquals(18, allRecords.size());
+
     /*
      check if the test data is unbalanced
-     balanced if all the buckets contains between n / bucket count and n / bucket count + bucket count rows
+     Balanced if all the buckets contain between n / bucket count and n / bucket count + bucket count rows,
      where n is the number of rows in the table.
-     In our test case, we inserted 6 extra rows into the first bucket so we can say it is properly unbalanced
+     In our test case, we inserted 6 extra rows into the first bucket so, we can say it is properly unbalanced
      if the first bucket has 6 more elements than the second one.
     */
     Assert.assertFalse(isBalanced(tableName, testDataProvider));

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
@@ -17,9 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.txn.compactor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -72,17 +69,14 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
 
   @Test
   public void testRebalanceCompactionOfNotPartitionedImplicitlyBucketedTableWithOrder() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+    prepareHiveConfForRebalanceCompaction();
 
-    //set grouping size to have 3 buckets, and re-create driver with the new config
     conf.set("tez.grouping.min-size", "400");
     conf.set("tez.grouping.max-size", "5000");
     driver = new Driver(conf);
 
     final String tableName = "rebalance_test";
-    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
+    TestDataProvider testDataProvider = prepareRebalanceTestData();
 
     //Try to do a rebalancing compaction
     executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' ORDER BY b DESC", driver);
@@ -97,12 +91,14 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     // Populate expected data
     Set<RowData> expectedData = new HashSet<>();
 
-    expectedData.add(new RowData("17", 17L));
-    expectedData.add(new RowData("16", 16L));
-    expectedData.add(new RowData("15", 15L));
-    expectedData.add(new RowData("14", 14L));
-    expectedData.add(new RowData("13", 13L));
-    expectedData.add(new RowData("12", 12L));
+    expectedData.addAll(List.of(
+        new RowData("17", 17L),
+        new RowData("16", 16L),
+        new RowData("15", 15L),
+        new RowData("14", 14L),
+        new RowData("13", 13L),
+        new RowData("12", 12L)
+    ));
 
     // Adding the '4' group
     expectedData.addAll(List.of(
@@ -123,17 +119,23 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     ));
 
     // Adding the '2' group
-    expectedData.add(new RowData("6", 2L));
-    expectedData.add(new RowData("5", 2L));
+    expectedData.addAll(List.of(
+        new RowData("6", 2L),
+        new RowData("5", 2L)
+    ));
 
-    verifyDataAfterCompaction(tableName, expectedData, testDataProvider);
+    verifyDataAfterCompaction(expectedData, testDataProvider);
+  }
+
+  private void prepareHiveConfForRebalanceCompaction() {
+    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
   }
 
   @Test
   public void testRebalanceCompactionOfNotPartitionedImplicitlyBucketedTable() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+    prepareHiveConfForRebalanceCompaction();
 
     // set grouping size to have 3 buckets, and re-create driver with the new config
     conf.set("tez.grouping.min-size", "400");
@@ -141,7 +143,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     driver = new Driver(conf);
 
     final String tableName = "rebalance_test";
-    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
+    TestDataProvider testDataProvider = prepareRebalanceTestData();
 
     // Run rebalance compaction
     executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance'", driver);
@@ -179,15 +181,13 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
             "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
         },
     };
-    verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
+    verifyRebalance(testDataProvider, null, expectedBuckets,
         new String[] {"bucket_00000", "bucket_00001", "bucket_00002","bucket_00003"});
   }
 
   @Test
   public void testRebalanceCompactionOfPartitionedImplicitlyBucketedTable() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+    prepareHiveConfForRebalanceCompaction();
 
     //set grouping size to have 3 buckets, and re-create driver with the new config
     conf.set("tez.grouping.min-size", "1");
@@ -291,15 +291,13 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
             "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":17}\t17\t17\ttomorrow",
         },
     };
-    verifyRebalance(testDataProvider, tableName, "ds=tomorrow", expectedBuckets,
+    verifyRebalance(testDataProvider, "ds=tomorrow", expectedBuckets,
         new String[] {"bucket_00000", "bucket_00001", "bucket_00002"});
   }
 
   @Test
   public void testRebalanceCompactionOfNotPartitionedExplicitlyBucketedTable() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+    prepareHiveConfForRebalanceCompaction();
 
     final String tableName = "rebalance_test";
     dropTables(driver, tableName);
@@ -317,15 +315,13 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     List<ShowCompactResponseElement> compacts = verifyCompaction(1, TxnStore.REFUSED_RESPONSE);
     assertEquals(
         "Expecting error message 'Cannot execute rebalancing compaction on bucketed tables.' and found:" +
-              compacts.get(0).getState(),
-        "Cannot execute rebalancing compaction on bucketed tables.", compacts.get(0).getErrorMessage());
+              compacts.getFirst().getState(),
+        "Cannot execute rebalancing compaction on bucketed tables.", compacts.getFirst().getErrorMessage());
   }
 
   @Test
   public void testRebalanceCompactionNotPartitionedExplicitBucketNumbers() throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+    prepareHiveConfForRebalanceCompaction();
 
     //set grouping size to have 3 buckets, and re-create driver with the new config
     conf.set("tez.grouping.min-size", "400");
@@ -333,7 +329,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     driver = new Driver(conf);
 
     final String tableName = "rebalance_test";
-    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
+    TestDataProvider testDataProvider = prepareRebalanceTestData();
 
     //Try to do a rebalancing compaction
     executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' CLUSTERED INTO 4 BUCKETS", driver);
@@ -369,15 +365,13 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
             "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
         },
     };
-    verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
+    verifyRebalance(testDataProvider, null, expectedBuckets,
         new String[] {"bucket_00000", "bucket_00001", "bucket_00002", "bucket_00003"});
   }
 
   @SuppressWarnings("java:S2925")
   private void testRebalanceCompactionWithParallelDeleteAsSecond(boolean optimisticLock) throws Exception {
-    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
-    conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
+    prepareHiveConfForRebalanceCompaction();
     conf.setBoolVar(HiveConf.ConfVars.TXN_WRITE_X_LOCK, optimisticLock);
 
     //set grouping size to have 3 buckets, and re-create driver with the new config
@@ -386,7 +380,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     driver = new Driver(conf);
 
     final String tableName = "rebalance_test";
-    TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
+    TestDataProvider testDataProvider = prepareRebalanceTestData();
 
     //Try to do a rebalancing compaction
     executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance' ORDER BY b DESC", driver);
@@ -445,11 +439,13 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     // Populate expected data
     Set<RowData> expectedData = new HashSet<>();
 
-    expectedData.add(new RowData("17", 17L));
-    expectedData.add(new RowData("16", 16L));
-    expectedData.add(new RowData("15", 15L));
-    expectedData.add(new RowData("14", 14L));
-    expectedData.add(new RowData("13", 13L));
+    expectedData.addAll(List.of(
+        new RowData("17", 17L),
+        new RowData("16", 16L),
+        new RowData("15", 15L),
+        new RowData("14", 14L),
+        new RowData("13", 13L)
+    ));
 
     // Adding the '4' group
     expectedData.addAll(List.of(
@@ -470,40 +466,33 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     ));
 
     // Adding the '2' group
-    expectedData.add(new RowData("6", 2L));
-    expectedData.add(new RowData("5", 2L));
+    expectedData.addAll(List.of(
+        new RowData("6", 2L),
+        new RowData("5", 2L)
+    ));
 
-    verifyDataAfterCompaction(tableName, expectedData, testDataProvider);
+    verifyDataAfterCompaction(expectedData, testDataProvider);
   }
 
   record RowData(String colA, Long colB) {}
 
-  record RowInfo(long writeId, long bucketId, long rowId, RowData rowData) {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    static RowInfo fromRawString(String row) throws JsonProcessingException {
-      // Example row data to parse: "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":10}\t5\t4",
-
-      String[] parts = row.split("\t", 3);
-
-      JsonNode json = MAPPER.readTree(parts[0]);
-
-      return new RowInfo(
-          json.get("writeid").asLong(),
-          json.get("bucketid").asLong(),
-          json.get("rowid").asLong(),
-          new RowData(
-              parts[1], // colA
-              Long.parseLong(parts[2])  // colB
-          )
-      );
-    }
-  }
-
-  private void verifyDataAfterCompaction(String tableName, Set<RowData> expectedData, TestDataProvider testDataProvider)
+  /**
+   * Validate the data after rebalance compaction
+   * - the table is balanced (or if not, only numberOfDeletedRows amount of rows are missing
+   * - there is only one writeId
+   * - buckets has unique bucketId and the bucketId doesn't change inside a bucket
+   * - data is sorted by column b (so the order of column a is not predictable)
+   * - all the required value present
+   * - rowId must be strictly monotonic
+   *
+   * @param expectedData      Expected row data
+   * @param testDataProvider  Test data provider
+   * @throws Exception        Any exception that occurs during the execution
+   */
+  private void verifyDataAfterCompaction(Set<RowData> expectedData, TestDataProvider testDataProvider)
       throws Exception {
     FileSystem fs = FileSystem.get(conf);
-    GetTableRequest getTableRequest = new GetTableRequest("default", tableName);
+    GetTableRequest getTableRequest = new GetTableRequest("default", "rebalance_test");
     Table table = msClient.getTable(getTableRequest);
     List<String> bucketFilenames = CompactorTestUtil.getBucketFileNames(
         fs, table, null, "base_0000001");
@@ -513,49 +502,46 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
 
     AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
 
-    /*
-      Validate the data after the test case
-        - the table is balanced (or if not, only numberOfDeletedRows amount of rows are missing
-        - there is only one writeId
-        - buckets has unique bucketId and the bucketId doesn't change inside a bucket
-        - data is sorted by column b (so the order of column a is not predictable)
-        - all the required value present
-     */
-
-    int maximumRecordCountInABucket = (expectedData.size() + bucketCount - 1) / bucketCount;
+    int upperBound = (expectedData.size() + bucketCount - 1) / bucketCount;
 
     long previousValueForColB = Long.MAX_VALUE;
+    long previousRowId = Long.MIN_VALUE;
 
     for (int i = 0; i < bucketCount; i++) {
-      List<String> bucket = testDataProvider.getBucketData(table.getTableName(), BucketCodec.V1.encode(options.bucket(i)) + "");
+      List<TestDataProvider.RowInfo> bucket = testDataProvider.getStructuredBucketData(table.getTableName(), BucketCodec.V1.encode(options.bucket(i)) + "");
 
       int bucketSize = bucket.size();
-      assertTrue(bucketSize <= maximumRecordCountInABucket);
+      assertTrue(bucketSize <= upperBound);
 
       long bucketId = -1L;
       long writeId = -1L;
 
-      for (String row : bucket) {
-        RowInfo rowInfo = RowInfo.fromRawString(row);
+      for (TestDataProvider.RowInfo rowInfo : bucket) {
+
+        // RowId must be strictly monotonic
+        assertTrue(
+          String.format("RowId must be strictly monotonic rule failed. Previous RowId: %d, Bucket: %s,  ", previousRowId, rowInfo),
+          rowInfo.rowId() > previousRowId);
+        previousRowId = rowInfo.rowId();
 
         // Check if writeId doesn't change
         if (writeId == -1L) {
           // we are at the first element
-          writeId = rowInfo.writeId;
+          writeId = rowInfo.writeId();
         } else {
-          assertEquals(writeId, rowInfo.writeId);
+          assertEquals(writeId, rowInfo.writeId());
         }
 
         // Check if bucketId doesn't change inside the bucket
         if (bucketId == -1) {
           // we are at the first element of the bucket
-          bucketId = rowInfo.bucketId;
+          bucketId = rowInfo.bucketId();
         } else {
-          assertEquals(bucketId, rowInfo.bucketId);
+          assertEquals(bucketId, rowInfo.bucketId());
         }
 
         // Check if the data is sorted by colB desc
-        RowData rowData = rowInfo.rowData;
+        RowData rowData = rowInfo.rowData();
         assertTrue(rowData.colB <= previousValueForColB);
         previousValueForColB = rowData.colB;
 
@@ -569,29 +555,29 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     assertEquals(0, expectedData.size()); // we have found all the elements in a proper order
   }
 
-  private TestDataProvider prepareRebalanceTestData(String tableName) throws Exception {
-    final String stageTableName = "stage_" + tableName;
+  private TestDataProvider prepareRebalanceTestData() throws Exception {
+    final String stageTableName = "stage_" + "rebalance_test";
 
     TestDataProvider testDataProvider = new TestDataProvider();
     testDataProvider.createFullAcidTable(stageTableName, true, false);
     testDataProvider.insertTestData(stageTableName, true);
 
-    dropTables(driver, tableName);
-    executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
+    dropTables(driver, "rebalance_test");
+    executeStatementOnDriver("CREATE TABLE " + "rebalance_test" + "(a string, b int) " +
         "STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
-    executeStatementOnDriver("INSERT OVERWRITE TABLE " + tableName + " select a, b from " + stageTableName, driver);
+    executeStatementOnDriver("INSERT OVERWRITE TABLE " + "rebalance_test" + " select a, b from " + stageTableName, driver);
 
     //do some single inserts to have more data in the first bucket.
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('12',12)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('13',13)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('14',14)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('15',15)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('16',16)", driver);
-    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + "rebalance_test" + " values ('12',12)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + "rebalance_test" + " values ('13',13)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + "rebalance_test" + " values ('14',14)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + "rebalance_test" + " values ('15',15)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + "rebalance_test" + " values ('16',16)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + "rebalance_test" + " values ('17',17)", driver);
 
     // Make sure we have all the records persisted
     List<String> allRecords = execSelectAndDumpData(
-        "SELECT * FROM " + tableName, driver, "Dumping data from test table, " + tableName);
+        "SELECT * FROM " + "rebalance_test", driver, "Dumping data from test table, " + "rebalance_test");
     Assert.assertEquals(18, allRecords.size());
 
     /*
@@ -601,16 +587,16 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
      In our test case, we inserted 6 extra rows into the first bucket so, we can say it is properly unbalanced
      if the first bucket has 6 more elements than the second one.
     */
-    Assert.assertFalse(isBalanced(tableName, testDataProvider));
+    Assert.assertFalse(isBalanced(testDataProvider));
 
     // Please note, as the test tests rebalance compaction, not insert overwrite, it is not necessary to test if
     // we have the exact same data after preparing the test data as we had at the source table.
     return testDataProvider;
   }
 
-  private boolean isBalanced(String tableName, TestDataProvider testDataProvider) throws Exception {
+  private boolean isBalanced(TestDataProvider testDataProvider) throws Exception {
     FileSystem fs = FileSystem.get(conf);
-    GetTableRequest getTableRequest = new GetTableRequest("default", tableName);
+    GetTableRequest getTableRequest = new GetTableRequest("default", "rebalance_test");
     Table table = msClient.getTable(getTableRequest);
 
     // Assert that we have multiple buckets
@@ -630,11 +616,11 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
         .map(Collection::size)
         .reduce(0, Integer::sum);
 
-    int optimalRecordsInBucket = allRecordCount / bucketCount;
-    int maximumRecordCountInABucket = (allRecordCount + bucketCount - 1) / bucketCount;
+    int lowerBound = allRecordCount / bucketCount;
+    int upperBound = (allRecordCount + bucketCount - 1) / bucketCount;
 
     for (int i = 0; i < bucketCount; i++) {
-      if (bucketData[i].size() > maximumRecordCountInABucket || bucketData[i].size() < optimalRecordsInBucket) {
+      if (bucketData[i].size() > upperBound || bucketData[i].size() < lowerBound) {
         return false;
       }
     }
@@ -642,10 +628,10 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     return true;
   }
 
-  private void verifyRebalance(TestDataProvider testDataProvider, String tableName, String partitionName,
+  private void verifyRebalance(TestDataProvider testDataProvider, String partitionName,
       String[][] expectedBucketContent, String[] bucketNames) throws Exception {
     // Verify buckets and their content after rebalance
-    GetTableRequest getTableRequest = new GetTableRequest("default", tableName);
+    GetTableRequest getTableRequest = new GetTableRequest("default", "rebalance_test");
     Table table = msClient.getTable(getTableRequest);
     FileSystem fs = FileSystem.get(conf);
     assertEquals("Buckets does not match after compaction", Arrays.asList(bucketNames),
@@ -653,7 +639,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
     for (int i = 0; i < expectedBucketContent.length; i++) {
       assertEquals("rebalanced bucket " + i, Arrays.asList(expectedBucketContent[i]),
-          testDataProvider.getBucketData(tableName, BucketCodec.V1.encode(options.bucket(i)) + ""));
+          testDataProvider.getBucketData("rebalance_test", BucketCodec.V1.encode(options.bucket(i)) + ""));
     }
   }
 
@@ -666,6 +652,6 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
         .map(FileStatus::getPath)
         .map(Path::getName)
         .sorted()
-        .findFirst().get();
+        .findFirst().orElse(null);
   }
 }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestRebalanceCompactor.java
@@ -135,7 +135,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
     conf.setBoolVar(HiveConf.ConfVars.HIVE_STATS_AUTOGATHER, false);
 
-    //set grouping size to have 3 buckets, and re-create driver with the new config
+    // set grouping size to have 3 buckets, and re-create driver with the new config
     conf.set("tez.grouping.min-size", "400");
     conf.set("tez.grouping.max-size", "5000");
     driver = new Driver(conf);
@@ -143,11 +143,11 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
     final String tableName = "rebalance_test";
     TestDataProvider testDataProvider = prepareRebalanceTestData(tableName);
 
-    //Try to do a rebalancing compaction
+    // Run rebalance compaction
     executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance'", driver);
     runWorker(conf);
 
-    //Check if the compaction succeed
+    // Check if the compaction succeed
     verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
 
     String[][] expectedBuckets = new String[][] {
@@ -522,8 +522,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
         - all the required value present
      */
 
-    int optimalRecordsInBucket = expectedData.size() / bucketCount;
-    int maximumRecordCountInABucket = optimalRecordsInBucket + bucketCount - 1;
+    int maximumRecordCountInABucket = (expectedData.size() + bucketCount - 1) / bucketCount;
 
     long previousValueForColB = Long.MAX_VALUE;
 
@@ -620,11 +619,6 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
 
     int bucketCount = bucketFilenames.size();
 
-    if (bucketCount == 1) {
-      // nothing to rebalance with a single bucket
-      return true;
-    }
-
     AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
     List<String>[] bucketData = new ArrayList[bucketCount];
     for (int i = 0; i < bucketCount; i++) {
@@ -637,7 +631,7 @@ public class TestRebalanceCompactor extends CompactorOnTezTest {
         .reduce(0, Integer::sum);
 
     int optimalRecordsInBucket = allRecordCount / bucketCount;
-    int maximumRecordCountInABucket = optimalRecordsInBucket + bucketCount - 1;
+    int maximumRecordCountInABucket = (allRecordCount + bucketCount - 1) / bucketCount;
 
     for (int i = 0; i < bucketCount; i++) {
       if (bucketData[i].size() > maximumRecordCountInABucket || bucketData[i].size() < optimalRecordsInBucket) {


### PR DESCRIPTION
Rebalance tests are sensitive and the hard-coded assertions need to be modified regularly. 
Some examples: 
- https://github.com/apache/hive/commit/388e80690373a064d1fa464579a8b22173395ef2
- https://github.com/apache/hive/commit/413069ea0faeb893fe78faa215b08a70ece80595#diff-dedd154465fd42855d9d6710d54553660dae87405ce2e4ea931475de1d5bb816
- https://github.com/apache/hive/commit/6e1f1ccf2aca58af4be06d6ceea1aa2b877a5d08#diff-dedd154465fd42855d9d6710d54553660dae87405ce2e4ea931475de1d5bb816
... 

There are two causes identified: 
- Firstly, the number of buckets and even the order of the elements inside a bucket depends on the version string of Orc: https://issues.apache.org/jira/browse/HIVE-29536?focusedCommentId=18080335&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18080335 (Thanks @thomasrebele to digging into it)
- Secondly, the base directory can change as well (like here: https://github.com/apache/hive/commit/1a90d278be9af1dc5b8aeb4c4cca24febac91936#diff-dedd154465fd42855d9d6710d54553660dae87405ce2e4ea931475de1d5bb816L199) 

### What changes were proposed in this pull request?
The goal of the change is to stabilize those tests by doing two things: 
- Rebalance assertions are not hard-coded. Instead of that, we can check if the buckets are balanced or not and if all the data is available.
- Base folder can be searched dinamically

Please note: I also refactored the code little bit and extracted rebalance compaction tests into a new class. 

### Why are the changes needed?
We experienced regular and serious regression issues due to the effect of the orc version number.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
With the existing tests.
