### PR TITLE
HIVE-29635: HS2 WebUI "Start Time" shows current time on every refresh

### DIFF
--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -465,9 +465,11 @@ public class HiveServer2 extends CompositeService {
     builder.setContextAttribute("hs2.failover.callback", new FailoverHandlerCallback(hs2HARegistry));
   }
   
-  private static HttpServer.Builder createHttpServerBuilder(String webHost, int port, String name, String contextPath,
+  @VisibleForTesting
+  static HttpServer.Builder createHttpServerBuilder(String webHost, int port, String name, String contextPath,
       HiveConf hiveConf, CLIService cliService, PamAuthenticator pamAuthenticator) throws IOException {
     HttpServer.Builder builder = new HttpServer.Builder(name);
+    hiveConf.set("startcode", String.valueOf(System.currentTimeMillis()));
     builder.setConf(hiveConf);
     builder.setHost(webHost);
     builder.setPort(port);
@@ -476,7 +478,6 @@ public class HiveServer2 extends CompositeService {
     builder.setAdmins(hiveConf.getVar(ConfVars.USERS_IN_ADMIN_ROLE));
     // SessionManager is initialized
     builder.setContextAttribute("hive.sm", cliService.getSessionManager());
-    hiveConf.set("startcode", String.valueOf(System.currentTimeMillis()));
     if (hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_SSL)) {
       String keyStorePath = hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYSTORE_PATH);
       if (StringUtils.isBlank(keyStorePath)) {

--- a/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
+++ b/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
@@ -119,8 +119,6 @@ public class TestHiveServer2 {
 
     HttpServer.Builder builder = HiveServer2.createHttpServerBuilder(
         "localhost", 0, "test", "/", conf, cli, null);
-    Thread.sleep(1000);
-    long now = System.currentTimeMillis();
 
     // setConf stores a *copy* of the conf on the Builder. Read that copy back via
     // reflection — that's the same instance the servlet context exposes to the JSP.
@@ -128,11 +126,6 @@ public class TestHiveServer2 {
     confField.setAccessible(true);
     HiveConf builderConf = (HiveConf) confField.get(builder);
     assertNotNull("Builder.conf must be set after createHttpServerBuilder", builderConf);
-
-    String startcodeStr = builderConf.get("startcode");
-    assertNotNull(startcodeStr);
-    long startcode = Long.parseLong(startcodeStr);
-    assertTrue("startcode " + startcode + " should be < test end " + now,
-        startcode < now);
+    assertNotNull("startcode must be exists", builderConf.get("startcode"));
   }
 }

--- a/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
+++ b/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
@@ -21,9 +21,19 @@ package org.apache.hive.service.server;
 import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hive.http.HttpServer;
+import org.apache.hive.service.cli.CLIService;
+import org.apache.hive.service.cli.session.SessionManager;
 import org.junit.Test;
+
+import java.lang.reflect.Field;
 import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestHiveServer2 {
 
@@ -97,5 +107,36 @@ public class TestHiveServer2 {
     assertEquals(Integer.valueOf(4), startedWorkers.get("pool2"));
     assertEquals(Integer.valueOf(5), startedWorkers.get("pool3"));
     assertEquals(Integer.valueOf(3), startedWorkers.get(Constants.COMPACTION_DEFAULT_POOL));
+  }
+
+  @Test
+  public void testCreateHttpServerBuilderStampsStartcodeBeforeConfIsCopied() throws Exception {
+    HiveConf conf = new HiveConf();
+
+    CLIService cli = mock(CLIService.class);
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(cli.getSessionManager()).thenReturn(sessionManager);
+
+    long before = System.currentTimeMillis();
+    Thread.sleep(1000);
+    HttpServer.Builder builder = HiveServer2.createHttpServerBuilder(
+        "localhost", 0, "test", "/", conf, cli, null);
+    Thread.sleep(1000);
+    long after = System.currentTimeMillis();
+
+    // setConf stores a *copy* of the conf on the Builder. Read that copy back via
+    // reflection — that's the same instance the servlet context exposes to the JSP.
+    Field confField = HttpServer.Builder.class.getDeclaredField("conf");
+    confField.setAccessible(true);
+    HiveConf builderConf = (HiveConf) confField.get(builder);
+    assertNotNull("Builder.conf must be set after createHttpServerBuilder", builderConf);
+
+    String startcodeStr = builderConf.get("startcode");
+    assertNotNull(startcodeStr);
+    long startcode = Long.parseLong(startcodeStr);
+    assertTrue("startcode " + startcode + " should be > test start " + before,
+        startcode > before);
+    assertTrue("startcode " + startcode + " should be < test end " + after,
+        startcode < after);
   }
 }

--- a/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
+++ b/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
@@ -117,12 +117,10 @@ public class TestHiveServer2 {
     SessionManager sessionManager = mock(SessionManager.class);
     when(cli.getSessionManager()).thenReturn(sessionManager);
 
-    long before = System.currentTimeMillis();
-    Thread.sleep(1000);
     HttpServer.Builder builder = HiveServer2.createHttpServerBuilder(
         "localhost", 0, "test", "/", conf, cli, null);
     Thread.sleep(1000);
-    long after = System.currentTimeMillis();
+    long now = System.currentTimeMillis();
 
     // setConf stores a *copy* of the conf on the Builder. Read that copy back via
     // reflection — that's the same instance the servlet context exposes to the JSP.
@@ -134,9 +132,7 @@ public class TestHiveServer2 {
     String startcodeStr = builderConf.get("startcode");
     assertNotNull(startcodeStr);
     long startcode = Long.parseLong(startcodeStr);
-    assertTrue("startcode " + startcode + " should be > test start " + before,
-        startcode > before);
-    assertTrue("startcode " + startcode + " should be < test end " + after,
-        startcode < after);
+    assertTrue("startcode " + startcode + " should be < test end " + now,
+        startcode < now);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

HIVE-29635


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


Move `hiveConf.set("startcode", ...)` to before `builder.setConf(hiveConf)` in `HiveServer2#createHttpServerBuilder`. One-line move.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

HttpServer.Builder#setConf defensively copies the conf into the servlet context. The previous code wrote startcode after the copy, so the JSP reading from the copy never saw it and fell through to its System.currentTimeMillis() default — making the WebUI "Start Time" advance on every refresh.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. WebUI "HiveServer2 Start Time" now shows the actual server start time and stays stable across refreshes.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

