### PR TITLE
HIVE-29628: Incorrect objectName in PARTITION HivePrivilegeObject for…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/command/CommandAuthorizerV2.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/command/CommandAuthorizerV2.java
@@ -149,6 +149,13 @@ final class CommandAuthorizerV2 {
         }
       }
 
+      if ((privObject.getTyp() == Type.PARTITION || privObject.getTyp() == Type.DUMMYPARTITION)
+          && privObject instanceof ReadEntity
+          && isPartitionAccessedViaRegularView((ReadEntity) privObject, privObjects)) {
+        // skip Partition Entity auth for regular view
+        continue;
+      }
+
       addHivePrivObject(privObject, tableName2Cols, hivePrivobjs, hiveOpType);
     }
     return hivePrivobjs;
@@ -178,6 +185,79 @@ final class CommandAuthorizerV2 {
       }
     }
     return false;
+  }
+
+  /**
+   * Returns true when a PARTITION entity should not produce its own privilege object
+   * because access is already covered by a view's TABLE_OR_VIEW object.
+   */
+  private static boolean isPartitionAccessedViaRegularView(ReadEntity partitionEntity,
+      List<? extends Entity> allEntities) {
+    if (hasDeferredViewParent(partitionEntity)) {
+      return false;
+    }
+    if (hasRegularViewParent(partitionEntity)) {
+      return true;
+    }
+    Table partTable = partitionEntity.getTable();
+    if (partTable == null) {
+      return false;
+    }
+    for (Entity entity : allEntities) {
+      if (!(entity instanceof ReadEntity) || entity.getTyp() != Type.TABLE) {
+        continue;
+      }
+      ReadEntity tableEntity = (ReadEntity) entity;
+      if (tableEntity.isDirect() || tableEntity.getTable() == null) {
+        continue;
+      }
+      Table table = tableEntity.getTable();
+      if (!partTable.getDbName().equals(table.getDbName())
+          || !partTable.getTableName().equals(table.getTableName())) {
+        continue;
+      }
+      if (hasDeferredViewParent(tableEntity)) {
+        return false;
+      }
+      if (hasRegularViewParent(tableEntity)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasDeferredViewParent(ReadEntity entity) {
+    Set<ReadEntity> parents = entity.getParents();
+    if (parents == null || parents.isEmpty()) {
+      return false;
+    }
+    for (ReadEntity parent : parents) {
+      if (parent.getTyp() == Type.TABLE && parent.getTable() != null
+          && isDeferredAuthView(parent.getTable())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasRegularViewParent(ReadEntity entity) {
+    Set<ReadEntity> parents = entity.getParents();
+    if (parents == null || parents.isEmpty()) {
+      return false;
+    }
+    for (ReadEntity parent : parents) {
+      if (parent.getTyp() == Type.TABLE && parent.getTable() != null
+          && isView(parent.getTable()) && !isDeferredAuthView(parent.getTable())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isView(Table t) {
+    String tableType = t.getTTable().getTableType();
+    return TableType.MATERIALIZED_VIEW.name().equals(tableType)
+        || TableType.VIRTUAL_VIEW.name().equals(tableType);
   }
 
   private static void addHivePrivObject(Entity privObject, Map<String, List<String>> tableName2Cols,

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/command/CommandAuthorizerV2.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/command/CommandAuthorizerV2.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.Map.Entry;
 
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.DataConnector;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Function;
@@ -189,13 +188,8 @@ final class CommandAuthorizerV2 {
    * @return boolean value
    */
   private static boolean isDeferredAuthView(Table t){
-    String tableType = t.getTTable().getTableType();
     String authorizedKeyword = "Authorized";
-    boolean isView = false;
-    if (TableType.MATERIALIZED_VIEW.name().equals(tableType) || TableType.VIRTUAL_VIEW.name().equals(tableType)) {
-      isView = true;
-    }
-    if (isView) {
+    if (t.isView() || t.isMaterializedView()) {
       Map<String, String> params = t.getParameters();
       if (params != null && params.containsKey(authorizedKeyword)) {
         String authorizedValue = params.get(authorizedKeyword);
@@ -252,17 +246,12 @@ final class CommandAuthorizerV2 {
     }
     for (ReadEntity parent : parents) {
       if (parent.getTyp() == Type.TABLE && parent.getTable() != null
-          && isView(parent.getTable()) && !isDeferredAuthView(parent.getTable())) {
+          && (parent.getTable().isView() || parent.getTable().isMaterializedView())
+          && !isDeferredAuthView(parent.getTable())) {
         return true;
       }
     }
     return false;
-  }
-
-  private static boolean isView(Table t) {
-    String tableType = t.getTTable().getTableType();
-    return TableType.MATERIALIZED_VIEW.name().equals(tableType)
-        || TableType.VIRTUAL_VIEW.name().equals(tableType);
   }
 
   private static void addHivePrivObject(Entity privObject, Map<String, List<String>> tableName2Cols,

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/command/CommandAuthorizerV2.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/command/CommandAuthorizerV2.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.security.authorization.command;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -105,6 +106,9 @@ final class CommandAuthorizerV2 {
       return hivePrivobjs;
     }
 
+    // Pre-scan once to collect base tables that are accessed via a regular view.
+    Set<String> baseTablesViaRegularView = buildBaseTablesViaRegularView(privObjects);
+
     for (Entity privObject : privObjects) {
       if (privObject.isDummy()) {
         //do not authorize dummy readEntity or writeEntity
@@ -148,10 +152,7 @@ final class CommandAuthorizerV2 {
           continue;
         }
       }
-
-      if ((privObject.getTyp() == Type.PARTITION || privObject.getTyp() == Type.DUMMYPARTITION)
-          && privObject instanceof ReadEntity
-          && isPartitionAccessedViaRegularView((ReadEntity) privObject, privObjects)) {
+      if (isPartitionAccessedViaRegularView(privObject, baseTablesViaRegularView)) {
         // skip Partition Entity auth for regular view
         continue;
       }
@@ -159,6 +160,25 @@ final class CommandAuthorizerV2 {
       addHivePrivObject(privObject, tableName2Cols, hivePrivobjs, hiveOpType);
     }
     return hivePrivobjs;
+  }
+
+  /**
+   * Pre-scans the entity list once and returns the set of "db.table" keys for base tables
+   * that are accessed indirectly via a regular view.
+   */
+  private static Set<String> buildBaseTablesViaRegularView(List<? extends Entity> entities) {
+    Set<String> result = new HashSet<>();
+    for (Entity entity : entities) {
+      if (!(entity instanceof ReadEntity) || entity.getTyp() != Type.TABLE) {
+        continue;
+      }
+      ReadEntity re = (ReadEntity) entity;
+      Table t = re.getTable();
+      if (!re.isDirect() && t != null && !hasDeferredViewParent(re) && hasRegularViewParent(re)) {
+        result.add(t.getDbName() + "." + t.getTableName());
+      }
+    }
+    return result;
   }
 
   /**
@@ -191,39 +211,24 @@ final class CommandAuthorizerV2 {
    * Returns true when a PARTITION entity should not produce its own privilege object
    * because access is already covered by a view's TABLE_OR_VIEW object.
    */
-  private static boolean isPartitionAccessedViaRegularView(ReadEntity partitionEntity,
-      List<? extends Entity> allEntities) {
-    if (hasDeferredViewParent(partitionEntity)) {
+  private static boolean isPartitionAccessedViaRegularView(Entity entity,
+      Set<String> baseTablesViaRegularView) {
+    if (!(entity instanceof ReadEntity)
+        || (entity.getTyp() != Type.PARTITION && entity.getTyp() != Type.DUMMYPARTITION)) {
       return false;
     }
-    if (hasRegularViewParent(partitionEntity)) {
+    ReadEntity re = (ReadEntity) entity;
+    // Deferred-auth views must still authorize the underlying base table.
+    if (hasDeferredViewParent(re)) {
+      return false;
+    }
+
+    if (hasRegularViewParent(re)) {
       return true;
     }
-    Table partTable = partitionEntity.getTable();
-    if (partTable == null) {
-      return false;
-    }
-    for (Entity entity : allEntities) {
-      if (!(entity instanceof ReadEntity) || entity.getTyp() != Type.TABLE) {
-        continue;
-      }
-      ReadEntity tableEntity = (ReadEntity) entity;
-      if (tableEntity.isDirect() || tableEntity.getTable() == null) {
-        continue;
-      }
-      Table table = tableEntity.getTable();
-      if (!partTable.getDbName().equals(table.getDbName())
-          || !partTable.getTableName().equals(table.getTableName())) {
-        continue;
-      }
-      if (hasDeferredViewParent(tableEntity)) {
-        return false;
-      }
-      if (hasRegularViewParent(tableEntity)) {
-        return true;
-      }
-    }
-    return false;
+    Table partTable = re.getTable();
+    return partTable != null
+        && baseTablesViaRegularView.contains(partTable.getDbName() + "." + partTable.getTableName());
   }
 
   private static boolean hasDeferredViewParent(ReadEntity entity) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestViewPartitionPrivilegeObjects.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestViewPartitionPrivilegeObjects.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -48,12 +47,6 @@ import static org.mockito.Mockito.verify;
  * for view queries over partitioned base tables.
  */
 public class TestViewPartitionPrivilegeObjects {
-
-  static final String DATA_DB = "datadb";
-  static final String VIEW_DB = "viewdb";
-  static final String BASE_TABLE = "t1";
-  static final String VIEW_NAME = "v1";
-  static final String TARGET_TABLE = "insert_target";
 
   protected static HiveConf conf;
   protected static Driver driver;
@@ -77,7 +70,6 @@ public class TestViewPartitionPrivilegeObjects {
     conf.setBoolVar(ConfVars.HIVE_SERVER2_ENABLE_DOAS, false);
     conf.setBoolVar(ConfVars.HIVE_SUPPORT_CONCURRENCY, true);
     conf.setVar(ConfVars.HIVE_TXN_MANAGER, DbTxnManager.class.getName());
-    conf.setVar(ConfVars.HIVE_MAPRED_MODE, "nonstrict");
     conf.setVar(ConfVars.DYNAMIC_PARTITIONING_MODE, "nonstrict");
     conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
     conf.setVar(ConfVars.HIVE_EXECUTION_ENGINE, "mr");
@@ -86,16 +78,13 @@ public class TestViewPartitionPrivilegeObjects {
     SessionState.start(conf);
     driver = new Driver(conf);
 
-    runCmd("CREATE DATABASE IF NOT EXISTS " + DATA_DB);
-    runCmd("CREATE TABLE IF NOT EXISTS " + DATA_DB + "." + BASE_TABLE
-        + " (i INT) PARTITIONED BY (dept STRING)");
-    runCmd("ALTER TABLE " + DATA_DB + "." + BASE_TABLE + " ADD IF NOT EXISTS PARTITION (dept='a')");
-    runCmd("CREATE DATABASE IF NOT EXISTS " + VIEW_DB);
-    runCmd("CREATE VIEW IF NOT EXISTS " + VIEW_DB + "." + VIEW_NAME
-        + " AS SELECT * FROM " + DATA_DB + "." + BASE_TABLE);
+    runCmd("CREATE DATABASE IF NOT EXISTS datadb");
+    runCmd("CREATE TABLE IF NOT EXISTS datadb.t1 (i INT) PARTITIONED BY (dept STRING)");
+    runCmd("ALTER TABLE datadb.t1 ADD IF NOT EXISTS PARTITION (dept='a')");
+    runCmd("CREATE DATABASE IF NOT EXISTS viewdb");
+    runCmd("CREATE VIEW IF NOT EXISTS viewdb.v1 AS SELECT * FROM datadb.t1");
     // Target table used by INSERT OVERWRITE tests — non-partitioned to keep DML simple
-    runCmd("CREATE TABLE IF NOT EXISTS " + DATA_DB + "." + TARGET_TABLE
-        + " (i INT, dept STRING)");
+    runCmd("CREATE TABLE IF NOT EXISTS datadb.insert_target (i INT, dept STRING)");
   }
 
   @Before
@@ -107,16 +96,16 @@ public class TestViewPartitionPrivilegeObjects {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    runCmd("DROP VIEW IF EXISTS " + VIEW_DB + "." + VIEW_NAME);
-    runCmd("DROP TABLE IF EXISTS " + DATA_DB + "." + BASE_TABLE);
-    runCmd("DROP TABLE IF EXISTS " + DATA_DB + "." + TARGET_TABLE);
-    runCmd("DROP DATABASE IF EXISTS " + VIEW_DB);
-    runCmd("DROP DATABASE IF EXISTS " + DATA_DB);
+    runCmd("DROP VIEW IF EXISTS viewdb.v1");
+    runCmd("DROP TABLE IF EXISTS datadb.t1");
+    runCmd("DROP TABLE IF EXISTS datadb.insert_target");
+    runCmd("DROP DATABASE IF EXISTS viewdb");
+    runCmd("DROP DATABASE IF EXISTS datadb");
     driver.close();
   }
 
   @Test
-  public void testViewSelectNoBaseTablePartitionPrivObj() throws Exception {
+  public void testViewSelectNoPartitionPrivObj() throws Exception {
     conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
     SessionState.get().setConf(conf);
 
@@ -124,27 +113,27 @@ public class TestViewPartitionPrivilegeObjects {
     Mockito.when(user1Auth.getUserName()).thenReturn("user1");
     SessionState.get().setAuthenticator(user1Auth);
 
-    driver.compile("SELECT * FROM " + VIEW_DB + "." + VIEW_NAME, true);
+    driver.compile("SELECT * FROM viewdb.v1", true);
 
     List<HivePrivilegeObject> inputs = getInputPrivObjects();
 
     Assert.assertTrue("Expected a TABLE_OR_VIEW object for the view",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.TABLE_OR_VIEW
-                && VIEW_NAME.equalsIgnoreCase(h.getObjectName())
-                && VIEW_DB.equalsIgnoreCase(h.getDbname())));
+                && "v1".equalsIgnoreCase(h.getObjectName())
+                && "viewdb".equalsIgnoreCase(h.getDbname())));
 
     Assert.assertFalse("HIVE-29628: view query must not send a PARTITION object on the base table",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.PARTITION
-                && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
-                && DATA_DB.equalsIgnoreCase(h.getDbname())));
+                && "t1".equalsIgnoreCase(h.getObjectName())
+                && "datadb".equalsIgnoreCase(h.getDbname())));
 
     Assert.assertFalse("HIVE-29628: view query must not send a base-table TABLE_OR_VIEW object",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.TABLE_OR_VIEW
-                && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
-                && DATA_DB.equalsIgnoreCase(h.getDbname())));
+                && "t1".equalsIgnoreCase(h.getObjectName())
+                && "datadb".equalsIgnoreCase(h.getDbname())));
   }
 
   /**
@@ -152,49 +141,46 @@ public class TestViewPartitionPrivilegeObjects {
    * so table/partition policies (e.g. Ranger) can be enforced.
    */
   @Test
-  public void testDirectTableSelectHasPartitionPrivObj() throws Exception {
+  public void testDirectTableSelect() throws Exception {
     conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
     SessionState.get().setConf(conf);
 
-    driver.compile("SELECT * FROM " + DATA_DB + "." + BASE_TABLE, true);
+    driver.compile("SELECT * FROM datadb.t1", true);
 
     List<HivePrivilegeObject> inputs = getInputPrivObjects();
 
     Assert.assertTrue("Expected a PARTITION privilege object for direct table access",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.PARTITION
-                && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
-                && DATA_DB.equalsIgnoreCase(h.getDbname())));
+                && "t1".equalsIgnoreCase(h.getObjectName())
+                && "datadb".equalsIgnoreCase(h.getDbname())));
   }
 
   /**
    * When a view over a partitioned table is the READ SOURCE of an INSERT OVERWRITE statement,
-   * {@code checkPrivileges} inputs must contain only {@code TABLE_OR_VIEW viewdb/v1}
+   * {@code checkPrivileges} inputs must contain only {@code TABLE_OR_VIEW viewdb/v1}.
    */
   @Test
-  public void testInsertOverwriteFromView_noBaseTablePartitionInInputs() throws Exception {
+  public void testInsertOverwriteFromView() throws Exception {
     conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
     SessionState.get().setConf(conf);
 
-    driver.compile(
-        "INSERT OVERWRITE TABLE " + DATA_DB + "." + TARGET_TABLE
-            + " SELECT * FROM " + VIEW_DB + "." + VIEW_NAME,
-        true);
+    driver.compile("INSERT OVERWRITE TABLE datadb.insert_target SELECT * FROM viewdb.v1", true);
 
     List<HivePrivilegeObject> inputs = getInputPrivObjects();
 
     Assert.assertTrue("Expected TABLE_OR_VIEW privilege object for view source in INSERT",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.TABLE_OR_VIEW
-                && VIEW_NAME.equalsIgnoreCase(h.getObjectName())
-                && VIEW_DB.equalsIgnoreCase(h.getDbname())));
+                && "v1".equalsIgnoreCase(h.getObjectName())
+                && "viewdb".equalsIgnoreCase(h.getDbname())));
 
     Assert.assertFalse(
         "INSERT from view must not send a PARTITION privilege object on the base table",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.PARTITION
-                && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
-                && DATA_DB.equalsIgnoreCase(h.getDbname())));
+                && "t1".equalsIgnoreCase(h.getObjectName())
+                && "datadb".equalsIgnoreCase(h.getDbname())));
   }
 
   @SuppressWarnings("unchecked")

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestViewPartitionPrivilegeObjects.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestViewPartitionPrivilegeObjects.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -44,7 +45,7 @@ import static org.mockito.Mockito.verify;
 
 /**
  * Tests the {@link HivePrivilegeObject} inputs passed to {@link HiveAuthorizer#checkPrivileges}
- * for view queries over partitioned base tables (HIVE-29628).
+ * for view queries over partitioned base tables.
  */
 public class TestViewPartitionPrivilegeObjects {
 
@@ -52,6 +53,7 @@ public class TestViewPartitionPrivilegeObjects {
   static final String VIEW_DB = "viewdb";
   static final String BASE_TABLE = "t1";
   static final String VIEW_NAME = "v1";
+  static final String TARGET_TABLE = "insert_target";
 
   protected static HiveConf conf;
   protected static Driver driver;
@@ -91,6 +93,9 @@ public class TestViewPartitionPrivilegeObjects {
     runCmd("CREATE DATABASE IF NOT EXISTS " + VIEW_DB);
     runCmd("CREATE VIEW IF NOT EXISTS " + VIEW_DB + "." + VIEW_NAME
         + " AS SELECT * FROM " + DATA_DB + "." + BASE_TABLE);
+    // Target table used by INSERT OVERWRITE tests — non-partitioned to keep DML simple
+    runCmd("CREATE TABLE IF NOT EXISTS " + DATA_DB + "." + TARGET_TABLE
+        + " (i INT, dept STRING)");
   }
 
   @Before
@@ -104,16 +109,12 @@ public class TestViewPartitionPrivilegeObjects {
   public static void afterClass() throws Exception {
     runCmd("DROP VIEW IF EXISTS " + VIEW_DB + "." + VIEW_NAME);
     runCmd("DROP TABLE IF EXISTS " + DATA_DB + "." + BASE_TABLE);
+    runCmd("DROP TABLE IF EXISTS " + DATA_DB + "." + TARGET_TABLE);
     runCmd("DROP DATABASE IF EXISTS " + VIEW_DB);
     runCmd("DROP DATABASE IF EXISTS " + DATA_DB);
     driver.close();
   }
 
-  /**
-   * Mirrors {@code authorization_view_without_base_select_priv.q} with
-   * {@code hive.fetch.task.conversion=none}: a view-only user must not produce a
-   * PARTITION privilege object on the underlying base table.
-   */
   @Test
   public void testViewSelectNoBaseTablePartitionPrivObj() throws Exception {
     conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
@@ -133,13 +134,13 @@ public class TestViewPartitionPrivilegeObjects {
                 && VIEW_NAME.equalsIgnoreCase(h.getObjectName())
                 && VIEW_DB.equalsIgnoreCase(h.getDbname())));
 
-    Assert.assertFalse("View query must not send a PARTITION object on the base table",
+    Assert.assertFalse("HIVE-29628: view query must not send a PARTITION object on the base table",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.PARTITION
                 && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
                 && DATA_DB.equalsIgnoreCase(h.getDbname())));
 
-    Assert.assertFalse("View query must not send a base-table TABLE_OR_VIEW object",
+    Assert.assertFalse("HIVE-29628: view query must not send a base-table TABLE_OR_VIEW object",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.TABLE_OR_VIEW
                 && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
@@ -160,6 +161,36 @@ public class TestViewPartitionPrivilegeObjects {
     List<HivePrivilegeObject> inputs = getInputPrivObjects();
 
     Assert.assertTrue("Expected a PARTITION privilege object for direct table access",
+        inputs.stream().anyMatch(h ->
+            h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.PARTITION
+                && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
+                && DATA_DB.equalsIgnoreCase(h.getDbname())));
+  }
+
+  /**
+   * When a view over a partitioned table is the READ SOURCE of an INSERT OVERWRITE statement,
+   * {@code checkPrivileges} inputs must contain only {@code TABLE_OR_VIEW viewdb/v1}
+   */
+  @Test
+  public void testInsertOverwriteFromView_noBaseTablePartitionInInputs() throws Exception {
+    conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
+    SessionState.get().setConf(conf);
+
+    driver.compile(
+        "INSERT OVERWRITE TABLE " + DATA_DB + "." + TARGET_TABLE
+            + " SELECT * FROM " + VIEW_DB + "." + VIEW_NAME,
+        true);
+
+    List<HivePrivilegeObject> inputs = getInputPrivObjects();
+
+    Assert.assertTrue("Expected TABLE_OR_VIEW privilege object for view source in INSERT",
+        inputs.stream().anyMatch(h ->
+            h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.TABLE_OR_VIEW
+                && VIEW_NAME.equalsIgnoreCase(h.getObjectName())
+                && VIEW_DB.equalsIgnoreCase(h.getDbname())));
+
+    Assert.assertFalse(
+        "INSERT from view must not send a PARTITION privilege object on the base table",
         inputs.stream().anyMatch(h ->
             h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.PARTITION
                 && BASE_TABLE.equalsIgnoreCase(h.getObjectName())

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestViewPartitionPrivilegeObjects.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestViewPartitionPrivilegeObjects.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.security.authorization.plugin;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
+import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
+import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+import org.apache.hadoop.hive.ql.security.HiveAuthenticationProvider;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests the {@link HivePrivilegeObject} inputs passed to {@link HiveAuthorizer#checkPrivileges}
+ * for view queries over partitioned base tables (HIVE-29628).
+ */
+public class TestViewPartitionPrivilegeObjects {
+
+  static final String DATA_DB = "datadb";
+  static final String VIEW_DB = "viewdb";
+  static final String BASE_TABLE = "t1";
+  static final String VIEW_NAME = "v1";
+
+  protected static HiveConf conf;
+  protected static Driver driver;
+  static HiveAuthorizer mockedAuthorizer;
+
+  static class MockedHiveAuthorizerFactory implements HiveAuthorizerFactory {
+    @Override
+    public HiveAuthorizer createHiveAuthorizer(HiveMetastoreClientFactory metastoreClientFactory,
+        HiveConf conf, HiveAuthenticationProvider authenticator, HiveAuthzSessionContext ctx) {
+      TestViewPartitionPrivilegeObjects.mockedAuthorizer = Mockito.mock(HiveAuthorizer.class);
+      return TestViewPartitionPrivilegeObjects.mockedAuthorizer;
+    }
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser("hive"));
+    conf = new HiveConfForTest(TestViewPartitionPrivilegeObjects.class);
+    conf.setVar(ConfVars.HIVE_AUTHORIZATION_MANAGER, MockedHiveAuthorizerFactory.class.getName());
+    conf.setBoolVar(ConfVars.HIVE_AUTHORIZATION_ENABLED, true);
+    conf.setBoolVar(ConfVars.HIVE_SERVER2_ENABLE_DOAS, false);
+    conf.setBoolVar(ConfVars.HIVE_SUPPORT_CONCURRENCY, true);
+    conf.setVar(ConfVars.HIVE_TXN_MANAGER, DbTxnManager.class.getName());
+    conf.setVar(ConfVars.HIVE_MAPRED_MODE, "nonstrict");
+    conf.setVar(ConfVars.DYNAMIC_PARTITIONING_MODE, "nonstrict");
+    conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
+    conf.setVar(ConfVars.HIVE_EXECUTION_ENGINE, "mr");
+
+    TestTxnDbUtil.prepDb(conf);
+    SessionState.start(conf);
+    driver = new Driver(conf);
+
+    runCmd("CREATE DATABASE IF NOT EXISTS " + DATA_DB);
+    runCmd("CREATE TABLE IF NOT EXISTS " + DATA_DB + "." + BASE_TABLE
+        + " (i INT) PARTITIONED BY (dept STRING)");
+    runCmd("ALTER TABLE " + DATA_DB + "." + BASE_TABLE + " ADD IF NOT EXISTS PARTITION (dept='a')");
+    runCmd("CREATE DATABASE IF NOT EXISTS " + VIEW_DB);
+    runCmd("CREATE VIEW IF NOT EXISTS " + VIEW_DB + "." + VIEW_NAME
+        + " AS SELECT * FROM " + DATA_DB + "." + BASE_TABLE);
+  }
+
+  @Before
+  public void resetMock() {
+    if (mockedAuthorizer != null) {
+      reset(mockedAuthorizer);
+    }
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    runCmd("DROP VIEW IF EXISTS " + VIEW_DB + "." + VIEW_NAME);
+    runCmd("DROP TABLE IF EXISTS " + DATA_DB + "." + BASE_TABLE);
+    runCmd("DROP DATABASE IF EXISTS " + VIEW_DB);
+    runCmd("DROP DATABASE IF EXISTS " + DATA_DB);
+    driver.close();
+  }
+
+  /**
+   * Mirrors {@code authorization_view_without_base_select_priv.q} with
+   * {@code hive.fetch.task.conversion=none}: a view-only user must not produce a
+   * PARTITION privilege object on the underlying base table.
+   */
+  @Test
+  public void testViewSelectNoBaseTablePartitionPrivObj() throws Exception {
+    conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
+    SessionState.get().setConf(conf);
+
+    HiveAuthenticationProvider user1Auth = Mockito.mock(HiveAuthenticationProvider.class);
+    Mockito.when(user1Auth.getUserName()).thenReturn("user1");
+    SessionState.get().setAuthenticator(user1Auth);
+
+    driver.compile("SELECT * FROM " + VIEW_DB + "." + VIEW_NAME, true);
+
+    List<HivePrivilegeObject> inputs = getInputPrivObjects();
+
+    Assert.assertTrue("Expected a TABLE_OR_VIEW object for the view",
+        inputs.stream().anyMatch(h ->
+            h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.TABLE_OR_VIEW
+                && VIEW_NAME.equalsIgnoreCase(h.getObjectName())
+                && VIEW_DB.equalsIgnoreCase(h.getDbname())));
+
+    Assert.assertFalse("View query must not send a PARTITION object on the base table",
+        inputs.stream().anyMatch(h ->
+            h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.PARTITION
+                && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
+                && DATA_DB.equalsIgnoreCase(h.getDbname())));
+
+    Assert.assertFalse("View query must not send a base-table TABLE_OR_VIEW object",
+        inputs.stream().anyMatch(h ->
+            h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.TABLE_OR_VIEW
+                && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
+                && DATA_DB.equalsIgnoreCase(h.getDbname())));
+  }
+
+  /**
+   * Direct reads on a partitioned table must still emit a PARTITION privilege object
+   * so table/partition policies (e.g. Ranger) can be enforced.
+   */
+  @Test
+  public void testDirectTableSelectHasPartitionPrivObj() throws Exception {
+    conf.setVar(ConfVars.HIVE_FETCH_TASK_CONVERSION, "none");
+    SessionState.get().setConf(conf);
+
+    driver.compile("SELECT * FROM " + DATA_DB + "." + BASE_TABLE, true);
+
+    List<HivePrivilegeObject> inputs = getInputPrivObjects();
+
+    Assert.assertTrue("Expected a PARTITION privilege object for direct table access",
+        inputs.stream().anyMatch(h ->
+            h.getType() == HivePrivilegeObject.HivePrivilegeObjectType.PARTITION
+                && BASE_TABLE.equalsIgnoreCase(h.getObjectName())
+                && DATA_DB.equalsIgnoreCase(h.getDbname())));
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<HivePrivilegeObject> getInputPrivObjects()
+      throws HiveAuthzPluginException, HiveAccessControlException {
+    Class<List<HivePrivilegeObject>> cls = (Class) List.class;
+    ArgumentCaptor<List<HivePrivilegeObject>> inputsCapturer = ArgumentCaptor.forClass(cls);
+    ArgumentCaptor<List<HivePrivilegeObject>> outputsCapturer = ArgumentCaptor.forClass(cls);
+
+    verify(mockedAuthorizer, atLeastOnce()).checkPrivileges(
+        any(HiveOperationType.class),
+        inputsCapturer.capture(),
+        outputsCapturer.capture(),
+        any(HiveAuthzContext.class));
+
+    List<List<HivePrivilegeObject>> all = inputsCapturer.getAllValues();
+    return all.get(all.size() - 1);
+  }
+
+  private static void runCmd(String cmd) throws Exception {
+    driver.run(cmd);
+  }
+}


### PR DESCRIPTION
… view queries on partitioned tables



### What changes were proposed in this pull request?

Fixed  incorrect `PARTITION` `HivePrivilegeObject` generation in `CommandAuthorizerV2` for queries that access a **regular (non-deferred) view** over a **partitioned base table**.
In `CommandAuthorizerV2.getHivePrivObjects()`, skip emitting a `HivePrivilegeObject` for `PARTITION` / `DUMMYPARTITION` entities when access is through a regular view. The view’s `TABLE_OR_VIEW` object already covers authorization.

Skip logic (`isPartitionAccessedViaRegularView`):
1. If the partition entity has a regular (non-deferred) view parent → skip.
2. If the partition entity lacks parent entity but a sibling indirect `TABLE` entity for the same base table has a regular view parent → skip.
3. If the partition is accessed through a **deferred-auth view** (`Authorized=false`) → emit `PARTITION` on the base table (existing behaviour).
4. If the partition is accessed **directly** (no view) → emit `PARTITION` on the base table

### Why are the changes needed?
HIVE-27892 added handling for `PARTITION` / `DUMMYPARTITION` entities in `addHivePrivObject`, always using the physical base-table name (`datadb/t1`). For view queries, this causes authorizers  to receive an extra `PARTITION` object on the base table in addition to the view’s `TABLE_OR_VIEW` object. Users with view-only policies are getting PERMISSION denied.


### Does this PR introduce _any_ user-facing change?
yes
View queries through regular views send only the view TABLE_OR_VIEW privilege object. Direct queries on partitioned tables and deferred-auth views still emit base-table PARTITION objects as before.

### How was this patch tested?
mvn test -Dtest=TestViewPartitionPrivilegeObjects
