### PR TITLE
HIVE-29626: Fix testFireInsertEvent() in TestHive

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -1093,6 +1093,7 @@ public class TestHive {
     assertTrue(prevHiveObj != newHiveObj);
   }
 
+  @Test
   public void testFireInsertEvent() throws Throwable {
     Hive hiveDb = Hive.getWithFastCheck(hiveConf, false);
     String tableName = "test_fire_insert_event";
@@ -1101,6 +1102,18 @@ public class TestHive {
         HiveIgnoreKeyTextOutputFormat.class);
     Table table = hiveDb.getTable(tableName);
     Path tablePath = table.getDataLocation();
+
+    // Fire the InsertEvent with empty folder
+    hiveDb.fireInsertEvent(table, null, false,
+        Lists.newArrayList(new FileStatus(5, true, 1, 64, 100, tablePath)));
+    // Get the last Metastore event
+    InsertEvent insertEvent1 = DummyFireInsertListener.getLastEvent();
+    // Check the event
+    Assert.assertNotNull(insertEvent1);
+    // getFiles should be empty and not null
+    Assert.assertNotNull(insertEvent1.getFiles());
+    Assert.assertTrue(insertEvent1.getFiles().isEmpty());
+
     // Create some files that "inserted"
     FileSystem fileSystem = tablePath.getFileSystem(hiveConf);
     fileSystem.deleteOnExit(tablePath);
@@ -1144,17 +1157,6 @@ public class TestHive {
       Path insertedPath = new Path(insertEvent.getFiles().get(i));
       Assert.assertEquals(expectedCheckSums.get(insertedPath.getName()), checkSums.get(i));
     }
-
-    // Fire the InsertEvent with empty folder
-    hiveDb.fireInsertEvent(table, null, false,
-      Lists.newArrayList(new FileStatus(5, true, 1, 64, 100, tablePath)));
-    // Get the last Metastore event
-    InsertEvent insertEvent1 = DummyFireInsertListener.getLastEvent();
-    // Check the event
-    Assert.assertNotNull(insertEvent1);
-    // getFiles should be empty and not null
-    Assert.assertNotNull(insertEvent1.getFiles());
-    Assert.assertTrue(insertEvent1.getFiles().isEmpty());
   }
 
   private String getFileCheckSum(FileSystem fileSystem, Path p) throws Exception {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixed testFireInsertEvent() test for TestHive and TestHiveRemote

### Why are the changes needed?
1. Modern versions of JUnit (4 and 5), methods do not run as tests without the @Test annotation. 
2. Fire InsertEvent with empty dir test should happen before inserting some data to the table data location. Otherwise test would fail since table dir is not empty anymore.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Executed the test
