### PR TITLE
HIVE-29642: Remove racy test-only counters from PartitionManagementTask

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionManagementTask.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionManagementTask.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hive.metastore.utils.TableFetcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
@@ -57,9 +56,6 @@ public class PartitionManagementTask implements MetastoreTaskThread {
   public static final String DISCOVER_PARTITIONS_TBLPROPERTY = "discover.partitions";
   public static final String PARTITION_RETENTION_PERIOD_TBLPROPERTY = "partition.retention.period";
   private static final Lock lock = new ReentrantLock();
-  // these are just for testing
-  private static int completedAttempts;
-  private static int skippedAttempts;
 
   private Configuration conf;
 
@@ -87,7 +83,6 @@ public class PartitionManagementTask implements MetastoreTaskThread {
   @Override
   public void run() {
     if (lock.tryLock()) {
-      skippedAttempts = 0;
       String qualifiedTableName = null;
       IMetaStoreClient msc = null;
       try {
@@ -136,10 +131,8 @@ public class PartitionManagementTask implements MetastoreTaskThread {
         }
         lock.unlock();
       }
-      completedAttempts++;
     } else {
-      skippedAttempts++;
-      LOG.info("Lock is held by some other partition discovery task. Skipping this attempt..#{}", skippedAttempts);
+      LOG.info("Lock is held by some other partition discovery task. Skipping this attempt.");
     }
   }
 
@@ -200,13 +193,4 @@ public class PartitionManagementTask implements MetastoreTaskThread {
     }
   }
 
-  @VisibleForTesting
-  public static int getSkippedAttempts() {
-    return skippedAttempts;
-  }
-
-  @VisibleForTesting
-  public static int getCompletedAttempts() {
-    return completedAttempts;
-  }
 }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartitionManagement.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartitionManagement.java
@@ -54,6 +54,11 @@ import org.apache.hadoop.hive.metastore.leader.StaticLeaderElection;
 import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
@@ -473,7 +478,7 @@ public class TestPartitionManagement {
   }
 
   @Test
-  public void testPartitionDiscoveryTransactionalTable()
+  public void testPartitionDiscoveryTransactionalTableConcurrent()
     throws TException, IOException, InterruptedException, ExecutionException {
     String dbName = "db6";
     String tableName = "tbl6";
@@ -503,45 +508,69 @@ public class TestPartitionManagement {
       TransactionalValidationListener.INSERTONLY_TRANSACTIONAL_PROPERTY);
     client.alter_table(dbName, tableName, table);
 
-    runPartitionManagementTask(conf);
-    partitions = client.listPartitions(dbName, tableName, (short) -1);
-    assertEquals(5, partitions.size());
+    final String appenderName = "testPartitionDiscoveryTransactionalTableConcurrentAppender";
+    LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+    LoggerConfig rootLoggerConfig = loggerContext.getConfiguration().getLoggerConfig("");
+    ListAppender skipAppender = new ListAppender(appenderName);
+    skipAppender.start();
+    rootLoggerConfig.addAppender(skipAppender, Level.INFO, null);
+    try {
+      runPartitionManagementTask(conf);
+      partitions = client.listPartitions(dbName, tableName, (short) -1);
+      assertEquals(5, partitions.size());
 
-    // only one partition discovery task is running, there will be no skipped attempts
-    assertEquals(0, PartitionManagementTask.getSkippedAttempts());
+      // only one partition discovery task is running, there will be no skipped attempts
+      assertEquals(0, countSkipMessages(skipAppender));
+      assertEquals(1, countDiscoveryEntries(skipAppender));
 
-    // delete a partition from fs, and submit 3 tasks at the same time each of them trying to acquire X lock on the
-    // same table, only one of them will run other attempts will be skipped
-    boolean deleted = fs.delete(newPart1.getParent(), true);
-    assertTrue(deleted);
-    assertEquals(4, fs.listStatus(tablePath).length);
+      // delete a partition from fs, and submit 3 tasks at the same time each of them trying to acquire X lock on the
+      // same table, only one of them will run other attempts will be skipped
+      boolean deleted = fs.delete(newPart1.getParent(), true);
+      assertTrue(deleted);
+      assertEquals(4, fs.listStatus(tablePath).length);
 
-    // 3 tasks are submitted at the same time, only one will eventually lock the table and only one get to run at a time
-    // This is to simulate, skipping partition discovery task attempt when previous attempt is still incomplete
-    PartitionManagementTask partitionDiscoveryTask1 = new PartitionManagementTask();
-    partitionDiscoveryTask1.setConf(conf);
-    PartitionManagementTask partitionDiscoveryTask2 = new PartitionManagementTask();
-    partitionDiscoveryTask2.setConf(conf);
-    PartitionManagementTask partitionDiscoveryTask3 = new PartitionManagementTask();
-    partitionDiscoveryTask3.setConf(conf);
-    List<PartitionManagementTask> tasks = Lists
-      .newArrayList(partitionDiscoveryTask1, partitionDiscoveryTask2, partitionDiscoveryTask3);
-    ExecutorService executorService = Executors.newFixedThreadPool(3);
-    int successBefore = PartitionManagementTask.getCompletedAttempts();
-    int skippedBefore = PartitionManagementTask.getSkippedAttempts();
-    List<Future<?>> futures = new ArrayList<>();
-    for (PartitionManagementTask task : tasks) {
-      futures.add(executorService.submit(task));
+      // 3 tasks are submitted at the same time, only one will eventually lock the table and only one get to run at a time
+      // This is to simulate, skipping partition discovery task attempt when previous attempt is still incomplete
+      PartitionManagementTask partitionDiscoveryTask1 = new PartitionManagementTask();
+      partitionDiscoveryTask1.setConf(conf);
+      PartitionManagementTask partitionDiscoveryTask2 = new PartitionManagementTask();
+      partitionDiscoveryTask2.setConf(conf);
+      PartitionManagementTask partitionDiscoveryTask3 = new PartitionManagementTask();
+      partitionDiscoveryTask3.setConf(conf);
+      List<PartitionManagementTask> tasks = Lists
+        .newArrayList(partitionDiscoveryTask1, partitionDiscoveryTask2, partitionDiscoveryTask3);
+      ExecutorService executorService = Executors.newFixedThreadPool(3);
+      List<Future<?>> futures = new ArrayList<>();
+      for (PartitionManagementTask task : tasks) {
+        futures.add(executorService.submit(task));
+      }
+      for (Future<?> future : futures) {
+        future.get();
+      }
+      long skips = countSkipMessages(skipAppender);
+      long discoveries = countDiscoveryEntries(skipAppender);
+      assertEquals(4, skips + discoveries);
+      assertTrue("at least one more task should have entered the work path during the race", discoveries >= 2);
+    } finally {
+      rootLoggerConfig.removeAppender(appenderName);
+      skipAppender.stop();
     }
-    for (Future<?> future : futures) {
-      future.get();
-    }
-    int successAfter = PartitionManagementTask.getCompletedAttempts();
-    int skippedAfter = PartitionManagementTask.getSkippedAttempts();
-    assertEquals(1, successAfter - successBefore);
-    assertEquals(2, skippedAfter - skippedBefore);
     partitions = client.listPartitions(dbName, tableName, (short) -1);
     assertEquals(4, partitions.size());
+  }
+
+  private static long countSkipMessages(ListAppender appender) {
+    return appender.getEvents().stream()
+        .map(e -> e.getMessage().getFormattedMessage())
+        .filter(m -> m.equals("Lock is held by some other partition discovery task. Skipping this attempt."))
+        .count();
+  }
+
+  private static long countDiscoveryEntries(ListAppender appender) {
+    return appender.getEvents().stream()
+        .map(e -> e.getMessage().getFormattedMessage())
+        .filter(m -> m.equals("Found 1 candidate tables for partition discovery"))
+        .count();
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartitionManagement.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartitionManagement.java
@@ -529,8 +529,9 @@ public class TestPartitionManagement {
       assertTrue(deleted);
       assertEquals(4, fs.listStatus(tablePath).length);
 
-      // 3 tasks are submitted at the same time, only one will eventually lock the table and only one get to run at a time
-      // This is to simulate, skipping partition discovery task attempt when previous attempt is still incomplete
+      // 3 tasks are submitted at the same time, only one will eventually lock the table and only one
+      // get to run at a time. This is to simulate, skipping partition discovery task attempt when
+      // previous attempt is still incomplete
       PartitionManagementTask partitionDiscoveryTask1 = new PartitionManagementTask();
       partitionDiscoveryTask1.setConf(conf);
       PartitionManagementTask partitionDiscoveryTask2 = new PartitionManagementTask();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
HIVE-29642: Remove racy test-only counters from PartitionManagementTask

Remove the test-only static counters (completedAttempts, skippedAttempts) and their @VisibleForTesting accessors from PartitionManagementTask. Rewrite
  TestPartitionManagement.testPartitionDiscoveryTransactionalTable (renamed to testPartitionDiscoveryTransactionalTableConcurrent to highlight the contention scenario) to verify the same properties
  via a Log4j2 ListAppender that observes the existing skip and discovery log messages emitted by PartitionManagementTask.run().

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
 The current test asserts that exactly 2 of 3 concurrent tasks are skipped, using test-only static counters in PartitionManagementTask. The assertion is flaky for two reasons. First, the JVM may
  schedule the 3 tasks so they do not actually overlap, in which case no skips happen at all. Second, the counters themselves are racy: the skippedAttempts = 0 reset inside the lock can clear the
  value while other threads are running skippedAttempts++ outside the lock. The counters were added in HIVE-20707 for this test and nothing in production reads them.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
  No. The only change in production source besides removing the counter fields is dropping the trailing "..#N" counter format from one INFO log message; the message prefix is unchanged.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
 Ran TestPartitionManagement locally (11 tests, all pass). The counter race was empirically reproduced before the fix by inserting a short Thread.sleep right after lock.tryLock() in production,
  which caused the original assertion to fail deterministically; the refactored test does not depend on this timing.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
