### PR TITLE
HIVE-29571: ACID Compaction: Marking the compaction as compacted should happen after its txn got committed

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
@@ -212,18 +212,18 @@ public class AcidCompactionService extends CompactionService {
 
       // Don't start compaction or cleaning if not necessary
       if (isDynPartAbort(table, ci)) {
-        compactionTxn.onCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
+        compactionTxn.markForCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
         return false;
       }
       dir = getAcidStateForWorker(ci, sd, tblValidWriteIds);
       if (!isEnoughToCompact(ci, dir, sd)) {
         if (needsCleaning(dir, sd)) {
-          compactionTxn.onCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
+          compactionTxn.markForCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
         } else {
           // do nothing
           ci.errorMessage = "None of the compaction thresholds met, compaction request is refused!";
           LOG.debug(ci.errorMessage + " Compaction info: {}", ci);
-          compactionTxn.onCommit(() -> msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
+          compactionTxn.markForCommit(() -> msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
 
         }
         return false;
@@ -232,7 +232,7 @@ public class AcidCompactionService extends CompactionService {
         ci.errorMessage = "Query based Minor compaction is not possible for full acid tables having raw format " +
             "(non-acid) data in them.";
         LOG.error(ci.errorMessage + " Compaction info: {}", ci);
-        compactionTxn.onAbort(() -> msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
+        compactionTxn.markForAbort(() -> msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
         return false;
       }
       CompactorUtil.checkInterrupt(CLASS_NAME);
@@ -257,7 +257,7 @@ public class AcidCompactionService extends CompactionService {
 
         LOG.info("Completed " + ci.type.toString() + " compaction for " + ci.getFullPartitionName() + " in "
             + compactionTxn + ", marking as compacted.");
-        compactionTxn.onCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
+        compactionTxn.markForCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
 
         AcidMetricService.updateMetricsFromWorker(ci.dbname, ci.tableName, ci.partName, ci.type,
             dir.getCurrentDirectories().size(), dir.getDeleteDeltas().size(), conf, msc);
@@ -342,8 +342,10 @@ public class AcidCompactionService extends CompactionService {
 
     private TxnStatus status = TxnStatus.UNKNOWN;
 
-    private ThrowingRunnable onCommitAction;
-    private ThrowingRunnable onAbortAction;
+    private ThrowingRunnable onCommitSuccess;
+    private ThrowingRunnable onAbortSuccess;
+
+    private boolean rollbackOnly = true;
 
     /**
      * Try to open a new txn.
@@ -374,14 +376,14 @@ public class AcidCompactionService extends CompactionService {
       return CompactorUtil.createLockRequest(conf, ci, txnId, lockAndOpType.getKey(), lockAndOpType.getValue());
     }
 
-    /**
-     * Mark compaction as successful. This means the txn will be committed; otherwise it will be aborted.
-     */
-    void onCommit(ThrowingRunnable action) {
-      this.onCommitAction = action;
+    void markForCommit(ThrowingRunnable action) {
+      this.rollbackOnly = false;
+      this.onCommitSuccess = action;
     }
-    void onAbort(ThrowingRunnable action) {
-      this.onAbortAction = action;
+
+    void markForAbort(ThrowingRunnable action) {
+      this.rollbackOnly = true;
+      this.onAbortSuccess = action;
     }
 
     /**
@@ -396,18 +398,16 @@ public class AcidCompactionService extends CompactionService {
         //the transaction is about to close, we can stop heartbeating regardless of it's state
         CompactionHeartbeatService.getInstance(conf).stopHeartbeat(txnId);
       } finally {
-        if (onCommitAction != null) {
-          try {
-            commit();
-          } catch (Exception e) {
-            abort();
-            if (onAbortAction != null) onAbortAction.run();
-            throw e;
-          }
-          onCommitAction.run();
-        } else {
+        if (rollbackOnly) {
           abort();
-          if (onAbortAction != null) onAbortAction.run();
+          if (onAbortSuccess != null) {
+            onAbortSuccess.run();
+          }
+          return;
+        }
+        commit();
+        if (onCommitSuccess != null) {
+          onCommitSuccess.run();
         }
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hive.ql.txn.compactor.CompactorContext;
 import org.apache.hadoop.hive.ql.txn.compactor.CompactorFactory;
 import org.apache.hadoop.hive.ql.txn.compactor.CompactorPipeline;
 import org.apache.hadoop.hive.ql.txn.compactor.CompactorUtil;
+import org.apache.hadoop.hive.ql.txn.compactor.CompactorUtil.ThrowingRunnable;
 import org.apache.hadoop.hive.ql.txn.compactor.QueryCompactor;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.common.util.Ref;
@@ -211,32 +212,27 @@ public class AcidCompactionService extends CompactionService {
 
       // Don't start compaction or cleaning if not necessary
       if (isDynPartAbort(table, ci)) {
-        msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci));
-        compactionTxn.wasSuccessful();
+        compactionTxn.onCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
         return false;
       }
       dir = getAcidStateForWorker(ci, sd, tblValidWriteIds);
       if (!isEnoughToCompact(ci, dir, sd)) {
         if (needsCleaning(dir, sd)) {
-          msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci));
+          compactionTxn.onCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
         } else {
           // do nothing
           ci.errorMessage = "None of the compaction thresholds met, compaction request is refused!";
           LOG.debug(ci.errorMessage + " Compaction info: {}", ci);
-          msc.markRefused(CompactionInfo.compactionInfoToStruct(ci));
+          compactionTxn.onCommit(() -> msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
+
         }
-        compactionTxn.wasSuccessful();
         return false;
       }
       if (!ci.isMajorCompaction() && !CompactorUtil.isMinorCompactionSupported(conf, table.getParameters(), dir)) {
         ci.errorMessage = "Query based Minor compaction is not possible for full acid tables having raw format " +
             "(non-acid) data in them.";
         LOG.error(ci.errorMessage + " Compaction info: {}", ci);
-        try {
-          msc.markRefused(CompactionInfo.compactionInfoToStruct(ci));
-        } catch (Throwable tr) {
-          LOG.error("Caught an exception while trying to mark compaction {} as failed: {}", ci, tr);
-        }
+        compactionTxn.onAbort(() -> msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
         return false;
       }
       CompactorUtil.checkInterrupt(CLASS_NAME);
@@ -261,8 +257,7 @@ public class AcidCompactionService extends CompactionService {
 
         LOG.info("Completed " + ci.type.toString() + " compaction for " + ci.getFullPartitionName() + " in "
             + compactionTxn + ", marking as compacted.");
-        msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci));
-        compactionTxn.wasSuccessful();
+        compactionTxn.onCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
 
         AcidMetricService.updateMetricsFromWorker(ci.dbname, ci.tableName, ci.partName, ci.type,
             dir.getCurrentDirectories().size(), dir.getDeleteDeltas().size(), conf, msc);
@@ -346,7 +341,9 @@ public class AcidCompactionService extends CompactionService {
     private long lockId = 0;
 
     private TxnStatus status = TxnStatus.UNKNOWN;
-    private boolean successfulCompaction = false;
+
+    private ThrowingRunnable onCommitAction;
+    private ThrowingRunnable onAbortAction;
 
     /**
      * Try to open a new txn.
@@ -380,8 +377,11 @@ public class AcidCompactionService extends CompactionService {
     /**
      * Mark compaction as successful. This means the txn will be committed; otherwise it will be aborted.
      */
-    void wasSuccessful() {
-      this.successfulCompaction = true;
+    void onCommit(ThrowingRunnable action) {
+      this.onCommitAction = action;
+    }
+    void onAbort(ThrowingRunnable action) {
+      this.onAbortAction = action;
     }
 
     /**
@@ -396,10 +396,18 @@ public class AcidCompactionService extends CompactionService {
         //the transaction is about to close, we can stop heartbeating regardless of it's state
         CompactionHeartbeatService.getInstance(conf).stopHeartbeat(txnId);
       } finally {
-        if (successfulCompaction) {
-          commit();
+        if (onCommitAction != null) {
+          try {
+            commit();
+          } catch (Exception e) {
+            abort();
+            if (onAbortAction != null) onAbortAction.run();
+            throw e;
+          }
+          onCommitAction.run();
         } else {
           abort();
+          if (onAbortAction != null) onAbortAction.run();
         }
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
@@ -382,7 +382,6 @@ public class AcidCompactionService extends CompactionService {
     }
 
     void markForAbort(ThrowingRunnable action) {
-      this.rollbackOnly = true;
       this.onAbortSuccess = action;
     }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
@@ -1208,7 +1208,7 @@ public class TestWorker extends CompactorTest {
 
   @Test
   public void testExceptionWhenTxnCommitAndMarkFailed() throws Exception {
-    prepareTableAndCompaction("default", "tableForCommitAndMarkFailedError");
+    prepareTableAndCompaction("default", "tbforcomperror");
     runWorkerWithException(MethodToFail.COMMIT_TXN, MethodToFail.MARK_FAILED);
 
     List<ShowCompactResponseElement> compacts =
@@ -1224,7 +1224,7 @@ public class TestWorker extends CompactorTest {
 
   @Test
   public void testExceptionWhenTxnCommit() throws Exception {
-    prepareTableAndCompaction("default", "tableForCommitError");
+    prepareTableAndCompaction("default", "tbforcomperror");
     runWorkerWithException(MethodToFail.COMMIT_TXN);
 
     List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
@@ -1241,7 +1241,7 @@ public class TestWorker extends CompactorTest {
 
   @Test
   public void testExceptionWhenMarkCompacted() throws Exception {
-    prepareTableAndCompaction("default", "tableForMarkCompactedError");
+    prepareTableAndCompaction("default", "tbforcomperror");
     runWorkerWithException(MethodToFail.MARK_COMPACTED);
 
     List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
@@ -1254,7 +1254,7 @@ public class TestWorker extends CompactorTest {
 
   @Test
   public void testExceptionDuringCompact() throws Exception {
-    prepareTableAndCompaction("default", "tableForCompactError");
+    prepareTableAndCompaction("default", "tbforcomperror");
     HiveConf.setBoolVar(conf, HiveConf.ConfVars.HIVE_IN_TEST, true);
     HiveConf.setBoolVar(conf, HiveConf.ConfVars.HIVE_TEST_MODE_FAIL_COMPACTION, true);
     startWorker();
@@ -1273,7 +1273,7 @@ public class TestWorker extends CompactorTest {
   @Test
   public void testWorkerIfIsDynPartAbort() throws Exception {
     String dbName = "default";
-    String tableName = "tableWithPartition";
+    String tableName = "tbforcomperror";
     Table t = newTable(dbName, tableName, true);
     addBaseFile(t, null, 1L, 3, 1);
     addDeltaFile(t, null, 2L, 2L, 1);
@@ -1297,7 +1297,7 @@ public class TestWorker extends CompactorTest {
   @Test
   public void testWorkerNotEnoughToCompact() throws Exception {
     String dbName = "default";
-    String tableName = "tableWithNoDelta";
+    String tableName = "tbforcomperror";
     Table t = newTable(dbName, tableName, false);
     addBaseFile(t, null, 1L, 3, 1);
     burnThroughTransactions(dbName, tableName, 1, null, null);
@@ -1317,12 +1317,14 @@ public class TestWorker extends CompactorTest {
   @Test
   public void testWorkerNotEnoughToCompactNeedsCleaning() throws Exception {
     String dbName = "default";
-    String tableName = "tableNeedsCleaning";
+    String tableName = "tbforcomperror";
     Table t = newTable(dbName, tableName, false);
-    addDeltaFile(t, null, 1L, 1L, 1);
-    addDeltaFile(t, null, 2L, 2L, 1);
-    addBaseFile(t, null, 4L, 3, 6);
-    burnThroughTransactions(dbName, tableName, 6, null, new HashSet<Long>(Arrays.asList(1L, 2L)));
+    addDeltaFile(t, null, 20L, 20L, 10);
+    addDeltaFile(t, null, 21L, 21L, 10);
+    addDeltaFile(t, null, 22L, 22L, 10);
+    addDeltaFile(t, null, 23L, 23L, 10);
+    addDeltaFile(t, null, 24L, 24L, 10);
+    burnThroughTransactions(dbName, tableName, 25, null, new HashSet<Long>(Arrays.asList(20L, 21L, 22L, 23L, 24L)));
     // trigger compaction
     CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MAJOR);
     txnHandler.compact(rqst);
@@ -1333,9 +1335,13 @@ public class TestWorker extends CompactorTest {
     assertEquals(TxnStore.CLEANING_RESPONSE, compaction.getState());
     assertTrue(compaction.getNextTxnId() > 0L);
     List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
-    assertEquals(2, openTxns.size());
-    assertEquals(1L, openTxns.get(0).getId());
-    assertEquals(2L, openTxns.get(1).getId());
+    assertEquals(5, openTxns.size());
+    assertEquals(20L, openTxns.get(0).getId());
+    assertEquals(21L, openTxns.get(1).getId());
+    assertEquals(22L, openTxns.get(2).getId());
+    assertEquals(23L, openTxns.get(3).getId());
+    assertEquals(24L, openTxns.get(4).getId());
+
   }
 
   private void runWorkerWithException(MethodToFail... methodToFail) throws Exception {
@@ -1362,11 +1368,13 @@ public class TestWorker extends CompactorTest {
 
   private void prepareTableAndCompaction(String dbName, String tableName) throws Exception {
     Table t = newTable(dbName, tableName, false);
-    addBaseFile(t, null, 1L, 3, 1);
-    addDeltaFile(t, null, 2L, 2L, 1);
-    addDeltaFile(t, null, 3L, 3L, 1);
-    addDeltaFile(t, null, 4L, 4L, 1);
-    burnThroughTransactions(dbName, tableName, 4, null, null);
+    addBaseFile(t, null, 20L, 20);
+    addDeltaFile(t, null, 21L, 23L, 2);
+    addDeltaFile(t, null, 23L, 23L, 3);
+    addDeltaFile(t, null, 24L, 24L, 2);
+    addDeltaFile(t, null, 25L, 25L, 3);
+    addDeltaFile(t, null, 26L, 26L, 3);
+    burnThroughTransactions(dbName, tableName, 27, null, null);
     // trigger compaction
     CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MAJOR);
     txnHandler.compact(rqst);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.MetastoreTaskThread;
 import org.apache.hadoop.hive.metastore.TransactionalValidationListener;
+import org.apache.hadoop.hive.metastore.api.AbortTxnRequest;
 import org.apache.hadoop.hive.metastore.api.CompactionRequest;
 import org.apache.hadoop.hive.metastore.api.CompactionType;
 import org.apache.hadoop.hive.metastore.api.FindNextCompactRequest;
@@ -40,9 +40,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.TxnInfo;
 import org.apache.hadoop.hive.metastore.api.TxnState;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
-import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
-import org.apache.hadoop.hive.metastore.txn.service.AcidHouseKeeperService;
 import org.apache.hadoop.hive.metastore.utils.StringableMap;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
@@ -78,6 +76,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.hadoop.hive.common.AcidConstants.VISIBILITY_PATTERN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
@@ -134,9 +133,9 @@ public class TestWorker extends CompactorTest {
       else Assert.fail("Unexpected value " + e.getKey());
     }
     assertEquals(3, saw.size());
-    Assert.assertTrue(saw.get("mary"));
-    Assert.assertTrue(saw.get("bert"));
-    Assert.assertTrue(saw.get(null));
+    assertTrue(saw.get("mary"));
+    assertTrue(saw.get("bert"));
+    assertTrue(saw.get(null));
    }
 
   @Test
@@ -152,7 +151,7 @@ public class TestWorker extends CompactorTest {
     ls.add(new Path("/tmp"));
     ls.add(new Path("/usr"));
     s = ls.toString();
-    Assert.assertTrue("Expected 2:4:/tmp4:/usr or 2:4:/usr4:/tmp, got " + s,
+    assertTrue("Expected 2:4:/tmp4:/usr or 2:4:/usr4:/tmp, got " + s,
         "2:4:/tmp4:/usr".equals(s) || "2:4:/usr4:/tmp".equals(s));
     ls = new MRCompactor.StringableList(s);
     assertEquals(2, ls.size());
@@ -162,8 +161,8 @@ public class TestWorker extends CompactorTest {
       else if ("/usr".equals(p.toString())) sawUsr = true;
       else Assert.fail("Unexpected path " + p.toString());
     }
-    Assert.assertTrue(sawTmp);
-    Assert.assertTrue(sawUsr);
+    assertTrue(sawTmp);
+    assertTrue(sawUsr);
   }
 
   @Test
@@ -337,8 +336,8 @@ public class TestWorker extends CompactorTest {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(104L, buckets[0].getLen());
         assertEquals(104L, buckets[1].getLen());
       }
@@ -346,8 +345,8 @@ public class TestWorker extends CompactorTest {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(104L, buckets[0].getLen());
         assertEquals(104L, buckets[1].getLen());
       }
@@ -355,7 +354,7 @@ public class TestWorker extends CompactorTest {
         LOG.debug("This is not the delta file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewDelta);
+    assertTrue(toString(stat), sawNewDelta);
   }
 
   /**
@@ -469,8 +468,8 @@ public class TestWorker extends CompactorTest {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(104L, buckets[0].getLen());
         assertEquals(104L, buckets[1].getLen());
       }
@@ -478,15 +477,15 @@ public class TestWorker extends CompactorTest {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(104L, buckets[0].getLen());
         assertEquals(104L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the delta file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewDelta);
+    assertTrue(toString(stat), sawNewDelta);
   }
 
   @Test
@@ -521,8 +520,8 @@ public class TestWorker extends CompactorTest {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(104L, buckets[0].getLen());
         assertEquals(104L, buckets[1].getLen());
       }
@@ -530,15 +529,15 @@ public class TestWorker extends CompactorTest {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(104L, buckets[0].getLen());
         assertEquals(104L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the delta file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewDelta);
+    assertTrue(toString(stat), sawNewDelta);
   }
 
   @Test
@@ -574,15 +573,15 @@ public class TestWorker extends CompactorTest {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(624L, buckets[0].getLen());
         assertEquals(624L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewBase);
+    assertTrue(toString(stat), sawNewBase);
   }
 
   @Test
@@ -675,7 +674,7 @@ public class TestWorker extends CompactorTest {
     if(matchesNotFound.size() == 0) {
       return;
     }
-    Assert.assertTrue("Files remaining: " + matchesNotFound + "; " + toString(stat), false);
+    assertTrue("Files remaining: " + matchesNotFound + "; " + toString(stat), false);
   }
   @Test
   public void majorPartitionWithBase() throws Exception {
@@ -712,15 +711,15 @@ public class TestWorker extends CompactorTest {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(624L, buckets[0].getLen());
         assertEquals(624L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewBase);
+    assertTrue(toString(stat), sawNewBase);
   }
 
   @Test
@@ -755,15 +754,15 @@ public class TestWorker extends CompactorTest {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(104L, buckets[0].getLen());
         assertEquals(104L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewBase);
+    assertTrue(toString(stat), sawNewBase);
   }
 
   private static String toString(FileStatus[] stat) {
@@ -810,15 +809,15 @@ public class TestWorker extends CompactorTest {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         assertEquals(624L, buckets[0].getLen());
         assertEquals(624L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewBase);
+    assertTrue(toString(stat), sawNewBase);
   }
 
   @Test
@@ -853,13 +852,13 @@ public class TestWorker extends CompactorTest {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewDelta);
+    assertTrue(toString(stat), sawNewDelta);
   }
 
   @Test
@@ -898,10 +897,10 @@ public class TestWorker extends CompactorTest {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
         assertEquals(2, buckets.length);
-        Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
+        assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         // Bucket 0 should be small and bucket 1 should be large, make sure that's the case
-        Assert.assertTrue(
+        assertTrue(
             ("bucket_00000".equals(buckets[0].getPath().getName()) && 104L == buckets[0].getLen()
             && "bucket_00001".equals(buckets[1].getPath().getName()) && 676L == buckets[1]
                 .getLen())
@@ -914,7 +913,7 @@ public class TestWorker extends CompactorTest {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
     }
-    Assert.assertTrue(toString(stat), sawNewBase);
+    assertTrue(toString(stat), sawNewBase);
   }
 
   @Test
@@ -1209,22 +1208,23 @@ public class TestWorker extends CompactorTest {
 
   @Test
   public void testExceptionWhenTxnCommitAndMarkFailed() throws Exception {
-    prepareTableForCompactionFailureTests("default", "campcnb");
+    prepareTableAndCompaction("default", "tableForCommitAndMarkFailedError");
     runWorkerWithException(MethodToFail.COMMIT_TXN, MethodToFail.MARK_FAILED);
 
     List<ShowCompactResponseElement> compacts =
         txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
     assertEquals(TxnStore.WORKING_RESPONSE, compacts.get(0).getState());
-
     List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
     assertEquals(1, openTxns.size());
-    assertEquals(compacts.get(0).getTxnId(), openTxns.get(0).getId());
-    assertEquals(TxnState.ABORTED, openTxns.get(0).getState());
+    TxnInfo txn = openTxns.get(0);
+    assertEquals(compacts.get(0).getTxnId(), txn.getId());
+    assertEquals(TxnState.OPEN, txn.getState());
+    txnHandler.abortTxn(new AbortTxnRequest(txn.getId()));
   }
 
   @Test
   public void testExceptionWhenTxnCommit() throws Exception {
-    prepareTableForCompactionFailureTests("default", "campcnb");
+    prepareTableAndCompaction("default", "tableForCommitError");
     runWorkerWithException(MethodToFail.COMMIT_TXN);
 
     List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
@@ -1235,22 +1235,107 @@ public class TestWorker extends CompactorTest {
     assertEquals(1, openTxns.size());
     TxnInfo txn = openTxns.get(0);
     assertEquals(compaction.getTxnId(), txn.getId());
-    assertEquals(TxnState.ABORTED, txn.getState());
+    assertEquals(TxnState.OPEN, txn.getState());
+    txnHandler.abortTxn(new AbortTxnRequest(txn.getId()));
   }
 
   @Test
   public void testExceptionWhenMarkCompacted() throws Exception {
-    prepareTableForCompactionFailureTests("default", "campcnb");
+    prepareTableAndCompaction("default", "tableForMarkCompactedError");
     runWorkerWithException(MethodToFail.MARK_COMPACTED);
 
     List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
     ShowCompactResponseElement compaction = compacts.get(0);
     assertEquals(TxnStore.FAILED_RESPONSE, compaction.getState());
     assertEquals("Simulated failure in markCompacted", compaction.getErrorMessage());
-    assertNotNull(compaction.getNextTxnId());
-
     List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
     assertEquals(0, openTxns.size());
+  }
+
+  @Test
+  public void testExceptionDuringCompact() throws Exception {
+    prepareTableAndCompaction("default", "tableForCompactError");
+    HiveConf.setBoolVar(conf, HiveConf.ConfVars.HIVE_IN_TEST, true);
+    HiveConf.setBoolVar(conf, HiveConf.ConfVars.HIVE_TEST_MODE_FAIL_COMPACTION, true);
+    startWorker();
+
+    List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
+    ShowCompactResponseElement compaction = compacts.get(0);
+    assertEquals(TxnStore.FAILED_RESPONSE, compaction.getState());
+    assertEquals("HIVE_TEST_MODE_FAIL_COMPACTION=true", compaction.getErrorMessage());
+    List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
+    assertEquals(1, openTxns.size());
+    TxnInfo txn = openTxns.get(0);
+    assertEquals(compaction.getTxnId(), txn.getId());
+    assertEquals(TxnState.ABORTED, txn.getState());
+  }
+
+  @Test
+  public void testWorkerIfIsDynPartAbort() throws Exception {
+    String dbName = "default";
+    String tableName = "tableWithPartition";
+    Table t = newTable(dbName, tableName, true);
+    addBaseFile(t, null, 1L, 3, 1);
+    addDeltaFile(t, null, 2L, 2L, 1);
+    addDeltaFile(t, null, 3L, 3L, 1);
+    addDeltaFile(t, null, 4L, 4L, 1);
+    burnThroughTransactions(dbName, tableName, 4, null, null);
+    // trigger compaction
+    CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MAJOR);
+    rqst.setPartitionname(null);
+    txnHandler.compact(rqst);
+    startWorker();
+
+    List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
+    ShowCompactResponseElement compaction = compacts.get(0);
+    assertEquals(TxnStore.CLEANING_RESPONSE, compaction.getState());
+    assertTrue(compaction.getNextTxnId() > 0L);
+    List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
+    assertEquals(0, openTxns.size());
+  }
+
+  @Test
+  public void testWorkerNotEnoughToCompact() throws Exception {
+    String dbName = "default";
+    String tableName = "tableWithNoDelta";
+    Table t = newTable(dbName, tableName, false);
+    addBaseFile(t, null, 1L, 3, 1);
+    burnThroughTransactions(dbName, tableName, 1, null, null);
+    // trigger compaction
+    CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MAJOR);
+    txnHandler.compact(rqst);
+    startWorker();
+
+    List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
+    ShowCompactResponseElement compaction = compacts.get(0);
+    assertEquals(TxnStore.REFUSED_RESPONSE, compaction.getState());
+    assertTrue(compaction.getErrorMessage().contains("None of the compaction thresholds met, compaction request is refused!"));
+    List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
+    assertEquals(0, openTxns.size());
+  }
+
+  @Test
+  public void testWorkerNotEnoughToCompactNeedsCleaning() throws Exception {
+    String dbName = "default";
+    String tableName = "tableNeedsCleaning";
+    Table t = newTable(dbName, tableName, false);
+    addDeltaFile(t, null, 1L, 1L, 1);
+    addDeltaFile(t, null, 2L, 2L, 1);
+    addBaseFile(t, null, 4L, 3, 6);
+    burnThroughTransactions(dbName, tableName, 6, null, new HashSet<Long>(Arrays.asList(1L, 2L)));
+    // trigger compaction
+    CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MAJOR);
+    txnHandler.compact(rqst);
+    startWorker();
+
+    List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
+    ShowCompactResponseElement compaction = compacts.get(0);
+    assertEquals(TxnStore.CLEANING_RESPONSE, compaction.getState());
+    assertTrue(compaction.getNextTxnId() > 0L);
+    List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
+    assertEquals(2, openTxns.size());
+    assertEquals(1L, openTxns.get(0).getId());
+    assertEquals(2L, openTxns.get(1).getId());
   }
 
   private void runWorkerWithException(MethodToFail... methodToFail) throws Exception {
@@ -1275,9 +1360,9 @@ public class TestWorker extends CompactorTest {
     ct.run();
   }
 
-  private void prepareTableForCompactionFailureTests(String dbName, String tableName) throws Exception {
+  private void prepareTableAndCompaction(String dbName, String tableName) throws Exception {
     Table t = newTable(dbName, tableName, false);
-    addBaseFile(t, null, 1L, 3, 2);
+    addBaseFile(t, null, 1L, 3, 1);
     addDeltaFile(t, null, 2L, 2L, 1);
     addDeltaFile(t, null, 3L, 3L, 1);
     addDeltaFile(t, null, 4L, 4L, 1);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.MetastoreTaskThread;
 import org.apache.hadoop.hive.metastore.TransactionalValidationListener;
 import org.apache.hadoop.hive.metastore.api.CompactionRequest;
 import org.apache.hadoop.hive.metastore.api.CompactionType;
@@ -39,9 +40,14 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.TxnInfo;
 import org.apache.hadoop.hive.metastore.api.TxnState;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
+import org.apache.hadoop.hive.metastore.txn.service.AcidHouseKeeperService;
 import org.apache.hadoop.hive.metastore.utils.StringableMap;
+import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -70,8 +76,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.hive.common.AcidConstants.VISIBILITY_PATTERN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -100,9 +110,9 @@ public class TestWorker extends CompactorTest {
     // Empty map case
     StringableMap m = new StringableMap(new HashMap<String, String>());
     String s = m.toString();
-    Assert.assertEquals("0:", s);
+    assertEquals("0:", s);
     m = new StringableMap(s);
-    Assert.assertEquals(0, m.size());
+    assertEquals(0, m.size());
 
     Map<String, String> base = new HashMap<String, String>();
     base.put("mary", "poppins");
@@ -111,19 +121,19 @@ public class TestWorker extends CompactorTest {
     m = new StringableMap(base);
     s = m.toString();
     m = new StringableMap(s);
-    Assert.assertEquals(3, m.size());
+    assertEquals(3, m.size());
     Map<String, Boolean> saw = new HashMap<String, Boolean>(3);
     saw.put("mary", false);
     saw.put("bert", false);
     saw.put(null, false);
     for (Map.Entry<String, String> e : m.entrySet()) {
       saw.put(e.getKey(), true);
-      if ("mary".equals(e.getKey())) Assert.assertEquals("poppins", e.getValue());
+      if ("mary".equals(e.getKey())) assertEquals("poppins", e.getValue());
       else if ("bert".equals(e.getKey())) Assert.assertNull(e.getValue());
-      else if (null == e.getKey()) Assert.assertEquals("banks", e.getValue());
+      else if (null == e.getKey()) assertEquals("banks", e.getValue());
       else Assert.fail("Unexpected value " + e.getKey());
     }
-    Assert.assertEquals(3, saw.size());
+    assertEquals(3, saw.size());
     Assert.assertTrue(saw.get("mary"));
     Assert.assertTrue(saw.get("bert"));
     Assert.assertTrue(saw.get(null));
@@ -134,9 +144,9 @@ public class TestWorker extends CompactorTest {
     // Empty list case
     MRCompactor.StringableList ls = new MRCompactor.StringableList();
     String s = ls.toString();
-    Assert.assertEquals("0:", s);
+    assertEquals("0:", s);
     ls = new MRCompactor.StringableList(s);
-    Assert.assertEquals(0, ls.size());
+    assertEquals(0, ls.size());
 
     ls = new MRCompactor.StringableList();
     ls.add(new Path("/tmp"));
@@ -145,7 +155,7 @@ public class TestWorker extends CompactorTest {
     Assert.assertTrue("Expected 2:4:/tmp4:/usr or 2:4:/usr4:/tmp, got " + s,
         "2:4:/tmp4:/usr".equals(s) || "2:4:/usr4:/tmp".equals(s));
     ls = new MRCompactor.StringableList(s);
-    Assert.assertEquals(2, ls.size());
+    assertEquals(2, ls.size());
     boolean sawTmp = false, sawUsr = false;
     for (Path p : ls) {
       if ("/tmp".equals(p.toString())) sawTmp = true;
@@ -181,10 +191,10 @@ public class TestWorker extends CompactorTest {
     MRCompactor.CompactorInputSplit split =
         new MRCompactor.CompactorInputSplit(conf, 3, files, new Path(basename), deltas, new HashMap<String, Integer>());
 
-    Assert.assertEquals(520L, split.getLength());
+    assertEquals(520L, split.getLength());
     String[] locations = split.getLocations();
-    Assert.assertEquals(1, locations.length);
-    Assert.assertEquals("localhost", locations[0]);
+    assertEquals(1, locations.length);
+    assertEquals("localhost", locations[0]);
 
     ByteArrayOutputStream buf = new ByteArrayOutputStream();
     DataOutput out = new DataOutputStream(buf);
@@ -194,12 +204,12 @@ public class TestWorker extends CompactorTest {
     DataInput in = new DataInputStream(new ByteArrayInputStream(buf.toByteArray()));
     split.readFields(in);
 
-    Assert.assertEquals(3, split.getBucket());
-    Assert.assertEquals(basename, split.getBaseDir().toString());
+    assertEquals(3, split.getBucket());
+    assertEquals(basename, split.getBaseDir().toString());
     deltas = split.getDeltaDirs();
-    Assert.assertEquals(2, deltas.length);
-    Assert.assertEquals(delta1, deltas[0].toString());
-    Assert.assertEquals(delta2, deltas[1].toString());
+    assertEquals(2, deltas.length);
+    assertEquals(delta1, deltas[0].toString());
+    assertEquals(delta2, deltas[1].toString());
   }
 
   @Test
@@ -234,12 +244,12 @@ public class TestWorker extends CompactorTest {
     DataInput in = new DataInputStream(new ByteArrayInputStream(buf.toByteArray()));
     split.readFields(in);
 
-    Assert.assertEquals(3, split.getBucket());
+    assertEquals(3, split.getBucket());
     Assert.assertNull(split.getBaseDir());
     deltas = split.getDeltaDirs();
-    Assert.assertEquals(2, deltas.length);
-    Assert.assertEquals(delta1, deltas[0].toString());
-    Assert.assertEquals(delta2, deltas[1].toString());
+    assertEquals(2, deltas.length);
+    assertEquals(delta1, deltas[0].toString());
+    assertEquals(delta2, deltas[1].toString());
   }
 
   @Test
@@ -264,7 +274,7 @@ public class TestWorker extends CompactorTest {
     // There should still be four directories in the location.
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(4, stat.length);
+    assertEquals(4, stat.length);
   }
 
   @Test
@@ -291,7 +301,7 @@ public class TestWorker extends CompactorTest {
     // There should still be four directories in the location.
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(p.getSd().getLocation()));
-    Assert.assertEquals(4, stat.length);
+    assertEquals(4, stat.length);
   }
 
   @Test
@@ -312,13 +322,13 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still now be 5 directories in the location
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(5, stat.length);
+    assertEquals(5, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     boolean sawNewDelta = false;
@@ -326,20 +336,20 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals(makeDeltaDirNameCompacted(21, 24) + "_v0000026")) {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(104L, buckets[0].getLen());
-        Assert.assertEquals(104L, buckets[1].getLen());
+        assertEquals(104L, buckets[0].getLen());
+        assertEquals(104L, buckets[1].getLen());
       }
       if (stat[i].getPath().getName().equals(makeDeleteDeltaDirNameCompacted(21, 24) + "_v0000026")) {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(104L, buckets[0].getLen());
-        Assert.assertEquals(104L, buckets[1].getLen());
+        assertEquals(104L, buckets[0].getLen());
+        assertEquals(104L, buckets[1].getLen());
       }
       else {
         LOG.debug("This is not the delta file you are looking for " + stat[i].getPath().getName());
@@ -372,20 +382,20 @@ public class TestWorker extends CompactorTest {
     // since compaction was not run, state should not be "ready for cleaning" but "refused"
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals(TxnStore.REFUSED_RESPONSE, compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals(TxnStore.REFUSED_RESPONSE, compacts.get(0).getState());
 
     // There should still be 4 directories in the location
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(toString(stat), 4, stat.length);
+    assertEquals(toString(stat), 4, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     Arrays.sort(stat);
-    Assert.assertEquals("base_20", stat[0].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(21, 22), stat[1].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(23, 25), stat[2].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(26, 27), stat[3].getPath().getName());
+    assertEquals("base_20", stat[0].getPath().getName());
+    assertEquals(makeDeltaDirName(21, 22), stat[1].getPath().getName());
+    assertEquals(makeDeltaDirName(23, 25), stat[2].getPath().getName());
+    assertEquals(makeDeltaDirName(26, 27), stat[3].getPath().getName());
   }
 
   @Test
@@ -407,22 +417,22 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still now be 6 directories in the location
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(6, stat.length);
+    assertEquals(6, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     Arrays.sort(stat);
-    Assert.assertEquals("base_20", stat[0].getPath().getName());
-    Assert.assertEquals(makeDeleteDeltaDirNameCompacted(21, 27) + "_v0000028", stat[1].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(21, 22), stat[2].getPath().getName());
-    Assert.assertEquals(makeDeltaDirNameCompacted(21, 27) + "_v0000028", stat[3].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(23, 25), stat[4].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(26, 27), stat[5].getPath().getName());
+    assertEquals("base_20", stat[0].getPath().getName());
+    assertEquals(makeDeleteDeltaDirNameCompacted(21, 27) + "_v0000028", stat[1].getPath().getName());
+    assertEquals(makeDeltaDirName(21, 22), stat[2].getPath().getName());
+    assertEquals(makeDeltaDirNameCompacted(21, 27) + "_v0000028", stat[3].getPath().getName());
+    assertEquals(makeDeltaDirName(23, 25), stat[4].getPath().getName());
+    assertEquals(makeDeltaDirName(26, 27), stat[5].getPath().getName());
   }
 
   @Test
@@ -444,13 +454,13 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still be four directories in the location.
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(p.getSd().getLocation()));
-    Assert.assertEquals(5, stat.length);
+    assertEquals(5, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     boolean sawNewDelta = false;
@@ -458,20 +468,20 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals(makeDeltaDirNameCompacted(21, 24) + "_v0000026")) {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(104L, buckets[0].getLen());
-        Assert.assertEquals(104L, buckets[1].getLen());
+        assertEquals(104L, buckets[0].getLen());
+        assertEquals(104L, buckets[1].getLen());
       }
       if (stat[i].getPath().getName().equals(makeDeleteDeltaDirNameCompacted(21, 24))) {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(104L, buckets[0].getLen());
-        Assert.assertEquals(104L, buckets[1].getLen());
+        assertEquals(104L, buckets[0].getLen());
+        assertEquals(104L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the delta file you are looking for " + stat[i].getPath().getName());
       }
@@ -496,13 +506,13 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still now be 5 directories in the location
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(4, stat.length);
+    assertEquals(4, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     boolean sawNewDelta = false;
@@ -510,20 +520,20 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals(makeDeltaDirNameCompacted(1, 4) + "_v0000006")) {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(104L, buckets[0].getLen());
-        Assert.assertEquals(104L, buckets[1].getLen());
+        assertEquals(104L, buckets[0].getLen());
+        assertEquals(104L, buckets[1].getLen());
       }
       if (stat[i].getPath().getName().equals(makeDeleteDeltaDirNameCompacted(1, 4) + "_v0000006")) {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(104L, buckets[0].getLen());
-        Assert.assertEquals(104L, buckets[1].getLen());
+        assertEquals(104L, buckets[0].getLen());
+        assertEquals(104L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the delta file you are looking for " + stat[i].getPath().getName());
       }
@@ -549,13 +559,13 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still now be 5 directories in the location
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(4, stat.length);
+    assertEquals(4, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     boolean sawNewBase = false;
@@ -563,11 +573,11 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals("base_0000024_v0000026")) {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(624L, buckets[0].getLen());
-        Assert.assertEquals(624L, buckets[1].getLen());
+        assertEquals(624L, buckets[0].getLen());
+        assertEquals(624L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
@@ -625,14 +635,14 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(p.getSd().getLocation()));
     /* delete_delta_21_23 and delete_delta_25_33 which are created as a result of compacting*/
     int numFilesExpected = 11 + (type == CompactionType.MINOR ? 1 : 0);
-    Assert.assertEquals(numFilesExpected, stat.length);
+    assertEquals(numFilesExpected, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     List<String> matchesNotFound = new ArrayList<>(numFilesExpected);
@@ -687,13 +697,13 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still be four directories in the location.
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(p.getSd().getLocation()));
-    Assert.assertEquals(4, stat.length);
+    assertEquals(4, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     boolean sawNewBase = false;
@@ -701,11 +711,11 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals("base_0000024_v0000026")) {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(624L, buckets[0].getLen());
-        Assert.assertEquals(624L, buckets[1].getLen());
+        assertEquals(624L, buckets[0].getLen());
+        assertEquals(624L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
@@ -730,13 +740,13 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should now be 3 directories in the location
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(3, stat.length);
+    assertEquals(3, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     boolean sawNewBase = false;
@@ -744,11 +754,11 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals("base_0000004_v0000005")) {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(104L, buckets[0].getLen());
-        Assert.assertEquals(104L, buckets[1].getLen());
+        assertEquals(104L, buckets[0].getLen());
+        assertEquals(104L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
@@ -785,8 +795,8 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still now be 5 directories in the location
     FileSystem fs = FileSystem.get(conf);
@@ -799,11 +809,11 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals("base_0000024_v0000026")) {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
-        Assert.assertEquals(624L, buckets[0].getLen());
-        Assert.assertEquals(624L, buckets[1].getLen());
+        assertEquals(624L, buckets[0].getLen());
+        assertEquals(624L, buckets[1].getLen());
       } else {
         LOG.debug("This is not the file you are looking for " + stat[i].getPath().getName());
       }
@@ -829,8 +839,8 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still now be 5 directories in the location
     FileSystem fs = FileSystem.get(conf);
@@ -842,7 +852,7 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals(makeDeltaDirNameCompacted(21, 24) + "_v0000026")) {
         sawNewDelta = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
       } else {
@@ -873,13 +883,13 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still be four directories in the location.
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(p.getSd().getLocation()));
-    Assert.assertEquals(4, stat.length);
+    assertEquals(4, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     boolean sawNewBase = false;
@@ -887,7 +897,7 @@ public class TestWorker extends CompactorTest {
       if (stat[i].getPath().getName().equals("base_0000026_v0000028")) {
         sawNewBase = true;
         FileStatus[] buckets = fs.listStatus(stat[i].getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-        Assert.assertEquals(2, buckets.length);
+        assertEquals(2, buckets.length);
         Assert.assertTrue(buckets[0].getPath().getName().matches("bucket_0000[01]"));
         Assert.assertTrue(buckets[1].getPath().getName().matches("bucket_0000[01]"));
         // Bucket 0 should be small and bucket 1 should be large, make sure that's the case
@@ -926,21 +936,21 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still now be 5 directories in the location
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(5, stat.length);
+    assertEquals(5, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     Arrays.sort(stat);
-    Assert.assertEquals("base_0000022_v0000028", stat[0].getPath().getName());
-    Assert.assertEquals("base_20", stat[1].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(21, 22), stat[2].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(23, 25), stat[3].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(26, 27), stat[4].getPath().getName());
+    assertEquals("base_0000022_v0000028", stat[0].getPath().getName());
+    assertEquals("base_20", stat[1].getPath().getName());
+    assertEquals(makeDeltaDirName(21, 22), stat[2].getPath().getName());
+    assertEquals(makeDeltaDirName(23, 25), stat[3].getPath().getName());
+    assertEquals(makeDeltaDirName(26, 27), stat[4].getPath().getName());
   }
 
   @Test
@@ -962,21 +972,21 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
 
     // There should still now be 5 directories in the location
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(5, stat.length);
+    assertEquals(5, stat.length);
 
     // Find the new delta file and make sure it has the right contents
     Arrays.sort(stat);
-    Assert.assertEquals("base_0000027_v0000028", stat[0].getPath().getName());
-    Assert.assertEquals("base_20", stat[1].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(21, 22), stat[2].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(23, 25), stat[3].getPath().getName());
-    Assert.assertEquals(makeDeltaDirName(26, 27), stat[4].getPath().getName());
+    assertEquals("base_0000027_v0000028", stat[0].getPath().getName());
+    assertEquals("base_20", stat[1].getPath().getName());
+    assertEquals(makeDeltaDirName(21, 22), stat[2].getPath().getName());
+    assertEquals(makeDeltaDirName(23, 25), stat[3].getPath().getName());
+    assertEquals(makeDeltaDirName(26, 27), stat[4].getPath().getName());
   }
   @Override
   boolean useHive130DeltaDirName() {
@@ -1008,10 +1018,10 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("ready for cleaning", compacts.get(0).getState());
-    Assert.assertEquals(initiatorVersion, compacts.get(0).getInitiatorVersion());
-    Assert.assertEquals(workerVersion, compacts.get(0).getWorkerVersion());
+    assertEquals(1, compacts.size());
+    assertEquals("ready for cleaning", compacts.get(0).getState());
+    assertEquals(initiatorVersion, compacts.get(0).getInitiatorVersion());
+    assertEquals(workerVersion, compacts.get(0).getWorkerVersion());
 
   }
 
@@ -1072,7 +1082,7 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(0, compacts.size());
+    assertEquals(0, compacts.size());
   }
 
   @Test
@@ -1097,7 +1107,7 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(0, compacts.size());
+    assertEquals(0, compacts.size());
   }
 
   @Test
@@ -1148,8 +1158,8 @@ public class TestWorker extends CompactorTest {
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
-    Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals("failed", compacts.get(0).getState());
+    assertEquals(1, compacts.size());
+    assertEquals("failed", compacts.get(0).getState());
 
   }
 
@@ -1162,21 +1172,21 @@ public class TestWorker extends CompactorTest {
     // Compaction should not have run on a single delta file
     FileSystem fs = FileSystem.get(conf);
     FileStatus[] stat = fs.listStatus(new Path(t.getSd().getLocation()));
-    Assert.assertEquals(1, stat.length);
-    Assert.assertEquals(makeDeltaDirName(0, 2), stat[0].getPath().getName());
+    assertEquals(1, stat.length);
+    assertEquals(makeDeltaDirName(0, 2), stat[0].getPath().getName());
 
     // State should not be "ready for cleaning" because we skip cleaning
     List<ShowCompactResponseElement> compacts =
         txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
-    Assert.assertEquals(compactionNum + 1, compacts.size());
-    Assert.assertEquals(TxnStore.REFUSED_RESPONSE, compacts.get(compactionNum).getState());
+    assertEquals(compactionNum + 1, compacts.size());
+    assertEquals(TxnStore.REFUSED_RESPONSE, compacts.get(compactionNum).getState());
 
     // assert transaction with txnId=1 is still aborted after cleaner is run
     startCleaner();
     List<TxnInfo> openTxns =
         HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
-    Assert.assertEquals(1, openTxns.get(0).getId());
-    Assert.assertEquals(TxnState.ABORTED, openTxns.get(0).getState());
+    assertEquals(1, openTxns.get(0).getId());
+    assertEquals(TxnState.ABORTED, openTxns.get(0).getState());
   }
 
   // With high timeout, but fast run we should finish without a problem
@@ -1195,6 +1205,92 @@ public class TestWorker extends CompactorTest {
   @Test(timeout=2000)
   public void testTimeoutWithoutInterrupt() throws Exception {
     runTimeoutTest(1, true, true);
+  }
+
+  @Test
+  public void testExceptionWhenTxnCommitAndMarkFailed() throws Exception {
+    prepareTableForCompactionFailureTests("default", "campcnb");
+    runWorkerWithException(MethodToFail.COMMIT_TXN, MethodToFail.MARK_FAILED);
+
+    List<ShowCompactResponseElement> compacts =
+        txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
+    assertEquals(TxnStore.WORKING_RESPONSE, compacts.get(0).getState());
+
+    List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
+    assertEquals(1, openTxns.size());
+    assertEquals(compacts.get(0).getTxnId(), openTxns.get(0).getId());
+    assertEquals(TxnState.ABORTED, openTxns.get(0).getState());
+  }
+
+  @Test
+  public void testExceptionWhenTxnCommit() throws Exception {
+    prepareTableForCompactionFailureTests("default", "campcnb");
+    runWorkerWithException(MethodToFail.COMMIT_TXN);
+
+    List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
+    ShowCompactResponseElement compaction = compacts.get(0);
+    assertEquals(TxnStore.FAILED_RESPONSE, compaction.getState());
+    assertEquals("Simulated failure in commitTxn", compaction.getErrorMessage());
+    List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
+    assertEquals(1, openTxns.size());
+    TxnInfo txn = openTxns.get(0);
+    assertEquals(compaction.getTxnId(), txn.getId());
+    assertEquals(TxnState.ABORTED, txn.getState());
+  }
+
+  @Test
+  public void testExceptionWhenMarkCompacted() throws Exception {
+    prepareTableForCompactionFailureTests("default", "campcnb");
+    runWorkerWithException(MethodToFail.MARK_COMPACTED);
+
+    List<ShowCompactResponseElement> compacts = txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
+    ShowCompactResponseElement compaction = compacts.get(0);
+    assertEquals(TxnStore.FAILED_RESPONSE, compaction.getState());
+    assertEquals("Simulated failure in markCompacted", compaction.getErrorMessage());
+    assertNotNull(compaction.getNextTxnId());
+
+    List<TxnInfo> openTxns = HiveMetaStoreUtils.getHiveMetastoreClient(conf).showTxns().getOpen_txns();
+    assertEquals(0, openTxns.size());
+  }
+
+  private void runWorkerWithException(MethodToFail... methodToFail) throws Exception {
+    IMetaStoreClient spyMsc = Mockito.spy(ms);
+    for (MethodToFail method: methodToFail) {
+      switch (method) {
+      case MARK_FAILED -> doThrow(new TTransportException("Simulated failure in markFailed")).when(spyMsc).markFailed(any());
+      case COMMIT_TXN -> doThrow(new TException("Simulated failure in commitTxn")).when(spyMsc).commitTxn(anyLong());
+      case MARK_COMPACTED -> doThrow(new TTransportException("Simulated failure in markCompacted")).when(spyMsc).markCompacted(any());
+      }
+    }
+
+    TestTxnDbUtil.setConfValues(conf);
+    Worker worker = Mockito.spy(new Worker());
+    worker.setConf(conf);
+    AtomicBoolean stop = new AtomicBoolean();
+    stop.set(true);
+    worker.init(stop);
+    worker.msc = spyMsc;
+    worker.setName("testworker");
+    CompactorThread ct = worker;
+    ct.run();
+  }
+
+  private void prepareTableForCompactionFailureTests(String dbName, String tableName) throws Exception {
+    Table t = newTable(dbName, tableName, false);
+    addBaseFile(t, null, 1L, 3, 2);
+    addDeltaFile(t, null, 2L, 2L, 1);
+    addDeltaFile(t, null, 3L, 3L, 1);
+    addDeltaFile(t, null, 4L, 4L, 1);
+    burnThroughTransactions(dbName, tableName, 4, null, null);
+    // trigger compaction
+    CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MAJOR);
+    txnHandler.compact(rqst);
+  }
+
+  enum MethodToFail {
+    MARK_COMPACTED,
+    MARK_FAILED,
+    COMMIT_TXN;
   }
 
   private void runTimeoutTest(long timeout, boolean runForever, boolean swallowInterrupt) throws Exception {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Change how the compaction gets committed by first committing its txn and just after that mark the compaction as ready for cleaning.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently the markCompacted call and the commitTxn call happens separately. The markCompacted call happens in the AcidCompactionService.compact method while the commitTxn happens in the close() method. This could lead to inconsistent state that the compaction is marked as finished and ready for cleaning, but the compaction transaction is still open.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
By unit tests
Ran the following unit tests against the master branch as well to see if there is no regression in these use-cases. They should not be affected by the changes in this patch.
- testExceptionDuringCompact
- testWorkerIfIsDynPartAbort
- testWorkerNotEnoughToCompact
- testWorkerNotEnoughToCompactNeedsCleaning