### PR TITLE
HIVE-29693: Fix broken Maven central badge in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 Apache Hive (TM)
 ================
 [![Master Build Status](https://travis-ci.org/apache/hive.svg?branch=master)](https://travis-ci.org/apache/hive/branches)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.hive/hive/badge.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.hive%22)
+[![Maven Central](https://maven-badges.sml.io/maven-central/org.apache.hive/hive/badge.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.hive%22)
 
 The Apache Hive (TM) data warehouse software facilitates reading,
 writing, and managing large datasets residing in distributed storage


### PR DESCRIPTION
The Maven central badge in `README` does not load; the [URL to the badge has changed](https://github.com/softwaremill/maven-badges#a-new-dns-address).

As such, updated.