### PR TITLE
HIVE-29571: ACID Compaction: Refused compaction Txn should not be aborted

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/service/AcidCompactionService.java
@@ -126,57 +126,56 @@ public class AcidCompactionService extends CompactionService {
   
   public Boolean compact(Table table, CompactionInfo ci) throws Exception {
 
-    try (CompactionTxn compactionTxn = new CompactionTxn()) {
+    if (ci.isRebalanceCompaction() && table.getSd().getNumBuckets() > 0) {
+      LOG.error("Cannot execute rebalancing compaction on bucketed tables.");
+      ci.errorMessage = "Cannot execute rebalancing compaction on bucketed tables.";
+      msc.markRefused(CompactionInfo.compactionInfoToStruct(ci));
+      return false;
+    }
 
-      if (ci.isRebalanceCompaction() && table.getSd().getNumBuckets() > 0) {
-        LOG.error("Cannot execute rebalancing compaction on bucketed tables.");
-        ci.errorMessage = "Cannot execute rebalancing compaction on bucketed tables.";
+    if (!ci.type.equals(CompactionType.REBALANCE) && ci.numberOfBuckets > 0) {
+      if (LOG.isWarnEnabled()) {
+        LOG.warn("Only the REBALANCE compaction accepts the number of buckets clause (CLUSTERED INTO {N} BUCKETS). " +
+            "Since the compaction request is {}, it will be ignored.", ci.type);
+      }
+    }
+
+    String fullTableName = TxnUtils.getFullTableName(table.getDbName(), table.getTableName());
+
+    // Find the partition we will be working with, if there is one.
+    Partition p;
+    try {
+      p = CompactorUtil.resolvePartition(conf, msc, ci.dbname, ci.tableName, ci.partName,
+          CompactorUtil.METADATA_FETCH_MODE.REMOTE);
+      if (p == null && ci.partName != null) {
+        ci.errorMessage = "Unable to find partition " + ci.getFullPartitionName() + ", assuming it was dropped and moving on.";
+        LOG.warn(ci.errorMessage + " Compaction info: {}", ci);
         msc.markRefused(CompactionInfo.compactionInfoToStruct(ci));
         return false;
       }
+    } catch (Exception e) {
+      LOG.error("Unexpected error during resolving partition.", e);
+      ci.errorMessage = e.getMessage();
+      msc.markFailed(CompactionInfo.compactionInfoToStruct(ci));
+      return false;
+    }
 
-      if (!ci.type.equals(CompactionType.REBALANCE) && ci.numberOfBuckets > 0) {
-        if (LOG.isWarnEnabled()) {
-          LOG.warn("Only the REBALANCE compaction accepts the number of buckets clause (CLUSTERED INTO {N} BUCKETS). " +
-              "Since the compaction request is {}, it will be ignored.", ci.type);
-        }
-      }
+    CompactorUtil.checkInterrupt(CLASS_NAME);
 
-      String fullTableName = TxnUtils.getFullTableName(table.getDbName(), table.getTableName());
+    // Find the appropriate storage descriptor
+    sd =  CompactorUtil.resolveStorageDescriptor(table, p);
 
-      // Find the partition we will be working with, if there is one.
-      Partition p;
-      try {
-        p = CompactorUtil.resolvePartition(conf, msc, ci.dbname, ci.tableName, ci.partName,
-            CompactorUtil.METADATA_FETCH_MODE.REMOTE);
-        if (p == null && ci.partName != null) {
-          ci.errorMessage = "Unable to find partition " + ci.getFullPartitionName() + ", assuming it was dropped and moving on.";
-          LOG.warn(ci.errorMessage + " Compaction info: {}", ci);
-          msc.markRefused(CompactionInfo.compactionInfoToStruct(ci));
-          return false;
-        }
-      } catch (Exception e) {
-        LOG.error("Unexpected error during resolving partition.", e);
-        ci.errorMessage = e.getMessage();
-        msc.markFailed(CompactionInfo.compactionInfoToStruct(ci));
-        return false;
-      }
+    if (isTableSorted(sd, ci)) {
+      return false;
+    }
 
-      CompactorUtil.checkInterrupt(CLASS_NAME);
+    if (ci.runAs == null) {
+      ci.runAs = TxnUtils.findUserToRunAs(sd.getLocation(), table, conf);
+    }
 
-      // Find the appropriate storage descriptor
-      sd =  CompactorUtil.resolveStorageDescriptor(table, p);
+    CompactorUtil.checkInterrupt(CLASS_NAME);
 
-      if (isTableSorted(sd, ci)) {
-        return false;
-      }
-
-      if (ci.runAs == null) {
-        ci.runAs = TxnUtils.findUserToRunAs(sd.getLocation(), table, conf);
-      }
-
-      CompactorUtil.checkInterrupt(CLASS_NAME);
-
+    try (CompactionTxn compactionTxn = new CompactionTxn()) {
       /*
        * we cannot have Worker use HiveTxnManager (which is on ThreadLocal) since
        * then the Driver would already have the an open txn but then this txn would have
@@ -212,19 +211,21 @@ public class AcidCompactionService extends CompactionService {
 
       // Don't start compaction or cleaning if not necessary
       if (isDynPartAbort(table, ci)) {
-        compactionTxn.markForCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
+        compactionTxn.commit(() ->
+            msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
         return false;
       }
       dir = getAcidStateForWorker(ci, sd, tblValidWriteIds);
       if (!isEnoughToCompact(ci, dir, sd)) {
         if (needsCleaning(dir, sd)) {
-          compactionTxn.markForCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
+          compactionTxn.commit(() ->
+              msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
         } else {
           // do nothing
           ci.errorMessage = "None of the compaction thresholds met, compaction request is refused!";
           LOG.debug(ci.errorMessage + " Compaction info: {}", ci);
-          compactionTxn.markForCommit(() -> msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
-
+          compactionTxn.commit(() ->
+              msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
         }
         return false;
       }
@@ -232,7 +233,8 @@ public class AcidCompactionService extends CompactionService {
         ci.errorMessage = "Query based Minor compaction is not possible for full acid tables having raw format " +
             "(non-acid) data in them.";
         LOG.error(ci.errorMessage + " Compaction info: {}", ci);
-        compactionTxn.markForAbort(() -> msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
+        compactionTxn.commit(() ->
+            msc.markRefused(CompactionInfo.compactionInfoToStruct(ci)));
         return false;
       }
       CompactorUtil.checkInterrupt(CLASS_NAME);
@@ -240,12 +242,12 @@ public class AcidCompactionService extends CompactionService {
       try {
         failCompactionIfSetForTest();
 
-      /*
-      First try to run compaction via HiveQL queries.
-      Compaction for MM tables happens here, or run compaction for Crud tables if query-based compaction is enabled.
-      todo Find a more generic approach to collecting files in the same logical bucket to compact within the same
-      task (currently we're using Tez split grouping).
-      */
+        /*
+        First try to run compaction via HiveQL queries.
+        Compaction for MM tables happens here, or run compaction for Crud tables if query-based compaction is enabled.
+        todo Find a more generic approach to collecting files in the same logical bucket to compact within the same
+        task (currently we're using Tez split grouping).
+        */
         CompactorPipeline compactorPipeline = compactorFactory.getCompactorPipeline(table, conf, ci, msc);
         computeStats = (compactorPipeline.isMRCompaction() && collectMrStats) || collectGenericStats;
 
@@ -257,7 +259,8 @@ public class AcidCompactionService extends CompactionService {
 
         LOG.info("Completed " + ci.type.toString() + " compaction for " + ci.getFullPartitionName() + " in "
             + compactionTxn + ", marking as compacted.");
-        compactionTxn.markForCommit(() -> msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
+        compactionTxn.commit(() ->
+            msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci)));
 
         AcidMetricService.updateMetricsFromWorker(ci.dbname, ci.tableName, ci.partName, ci.type,
             dir.getCurrentDirectories().size(), dir.getDeleteDeltas().size(), conf, msc);
@@ -267,9 +270,6 @@ public class AcidCompactionService extends CompactionService {
       }
 
       return true;
-    } catch (Exception e) {
-      LOG.error("Caught exception in " + CLASS_NAME + " while trying to compact " + ci, e);
-      throw e;
     }
   }
 
@@ -341,11 +341,8 @@ public class AcidCompactionService extends CompactionService {
     private long lockId = 0;
 
     private TxnStatus status = TxnStatus.UNKNOWN;
-
-    private ThrowingRunnable onCommitSuccess;
-    private ThrowingRunnable onAbortSuccess;
-
     private boolean rollbackOnly = true;
+    private ThrowingRunnable<?> onCommitSuccess;
 
     /**
      * Try to open a new txn.
@@ -376,13 +373,9 @@ public class AcidCompactionService extends CompactionService {
       return CompactorUtil.createLockRequest(conf, ci, txnId, lockAndOpType.getKey(), lockAndOpType.getValue());
     }
 
-    void markForCommit(ThrowingRunnable action) {
+    void commit(ThrowingRunnable<?> postAction) {
       this.rollbackOnly = false;
-      this.onCommitSuccess = action;
-    }
-
-    void markForAbort(ThrowingRunnable action) {
-      this.onAbortSuccess = action;
+      this.onCommitSuccess = postAction;
     }
 
     /**
@@ -397,16 +390,13 @@ public class AcidCompactionService extends CompactionService {
         //the transaction is about to close, we can stop heartbeating regardless of it's state
         CompactionHeartbeatService.getInstance(conf).stopHeartbeat(txnId);
       } finally {
-        if (rollbackOnly) {
-          abort();
-          if (onAbortSuccess != null) {
-            onAbortSuccess.run();
+        if (!rollbackOnly) {
+          commit();
+          if (onCommitSuccess != null) {
+            onCommitSuccess.run();
           }
-          return;
-        }
-        commit();
-        if (onCommitSuccess != null) {
-          onCommitSuccess.run();
+        } else {
+          abort();
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Housekeeping and refactor
- moved CompactionTxn creation closer to it's usage;
- changed compactionTxn abort to commit for refused scenario;
- removed redundant catch-throw

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We don't need leftover TXN_COMPONENTS for the refused scenario

/this writes TXN_COMPONENTS to ensure that if compactorTxnId fails, we keep metadata about
//it until after any data written by it are physically removed
msc.updateCompactorState(CompactionInfo.compactionInfoToStruct(ci), compactionTxn.getTxnId());

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Jenkins
