### PR TITLE
HIVE-29618: fix multiline string matches for vectorization too (follows up on HIVE-22008)

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/AbstractFilterStringColLikeStringScalar.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/AbstractFilterStringColLikeStringScalar.java
@@ -419,7 +419,7 @@ public abstract class AbstractFilterStringColLikeStringScalar extends VectorExpr
     FastUTF8Decoder decoder;
 
     public ComplexChecker(String pattern) {
-      compiledPattern = Pattern.compile(pattern);
+      compiledPattern = Pattern.compile(pattern, Pattern.DOTALL);
       matcher = compiledPattern.matcher("");
       decoder = new FastUTF8Decoder();
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/expressions/TestVectorStringExpressions.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/expressions/TestVectorStringExpressions.java
@@ -4407,6 +4407,33 @@ public class TestVectorStringExpressions {
         expr.checker.getClass());
   }
 
+  // Regression: vec ComplexChecker must apply Pattern.DOTALL (mirroring HIVE-22008).
+  @Test
+  public void testStringLikeComplexCheckerMultiLine() throws HiveException {
+    VectorizedRowBatch batch = new VectorizedRowBatch(1);
+    BytesColumnVector col = new BytesColumnVector();
+    batch.cols[0] = col;
+    byte[] rowA = "first\nsecond".getBytes(StandardCharsets.UTF_8);
+    byte[] rowB = "first_second\nthird".getBytes(StandardCharsets.UTF_8);
+    col.setRef(0, rowA, 0, rowA.length);
+    col.setRef(1, rowB, 0, rowB.length);
+    col.isNull[0] = false;
+    col.isNull[1] = false;
+    col.noNulls = true;
+    batch.size = 2;
+
+    FilterStringColLikeStringScalar expr =
+        new FilterStringColLikeStringScalar(0, "%first_second%".getBytes(StandardCharsets.UTF_8));
+    expr.transientInit(hiveConf);
+    Assert.assertEquals(FilterStringColLikeStringScalar.ComplexChecker.class,
+        expr.checker.getClass());
+
+    expr.evaluate(batch);
+
+    // Both rows must survive the LIKE filter.
+    Assert.assertEquals(2, batch.size);
+  }
+
   @Test
   public void testStringLikeMultiByte() throws HiveException {
     FilterStringColLikeStringScalar expr;

--- a/ql/src/test/queries/clientpositive/udf_like.q
+++ b/ql/src/test/queries/clientpositive/udf_like.q
@@ -28,3 +28,36 @@ FROM src tablesample (1 rows);
 CREATE TEMPORARY TABLE SplitLines(`id` string) STORED AS ORC;
 INSERT INTO SplitLines SELECT 'withdraw\ncash';
 SELECT `id` LIKE '%withdraw%cash' FROM SplitLines ;
+
+CREATE TABLE SplitLinesUnderscore (q STRING) STORED AS ORC;
+INSERT INTO SplitLinesUnderscore
+  SELECT 'first\nsecond' UNION ALL SELECT 'first_second\nthird';
+SELECT count(*) FROM SplitLinesUnderscore WHERE q LIKE '%first_second%';
+
+-- Repeat with vectorization off to ensure consistency either way
+set hive.vectorized.execution.enabled=false;
+
+DESCRIBE FUNCTION like;
+DESCRIBE FUNCTION EXTENDED like;
+
+EXPLAIN
+SELECT '_%_' LIKE '%\_\%\_%', '__' LIKE '%\_\%\_%', '%%_%_' LIKE '%\_\%\_%', '%_%_%' LIKE '%\%\_\%',
+  '_%_' LIKE '\%\_%', '%__' LIKE '__\%%', '_%' LIKE '\_\%\_\%%', '_%' LIKE '\_\%_%',
+  '%_' LIKE '\%\_', 'ab' LIKE '\%\_', 'ab' LIKE '_a%', 'ab' LIKE 'a','ab' LIKE '','' LIKE ''
+FROM src WHERE src.key = 86;
+
+SELECT '_%_' LIKE '%\_\%\_%', '__' LIKE '%\_\%\_%', '%%_%_' LIKE '%\_\%\_%', '%_%_%' LIKE '%\%\_\%',
+  '_%_' LIKE '\%\_%', '%__' LIKE '__\%%', '_%' LIKE '\_\%\_\%%', '_%' LIKE '\_\%_%',
+  '%_' LIKE '\%\_', 'ab' LIKE '\%\_', 'ab' LIKE '_a%', 'ab' LIKE 'a','ab' LIKE '','' LIKE ''
+FROM src WHERE src.key = 86;
+
+
+SELECT '1+2' LIKE '_+_',
+       '1+2' LIKE '1+_',
+       '112' LIKE '1+_',
+       '|||' LIKE '|_|',
+       '+++' LIKE '1+_'
+FROM src tablesample (1 rows);
+
+SELECT `id` LIKE '%withdraw%cash' FROM SplitLines;
+SELECT count(*) FROM SplitLinesUnderscore WHERE q LIKE '%first_second%';

--- a/ql/src/test/results/clientpositive/llap/udf_like.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_like.q.out
@@ -107,3 +107,132 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@splitlines
 #### A masked pattern was here ####
 true
+PREHOOK: query: CREATE TABLE SplitLinesUnderscore (q STRING) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@SplitLinesUnderscore
+POSTHOOK: query: CREATE TABLE SplitLinesUnderscore (q STRING) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@SplitLinesUnderscore
+PREHOOK: query: INSERT INTO SplitLinesUnderscore
+  SELECT 'first\nsecond' UNION ALL SELECT 'first_second\nthird'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@splitlinesunderscore
+POSTHOOK: query: INSERT INTO SplitLinesUnderscore
+  SELECT 'first\nsecond' UNION ALL SELECT 'first_second\nthird'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@splitlinesunderscore
+POSTHOOK: Lineage: splitlinesunderscore.q SCRIPT []
+PREHOOK: query: SELECT count(*) FROM SplitLinesUnderscore WHERE q LIKE '%first_second%'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@splitlinesunderscore
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT count(*) FROM SplitLinesUnderscore WHERE q LIKE '%first_second%'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@splitlinesunderscore
+#### A masked pattern was here ####
+2
+PREHOOK: query: DESCRIBE FUNCTION like
+PREHOOK: type: DESCFUNCTION
+POSTHOOK: query: DESCRIBE FUNCTION like
+POSTHOOK: type: DESCFUNCTION
+like(str, pattern) - Checks if str matches pattern
+PREHOOK: query: DESCRIBE FUNCTION EXTENDED like
+PREHOOK: type: DESCFUNCTION
+POSTHOOK: query: DESCRIBE FUNCTION EXTENDED like
+POSTHOOK: type: DESCFUNCTION
+like(str, pattern) - Checks if str matches pattern
+Example:
+  > SELECT a.* FROM srcpart a WHERE a.hr like '%2' LIMIT 1;
+  27      val_27  2008-04-08      12
+Function class:org.apache.hadoop.hive.ql.udf.UDFLike
+Function type:BUILTIN
+PREHOOK: query: EXPLAIN
+SELECT '_%_' LIKE '%\_\%\_%', '__' LIKE '%\_\%\_%', '%%_%_' LIKE '%\_\%\_%', '%_%_%' LIKE '%\%\_\%',
+  '_%_' LIKE '\%\_%', '%__' LIKE '__\%%', '_%' LIKE '\_\%\_\%%', '_%' LIKE '\_\%_%',
+  '%_' LIKE '\%\_', 'ab' LIKE '\%\_', 'ab' LIKE '_a%', 'ab' LIKE 'a','ab' LIKE '','' LIKE ''
+FROM src WHERE src.key = 86
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT '_%_' LIKE '%\_\%\_%', '__' LIKE '%\_\%\_%', '%%_%_' LIKE '%\_\%\_%', '%_%_%' LIKE '%\%\_\%',
+  '_%_' LIKE '\%\_%', '%__' LIKE '__\%%', '_%' LIKE '\_\%\_\%%', '_%' LIKE '\_\%_%',
+  '%_' LIKE '\%\_', 'ab' LIKE '\%\_', 'ab' LIKE '_a%', 'ab' LIKE 'a','ab' LIKE '','' LIKE ''
+FROM src WHERE src.key = 86
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: src
+          filterExpr: (UDFToDouble(key) = 86.0D) (type: boolean)
+          Filter Operator
+            predicate: (UDFToDouble(key) = 86.0D) (type: boolean)
+            Select Operator
+              expressions: true (type: boolean), false (type: boolean), true (type: boolean), true (type: boolean), false (type: boolean), false (type: boolean), false (type: boolean), false (type: boolean), true (type: boolean), false (type: boolean), false (type: boolean), false (type: boolean), false (type: boolean), true (type: boolean)
+              outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
+              ListSink
+
+PREHOOK: query: SELECT '_%_' LIKE '%\_\%\_%', '__' LIKE '%\_\%\_%', '%%_%_' LIKE '%\_\%\_%', '%_%_%' LIKE '%\%\_\%',
+  '_%_' LIKE '\%\_%', '%__' LIKE '__\%%', '_%' LIKE '\_\%\_\%%', '_%' LIKE '\_\%_%',
+  '%_' LIKE '\%\_', 'ab' LIKE '\%\_', 'ab' LIKE '_a%', 'ab' LIKE 'a','ab' LIKE '','' LIKE ''
+FROM src WHERE src.key = 86
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT '_%_' LIKE '%\_\%\_%', '__' LIKE '%\_\%\_%', '%%_%_' LIKE '%\_\%\_%', '%_%_%' LIKE '%\%\_\%',
+  '_%_' LIKE '\%\_%', '%__' LIKE '__\%%', '_%' LIKE '\_\%\_\%%', '_%' LIKE '\_\%_%',
+  '%_' LIKE '\%\_', 'ab' LIKE '\%\_', 'ab' LIKE '_a%', 'ab' LIKE 'a','ab' LIKE '','' LIKE ''
+FROM src WHERE src.key = 86
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+true	false	true	true	false	false	false	false	true	false	false	false	false	true
+PREHOOK: query: SELECT '1+2' LIKE '_+_',
+       '1+2' LIKE '1+_',
+       '112' LIKE '1+_',
+       '|||' LIKE '|_|',
+       '+++' LIKE '1+_'
+FROM src tablesample (1 rows)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT '1+2' LIKE '_+_',
+       '1+2' LIKE '1+_',
+       '112' LIKE '1+_',
+       '|||' LIKE '|_|',
+       '+++' LIKE '1+_'
+FROM src tablesample (1 rows)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+true	true	false	true	false
+PREHOOK: query: SELECT `id` LIKE '%withdraw%cash' FROM SplitLines
+PREHOOK: type: QUERY
+PREHOOK: Input: default@splitlines
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT `id` LIKE '%withdraw%cash' FROM SplitLines
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@splitlines
+#### A masked pattern was here ####
+true
+PREHOOK: query: SELECT count(*) FROM SplitLinesUnderscore WHERE q LIKE '%first_second%'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@splitlinesunderscore
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT count(*) FROM SplitLinesUnderscore WHERE q LIKE '%first_second%'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@splitlinesunderscore
+#### A masked pattern was here ####
+2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
HIVE-29618: fix multiline string matches for vectorization too (follows up on HIVE-22008)

Add the `Pattern.DOTALL` flag to the vectorized `LIKE` operator's `ComplexChecker` regex compile (`AbstractFilterStringColLikeStringScalar.java:422`), restoring parity with the non-vectorized
  `UDFLike` (`UDFLike.java:194`, fixed by HIVE-22008 in 2019). Extend `udf_like.q` with a regression test for the `COMPLEX`/regex path and run every statement once more with
  `hive.vectorized.execution.enabled=false` to lock in cross-mode parity. Add a focused Java unit test in `TestVectorStringExpressions`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
https://github.com/apache/hive/commit/d7475aa98f6a2fc813e2e1c0ad99f902cb28cc00
HIVE-22008 fixed non-vectorized LIKE to match multi-line input but missed the parallel vectorized implementation. Patterns containing an unescaped `_` route through `ComplexChecker`, which compiled
  its regex without `DOTALL`; the resulting `.` (from `_`) and `.*?` (from `%`) cannot cross newlines, so vectorized LIKE silently drops rows whose values contain `\n`. The result is silently wrong
  query output — the same `LIKE` query returns different row counts in vectorized vs non-vectorized mode.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, as a bug fix. Vectorized `LIKE` patterns containing `_` now match multi-line strings consistently with non-vectorized execution and with SQL semantics. Queries that previously dropped rows now
  return them. No syntax, API, or config changes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- New unit test `TestVectorStringExpressions#testStringLikeComplexCheckerMultiLine` — fails before the fix, passes after.
  - `udf_like.q` extended; the regenerated `udf_like.q.out` differs from the pre-fix snapshot by a single character (`0` → `2`) at the new test's vectorized-mode result line — every other expected
  output is unchanged.
  - `mvn checkstyle:check -pl ql` clean.
  - Manually verified the diff produced no other behavior changes in the `udf_like` golden.