### PR TITLE
HIVE-29617: Unable to load column statistics of Iceberg table after upgrading Hive

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -188,6 +188,9 @@ import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.actions.HiveIcebergDeleteOrphanFiles;
 import org.apache.iceberg.mr.hive.plan.IcebergBucketFunction;
+import org.apache.iceberg.mr.hive.stats.ColumnStatsConverter;
+import org.apache.iceberg.mr.hive.stats.HiveColumnStatistics;
+import org.apache.iceberg.mr.hive.stats.HiveColumnStatisticsObj;
 import org.apache.iceberg.mr.hive.udf.GenericUDFIcebergZorder;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.BlobMetadata;
@@ -644,8 +647,12 @@ public class HiveIcebergStorageHandler extends DefaultStorageHandler implements 
           Map<String, String> properties = isTblLevel ? Map.of() :
               Map.of(PARTITION, String.valueOf(stats.getStatsDesc().getPartName()));
 
-          List<? extends Serializable> statsObjects = isTblLevel ?
-              stats.getStatsObj() : List.of(stats);
+          List<? extends Serializable> statsObjects;
+          if (isTblLevel) {
+            statsObjects = stats.getStatsObj().stream().map(ColumnStatsConverter::fromThrift).toList();
+          } else {
+            statsObjects = List.of(ColumnStatsConverter.fromThrift(stats));
+          }
 
           List<Integer> fieldIds = null;
 
@@ -664,11 +671,11 @@ public class HiveIcebergStorageHandler extends DefaultStorageHandler implements 
 
             if (isTblLevel) {
               fieldIds = List.of(schema.findField(
-                  ((ColumnStatisticsObj) statsObj).getColName()).fieldId());
+                  ((HiveColumnStatisticsObj) statsObj).colName()).fieldId());
             }
 
             writer.add(new Blob(
-                ColumnStatisticsObj.class.getSimpleName(),
+                HiveColumnStatisticsObj.class.getSimpleName(),
                 fieldIds,
                 snapshotId,
                 snapshotSequenceNumber,
@@ -753,7 +760,9 @@ public class HiveIcebergStorageHandler extends DefaultStorageHandler implements 
       filter = null;
     }
 
-    return IcebergTableUtil.readColStats(table, snapshot.snapshotId(), filter);
+    List<HiveColumnStatisticsObj> columnStatisticsObjList =
+        IcebergTableUtil.readColStats(table, snapshot.snapshotId(), filter);
+    return columnStatisticsObjList.stream().map(ColumnStatsConverter::toThrift).toList();
   }
 
   @Override
@@ -773,7 +782,9 @@ public class HiveIcebergStorageHandler extends DefaultStorageHandler implements 
     Set<String> partitions = Sets.newHashSet(partNames);
     Predicate<BlobMetadata> filter = metadata -> partitions.contains(metadata.properties().get(PARTITION));
 
-    List<ColumnStatistics> partStats = IcebergTableUtil.readColStats(table, snapshot.snapshotId(), filter);
+    List<HiveColumnStatistics> storedStats =
+        IcebergTableUtil.readColStats(table, snapshot.snapshotId(), filter);
+    List<ColumnStatistics> partStats = storedStats.stream().map(ColumnStatsConverter::toThrift).toList();
 
     partStats.forEach(colStats ->
         colStats.getStatsObj().removeIf(statsObj -> !colNames.contains(statsObj.getColName())));
@@ -831,13 +842,17 @@ public class HiveIcebergStorageHandler extends DefaultStorageHandler implements 
       boolean isTblLevel = statsNew.getFirst().getStatsDesc().isIsTblLevel();
       Map<String, ColumnStatistics> oldStatsMap = Maps.newHashMap();
 
-      List<?> statsOld = IcebergTableUtil.readColStats(tbl, previousSnapshotId, null);
-
+      List<?> statsOld;
       if (!isTblLevel) {
+        List<HiveColumnStatistics> storedStats = IcebergTableUtil.readColStats(tbl, previousSnapshotId, null);
+        statsOld = storedStats.stream().map(ColumnStatsConverter::toThrift).toList();
+
         for (ColumnStatistics statsObjOld : (List<ColumnStatistics>) statsOld) {
           oldStatsMap.put(statsObjOld.getStatsDesc().getPartName(), statsObjOld);
         }
       } else {
+        List<HiveColumnStatisticsObj> storedStatObjects = IcebergTableUtil.readColStats(tbl, previousSnapshotId, null);
+        statsOld = storedStatObjects.stream().map(ColumnStatsConverter::toThrift).toList();
         statsOld = Collections.singletonList(
             new ColumnStatistics(null, (List<ColumnStatisticsObj>) statsOld));
       }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.hive.common.type.TimestampTZUtil;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.Warehouse;
-import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.utils.TableFetcher;
@@ -101,6 +100,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.mr.hive.stats.HiveColumnStatisticsObj;
 import org.apache.iceberg.puffin.BlobMetadata;
 import org.apache.iceberg.puffin.Puffin;
 import org.apache.iceberg.puffin.PuffinReader;
@@ -256,7 +256,7 @@ public class IcebergTableUtil {
     return table.statisticsFiles().stream()
       .filter(stats -> stats.snapshotId() == snapshotId)
       .filter(stats -> stats.blobMetadata().stream()
-        .anyMatch(metadata -> ColumnStatisticsObj.class.getSimpleName().equals(metadata.type()))
+        .anyMatch(metadata -> HiveColumnStatisticsObj.class.getSimpleName().equals(metadata.type()))
       )
       .map(StatisticsFile::path)
       .findAny().orElse(null);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/ColumnStatsConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/ColumnStatsConverter.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.nio.ByteBuffer;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+
+public final class ColumnStatsConverter {
+  private static final HiveBooleanConverter BOOLEAN = new HiveBooleanConverter();
+  private static final HiveLongConverter LONG = new HiveLongConverter();
+  private static final HiveDoubleConverter DOUBLE = new HiveDoubleConverter();
+  private static final HiveStringConverter STRING = new HiveStringConverter();
+  private static final HiveBinaryConverter BINARY = new HiveBinaryConverter();
+  private static final HiveDecimalConverter DECIMAL = new HiveDecimalConverter();
+  private static final HiveDateConverter DATE = new HiveDateConverter();
+  private static final HiveTimestampConverter TIMESTAMP = new HiveTimestampConverter();
+
+  private ColumnStatsConverter() {
+
+  }
+
+  public static HiveColumnStatistics fromThrift(ColumnStatistics columnStatistics) {
+    if (columnStatistics == null) {
+      return null;
+    }
+
+    ColumnStatisticsDesc tDesc = columnStatistics.getStatsDesc();
+    return new HiveColumnStatistics(
+        new HiveColumnStatisticsDesc(tDesc.isIsTblLevel(), tDesc.getDbName(), tDesc.getTableName(),
+            tDesc.getPartName(), tDesc.isSetLastAnalyzed() ? tDesc.getLastAnalyzed() : null, tDesc.getCatName()),
+        columnStatistics.getStatsObj().stream().map(ColumnStatsConverter::fromThrift).collect(Collectors.toList()),
+        columnStatistics.isSetIsStatsCompliant() ? columnStatistics.isIsStatsCompliant() : null,
+        columnStatistics.getEngine()
+    );
+  }
+
+  public static HiveColumnStatisticsObj fromThrift(ColumnStatisticsObj columnStatisticsObj) {
+    return new HiveColumnStatisticsObj(
+        columnStatisticsObj.getColName(),
+        columnStatisticsObj.getColType(),
+        fromThriftData(columnStatisticsObj.getStatsData()));
+  }
+
+  private static HiveColumnStatisticsData fromThriftData(ColumnStatisticsData columnStatisticsData) {
+    if (columnStatisticsData.isSetBooleanStats()) {
+      return BOOLEAN.fromThrift(columnStatisticsData.getBooleanStats());
+    }
+
+    if (columnStatisticsData.isSetLongStats()) {
+      return LONG.fromThrift(columnStatisticsData.getLongStats());
+    }
+
+    if (columnStatisticsData.isSetDoubleStats()) {
+      return DOUBLE.fromThrift(columnStatisticsData.getDoubleStats());
+    }
+
+    if (columnStatisticsData.isSetStringStats()) {
+      return STRING.fromThrift(columnStatisticsData.getStringStats());
+    }
+
+    if (columnStatisticsData.isSetBinaryStats()) {
+      return BINARY.fromThrift(columnStatisticsData.getBinaryStats());
+    }
+
+    if (columnStatisticsData.isSetDecimalStats()) {
+      return DECIMAL.fromThrift(columnStatisticsData.getDecimalStats());
+    }
+
+    if (columnStatisticsData.isSetDateStats()) {
+      return DATE.fromThrift(columnStatisticsData.getDateStats());
+    }
+
+    if (columnStatisticsData.isSetTimestampStats()) {
+      return TIMESTAMP.fromThrift(columnStatisticsData.getTimestampStats());
+    }
+
+    throw new UnsupportedOperationException("Unsupported Hive Stat Type");
+  }
+
+  public static ColumnStatistics toThrift(HiveColumnStatistics record) {
+    if (record == null) {
+      return null;
+    }
+
+    ColumnStatistics result = new ColumnStatistics();
+
+    if (record.statsDesc() != null) {
+      result.setStatsDesc(toThrift(record.statsDesc()));
+    }
+
+    if (record.statsObj() != null) {
+      result.setStatsObj(record.statsObj().stream()
+          .map(ColumnStatsConverter::toThrift)
+          .collect(java.util.stream.Collectors.toList()));
+    }
+
+    if (record.isStatsCompliant() != null) {
+      result.setIsStatsCompliant(record.isStatsCompliant());
+    }
+
+    result.setEngine(record.engine());
+
+    return result;
+  }
+
+  private static ColumnStatisticsDesc toThrift(HiveColumnStatisticsDesc columnStatisticsDesc) {
+    var result = new ColumnStatisticsDesc(
+        columnStatisticsDesc.isTblLevel(),
+        columnStatisticsDesc.dbName(),
+        columnStatisticsDesc.tableName());
+
+    if (columnStatisticsDesc.partName() != null) {
+      result.setPartName(columnStatisticsDesc.partName());
+    }
+    if (columnStatisticsDesc.lastAnalyzed() != null) {
+      result.setLastAnalyzed(columnStatisticsDesc.lastAnalyzed());
+    }
+    if (columnStatisticsDesc.catName() != null) {
+      result.setCatName(columnStatisticsDesc.catName());
+    }
+
+    return result;
+  }
+
+  public static ColumnStatisticsObj toThrift(HiveColumnStatisticsObj columnStatisticsObj) {
+    return new ColumnStatisticsObj(
+        columnStatisticsObj.colName(),
+        columnStatisticsObj.colType(),
+        toThrift(columnStatisticsObj.statsData())
+    );
+  }
+
+  private static ColumnStatisticsData toThrift(HiveColumnStatisticsData columnStatisticsData) {
+    ColumnStatisticsData result = new ColumnStatisticsData();
+    switch (columnStatisticsData) {
+      case HiveBooleanStats statsValue -> result.setBooleanStats(BOOLEAN.toThrift(statsValue));
+      case HiveLongStats statsValue -> result.setLongStats(LONG.toThrift(statsValue));
+      case HiveDoubleStats statsValue -> result.setDoubleStats(DOUBLE.toThrift(statsValue));
+      case HiveStringStats statsValue -> result.setStringStats(STRING.toThrift(statsValue));
+      case HiveBinaryStats statsValue -> result.setBinaryStats(BINARY.toThrift(statsValue));
+      case HiveDecimalStats statsValue -> result.setDecimalStats(DECIMAL.toThrift(statsValue));
+      case HiveDateStats statsValue -> result.setDateStats(DATE.toThrift(statsValue));
+      case HiveTimestampStats statsValue -> result.setTimestampStats(TIMESTAMP.toThrift(statsValue));
+    }
+    return result;
+  }
+
+  public static byte[] toBytes(ByteBuffer byteBuffer) {
+    if (byteBuffer == null) {
+      return null;
+    }
+
+    byte[] arr = new byte[byteBuffer.remaining()];
+    byteBuffer.duplicate().get(arr);
+    return arr;
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveBinaryConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveBinaryConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import org.apache.hadoop.hive.metastore.api.BinaryColumnStatsData;
+
+public class HiveBinaryConverter implements HiveTypeStatsConverter<BinaryColumnStatsData, HiveBinaryStats> {
+
+  public HiveBinaryStats fromThrift(BinaryColumnStatsData binaryColumnStatsData) {
+    return new HiveBinaryStats(
+        binaryColumnStatsData.getMaxColLen(),
+        binaryColumnStatsData.getAvgColLen(),
+        binaryColumnStatsData.getNumNulls(),
+        ColumnStatsConverter.toBytes(binaryColumnStatsData.bufferForBitVectors()));
+  }
+
+  public BinaryColumnStatsData toThrift(HiveBinaryStats binaryStats) {
+    BinaryColumnStatsData binaryColumnStatsData =
+        new BinaryColumnStatsData(binaryStats.maxColLen(), binaryStats.avgColLen(), binaryStats.numNulls());
+
+    binaryColumnStatsData.setBitVectors(binaryStats.bitVectors());
+
+    return binaryColumnStatsData;
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveBinaryStats.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveBinaryStats.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+
+public record HiveBinaryStats(
+    long maxColLen,
+    double avgColLen,
+    long numNulls,
+    byte[] bitVectors
+) implements HiveColumnStatisticsData {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveBooleanConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveBooleanConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
+
+public class HiveBooleanConverter implements HiveTypeStatsConverter<BooleanColumnStatsData, HiveBooleanStats> {
+  public HiveBooleanStats fromThrift(BooleanColumnStatsData booleanColumnStatsData) {
+    return new HiveBooleanStats(
+        booleanColumnStatsData.getNumTrues(),
+        booleanColumnStatsData.getNumFalses(),
+        booleanColumnStatsData.getNumNulls(),
+        ColumnStatsConverter.toBytes(booleanColumnStatsData.bufferForBitVectors()));
+  }
+
+  public BooleanColumnStatsData toThrift(HiveBooleanStats booleanStats) {
+    BooleanColumnStatsData booleanColumnStatsData = new BooleanColumnStatsData(
+        booleanStats.numTrues(),
+        booleanStats.numFalses(),
+        booleanStats.numNulls());
+    booleanColumnStatsData.setBitVectors(booleanStats.bitVectors());
+    return booleanColumnStatsData;
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveBooleanStats.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveBooleanStats.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+
+public record HiveBooleanStats(
+    long numTrues,
+    long numFalses,
+    long numNulls,
+    byte[] bitVectors
+) implements HiveColumnStatisticsData {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveColumnStatistics.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveColumnStatistics.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+
+public record HiveColumnStatistics(
+    HiveColumnStatisticsDesc statsDesc,
+    List<HiveColumnStatisticsObj> statsObj,
+    Boolean isStatsCompliant,
+    String engine
+) implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveColumnStatisticsData.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveColumnStatisticsData.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serializable;
+
+public sealed interface HiveColumnStatisticsData extends Serializable
+    permits HiveBooleanStats, HiveLongStats, HiveDoubleStats, HiveStringStats,
+    HiveBinaryStats, HiveDecimalStats, HiveDateStats, HiveTimestampStats {
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveColumnStatisticsDesc.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveColumnStatisticsDesc.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public record HiveColumnStatisticsDesc(
+    boolean isTblLevel,
+    String dbName,
+    String tableName,
+    String partName,
+    Long lastAnalyzed,
+    String catName
+) implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveColumnStatisticsObj.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveColumnStatisticsObj.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public record HiveColumnStatisticsObj(
+    String colName,
+    String colType,
+    HiveColumnStatisticsData statsData
+) implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDateConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDateConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import org.apache.hadoop.hive.metastore.api.Date;
+import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
+
+public class HiveDateConverter implements HiveTypeStatsConverter<DateColumnStatsData, HiveDateStats> {
+  public HiveDateStats fromThrift(DateColumnStatsData dateColumnStatsData) {
+    return new HiveDateStats(
+        fromThrift(dateColumnStatsData.getLowValue()),
+        fromThrift(dateColumnStatsData.getHighValue()),
+        dateColumnStatsData.getNumNulls(),
+        dateColumnStatsData.getNumDVs(),
+        ColumnStatsConverter.toBytes(dateColumnStatsData.bufferForBitVectors()),
+        ColumnStatsConverter.toBytes(dateColumnStatsData.bufferForHistogram()));
+  }
+
+  private HiveSerializableDate fromThrift(Date date) {
+    return (date == null) ? null : new HiveSerializableDate(date.getDaysSinceEpoch());
+  }
+
+  public DateColumnStatsData toThrift(HiveDateStats dateStats) {
+    DateColumnStatsData dateColumnStatsData = new DateColumnStatsData(dateStats.numNulls(), dateStats.numDVs());
+    if (dateStats.lowValue() != null) {
+      dateColumnStatsData.setLowValue(toThrift(dateStats.lowValue()));
+    }
+    if (dateStats.highValue() != null) {
+      dateColumnStatsData.setHighValue(toThrift(dateStats.highValue()));
+    }
+    dateColumnStatsData.setBitVectors(dateStats.bitVectors());
+    dateColumnStatsData.setHistogram(dateStats.histogram());
+    return dateColumnStatsData;
+  }
+
+  private Date toThrift(HiveSerializableDate serializableDate) {
+    return new Date(serializableDate.daysSinceEpoch());
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDateStats.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDateStats.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+
+public record HiveDateStats(
+    HiveSerializableDate lowValue,
+    HiveSerializableDate highValue,
+    long numNulls,
+    long numDVs,
+    byte[] bitVectors,
+    byte[] histogram
+) implements HiveColumnStatisticsData {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDecimalConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDecimalConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.nio.ByteBuffer;
+import org.apache.hadoop.hive.metastore.api.Decimal;
+import org.apache.hadoop.hive.metastore.api.DecimalColumnStatsData;
+
+public class HiveDecimalConverter implements HiveTypeStatsConverter<DecimalColumnStatsData, HiveDecimalStats> {
+
+  public HiveDecimalStats fromThrift(DecimalColumnStatsData decimalColumnStatsData) {
+    return new HiveDecimalStats(
+        fromThrift(decimalColumnStatsData.getLowValue()),
+        fromThrift(decimalColumnStatsData.getHighValue()),
+        decimalColumnStatsData.getNumNulls(),
+        decimalColumnStatsData.getNumDVs(),
+        ColumnStatsConverter.toBytes(decimalColumnStatsData.bufferForBitVectors()),
+        ColumnStatsConverter.toBytes(decimalColumnStatsData.bufferForHistogram()));
+  }
+
+  private HiveSerializableDecimal fromThrift(Decimal decimal) {
+    return (decimal == null) ? null : new HiveSerializableDecimal(
+        decimal.getScale(), ColumnStatsConverter.toBytes(decimal.bufferForUnscaled()));
+  }
+
+  public DecimalColumnStatsData toThrift(HiveDecimalStats decimalStats) {
+    DecimalColumnStatsData decimalColumnStatsData =
+        new DecimalColumnStatsData(decimalStats.numNulls(), decimalStats.numDVs());
+
+    if (decimalStats.lowValue() != null) {
+      decimalColumnStatsData.setLowValue(toThrift(decimalStats.lowValue()));
+    }
+    if (decimalStats.highValue() != null) {
+      decimalColumnStatsData.setHighValue(toThrift(decimalStats.highValue()));
+    }
+    decimalColumnStatsData.setBitVectors(decimalStats.bitVectors());
+    decimalColumnStatsData.setHistogram(decimalStats.histogram());
+
+    return decimalColumnStatsData;
+  }
+
+  private Decimal toThrift(HiveSerializableDecimal serializableDecimal) {
+    return new Decimal(serializableDecimal.scale(), ByteBuffer.wrap(serializableDecimal.unscaled()));
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDecimalStats.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDecimalStats.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+
+public record HiveDecimalStats(
+    HiveSerializableDecimal lowValue,
+    HiveSerializableDecimal highValue,
+    long numNulls,
+    long numDVs,
+    byte[] bitVectors,
+    byte[] histogram
+) implements HiveColumnStatisticsData {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDoubleConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDoubleConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import org.apache.hadoop.hive.metastore.api.DoubleColumnStatsData;
+
+public class HiveDoubleConverter implements HiveTypeStatsConverter<DoubleColumnStatsData, HiveDoubleStats> {
+  public HiveDoubleStats fromThrift(DoubleColumnStatsData doubleColumnStatsData) {
+    return new HiveDoubleStats(
+        doubleColumnStatsData.isSetLowValue() ? doubleColumnStatsData.getLowValue() : null,
+        doubleColumnStatsData.isSetHighValue() ? doubleColumnStatsData.getHighValue() : null,
+        doubleColumnStatsData.getNumNulls(),
+        doubleColumnStatsData.getNumDVs(),
+        ColumnStatsConverter.toBytes(doubleColumnStatsData.bufferForBitVectors()),
+        ColumnStatsConverter.toBytes(doubleColumnStatsData.bufferForHistogram()));
+  }
+
+  public DoubleColumnStatsData toThrift(HiveDoubleStats doubleStats) {
+    DoubleColumnStatsData doubleColumnStatsData =
+        new DoubleColumnStatsData(doubleStats.numNulls(), doubleStats.numDVs());
+
+    if (doubleStats.lowValue() != null) {
+      doubleColumnStatsData.setLowValue(doubleStats.lowValue());
+    }
+    if (doubleStats.highValue() != null) {
+      doubleColumnStatsData.setHighValue(doubleStats.highValue());
+    }
+    doubleColumnStatsData.setBitVectors(doubleStats.bitVectors());
+    doubleColumnStatsData.setHistogram(doubleStats.histogram());
+
+    return doubleColumnStatsData;
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDoubleStats.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveDoubleStats.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+
+public record HiveDoubleStats(
+    Double lowValue,
+    Double highValue,
+    long numNulls,
+    long numDVs,
+    byte[] bitVectors,
+    byte[] histogram
+) implements HiveColumnStatisticsData {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveLongConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveLongConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import org.apache.hadoop.hive.metastore.api.LongColumnStatsData;
+
+public class HiveLongConverter implements HiveTypeStatsConverter<LongColumnStatsData, HiveLongStats> {
+  public HiveLongStats fromThrift(LongColumnStatsData longColumnStatsData) {
+    return new HiveLongStats(
+        longColumnStatsData.isSetLowValue() ? longColumnStatsData.getLowValue() : null,
+        longColumnStatsData.isSetHighValue() ? longColumnStatsData.getHighValue() : null,
+        longColumnStatsData.getNumNulls(),
+        longColumnStatsData.getNumDVs(),
+        ColumnStatsConverter.toBytes(longColumnStatsData.bufferForBitVectors()),
+        ColumnStatsConverter.toBytes(longColumnStatsData.bufferForHistogram()));
+  }
+
+  public LongColumnStatsData toThrift(HiveLongStats longStats) {
+    LongColumnStatsData longColumnStatsData = new LongColumnStatsData(longStats.numNulls(), longStats.numDVs());
+    if (longStats.lowValue() != null) {
+      longColumnStatsData.setLowValue(longStats.lowValue());
+    }
+    if (longStats.highValue() != null) {
+      longColumnStatsData.setHighValue(longStats.highValue());
+    }
+    longColumnStatsData.setBitVectors(longStats.bitVectors());
+    longColumnStatsData.setHistogram(longStats.histogram());
+    return longColumnStatsData;
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveLongStats.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveLongStats.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+
+public record HiveLongStats(
+    Long lowValue,
+    Long highValue,
+    long numNulls,
+    long numDVs,
+    byte[] bitVectors,
+    byte[] histogram
+) implements HiveColumnStatisticsData {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveSerializableDate.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveSerializableDate.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public record HiveSerializableDate(long daysSinceEpoch) implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveSerializableDecimal.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveSerializableDecimal.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public record HiveSerializableDecimal(short scale, byte[] unscaled) implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveSerializableTimestamp.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveSerializableTimestamp.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public record HiveSerializableTimestamp(long secondsSinceEpoch) implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveStringConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveStringConverter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import org.apache.hadoop.hive.metastore.api.StringColumnStatsData;
+
+public class HiveStringConverter implements HiveTypeStatsConverter<StringColumnStatsData, HiveStringStats> {
+
+  public HiveStringStats fromThrift(StringColumnStatsData stringColumnStatsData) {
+    return new HiveStringStats(
+        stringColumnStatsData.getMaxColLen(),
+        stringColumnStatsData.getAvgColLen(),
+        stringColumnStatsData.getNumNulls(),
+        stringColumnStatsData.getNumDVs(),
+        ColumnStatsConverter.toBytes(stringColumnStatsData.bufferForBitVectors()));
+  }
+
+  public StringColumnStatsData toThrift(HiveStringStats stringStats) {
+    StringColumnStatsData stringColumnStatsData = new StringColumnStatsData(
+        stringStats.maxColLen(),
+        stringStats.avgColLen(),
+        stringStats.numNulls(),
+        stringStats.numDVs());
+
+    stringColumnStatsData.setBitVectors(stringStats.bitVectors());
+
+    return stringColumnStatsData;
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveStringStats.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveStringStats.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+
+public record HiveStringStats(
+    long maxColLen,
+    double avgColLen,
+    long numNulls,
+    long numDVs,
+    byte[] bitVectors
+) implements HiveColumnStatisticsData {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveTimestampConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveTimestampConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import org.apache.hadoop.hive.metastore.api.Timestamp;
+import org.apache.hadoop.hive.metastore.api.TimestampColumnStatsData;
+
+public class HiveTimestampConverter implements HiveTypeStatsConverter<TimestampColumnStatsData, HiveTimestampStats> {
+
+  public HiveTimestampStats fromThrift(TimestampColumnStatsData timestampColumnStatsData) {
+    return new HiveTimestampStats(
+        fromThrift(timestampColumnStatsData.getLowValue()),
+        fromThrift(timestampColumnStatsData.getHighValue()),
+        timestampColumnStatsData.getNumNulls(),
+        timestampColumnStatsData.getNumDVs(),
+        ColumnStatsConverter.toBytes(timestampColumnStatsData.bufferForBitVectors()),
+        ColumnStatsConverter.toBytes(timestampColumnStatsData.bufferForHistogram()));
+  }
+
+  private HiveSerializableTimestamp fromThrift(Timestamp timestamp) {
+    return (timestamp == null) ? null : new HiveSerializableTimestamp(timestamp.getSecondsSinceEpoch());
+  }
+
+  public TimestampColumnStatsData toThrift(HiveTimestampStats timestampStats) {
+    TimestampColumnStatsData timestampColumnStatsData =
+        new TimestampColumnStatsData(timestampStats.numNulls(), timestampStats.numDVs());
+
+    if (timestampStats.lowValue() != null) {
+      timestampColumnStatsData.setLowValue(toThrift(timestampStats.lowValue()));
+    }
+
+    if (timestampStats.highValue() != null) {
+      timestampColumnStatsData.setHighValue(toThrift(timestampStats.highValue()));
+    }
+
+    timestampColumnStatsData.setBitVectors(timestampStats.bitVectors());
+    timestampColumnStatsData.setHistogram(timestampStats.histogram());
+
+    return timestampColumnStatsData;
+  }
+
+  private Timestamp toThrift(HiveSerializableTimestamp serializableTimestamp) {
+    return new Timestamp(serializableTimestamp.secondsSinceEpoch());
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveTimestampStats.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveTimestampStats.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+import java.io.Serial;
+
+public record HiveTimestampStats(
+    HiveSerializableTimestamp lowValue,
+    HiveSerializableTimestamp highValue,
+    long numNulls,
+    long numDVs,
+    byte[] bitVectors,
+    byte[] histogram
+) implements HiveColumnStatisticsData {
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveTypeStatsConverter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/stats/HiveTypeStatsConverter.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.stats;
+
+public interface HiveTypeStatsConverter<T, R extends HiveColumnStatisticsData> {
+  R fromThrift(T thrift);
+  T toThrift(R record);
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
@@ -239,22 +239,29 @@ public class StatsUtils {
     return aggregateStat.getNumRows();
   }
 
-  private static void estimateStatsForMissingCols(List<String> neededColumns, List<ColStatistics> columnStats,
+  private static List<ColStatistics> estimateStatsForMissingCols(
+      List<String> neededColumns, List<ColStatistics> existingColStats,
       HiveConf conf, long nr, List<ColumnInfo> schema) {
 
     Set<String> neededCols = new HashSet<>(neededColumns);
     Set<String> colsWithStats = new HashSet<>();
+    List<ColStatistics> neededColStats = new ArrayList<>(neededCols.size());
 
-    for (ColStatistics cstats : columnStats) {
-      colsWithStats.add(cstats.getColumnName());
+    for (ColStatistics colStatistics : existingColStats) {
+      colsWithStats.add(colStatistics.getColumnName());
+      if (neededCols.contains(colStatistics.getColumnName())) {
+        neededColStats.add(colStatistics);
+      }
     }
 
     List<String> missingColStats = new ArrayList<>(Sets.difference(neededCols, colsWithStats));
 
     if (!missingColStats.isEmpty()) {
-      columnStats.addAll(
+      neededColStats.addAll(
           estimateStats(schema, missingColStats, conf, nr));
     }
+
+    return neededColStats;
   }
 
   public static Statistics collectStatistics(HiveConf conf, PrunedPartitionList partList,
@@ -300,7 +307,7 @@ public class StatsUtils {
       if (needColStats && !metaTable) {
         colStats = getTableColumnStats(table, neededColumns, colStatsCache, fetchColStats);
         if (estimateStats) {
-          estimateStatsForMissingCols(neededColumns, colStats, conf, nr, schema);
+          colStats = estimateStatsForMissingCols(neededColumns, colStats, conf, nr, schema);
         }
         // we should have stats for all columns (estimated or actual)
         if (neededColumns.size() == colStats.size()) {
@@ -386,7 +393,7 @@ public class StatsUtils {
         boolean statsRetrieved = aggrStats != null &&
             aggrStats.getColStats() != null && aggrStats.getColStatsSize() != 0;
         if (neededColumns.isEmpty() || (!neededColsToRetrieve.isEmpty() && !statsRetrieved)) {
-          estimateStatsForMissingCols(neededColsToRetrieve, columnStats, conf, nr, schema);
+          columnStats = estimateStatsForMissingCols(neededColsToRetrieve, columnStats, conf, nr, schema);
           // There are some partitions with no state (or we didn't fetch any state).
           // Update the stats with empty list to reflect that in the
           // state/initialize structures.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
* Use custom DTOs to store column statistics and ensure that serialVersionUID is specified explicitly.
* Modify `StatsUtils.estimateStatsForMissingCols` to return a new list of column statistics instead of adding the newly estimated stats to its input parameter.

### Why are the changes needed?
* Currently, Thrift-generated objects are serialized when storing the column statistics of an Iceberg table. However, the `serialVersionUID` is not explicitly specified, hence the Java compiler generates one at build time. This can lead to compatibility issues when a newer Hive version attempts to read column stats from a table created by an older version.
* When reading the column statistics of an Iceberg table fails, `Collections.emptyList()` is returned. Because this is an unmodifiable list, the current implementation of `estimateStatsForMissingCols` [tries to add](https://github.com/apache/hive/blob/1516fb91e8a622b4655b0e07a37fb449634c1637/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java#L254-L257) the estimated column statistics to it and an exception is thrown.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
```
mvn test -Dtest=TestHiveIcebergStatistics -pl iceberg/iceberg-handler
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestIcebergLlapLocalCliDriver -Dqfile=merge_iceberg_partitioned_orc.q -pl itests/qtest-iceberg -Pitests
mvn test -Dtest.output.overwrite -Dtest=TestIcebergCliDriver -Dqfile=puffin_col_stats.q -pl itests/qtest-iceberg -Pitests
```