### PR TITLE
HIVE-29639: Support a pluggable authentication filter for the HiveServer2 WebUI

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3869,6 +3869,12 @@ public class HiveConf extends Configuration {
         + " for HiveServer2 WebUI."),
     HIVE_SERVER2_WEBUI_SSL_KEYMANAGERFACTORY_ALGORITHM("hive.server2.webui.keymanagerfactory.algorithm",
         "","SSL certificate key manager factory algorithm for HiveServer2 WebUI."),
+    HIVE_SERVER2_WEBUI_USE_CUSTOM_AUTH_FILTER("hive.server2.webui.use.custom.auth.filter", false,
+        "If true, the HiveServer2 WebUI will be secured with custom auth filter"),
+    HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER("hive.server2.webui.custom.auth.filter", "",
+        "Filter class name to apply to the Web UI. The filter should be a standard javax servlet Filter. "
+        + "Filter parameters can also be specified in the configuration, by setting config entries of the form "
+        + "hive.server2.webui.custom.auth.filter.param.<param name>=<value>"),
     HIVE_SERVER2_WEBUI_USE_SPNEGO("hive.server2.webui.use.spnego", false,
         "If true, the HiveServer2 WebUI will be secured with SPNEGO. Clients must authenticate with Kerberos."),
     HIVE_SERVER2_WEBUI_SPNEGO_KEYTAB("hive.server2.webui.spnego.keytab", "",

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3869,12 +3869,6 @@ public class HiveConf extends Configuration {
         + " for HiveServer2 WebUI."),
     HIVE_SERVER2_WEBUI_SSL_KEYMANAGERFACTORY_ALGORITHM("hive.server2.webui.keymanagerfactory.algorithm",
         "","SSL certificate key manager factory algorithm for HiveServer2 WebUI."),
-    HIVE_SERVER2_WEBUI_USE_CUSTOM_AUTH_FILTER("hive.server2.webui.use.custom.auth.filter", false,
-        "If true, the HiveServer2 WebUI will be secured with custom auth filter"),
-    HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER("hive.server2.webui.custom.auth.filter", "",
-        "Filter class name to apply to the Web UI. The filter should be a standard javax servlet Filter. "
-        + "Filter parameters can also be specified in the configuration, by setting config entries of the form "
-        + "hive.server2.webui.custom.auth.filter.param.<param name>=<value>"),
     HIVE_SERVER2_WEBUI_USE_SPNEGO("hive.server2.webui.use.spnego", false,
         "If true, the HiveServer2 WebUI will be secured with SPNEGO. Clients must authenticate with Kerberos."),
     HIVE_SERVER2_WEBUI_SPNEGO_KEYTAB("hive.server2.webui.spnego.keytab", "",
@@ -3922,10 +3916,17 @@ public class HiveConf extends Configuration {
     HIVE_SERVER2_WEBUI_HTTP_COOKIE_PATH("hive.server2.ui.http.cookie.path", null,
         "Path for the HS2 generated cookies"),
     HIVE_SERVER2_WEBUI_AUTH_METHOD("hive.server2.webui.auth.method", "NONE",
-        new StringSet("NONE", "LDAP"),
+        new StringSet("NONE", "LDAP", "CUSTOM"),
         "HS2 WebUI authentication method available to clients to be set at session level.\n" +
             "  NONE: No authentication\n" +
-            "  LDAP" ),
+            "  LDAP\n" +
+            "  CUSTOM: Custom authentication filter\n" +
+            "     (Use with property hive.server2.webui.custom.auth.filter)"),
+    HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER("hive.server2.webui.custom.auth.filter", "",
+        "Filter class name to apply to the Web UI when " + "hive.server2.webui.auth.method" +
+            "=CUSTOM. The filter should be a standard javax servlet Filter. " +
+            "Filter parameters can also be specified in the configuration, by setting config entries of the form " +
+            "hive.server2.webui.custom.auth.filter.param.<param name>=<value>"),
     HIVE_SERVER2_SHOW_OPERATION_DRILLDOWN_LINK("hive.server2.show.operation.drilldown.link", false,
         "Whether to show the operation's drilldown link to thrift client.\n"),
 

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3924,7 +3924,7 @@ public class HiveConf extends Configuration {
             "     (Use with property hive.server2.webui.custom.auth.filter)"),
     HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER("hive.server2.webui.custom.auth.filter", "",
         "Filter class name to apply to the Web UI when " + "hive.server2.webui.auth.method" +
-            "=CUSTOM. The filter should be a standard javax servlet Filter. " +
+            "=CUSTOM. The filter should be a standard javax.servlet.Filter. " +
             "Filter parameters can also be specified in the configuration, by setting config entries of the form " +
             "hive.server2.webui.custom.auth.filter.param.<param name>=<value>"),
     HIVE_SERVER2_SHOW_OPERATION_DRILLDOWN_LINK("hive.server2.show.operation.drilldown.link", false,

--- a/common/src/java/org/apache/hive/http/HttpServer.java
+++ b/common/src/java/org/apache/hive/http/HttpServer.java
@@ -176,6 +176,12 @@ public class HttpServer {
     private boolean useSPNEGO;
     private boolean useSSL;
     private boolean usePAM;
+    @VisibleForTesting
+    public boolean useCustomAuthFilter;
+    @VisibleForTesting
+    public String customAuthFilter;
+    @VisibleForTesting
+    public Map<String, String> customAuthFilterParams;
     private boolean enableCORS;
     private String allowedOrigins;
     private String allowedMethods;
@@ -280,6 +286,21 @@ public class HttpServer {
 
     public Builder setUseSPNEGO(boolean useSPNEGO) {
       this.useSPNEGO = useSPNEGO;
+      return this;
+    }
+
+    public Builder setUseCustomAuthFilter(boolean useCustomAuthFilter) {
+      this.useCustomAuthFilter = useCustomAuthFilter;
+      return this;
+    }
+
+    public Builder setCustomAuthFilter(String customAuthFilter) {
+      this.customAuthFilter = customAuthFilter;
+      return this;
+    }
+
+    public Builder setCustomAuthFilterParams(Map<String, String> customAuthFilterParams) {
+      this.customAuthFilterParams = customAuthFilterParams;
       return this;
     }
 
@@ -542,6 +563,19 @@ public class HttpServer {
   }
 
   /**
+   * Secure the web server with a custom {@link javax.servlet.Filter}.
+   * The filter class name and its init parameters come from the {@link Builder}.
+   */
+  void setupCustomAuthFilter(Builder b, ServletContextHandler ctx) {
+    FilterHolder holder = new FilterHolder();
+    holder.setClassName(b.customAuthFilter);
+    holder.setInitParameters(b.customAuthFilterParams);
+    ServletHandler handler = ctx.getServletHandler();
+    handler.addFilterWithMapping(
+        holder, "/*", FilterMapping.ALL);
+  }
+
+  /**
    * Setup cross-origin requests (CORS) filter.
    * @param b - builder
    * @param webAppContext - webAppContext
@@ -615,6 +649,10 @@ public class HttpServer {
     if (builder.useSPNEGO) {
       // Secure the web server with kerberos
       setupSpnegoFilter(builder, webAppContext);
+    }
+
+    if (builder.useCustomAuthFilter) {
+      setupCustomAuthFilter(builder, webAppContext);
     }
 
     if (builder.enableCORS) {
@@ -840,6 +878,9 @@ public class HttpServer {
       setContextAttributes(logCtx.getServletContext(), b.contextAttrs);
       if(b.useSPNEGO) {
         setupSpnegoFilter(b,logCtx);
+      }
+      if (b.useCustomAuthFilter) {
+        setupCustomAuthFilter(b, logCtx);
       }
       logCtx.addServlet(AdminAuthorizedServlet.class, "/*");
       logCtx.setResourceBase(logDir);

--- a/common/src/java/org/apache/hive/http/HttpServer.java
+++ b/common/src/java/org/apache/hive/http/HttpServer.java
@@ -176,12 +176,6 @@ public class HttpServer {
     private boolean useSPNEGO;
     private boolean useSSL;
     private boolean usePAM;
-    @VisibleForTesting
-    public boolean useCustomAuthFilter;
-    @VisibleForTesting
-    public String customAuthFilter;
-    @VisibleForTesting
-    public Map<String, String> customAuthFilterParams;
     private boolean enableCORS;
     private String allowedOrigins;
     private String allowedMethods;
@@ -193,8 +187,11 @@ public class HttpServer {
     private final List<Pair<String, Class<? extends HttpServlet>>> servlets =
         new LinkedList<Pair<String, Class<? extends HttpServlet>>>();
     private boolean disableDirListing = false;
-    private final Map<String, Pair<String, Filter>> globalFilters = new LinkedHashMap<>();
+    private final Map<String, GlobalFilter> globalFilters = new LinkedHashMap<>();
     private String contextPath = "/";
+
+    record GlobalFilter(String pathSpec, Filter filter, String className,
+        Map<String, String> initParams) {}
 
     public Builder(String name) {
       Preconditions.checkArgument(name != null && !name.isEmpty(), "Name must be specified");
@@ -289,21 +286,6 @@ public class HttpServer {
       return this;
     }
 
-    public Builder setUseCustomAuthFilter(boolean useCustomAuthFilter) {
-      this.useCustomAuthFilter = useCustomAuthFilter;
-      return this;
-    }
-
-    public Builder setCustomAuthFilter(String customAuthFilter) {
-      this.customAuthFilter = customAuthFilter;
-      return this;
-    }
-
-    public Builder setCustomAuthFilterParams(Map<String, String> customAuthFilterParams) {
-      this.customAuthFilterParams = customAuthFilterParams;
-      return this;
-    }
-
     public Builder setEnableCORS(boolean enableCORS) {
       this.enableCORS = enableCORS;
       return this;
@@ -350,7 +332,18 @@ public class HttpServer {
     }
 
     public Builder addGlobalFilter(String name, String pathSpec, Filter filter) {
-      globalFilters.put(name, Pair.create(pathSpec, filter));
+      return addGlobalFilter(name, pathSpec, filter, null);
+    }
+
+    public Builder addGlobalFilter(String name, String pathSpec, Filter filter,
+        Map<String, String> initParams) {
+      globalFilters.put(name, new GlobalFilter(pathSpec, filter, null, initParams));
+      return this;
+    }
+
+    public Builder addGlobalFilter(String name, String pathSpec, String filterClassName,
+        Map<String, String> initParams) {
+      globalFilters.put(name, new GlobalFilter(pathSpec, null, filterClassName, initParams));
       return this;
     }
 
@@ -563,19 +556,6 @@ public class HttpServer {
   }
 
   /**
-   * Secure the web server with a custom {@link javax.servlet.Filter}.
-   * The filter class name and its init parameters come from the {@link Builder}.
-   */
-  void setupCustomAuthFilter(Builder b, ServletContextHandler ctx) {
-    FilterHolder holder = new FilterHolder();
-    holder.setClassName(b.customAuthFilter);
-    holder.setInitParameters(b.customAuthFilterParams);
-    ServletHandler handler = ctx.getServletHandler();
-    handler.addFilterWithMapping(
-        holder, "/*", FilterMapping.ALL);
-  }
-
-  /**
    * Setup cross-origin requests (CORS) filter.
    * @param b - builder
    * @param webAppContext - webAppContext
@@ -613,8 +593,8 @@ public class HttpServer {
       addServlet(p.getKey(), "/" + p.getKey(), p.getValue(), webAppContext);
     }
 
-    builder.globalFilters.forEach((k, v) -> 
-        addFilter(k, v.getKey(), v.getValue(), webAppContext.getServletHandler()));
+    builder.globalFilters.forEach((k, v) ->
+        addFilter(k, v, webAppContext.getServletHandler()));
 
     // Associate the port handler with the a new connector and add it to the server
     ServerConnector connector = createAndAddChannelConnector(threadPool.getQueueSize(), builder);
@@ -649,10 +629,6 @@ public class HttpServer {
     if (builder.useSPNEGO) {
       // Secure the web server with kerberos
       setupSpnegoFilter(builder, webAppContext);
-    }
-
-    if (builder.useCustomAuthFilter) {
-      setupCustomAuthFilter(builder, webAppContext);
     }
 
     if (builder.enableCORS) {
@@ -879,9 +855,6 @@ public class HttpServer {
       if(b.useSPNEGO) {
         setupSpnegoFilter(b,logCtx);
       }
-      if (b.useCustomAuthFilter) {
-        setupCustomAuthFilter(b, logCtx);
-      }
       logCtx.addServlet(AdminAuthorizedServlet.class, "/*");
       logCtx.setResourceBase(logDir);
       logCtx.setDisplayName("logs");
@@ -892,7 +865,7 @@ public class HttpServer {
     handlers.ifPresent(hs -> Arrays.stream(hs)
         .filter(h -> h instanceof ServletContextHandler && !"static".equals(((ServletContextHandler) h).getDisplayName()))
         .forEach(h -> b.globalFilters.forEach((k, v) ->
-            addFilter(k, v.getKey(), v.getValue(), ((ServletContextHandler) h).getServletHandler()))));
+            addFilter(k, v, ((ServletContextHandler) h).getServletHandler()))));
   }
 
   private Map<String, String> setHeaders() {
@@ -1018,12 +991,20 @@ public class HttpServer {
     webAppContext.addServlet(holder, pathSpec);
   }
 
-  public void addFilter(String name, String pathSpec, Filter filter, ServletHandler handler) {
-    FilterHolder holder = new FilterHolder(filter);
+  private void addFilter(String name, Builder.GlobalFilter gf, ServletHandler handler) {
+    FilterHolder holder = gf.filter() != null
+        ? new FilterHolder(gf.filter())
+        : new FilterHolder();
+    if (gf.className() != null) {
+      holder.setClassName(gf.className());
+    }
     if (name != null) {
       holder.setName(name);
     }
-    handler.addFilterWithMapping(holder, pathSpec, FilterMapping.ALL);
+    if (gf.initParams() != null) {
+      holder.setInitParameters(gf.initParams());
+    }
+    handler.addFilterWithMapping(holder, gf.pathSpec(), FilterMapping.ALL);
   }
 
   private static void disableDirectoryListingOnServlet(ServletContextHandler contextHandler) {

--- a/common/src/test/org/apache/hive/http/TestHttpServerCustomAuthFilter.java
+++ b/common/src/test/org/apache/hive/http/TestHttpServerCustomAuthFilter.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.http;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * End-to-end test that wires a sample {@link Filter} into HttpServer via
+ * the custom-auth-filter Builder API and verifies that real HTTP requests
+ * to the running server flow through the filter — and that the filter's
+ * decision (pass through or short-circuit with 401) is honored.
+ */
+public class TestHttpServerCustomAuthFilter {
+
+  private HttpServer server;
+
+  @Before
+  public void resetCounters() {
+    RecordingFilter.reset();
+    BlockingFilter.reset();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (server != null) {
+      server.stop();
+      server = null;
+    }
+  }
+
+  /**
+   * With {@code useCustomAuthFilter=true} and a passthrough filter, requests
+   * reach the underlying servlet AND the filter sees them, including the
+   * configured init parameters.
+   */
+  @Test(timeout = 30_000)
+  public void testCustomAuthFilterInterceptsRequests() throws Exception {
+    Map<String, String> params = new HashMap<>();
+    params.put("realm", "hive");
+    params.put("ttl", "600");
+
+    int port = freePort();
+    server = new HttpServer.Builder("test")
+        .setConf(new HiveConf())
+        .setHost("localhost")
+        .setPort(port)
+        .setUseCustomAuthFilter(true)
+        .setCustomAuthFilter(RecordingFilter.class.getName())
+        .setCustomAuthFilterParams(params)
+        .build();
+    server.start();
+
+    int code = doGet("/jmx");
+    assertEquals("Passthrough filter should not block the request", 200, code);
+
+    assertTrue("Filter should have been invoked at least once; was "
+        + RecordingFilter.callCount.get(), RecordingFilter.callCount.get() >= 1);
+    assertEquals("Init params should be threaded through to the filter",
+        "hive", RecordingFilter.initParams.get("realm"));
+    assertEquals("600", RecordingFilter.initParams.get("ttl"));
+  }
+
+  /**
+   * The filter's decision is authoritative: when the filter short-circuits
+   * with a 401, the underlying servlet is never reached and the client
+   * receives the 401 response code.
+   */
+  @Test(timeout = 30_000)
+  public void testCustomAuthFilterCanBlockRequest() throws Exception {
+    int port = freePort();
+    server = new HttpServer.Builder("test")
+        .setConf(new HiveConf())
+        .setHost("localhost")
+        .setPort(port)
+        .setUseCustomAuthFilter(true)
+        .setCustomAuthFilter(BlockingFilter.class.getName())
+        .setCustomAuthFilterParams(new HashMap<>())
+        .build();
+    server.start();
+
+    int code = doGet("/jmx");
+    assertEquals("Blocking filter should short-circuit with 401", 401, code);
+    assertTrue("Filter should have run before blocking",
+        BlockingFilter.callCount.get() >= 1);
+  }
+
+  /**
+   * Without {@code useCustomAuthFilter=true}, no custom filter is installed
+   * and requests proceed normally; the recording filter sees nothing even
+   * though it is present on the classpath.
+   */
+  @Test(timeout = 30_000)
+  public void testCustomAuthFilterNotInstalledWhenDisabled() throws Exception {
+    int port = freePort();
+    server = new HttpServer.Builder("test")
+        .setConf(new HiveConf())
+        .setHost("localhost")
+        .setPort(port)
+        .build();
+    server.start();
+
+    int code = doGet("/jmx");
+    assertEquals(200, code);
+    assertEquals("Filter must not be installed when useCustomAuthFilter is off",
+        0, RecordingFilter.callCount.get());
+  }
+
+  // ---- helpers -------------------------------------------------------------
+
+  /**
+   * Picks a currently-free port. HttpServer's PortHandlerWrapper keys handlers
+   * by the configured port, so we cannot pass 0 (dynamic) — the actual bound
+   * port would not match the registered handler. There is a small race window
+   * between closing this socket and Jetty binding, which is acceptable for a
+   * unit test.
+   */
+  private static int freePort() throws IOException {
+    try (ServerSocket s = new ServerSocket(0)) {
+      return s.getLocalPort();
+    }
+  }
+
+  private int doGet(String path) throws IOException {
+    URL url = new URL("http://localhost:" + server.getPort() + path);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    try {
+      conn.setRequestMethod("GET");
+      conn.setConnectTimeout(5_000);
+      conn.setReadTimeout(5_000);
+      return conn.getResponseCode();
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  // ---- sample filters ------------------------------------------------------
+
+  /** Records every invocation and the init parameters seen at startup. */
+  public static class RecordingFilter implements Filter {
+    static final AtomicInteger callCount = new AtomicInteger(0);
+    static volatile Map<String, String> initParams = new HashMap<>();
+
+    static void reset() {
+      callCount.set(0);
+      initParams = new HashMap<>();
+    }
+
+    @Override
+    public void init(FilterConfig fc) {
+      Map<String, String> seen = new HashMap<>();
+      Enumeration<String> names = fc.getInitParameterNames();
+      while (names.hasMoreElements()) {
+        String n = names.nextElement();
+        seen.put(n, fc.getInitParameter(n));
+      }
+      initParams = seen;
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain)
+        throws IOException, ServletException {
+      callCount.incrementAndGet();
+      chain.doFilter(req, resp);
+    }
+
+    @Override
+    public void destroy() {
+    }
+  }
+
+  /** Short-circuits every request with 401, like a deny-by-default auth filter. */
+  public static class BlockingFilter implements Filter {
+    static final AtomicInteger callCount = new AtomicInteger(0);
+
+    static void reset() {
+      callCount.set(0);
+    }
+
+    @Override
+    public void init(FilterConfig fc) {
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain)
+        throws IOException, ServletException {
+      callCount.incrementAndGet();
+      ((HttpServletResponse) resp).sendError(HttpServletResponse.SC_UNAUTHORIZED, "blocked");
+    }
+
+    @Override
+    public void destroy() {
+    }
+  }
+}

--- a/common/src/test/org/apache/hive/http/TestHttpServerCustomAuthFilter.java
+++ b/common/src/test/org/apache/hive/http/TestHttpServerCustomAuthFilter.java
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.ServerSocket;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,12 +42,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
- * End-to-end test that wires a sample {@link Filter} into HttpServer via
- * the custom-auth-filter Builder API and verifies that real HTTP requests
- * to the running server flow through the filter — and that the filter's
- * decision (pass through or short-circuit with 401) is honored.
+ * End-to-end test that wires a sample {@link Filter} into HttpServer via the
+ * {@code addGlobalFilter(name, pathSpec, Filter, initParams)} Builder API and
+ * verifies that real HTTP requests to the running server flow through the
+ * filter — and that the filter's decision (pass through or short-circuit with
+ * 401) is honored.
+ *
+ * <p>This mirrors the wiring HiveServer2 performs at startup when
+ * {@code hive.server2.webui.auth.method=CUSTOM} is set: instantiate the
+ * configured filter class, read prefix-scoped init parameters off HiveConf,
+ * then register the pair on the builder.
  */
 public class TestHttpServerCustomAuthFilter {
 
@@ -66,9 +75,9 @@ public class TestHttpServerCustomAuthFilter {
   }
 
   /**
-   * With {@code useCustomAuthFilter=true} and a passthrough filter, requests
-   * reach the underlying servlet AND the filter sees them, including the
-   * configured init parameters.
+   * A passthrough custom filter registered against the global filter map
+   * sees every request to the root webapp AND receives its configured init
+   * parameters.
    */
   @Test(timeout = 30_000)
   public void testCustomAuthFilterInterceptsRequests() throws Exception {
@@ -81,9 +90,7 @@ public class TestHttpServerCustomAuthFilter {
         .setConf(new HiveConf())
         .setHost("localhost")
         .setPort(port)
-        .setUseCustomAuthFilter(true)
-        .setCustomAuthFilter(RecordingFilter.class.getName())
-        .setCustomAuthFilterParams(params)
+        .addGlobalFilter("custom-auth-filter", "/*", new RecordingFilter(), params)
         .build();
     server.start();
 
@@ -109,9 +116,7 @@ public class TestHttpServerCustomAuthFilter {
         .setConf(new HiveConf())
         .setHost("localhost")
         .setPort(port)
-        .setUseCustomAuthFilter(true)
-        .setCustomAuthFilter(BlockingFilter.class.getName())
-        .setCustomAuthFilterParams(new HashMap<>())
+        .addGlobalFilter("custom-auth-filter", "/*", new BlockingFilter())
         .build();
     server.start();
 
@@ -122,12 +127,11 @@ public class TestHttpServerCustomAuthFilter {
   }
 
   /**
-   * Without {@code useCustomAuthFilter=true}, no custom filter is installed
-   * and requests proceed normally; the recording filter sees nothing even
-   * though it is present on the classpath.
+   * Without any global filter registered, requests proceed normally; the
+   * recording filter sees nothing even though it is present on the classpath.
    */
   @Test(timeout = 30_000)
-  public void testCustomAuthFilterNotInstalledWhenDisabled() throws Exception {
+  public void testCustomAuthFilterNotInstalledWhenAbsent() throws Exception {
     int port = freePort();
     server = new HttpServer.Builder("test")
         .setConf(new HiveConf())
@@ -138,8 +142,141 @@ public class TestHttpServerCustomAuthFilter {
 
     int code = doGet("/jmx");
     assertEquals(200, code);
-    assertEquals("Filter must not be installed when useCustomAuthFilter is off",
+    assertEquals("Filter must not be installed when not registered on the builder",
         0, RecordingFilter.callCount.get());
+  }
+
+  /**
+   * Reproduces HiveServer2's config-driven wiring path: read the filter class
+   * name and prefix-scoped init params straight off {@link HiveConf} via
+   * {@code getPropsWithPrefix}, then hand both to the className-based
+   * {@code addGlobalFilter} overload. The Builder owns instantiation, so the
+   * caller code stays free of reflection.
+   */
+  @Test(timeout = 30_000)
+  public void testCustomAuthFilterWiredFromHiveConfPropsWithPrefix() throws Exception {
+    HiveConf conf = new HiveConf();
+    conf.set(HiveConf.ConfVars.HIVE_SERVER2_WEBUI_AUTH_METHOD.varname, "CUSTOM");
+    conf.set(HiveConf.ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname,
+        RecordingFilter.class.getName());
+    String paramPrefix =
+        HiveConf.ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.";
+    conf.set(paramPrefix + "realm", "hive");
+    conf.set(paramPrefix + "ttl", "600");
+
+    String authFilter = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER);
+    Map<String, String> params = conf.getPropsWithPrefix(paramPrefix);
+
+    int port = freePort();
+    server = new HttpServer.Builder("test")
+        .setConf(conf)
+        .setHost("localhost")
+        .setPort(port)
+        .addGlobalFilter("custom-auth-filter", "/*", authFilter, params)
+        .build();
+    server.start();
+
+    int code = doGet("/jmx");
+    assertEquals(200, code);
+    assertTrue("Filter should have been invoked",
+        RecordingFilter.callCount.get() >= 1);
+    assertEquals("realm param flowed through from HiveConf to filter init",
+        "hive", RecordingFilter.initParams.get("realm"));
+    assertEquals("ttl param flowed through from HiveConf to filter init",
+        "600", RecordingFilter.initParams.get("ttl"));
+  }
+
+  /**
+   * The {@code /logs} endpoint is mounted on a sibling {@code ServletContextHandler},
+   * not on the root webapp context, so it does not automatically inherit filters
+   * registered against the webapp. This test asserts that a global custom auth
+   * filter still applies to {@code /logs} — leaving log files unauthenticated
+   * would defeat the point of enabling WebUI auth at all.
+   */
+  @Test(timeout = 30_000)
+  public void testCustomAuthFilterAppliedToLogsEndpoint() throws Exception {
+    Path logDir = Files.createTempDirectory("hs2-webui-logs-");
+
+    HiveConf conf = new HiveConf();
+    conf.set("hive.log.dir", logDir.toAbsolutePath().toString());
+
+    int port = freePort();
+    server = new HttpServer.Builder("test")
+        .setConf(conf)
+        .setHost("localhost")
+        .setPort(port)
+        .addGlobalFilter("custom-auth-filter", "/*", new RecordingFilter())
+        .build();
+    server.start();
+
+    doGet("/logs/");
+
+    assertTrue("Custom auth filter must intercept /logs as well; was "
+        + RecordingFilter.callCount.get(), RecordingFilter.callCount.get() >= 1);
+  }
+
+  /**
+   * The blocking variant: a deny-by-default filter on {@code /logs} must
+   * short-circuit with 401 before the log-serving servlet runs.
+   */
+  @Test(timeout = 30_000)
+  public void testCustomAuthFilterCanBlockLogsEndpoint() throws Exception {
+    Path logDir = Files.createTempDirectory("hs2-webui-logs-");
+
+    HiveConf conf = new HiveConf();
+    conf.set("hive.log.dir", logDir.toAbsolutePath().toString());
+
+    int port = freePort();
+    server = new HttpServer.Builder("test")
+        .setConf(conf)
+        .setHost("localhost")
+        .setPort(port)
+        .addGlobalFilter("custom-auth-filter", "/*", new BlockingFilter())
+        .build();
+    server.start();
+
+    int code = doGet("/logs/");
+    assertEquals("Blocking filter must short-circuit /logs with 401", 401, code);
+    assertTrue("Filter should have run before blocking",
+        BlockingFilter.callCount.get() >= 1);
+  }
+
+  /**
+   * The className overload defers class resolution to Jetty's lifecycle:
+   * Builder.addGlobalFilter just stores the name, FilterHolder.doStart()
+   * loads the class. So a bad class name must surface as a startup failure
+   * (server.start()) — not silently — and the resulting stack should name
+   * the offending class so the operator can fix the config.
+   */
+  @Test(timeout = 30_000)
+  public void testCustomAuthFilterRejectsBadClassName() throws Exception {
+    int port = freePort();
+    server = new HttpServer.Builder("test")
+        .setConf(new HiveConf())
+        .setHost("localhost")
+        .setPort(port)
+        .addGlobalFilter("custom-auth-filter", "/*",
+            "com.example.NonExistentFilterClass", null)
+        .build();
+
+    try {
+      server.start();
+      fail("Expected server.start() to fail when the filter class is missing");
+    } catch (Exception expected) {
+      String trace = stackTraceAsString(expected);
+      assertTrue("Failure should name the offending class somewhere in the trace; was:\n" + trace,
+          trace.contains("com.example.NonExistentFilterClass"));
+    } finally {
+      // Server may be partially started — make sure we don't leak the connector.
+      try { server.stop(); } catch (Exception ignore) { }
+      server = null;
+    }
+  }
+
+  private static String stackTraceAsString(Throwable t) {
+    java.io.StringWriter sw = new java.io.StringWriter();
+    t.printStackTrace(new java.io.PrintWriter(sw));
+    return sw.toString();
   }
 
   // ---- helpers -------------------------------------------------------------

--- a/common/src/test/resources/hive-webapps/test/index.html
+++ b/common/src/test/resources/hive-webapps/test/index.html
@@ -1,0 +1,1 @@
+<html><body>test webapp root</body></html>

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -433,7 +433,7 @@ public class HiveServer2 extends CompositeService {
             String paramPrefix = ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.";
             Map<String, String> params = hiveConf.getPropsWithPrefix(paramPrefix);
             builder.addGlobalFilter("custom-auth-filter", "/*", authFilter, params);
-            LOG.info("WebUI will use Custom Auth Filter: {}  params: {}", authFilter, params);
+            LOG.info("WebUI will use Custom Auth Filter: {} with init param kyes: {}", authFilter, params.keySet());
           }
           webServer = builder.build();
           webServer.addServlet("query_page", "/query_page.html", QueryProfileServlet.class);

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -543,6 +543,20 @@ public class HiveServer2 extends CompositeService {
         throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_WEBUI_USE_SSL.varname + " has false value. It is recommended to set to true when PAM is used.");
       }
     }
+    if (hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_CUSTOM_AUTH_FILTER)) {
+      String authFilter = hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER);
+      if (authFilter == null || authFilter.isEmpty()) {
+        throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname
+            + " is not configured. It is required when Custom Auth Filter is used.");
+      }
+      String paramPrefix = ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.";
+      Map<String, String> params = hiveConf.getPropsWithPrefix(paramPrefix);
+
+      builder.setUseCustomAuthFilter(true);
+      builder.setCustomAuthFilter(authFilter);
+      builder.setCustomAuthFilterParams(params);
+      LOG.info("WebUI will use Custom Auth Filter: {}  params: {}", authFilter, params);
+    }
     
     return builder;
   }

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -196,7 +196,7 @@ public class HiveServer2 extends CompositeService {
   private QueryHistoryService queryHistoryService;
 
   public enum WebUIAuthMethod {
-    NONE, LDAP
+    NONE, LDAP, CUSTOM
   }
 
   public static WebUIAuthMethod getWebUIAuthMethod(String method) {
@@ -204,6 +204,8 @@ public class HiveServer2 extends CompositeService {
     switch (m) {
       case "ldap":
         return WebUIAuthMethod.LDAP;
+      case "custom":
+        return WebUIAuthMethod.CUSTOM;
       default:
         return WebUIAuthMethod.NONE;
     }
@@ -422,6 +424,16 @@ public class HiveServer2 extends CompositeService {
           if (WebUIAuthMethod.LDAP == webUIAuthMethod) {
             ldapAuthService = new LdapAuthService(hiveConf, passwdAuthenticationProvider);
             builder.addGlobalFilter("ldap", "/*", new LDAPAuthenticationFilter(ldapAuthService));
+          } else if (WebUIAuthMethod.CUSTOM == webUIAuthMethod) {
+            String authFilter = hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER);
+            if (authFilter == null || authFilter.isEmpty()) {
+              throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname
+                  + " is not configured. It is required when Custom Auth Filter is used.");
+            }
+            String paramPrefix = ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.";
+            Map<String, String> params = hiveConf.getPropsWithPrefix(paramPrefix);
+            builder.addGlobalFilter("custom-auth-filter", "/*", authFilter, params);
+            LOG.info("WebUI will use Custom Auth Filter: {}  params: {}", authFilter, params);
           }
           webServer = builder.build();
           webServer.addServlet("query_page", "/query_page.html", QueryProfileServlet.class);
@@ -543,21 +555,6 @@ public class HiveServer2 extends CompositeService {
         throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_WEBUI_USE_SSL.varname + " has false value. It is recommended to set to true when PAM is used.");
       }
     }
-    if (hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_CUSTOM_AUTH_FILTER)) {
-      String authFilter = hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER);
-      if (authFilter == null || authFilter.isEmpty()) {
-        throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname
-            + " is not configured. It is required when Custom Auth Filter is used.");
-      }
-      String paramPrefix = ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.";
-      Map<String, String> params = hiveConf.getPropsWithPrefix(paramPrefix);
-
-      builder.setUseCustomAuthFilter(true);
-      builder.setCustomAuthFilter(authFilter);
-      builder.setCustomAuthFilterParams(params);
-      LOG.info("WebUI will use Custom Auth Filter: {}  params: {}", authFilter, params);
-    }
-    
     return builder;
   }
   

--- a/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
+++ b/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
@@ -20,6 +20,7 @@ package org.apache.hive.service.server;
 
 import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hive.http.HttpServer;
 import org.apache.hive.service.cli.CLIService;
@@ -32,6 +33,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -127,5 +130,73 @@ public class TestHiveServer2 {
     HiveConf builderConf = (HiveConf) confField.get(builder);
     assertNotNull("Builder.conf must be set after createHttpServerBuilder", builderConf);
     assertNotNull("startcode must be exists", builderConf.get("startcode"));
+  }
+
+  // ---- WebUI custom auth filter wiring (createHttpServerBuilder) ----------
+
+  /**
+   * Default config: custom auth filter is off, builder must not carry any
+   * filter wiring.
+   */
+  @Test
+  public void testCustomAuthFilterDisabledByDefault() throws Exception {
+    HiveConf conf = new HiveConf();
+    HttpServer.Builder builder = invokeCreateHttpServerBuilder(conf);
+
+    assertFalse("useCustomAuthFilter should default to false",
+        builder.useCustomAuthFilter);
+  }
+
+  /**
+   * When the ConfVars are set, createHttpServerBuilder must thread the filter
+   * class name and every {@code ...custom.auth.filter.param.<name>} key into
+   * the Builder (the param key is stored without the prefix).
+   */
+  @Test
+  public void testCustomAuthFilterWiredFromConfig() throws Exception {
+    HiveConf conf = new HiveConf();
+    conf.setBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_CUSTOM_AUTH_FILTER, true);
+    conf.setVar(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER, "com.example.MyAuthFilter");
+    conf.set(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.realm", "hive");
+    conf.set(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.ttl", "600");
+
+    HttpServer.Builder builder = invokeCreateHttpServerBuilder(conf);
+
+    assertTrue("useCustomAuthFilter should be true",
+        builder.useCustomAuthFilter);
+    assertEquals("com.example.MyAuthFilter",
+        builder.customAuthFilter);
+
+    @SuppressWarnings("unchecked")
+    Map<String, String> params = builder.customAuthFilterParams;
+    assertNotNull("customAuthFilterParams must be populated", params);
+    assertEquals("hive", params.get("realm"));
+    assertEquals("600", params.get("ttl"));
+  }
+
+  /**
+   * Enabling the filter without providing a class name is a configuration
+   * error and must fail fast at builder construction.
+   */
+  @Test
+  public void testCustomAuthFilterRejectsEmptyClassName() throws Exception {
+    HiveConf conf = new HiveConf();
+    conf.setBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_CUSTOM_AUTH_FILTER, true);
+    conf.setVar(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER, "");
+
+    try {
+      invokeCreateHttpServerBuilder(conf);
+      fail("Expected IllegalArgumentException when custom auth filter class name is empty");
+    } catch (IllegalArgumentException expected) {
+      assertTrue("Exception message should reference the custom auth filter ConfVar",
+          expected.getMessage().contains(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname));
+    }
+  }
+
+  private static HttpServer.Builder invokeCreateHttpServerBuilder(HiveConf conf) throws Exception {
+    CLIService cli = mock(CLIService.class);
+    SessionManager sm = mock(SessionManager.class);
+    when(cli.getSessionManager()).thenReturn(sm);
+    return HiveServer2.createHttpServerBuilder("localhost", 0, "test", "/", conf, cli, null);
   }
 }

--- a/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
+++ b/service/src/test/org/apache/hive/service/server/TestHiveServer2.java
@@ -32,9 +32,6 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -132,71 +129,43 @@ public class TestHiveServer2 {
     assertNotNull("startcode must be exists", builderConf.get("startcode"));
   }
 
-  // ---- WebUI custom auth filter wiring (createHttpServerBuilder) ----------
-
   /**
-   * Default config: custom auth filter is off, builder must not carry any
-   * filter wiring.
+   * {@code hive.server2.webui.auth.method=CUSTOM} (case-insensitive) must
+   * resolve to {@link HiveServer2.WebUIAuthMethod#CUSTOM}; unknown / null /
+   * empty values fall back to NONE. This is the gate that lets the CUSTOM
+   * branch in {@code init()} run.
    */
   @Test
-  public void testCustomAuthFilterDisabledByDefault() throws Exception {
-    HiveConf conf = new HiveConf();
-    HttpServer.Builder builder = invokeCreateHttpServerBuilder(conf);
-
-    assertFalse("useCustomAuthFilter should default to false",
-        builder.useCustomAuthFilter);
+  public void testGetWebUIAuthMethod() {
+    assertEquals(HiveServer2.WebUIAuthMethod.NONE,
+        HiveServer2.getWebUIAuthMethod(null));
+    assertEquals(HiveServer2.WebUIAuthMethod.NONE,
+        HiveServer2.getWebUIAuthMethod(""));
+    assertEquals(HiveServer2.WebUIAuthMethod.NONE,
+        HiveServer2.getWebUIAuthMethod("NONE"));
+    assertEquals(HiveServer2.WebUIAuthMethod.LDAP,
+        HiveServer2.getWebUIAuthMethod("LDAP"));
+    assertEquals("lower-case input must resolve the same as upper-case",
+        HiveServer2.WebUIAuthMethod.LDAP, HiveServer2.getWebUIAuthMethod("ldap"));
+    assertEquals(HiveServer2.WebUIAuthMethod.CUSTOM,
+        HiveServer2.getWebUIAuthMethod("CUSTOM"));
+    assertEquals("lower-case input must resolve the same as upper-case",
+        HiveServer2.WebUIAuthMethod.CUSTOM, HiveServer2.getWebUIAuthMethod("custom"));
+    assertEquals("unknown values fall back to NONE",
+        HiveServer2.WebUIAuthMethod.NONE, HiveServer2.getWebUIAuthMethod("bogus"));
   }
 
   /**
-   * When the ConfVars are set, createHttpServerBuilder must thread the filter
-   * class name and every {@code ...custom.auth.filter.param.<name>} key into
-   * the Builder (the param key is stored without the prefix).
+   * Sanity check that the conf carries the CUSTOM mode end-to-end: writing
+   * the ConfVar with the string "CUSTOM" must round-trip through HiveConf
+   * and through {@link HiveServer2#getWebUIAuthMethod} without coercion.
    */
   @Test
-  public void testCustomAuthFilterWiredFromConfig() throws Exception {
+  public void testWebUIAuthMethodFromHiveConfRoundTrip() {
     HiveConf conf = new HiveConf();
-    conf.setBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_CUSTOM_AUTH_FILTER, true);
-    conf.setVar(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER, "com.example.MyAuthFilter");
-    conf.set(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.realm", "hive");
-    conf.set(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname + ".param.ttl", "600");
-
-    HttpServer.Builder builder = invokeCreateHttpServerBuilder(conf);
-
-    assertTrue("useCustomAuthFilter should be true",
-        builder.useCustomAuthFilter);
-    assertEquals("com.example.MyAuthFilter",
-        builder.customAuthFilter);
-
-    @SuppressWarnings("unchecked")
-    Map<String, String> params = builder.customAuthFilterParams;
-    assertNotNull("customAuthFilterParams must be populated", params);
-    assertEquals("hive", params.get("realm"));
-    assertEquals("600", params.get("ttl"));
-  }
-
-  /**
-   * Enabling the filter without providing a class name is a configuration
-   * error and must fail fast at builder construction.
-   */
-  @Test
-  public void testCustomAuthFilterRejectsEmptyClassName() throws Exception {
-    HiveConf conf = new HiveConf();
-    conf.setBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_CUSTOM_AUTH_FILTER, true);
-    conf.setVar(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER, "");
-
-    try {
-      invokeCreateHttpServerBuilder(conf);
-      fail("Expected IllegalArgumentException when custom auth filter class name is empty");
-    } catch (IllegalArgumentException expected) {
-      assertTrue("Exception message should reference the custom auth filter ConfVar",
-          expected.getMessage().contains(ConfVars.HIVE_SERVER2_WEBUI_CUSTOM_AUTH_FILTER.varname));
-    }
-  }
-
-  private static HttpServer.Builder invokeCreateHttpServerBuilder(HiveConf conf) throws Exception {
-    CLIService cli = mock(CLIService.class);
-    SessionManager sm = mock(SessionManager.class);
-    when(cli.getSessionManager()).thenReturn(sm);
-    return HiveServer2.createHttpServerBuilder("localhost", 0, "test", "/", conf, cli, null);
+    conf.setVar(ConfVars.HIVE_SERVER2_WEBUI_AUTH_METHOD, "CUSTOM");
+    assertEquals(HiveServer2.WebUIAuthMethod.CUSTOM,
+        HiveServer2.getWebUIAuthMethod(
+            conf.getVar(ConfVars.HIVE_SERVER2_WEBUI_AUTH_METHOD)));
   }
 }


### PR DESCRIPTION
HIVE-29639

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Proposal

Add a configurable `javax.servlet.Filter` slot to the WebUI, mirroring
Spark's `spark.ui.filters`. Any `Filter` can then be
installed via configuration alone, with no code changes


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- Problem

In a Kerberized cluster, the HS2 WebUI is typically protected with
SPNEGO (`hive.server2.webui.use.spnego` + keytab/principal). SPNEGO
works fine for command-line / Kerberos clients, but in a browser it is
clunky: end users need a working Kerberos ticket cache on their
workstation, the browser has to be whitelisted for the SPNEGO domain,
and there is no clean way to plug the UI into an organisation's
broader SSO flow.

Elsewhere in the Hadoop ecosystem, this gap is commonly closed by
KnoxSSO in front of Kerberized NameNode / YARN ResourceManager /
Oozie UIs so end users get a single browser SSO experience instead of
raw SPNEGO, while the services themselves stay Kerberized.

HS2 cannot join that story today. There is no supported way to insert
a custom `javax.servlet.Filter` into the WebUI servlet pipeline, so
operators either live with browser SPNEGO



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


- New configuration

| Key | Default | Meaning |
|---|---|---|
| `hive.server2.webui.custom.auth.filter` | (empty) | Fully-qualified `Filter` class. Required when the switch is on; empty is rejected at startup. |
| `hive.server2.webui.custom.auth.filter.param.<name>` | — | Init parameters passed to the filter. The prefix is stripped; `<name>` becomes the parameter key. |

- Example (KnoxSSO)

```
hive.server2.webui.auth.method=CUSTOM
hive.server2.webui.custom.auth.filter=org.apache.hadoop.security.authentication.server.AuthenticationFilter
hive.server2.webui.custom.auth.filter.param.type=org.apache.hadoop.security.authentication.server.JWTRedirectAuthenticationHandler
hive.server2.webui.custom.auth.filter.param.alt-kerberos.non-browser.user-agents=${hadoop.http.authentication.alt-kerberos.non-browser.user-agents}
hive.server2.webui.custom.auth.filter.param.signer.secret.provider=${hadoop.http.authentication.signer.secret.provider}
hive.server2.webui.custom.auth.filter.param.signature.secret.file=${hadoop.http.authentication.signature.secret.file}
hive.server2.webui.custom.auth.filter.param.authentication.provider.url=${hadoop.http.authentication.authentication.provider.url}
hive.server2.webui.custom.auth.filter.param.public.key.pem=${hadoop.http.authentication.public.key.pem}
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
