### PR TITLE
HIVE-29644: HMS hang/deadlock during ACID replication: compaction enqueue incorrectly runs inside replTableWriteIdState transaction

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/TransactionHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/TransactionHandler.java
@@ -100,6 +100,7 @@ import org.apache.hadoop.hive.metastore.events.OpenTxnEvent;
 import org.apache.hadoop.hive.metastore.messaging.EventMessage;
 import org.apache.hadoop.hive.metastore.txn.CompactionMetricsDataConverter;
 import org.apache.hadoop.hive.metastore.txn.entities.CompactionInfo;
+import org.apache.hadoop.hive.metastore.txn.jdbc.functions.ReplAbortedWriteCompactionScheduler;
 import org.apache.hadoop.hive.metastore.utils.FileUtils;
 import org.apache.hadoop.hive.metastore.utils.FilterUtils;
 import org.apache.thrift.TException;
@@ -249,7 +250,9 @@ public abstract class TransactionHandler extends DeprecatedHandler {
 
   @Override
   public void repl_tbl_writeid_state(ReplTblWriteIdStateRequest rqst) throws TException {
-    getTxnHandler().replTableWriteIdState(rqst);
+    if (getTxnHandler().replTableWriteIdState(rqst)) {
+      ReplAbortedWriteCompactionScheduler.scheduleMajorCompactions(getTxnHandler(), rqst);
+    }
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -661,8 +661,8 @@ public abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
    * @throws MetaException
    */
   @Override
-  public void replTableWriteIdState(ReplTblWriteIdStateRequest rqst) throws MetaException {
-    new ReplTableWriteIdStateFunction(rqst, mutexAPI, transactionalListeners).execute(jdbcResource);
+  public boolean replTableWriteIdState(ReplTblWriteIdStateRequest rqst) throws MetaException {
+    return new ReplTableWriteIdStateFunction(rqst, transactionalListeners).execute(jdbcResource);
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnStore.java
@@ -268,7 +268,7 @@ public interface TxnStore extends Configurable {
   @SqlRetry(lockInternally = true)
   @Transactional(POOL_TX)
   @RetrySemantics.Idempotent("No-op if already replicated the writeid state")
-  void replTableWriteIdState(ReplTblWriteIdStateRequest rqst) throws MetaException;
+  boolean replTableWriteIdState(ReplTblWriteIdStateRequest rqst) throws MetaException;
 
   @Transactional(POOL_TX)
   void updateTransactionStatistics(UpdateTransactionalStatsRequest req) throws MetaException;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/functions/ReplAbortedWriteCompactionScheduler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/functions/ReplAbortedWriteCompactionScheduler.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.txn.jdbc.functions;
+
+import org.apache.hadoop.hive.metastore.api.CompactionRequest;
+import org.apache.hadoop.hive.metastore.api.CompactionType;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.ReplTblWriteIdStateRequest;
+import org.apache.hadoop.hive.metastore.txn.TxnStore;
+
+/**
+ * Schedules major compactions after replication write-id state is committed.
+ * Each compaction is enqueued via {@link TxnStore#compact(CompactionRequest)}, which runs in its
+ * own transaction, avoiding cross-pool deadlocks when multiple partitions are processed.
+ */
+public final class ReplAbortedWriteCompactionScheduler {
+
+  private ReplAbortedWriteCompactionScheduler() {}
+
+  public static void scheduleMajorCompactions(TxnStore txnStore, ReplTblWriteIdStateRequest rqst)
+      throws MetaException {
+    CompactionRequest compactRqst = new CompactionRequest(rqst.getDbName(), rqst.getTableName(),
+        CompactionType.MAJOR);
+    if (rqst.isSetPartNames()) {
+      for (String partName : rqst.getPartNames()) {
+        compactRqst.setPartitionname(partName);
+        txnStore.compact(compactRqst);
+      }
+    } else {
+      txnStore.compact(compactRqst);
+    }
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/functions/ReplTableWriteIdStateFunction.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/functions/ReplTableWriteIdStateFunction.java
@@ -20,14 +20,11 @@ package org.apache.hadoop.hive.metastore.txn.jdbc.functions;
 import org.apache.hadoop.hive.common.ValidReaderWriteIdList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.metastore.TransactionalMetaStoreEventListener;
-import org.apache.hadoop.hive.metastore.api.CompactionRequest;
-import org.apache.hadoop.hive.metastore.api.CompactionType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.OpenTxnRequest;
 import org.apache.hadoop.hive.metastore.api.ReplTblWriteIdStateRequest;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.txn.TxnErrorMsg;
-import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.jdbc.MultiDataSourceJdbcResource;
 import org.apache.hadoop.hive.metastore.txn.jdbc.TransactionalFunction;
 import org.slf4j.Logger;
@@ -43,22 +40,21 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-public class ReplTableWriteIdStateFunction implements TransactionalFunction<Void> {
+public class ReplTableWriteIdStateFunction implements TransactionalFunction<Boolean> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReplTableWriteIdStateFunction.class);
   
   private final ReplTblWriteIdStateRequest rqst;
-  private final TxnStore.MutexAPI mutexAPI;
   private final List<TransactionalMetaStoreEventListener> transactionalListeners;
 
-  public ReplTableWriteIdStateFunction(ReplTblWriteIdStateRequest rqst, TxnStore.MutexAPI mutexAPI, List<TransactionalMetaStoreEventListener> transactionalListeners) {
+  public ReplTableWriteIdStateFunction(ReplTblWriteIdStateRequest rqst,
+      List<TransactionalMetaStoreEventListener> transactionalListeners) {
     this.rqst = rqst;
-    this.mutexAPI = mutexAPI;
     this.transactionalListeners = transactionalListeners;
   }
 
   @Override
-  public Void execute(MultiDataSourceJdbcResource jdbcResource) throws MetaException {
+  public Boolean execute(MultiDataSourceJdbcResource jdbcResource) throws MetaException {
     long openTxnTimeOutMillis = MetastoreConf.getTimeVar(jdbcResource.getConf(), MetastoreConf.ConfVars.TXN_OPENTXN_TIMEOUT, TimeUnit.MILLISECONDS);
 
     String dbName = rqst.getDbName().toLowerCase();
@@ -79,7 +75,7 @@ public class ReplTableWriteIdStateFunction implements TransactionalFunction<Void
     if (found) {
       LOG.info("Idempotent flow: WriteId state <{}> is already applied for the table: {}.{}",
           validWriteIdList, dbName, tblName);
-      return null;
+      return false;
     }
 
     // Get the abortedWriteIds which are already sorted in ascending order.
@@ -131,21 +127,7 @@ public class ReplTableWriteIdStateFunction implements TransactionalFunction<Void
             .addValue("tableName", tblName)
             .addValue("nextWriteId", nextWriteId));
     LOG.info("WriteId state <{}> is applied for the table: {}.{}", validWriteIdList, dbName, tblName);
-
-    // Schedule Major compaction on all the partitions/table to clean aborted data
-    if (numAbortedWrites > 0) {
-      CompactionRequest compactRqst = new CompactionRequest(rqst.getDbName(), rqst.getTableName(),
-          CompactionType.MAJOR);
-      if (rqst.isSetPartNames()) {
-        for (String partName : rqst.getPartNames()) {
-          compactRqst.setPartitionname(partName);
-          new CompactFunction(compactRqst, openTxnTimeOutMillis, mutexAPI).execute(jdbcResource);
-        }
-      } else {
-        new CompactFunction(compactRqst, openTxnTimeOutMillis, mutexAPI).execute(jdbcResource);
-      }
-    }
-    return null;
+    return numAbortedWrites > 0;
   }
 
   private List<Long> getAbortedWriteIds(ValidWriteIdList validWriteIdList) {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
replTableWriteIdState now only applies the write-id state and returns whether compaction is needed; TransactionHandler.repl_tbl_writeid_state schedules the per-partition major compactions afterwards via ReplAbortedWriteCompactionScheduler, each in its own compact() transaction (restoring the pre-HIVE-27481 behaviour, same as manual ALTER TABLE COMPACT).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
 ReplTableWriteIdStateFunction enqueued major compactions inline (via CompactFunction) inside the long @Transactional(POOL_TX) replTableWriteIdState call, holding the NEXT_COMPACTION_QUEUE_ID row lock across all partitions while re-acquiring the CompactionScheduler mutex; this could AB-BA deadlock with a concurrent compact() caller (initiator or another replication job) across the POOL_TX/POOL_MUTEX connection pools.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
