### PR TITLE
HIVE-29622: Improve metastore direct-SQL partition lookup robustness

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/directsql/DirectSqlUpdatePart.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/directsql/DirectSqlUpdatePart.java
@@ -77,6 +77,7 @@ import static org.apache.hadoop.hive.metastore.directsql.MetastoreDirectSqlUtils
 import static org.apache.hadoop.hive.metastore.directsql.MetastoreDirectSqlUtils.extractSqlInt;
 import static org.apache.hadoop.hive.metastore.directsql.MetastoreDirectSqlUtils.extractSqlLong;
 import static org.apache.hadoop.hive.metastore.directsql.MetastoreDirectSqlUtils.getModelIdentity;
+import static org.apache.hadoop.hive.metastore.directsql.MetastoreDirectSqlUtils.makeParams;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getPartValsFromName;
 
 /**
@@ -96,10 +97,6 @@ class DirectSqlUpdatePart extends DirectSqlBase {
     super(pm, dbType, batchSize);
     this.conf = conf;
     sqlGenerator = new SQLGenerator(dbType, conf);
-  }
-
-  static String quoteString(String input) {
-    return "'" + input + "'";
   }
 
   private void populateInsertUpdateMap(Map<PartitionInfo, ColumnStatistics> statsPartInfoMap,
@@ -412,35 +409,39 @@ class DirectSqlUpdatePart extends DirectSqlBase {
 
   private Map<PartitionInfo, ColumnStatistics> getPartitionInfo(Connection dbConn, long tblId,
                                                                  Map<String, ColumnStatistics> partColStatsMap)
-          throws SQLException, MetaException {
-    List<String> queries = new ArrayList<>();
-    StringBuilder prefix = new StringBuilder();
-    StringBuilder suffix = new StringBuilder();
+          throws MetaException {
     Map<PartitionInfo, ColumnStatistics> partitionInfoMap = new HashMap<>();
+    List<String> partNames = new ArrayList<>(partColStatsMap.keySet());
+    if (partNames.isEmpty()) {
+      return partitionInfoMap;
+    }
 
-    List<String> partKeys = partColStatsMap.keySet().stream().map(
-            e -> quoteString(e)).collect(Collectors.toList()
-    );
-
-    prefix.append("select \"PART_ID\", \"WRITE_ID\", \"PART_NAME\"  from \"PARTITIONS\" where ");
-    suffix.append(" and  \"TBL_ID\" = " + tblId);
-    TxnUtils.buildQueryWithINClauseStrings(conf, queries, prefix, suffix,
-            partKeys, "\"PART_NAME\"", true, false);
-
-    try (Statement statement = dbConn.createStatement()) {
-      for (String query : queries) {
+    Batchable.runBatched(maxBatchSize, partNames, new Batchable<String, Void>() {
+      @Override
+      public List<Void> run(List<String> input) throws Exception {
+        String placeholders = makeParams(input.size());
+        String query = "select \"PART_ID\", \"WRITE_ID\", \"PART_NAME\" from \"PARTITIONS\" where "
+            + "\"PART_NAME\" in (" + placeholders + ") and \"TBL_ID\" = ?";
         // Select for update makes sure that the partitions are not modified while the stats are getting updated.
         query = sqlGenerator.addForUpdateClause(query);
         LOG.debug("Execute query: " + query);
-        try (ResultSet rs = statement.executeQuery(query)) {
-          while (rs.next()) {
-            PartitionInfo partitionInfo = new PartitionInfo(rs.getLong(1),
-                rs.getLong(2), rs.getString(3));
-            partitionInfoMap.put(partitionInfo, partColStatsMap.get(rs.getString(3)));
+        try (PreparedStatement ps = dbConn.prepareStatement(query)) {
+          int paramIndex = 1;
+          for (String partName : input) {
+            ps.setString(paramIndex++, partName);
+          }
+          ps.setLong(paramIndex, tblId);
+          try (ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+              String partName = rs.getString(3);
+              PartitionInfo partitionInfo = new PartitionInfo(rs.getLong(1), rs.getLong(2), partName);
+              partitionInfoMap.put(partitionInfo, partColStatsMap.get(partName));
+            }
           }
         }
+        return Collections.emptyList();
       }
-    }
+    });
     return partitionInfoMap;
   }
 
@@ -472,6 +473,10 @@ class DirectSqlUpdatePart extends DirectSqlBase {
         setAnsiQuotes(dbConn);
 
         Map<PartitionInfo, ColumnStatistics> partitionInfoMap = getPartitionInfo(dbConn, tbl.getId(), partColStatsMap);
+
+        if (partitionInfoMap.isEmpty()) {
+          return Collections.emptyMap();
+        }
 
         result = updatePartitionParamTable(dbConn, partitionInfoMap, validWriteIds,
             writeId, TxnUtils.isAcidTable(tbl));

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/directsql/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/directsql/MetaStoreDirectSql.java
@@ -738,7 +738,7 @@ public class MetaStoreDirectSql {
     return Batchable.runBatched(batchSize, partNames, new Batchable<String, Partition>() {
       @Override
       public List<Partition> run(List<String> input) throws MetaException {
-        return getPartitionsByNames(catName, dbName, tblName, partNames, false, args);
+        return getPartitionsByNames(catName, dbName, tblName, input, false, args);
       }
     });
   }
@@ -1028,9 +1028,7 @@ public class MetaStoreDirectSql {
       throws MetaException {
     // Get most of the fields for the partNames provided.
     // Assume db and table names are the same for all partition, as provided in arguments.
-    String quotedPartNames = partNameList.stream()
-        .map(DirectSqlUpdatePart::quoteString)
-        .collect(Collectors.joining(","));
+    String partNameParams = makeParams(partNameList.size());
 
     String queryText =
         "select " + PARTITIONS + ".\"PART_ID\"," + SDS + ".\"SD_ID\"," + SDS + ".\"CD_ID\","
@@ -1043,11 +1041,18 @@ public class MetaStoreDirectSql {
         + " left outer join " + SERDES + " on " + SDS + ".\"SERDE_ID\" = " + SERDES + ".\"SERDE_ID\" "
         + " inner join " + TBLS + " on " + TBLS + ".\"TBL_ID\" = " + PARTITIONS + ".\"TBL_ID\" "
         + " inner join " + DBS + " on " + DBS + ".\"DB_ID\" = " + TBLS + ".\"DB_ID\" "
-        + " where \"PART_NAME\" in (" + quotedPartNames + ") "
+        + " where " + PARTITIONS + ".\"PART_NAME\" in (" + partNameParams + ") "
         + " and " + TBLS + ".\"TBL_NAME\" = ? and " + DBS + ".\"NAME\" = ? and " + DBS
         + ".\"CTLG_NAME\" = ? order by \"PART_NAME\" asc";
 
-    Object[] params = new Object[]{tblName, dbName, catName};
+    Object[] params = new Object[partNameList.size() + 3];
+    int i = 0;
+    for (String partName : partNameList) {
+      params[i++] = partName;
+    }
+    params[i++] = tblName;
+    params[i++] = dbName;
+    params[i] = catName;
     return getPartitionsByQuery(catName, dbName, tblName, queryText, params, isAcidTable, args);
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -149,6 +149,9 @@ public class TestObjectStore {
   private static final String USER1 = "testobjectstoreuser1";
   private static final String ROLE1 = "testobjectstorerole1";
   private static final String ROLE2 = "testobjectstorerole2";
+  private static final String SQLI_PART_NAME = "test_part_col=missing') OR 1=1 -- ";
+  private static final List<String> ALL_PART_NAMES =
+      Arrays.asList("test_part_col=a0", "test_part_col=a1", "test_part_col=a2");
   private static final Logger LOG = LoggerFactory.getLogger(TestObjectStore.class.getName());
 
   private static final class LongSupplier implements Supplier<Long> {
@@ -802,6 +805,21 @@ public class TestObjectStore {
     Assert.assertEquals(1, partitions.size());
   }
 
+  @Test
+  public void testDirectSQLDropPartitionsRejectsSqlInjectionInPartName()
+      throws Exception {
+    createPartitionedTable(false, false, new HashSet<>());
+
+    objectStore.dropPartitionsInternal(DEFAULT_CATALOG_NAME, DB1, TABLE1,
+        Collections.singletonList(SQLI_PART_NAME), true, false);
+
+    List<Partition> partitions;
+    try (AutoCloseable c = deadline()) {
+      partitions = objectStore.getPartitionsByNames(DEFAULT_CATALOG_NAME, DB1, TABLE1, ALL_PART_NAMES);
+    }
+    Assert.assertEquals(3, partitions.size());
+  }
+
   /**
    * Checks if the JDO cache is able to handle directSQL partition drops cross sessions.
    */
@@ -1022,6 +1040,63 @@ public class TestObjectStore {
     createPartitionedTable(true, true, new HashSet<>());
     objectStore.deletePartitionColumnStatistics(DEFAULT_CATALOG_NAME, DB1, TABLE1,
             List.of("test_part_col=a2"), null, "special '");
+  }
+
+  @Test
+  public void testGetPartitionsByNamesRejectsSqlInjectionInPartName() throws Exception {
+    createPartitionedTable(true, true, new HashSet<>());
+    List<Partition> partitions;
+    try (AutoCloseable c = deadline()) {
+      partitions = objectStore.getPartitionsByNames(DEFAULT_CATALOG_NAME, DB1, TABLE1,
+          Collections.singletonList(SQLI_PART_NAME));
+    }
+    Assert.assertEquals(0, partitions.size());
+    try (AutoCloseable c = deadline()) {
+      partitions = objectStore.getPartitionsByNames(DEFAULT_CATALOG_NAME, DB1, TABLE1, ALL_PART_NAMES);
+    }
+    Assert.assertEquals(3, partitions.size());
+  }
+
+  @Test
+  public void testUpdatePartitionColumnStatisticsInBatchRejectsSqlInjectionInPartName()
+      throws Exception {
+    createPartitionedTable(true, true, new HashSet<>());
+    Table tbl = objectStore.getTable(DEFAULT_CATALOG_NAME, DB1, TABLE1);
+
+    List<List<ColumnStatistics>> baseline;
+    try (AutoCloseable c = deadline()) {
+      baseline = objectStore.getPartitionColumnStatistics(DEFAULT_CATALOG_NAME, DB1, TABLE1,
+          ALL_PART_NAMES, Collections.singletonList("test_part_col"));
+    }
+    Assert.assertEquals(1, baseline.size());
+    Assert.assertEquals(3, baseline.get(0).size());
+    long baselineNumNulls = baseline.get(0).get(0).getStatsObj().get(0).getStatsData()
+        .getLongStats().getNumNulls();
+
+    ColumnStatisticsDesc statsDesc = new ColumnStatisticsDesc(false, DB1, TABLE1);
+    statsDesc.setCatName(DEFAULT_CATALOG_NAME);
+    statsDesc.setPartName(SQLI_PART_NAME);
+    ColumnStatisticsData injectedData = new ColStatsBuilder<>(long.class).numNulls(999).numDVs(2)
+        .low(3L).high(4L).build();
+    ColumnStatisticsObj statsObj = new ColumnStatisticsObj("test_part_col", "int", injectedData);
+    ColumnStatistics maliciousStats = new ColumnStatistics(statsDesc,
+        Collections.singletonList(statsObj));
+    maliciousStats.setEngine(ENGINE);
+
+    Map<String, ColumnStatistics> statsMap = new HashMap<>();
+    statsMap.put(SQLI_PART_NAME, maliciousStats);
+    objectStore.updatePartitionColumnStatisticsInBatch(statsMap, tbl, null, null, -1);
+
+    List<List<ColumnStatistics>> after;
+    try (AutoCloseable c = deadline()) {
+      after = objectStore.getPartitionColumnStatistics(DEFAULT_CATALOG_NAME, DB1, TABLE1,
+          ALL_PART_NAMES, Collections.singletonList("test_part_col"));
+    }
+    Assert.assertEquals(3, after.get(0).size());
+    for (ColumnStatistics cs : after.get(0)) {
+      Assert.assertEquals(baselineNumNulls,
+          cs.getStatsObj().get(0).getStatsData().getLongStats().getNumNulls());
+    }
   }
 
   private void setAggrConf(boolean enableBitVector, boolean enableKll, int batchSize) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Direct-SQL partition name handling in the metastore was tightened. Partition lookups and related batch updates now use bound parameters instead of embedding names in SQL text.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Some partition-name inputs could be mishandled in direct-SQL paths, leading to incorrect partition resolution. This change makes name-based metastore operations more predictable and robust.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
Existing test framework + Added a new test in TestObjectStore class
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
