### PR TITLE
HIVE-29640: ADD JAR from a non-default fs fails on Tez due to missing delegation token

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -68,6 +69,7 @@ import org.apache.hadoop.hive.ql.wm.WmContext;
 import org.apache.hadoop.hive.shims.Utils;
 import org.apache.hadoop.mapred.JobContext;
 import org.apache.hadoop.registry.client.api.RegistryOperations;
+import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
@@ -291,6 +293,27 @@ public class TezSessionState implements TezSession {
       commonLocalResources.put(DagUtils.getBaseName(lr), lr);
     }
     return commonLocalResources;
+  }
+
+  @VisibleForTesting
+  Credentials createLocalResourceCredentialsExcludingDefaultFS(
+      Map<String, LocalResource> resourceMap) throws IOException, URISyntaxException {
+    String defaultFS = conf.get(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY);
+    Credentials credentials = new Credentials();
+    List<Path> ps = new ArrayList<>();
+
+    for (LocalResource resource : resourceMap.values()) {
+      Path p = resource.getResource().toPath();
+      String path = p.toString();
+      if (path.startsWith("/") || path.startsWith(defaultFS)) {
+        LOG.info("skip collecting path to issue token because it is defaultFS: path={}", p);
+      } else {
+        LOG.info("collect path to issue token: path={}", p);
+        ps.add(p);
+      }
+    }
+    TokenCache.obtainTokensForNamenodes(credentials, ps.toArray(new Path[0]), conf);
+    return credentials;
   }
 
   /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
@@ -117,7 +117,7 @@ public class TestTezSessionState {
    */
   @Test
   public void testCommonLocalResourcesPopulatedOnSessionOpen() throws Exception {
-    Path jarPath = Files.createTempFile("test-jar", ".jar");
+    java.nio.file.Path = Files.createTempFile("test-jar", ".jar");
     Files.write(jarPath, "testCommonLocalResourcesPopulated".getBytes(), StandardOpenOption.APPEND);
 
     SessionState ss = createSessionState();

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
@@ -16,23 +16,36 @@
  */
 package org.apache.hadoop.hive.ql.exec.tez;
 
+import java.net.URISyntaxException;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConfForTest;
+import org.apache.hadoop.mapreduce.security.TokenCache;
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.tez.dag.api.TezException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 
 public class TestTezSessionState {
   private static final Logger LOG = LoggerFactory.getLogger(TestTezSessionState.class.getName());
@@ -46,8 +59,8 @@ public class TestTezSessionState {
 
   @Test
   public void testSymlinkedLocalFilesAreLocalizedOnce() throws Exception {
-    Path jarPath = Files.createTempFile("jar", "");
-    Path symlinkPath = Paths.get(jarPath.toString() + ".symlink");
+    java.nio.file.Path jarPath = Files.createTempFile("jar", "");
+    java.nio.file.Path symlinkPath = Paths.get(jarPath.toString() + ".symlink");
     Files.createSymbolicLink(symlinkPath, jarPath);
 
     // write some data into the fake jar, it's not a 0 length file in real life
@@ -132,5 +145,100 @@ public class TestTezSessionState {
     };
 
     sessionStateForTest.open(resources);
+  }
+
+  // --- createLocalResourceCredentialsExcludingDefaultFS ------------------------------------------
+
+  private static final String DEFAULT_FS = "hdfs://defaultnn";
+
+  private static LocalResource resourceAt(String pathStr) throws URISyntaxException {
+    LocalResource lr = Mockito.mock(LocalResource.class);
+    URL url = Mockito.mock(URL.class);
+    Mockito.when(lr.getResource()).thenReturn(url);
+    Mockito.when(url.toPath()).thenReturn(new Path(pathStr));
+    return lr;
+  }
+
+  private static Map<String, LocalResource> resourceMapOf(String... pathStrs) throws URISyntaxException {
+    // preserve insertion order so the assertions don't depend on HashMap ordering
+    Map<String, LocalResource> m = new LinkedHashMap<>();
+    for (int i = 0; i < pathStrs.length; i++) {
+      m.put("r" + i, resourceAt(pathStrs[i]));
+    }
+    return m;
+  }
+
+  private static TezSessionState newSession() {
+    HiveConf conf = new HiveConf();
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, DEFAULT_FS);
+    return new TezSessionState(DagUtils.getInstance(), conf);
+  }
+
+  @Test
+  public void testCredentialsEmptyResourceMapDoesNotRequestTokens() throws Exception {
+    TezSessionState sessionState = newSession();
+    try (MockedStatic<TokenCache> tokenCache = Mockito.mockStatic(TokenCache.class)) {
+      Credentials credentials = sessionState.createLocalResourceCredentialsExcludingDefaultFS(new HashMap<>());
+
+      Assert.assertNotNull(credentials);
+      ArgumentCaptor<Path[]> paths = ArgumentCaptor.forClass(Path[].class);
+      tokenCache.verify(() -> TokenCache.obtainTokensForNamenodes(
+          Mockito.eq(credentials), paths.capture(), Mockito.any()));
+      Assert.assertEquals(0, paths.getValue().length);
+    }
+  }
+
+  @Test
+  public void testCredentialsDefaultFsResourceIsSkipped() throws Exception {
+    TezSessionState sessionState = newSession();
+    Map<String, LocalResource> resources = resourceMapOf(DEFAULT_FS + "/user/x/hive-exec.jar", "/user/x/hadoop-auth.jar");
+
+    try (MockedStatic<TokenCache> tokenCache = Mockito.mockStatic(TokenCache.class)) {
+      Credentials credentials = sessionState.createLocalResourceCredentialsExcludingDefaultFS(resources);
+
+      ArgumentCaptor<Path[]> paths = ArgumentCaptor.forClass(Path[].class);
+      tokenCache.verify(() -> TokenCache.obtainTokensForNamenodes(
+          Mockito.eq(credentials), paths.capture(), Mockito.any()));
+      Assert.assertEquals(0, paths.getValue().length);
+    }
+  }
+
+  @Test
+  public void testCredentialsNonDefaultFsResourceCollectsPath() throws Exception {
+    TezSessionState sessionState = newSession();
+    String addedJar = "hdfs://othernn/user/u/add-jar.jar";
+    Map<String, LocalResource> resources = resourceMapOf(addedJar);
+
+    try (MockedStatic<TokenCache> tokenCache = Mockito.mockStatic(TokenCache.class)) {
+      Credentials credentials = sessionState.createLocalResourceCredentialsExcludingDefaultFS(resources);
+
+      ArgumentCaptor<Path[]> paths = ArgumentCaptor.forClass(Path[].class);
+      tokenCache.verify(() -> TokenCache.obtainTokensForNamenodes(
+          Mockito.eq(credentials), paths.capture(), Mockito.any()));
+      Assert.assertArrayEquals(new Path[] { new Path(addedJar) }, paths.getValue());
+    }
+  }
+
+  @Test
+  public void testCredentialsMixedResourcesOnlyNonDefaultFsCollected() throws Exception {
+    TezSessionState sessionState = newSession();
+    String addedJarA = "hdfs://nn-a/user/u/jar-a.jar";
+    String addedJarB = "hdfs://nn-b/user/u/jar-b.jar";
+    Map<String, LocalResource> resources = resourceMapOf(
+        DEFAULT_FS + "/tmp/hive/session/hive-exec.jar",   // defaultFS — skipped
+        "/user/x/hadoop-auth.jar",                        // defaultFS — skipped
+        addedJarA,                                        // collected
+        addedJarB);                                       // collected
+
+    try (MockedStatic<TokenCache> tokenCache = Mockito.mockStatic(TokenCache.class)) {
+      Credentials credentials = sessionState.createLocalResourceCredentialsExcludingDefaultFS(resources);
+
+      ArgumentCaptor<Path[]> paths = ArgumentCaptor.forClass(Path[].class);
+      tokenCache.verify(() -> TokenCache.obtainTokensForNamenodes(
+          Mockito.eq(credentials), paths.capture(), Mockito.any()));
+      Assert.assertEquals(
+          Arrays.asList(new Path(addedJarA), new Path(addedJarB)),
+          Arrays.asList(paths.getValue()));
+    }
   }
 }


### PR DESCRIPTION
HIVE-29640

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Root cause

`TezClientUtils.setupAMLocalResources` does not fetch HDFS delegation
tokens for AM-local resources — it expects the caller to provide them
via `AMCredentials`. HS2 (`TezSessionState`) currently passes only the
LLAP credentials and never enumerates the non-defaultFS namenodes
referenced by `ADD JAR` / `ADD FILE` resources, so the AM ends up
without a token for those namenodes.

- Fix

Before handing local resources to TezClient, walk the common local
resource map, collect every distinct non-`fs.defaultFS` HDFS namenode
referenced, fetch delegation tokens for those namenodes via
`TokenCache.obtainTokensForNamenodes`, and merge them into the
credentials passed to TezClient (alongside any existing LLAP
credentials).

Implementation lives in a new helper
`TezSessionState#createLocalResourceCredentialsExcludingDefaultFS` and
filters out:

Resources on `fs.defaultFS` (Tez/Hadoop issues that token already;
  duplicate issuance adds latency and NameNode heap pressure).

- Repro

1. Kerberized HS2 with `hive.execution.engine=tez`.
2. From beeline:

```
ADD JAR hdfs://other-nn/path/to/udf.jar;
CREATE TEMPORARY FUNCTION my_udf AS '…';
SELECT my_udf(col) FROM tbl;
```

where `other-nn` is a federated namenode distinct from
`fs.defaultFS`.
3. Expected: query runs.
Actual: localization fails on the AM/container with a missing
delegation token error for `other-nn`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- Problem

In a Kerberized cluster, a query that pulls in jars from an HDFS
namenode other than `fs.defaultFS` fails when the execution engine is
Tez:

```
SET hive.execution.engine=tez;
ADD JAR hdfs://other-nn/libs/my-udf.jar;
SELECT my_udf(...) FROM t;
```

The jar is distributed to Tez containers as an AM-local resource via
the distributed cache. The container tries to localize it from
`hdfs://other-nn/...`, finds no HDFS delegation token for `other-nn`
in its `Credentials`, and fails resource localization. The query
aborts before any task runs.

`fs.defaultFS` jars work fine because Tez/Hadoop's standard code path
issues a token for the default namenode on its own.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

- Compatibility

Behaviour is unchanged when all `ADD JAR` resources live on
`fs.defaultFS` or on the local filesystem.
Non-Kerberized clusters are unaffected (token issuance is a no-op).
No new configuration. No new dependencies.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

