### PR TITLE
HIVE-29647: Parallelize Parquet split generation directory listing

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/MapredParquetInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/MapredParquetInputFormat.java
@@ -14,22 +14,11 @@
 package org.apache.hadoop.hive.ql.io.parquet;
 
 import java.io.IOException;
-import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.common.BlobStorageUtils;
-import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.common.io.DataCache;
 import org.apache.hadoop.hive.common.io.FileMetadataCache;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -45,12 +34,11 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.parquet.hadoop.ParquetInputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import static org.apache.hadoop.mapreduce.lib.input.FileInputFormat.LIST_STATUS_NUM_THREADS;
 
 
 /**
@@ -60,8 +48,6 @@ public class MapredParquetInputFormat extends FileInputFormat<NullWritable, Arra
   implements InputFormatChecker, VectorizedInputFormatInterface, LlapCacheOnlyInputFormatInterface {
 
   private static final Logger LOG = LoggerFactory.getLogger(MapredParquetInputFormat.class);
-
-  private static ExecutorService threadPool;
 
   private final ParquetInputFormat<ArrayWritable> realInput;
 
@@ -77,87 +63,16 @@ public class MapredParquetInputFormat extends FileInputFormat<NullWritable, Arra
   }
 
   /**
-   * On blob storage with multiple recursive input directories, list them in parallel instead of the
-   * default serial per-directory listing that dominates split generation. Listed files flow through
-   * the inherited {@link FileInputFormat#getSplits} unchanged; all other cases defer to the default.
+   * Parallelize split-generation file listing by sizing Hadoop's {@code LocatedFileStatusFetcher}
+   * from {@code hive.compute.splits.num.threads}. We set it on the job conf here because that
+   * property's cluster default does not reach the conf split generation uses; a value of 1 stays
+   * serial.
    */
   @Override
   protected FileStatus[] listStatus(JobConf job) throws IOException {
-    Path[] dirs = getInputPaths(job);
-    // Only the recursive case (the Tez default) takes the parallel path; non-recursive listing has
-    // subtler sub-directory semantics, so defer to the default.
-    if (dirs.length <= 1
-        || !job.getBoolean(FileInputFormat.INPUT_DIR_RECURSIVE, false)
-        || !BlobStorageUtils.isBlobStorageFileSystem(job, dirs[0].getFileSystem(job))) {
-      return super.listStatus(job);
-    }
-
-    long start = System.currentTimeMillis();
-    // List as the caller's end-user, not the pool threads' login user; FileSystem.get is UGI-keyed.
-    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-
-    int numThreads = Math.max(2, HiveConf.getIntVar(job, HiveConf.ConfVars.HIVE_COMPUTE_SPLITS_NUM_THREADS));
-    ExecutorService pool = getThreadPool(numThreads);
-    CompletionService<List<FileStatus>> completionService = new ExecutorCompletionService<>(pool);
-
-    List<Future<List<FileStatus>>> pathFutures = new ArrayList<>(dirs.length);
-    List<FileStatus> files = new ArrayList<>();
-    try {
-      for (Path dir : dirs) {
-        pathFutures.add(completionService.submit(() -> listDirectory(job, dir, ugi)));
-      }
-      for (int resultsLeft = dirs.length; resultsLeft > 0; resultsLeft--) {
-        files.addAll(completionService.take().get());
-      }
-    } catch (InterruptedException e) {
-      cancelFutures(pathFutures);
-      Thread.currentThread().interrupt();
-      throw new IOException("Interrupted while listing input directories", e);
-
-    } catch (ExecutionException e) {
-      cancelFutures(pathFutures);
-      Throwable cause = e.getCause();
-
-      if (cause instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-        throw new IOException("Interrupted while listing input directories", cause);
-      }
-      if (cause instanceof IOException) {
-        throw (IOException) cause;
-      }
-      throw new IOException("Failed to list input directories", cause);
-    }
-
-    LOG.info("Parquet parallel listStatus: {} files from {} dirs in {} ms ({} threads)",
-        files.size(), dirs.length, System.currentTimeMillis() - start, numThreads);
-    return files.toArray(new FileStatus[0]);
-  }
-
-  private static List<FileStatus> listDirectory(JobConf job, Path dir, UserGroupInformation ugi)
-      throws IOException, InterruptedException {
-    return ugi.doAs((PrivilegedExceptionAction<List<FileStatus>>) () -> {
-      FileSystem dirFs = dir.getFileSystem(job);
-      List<FileStatus> dirFiles = new ArrayList<>();
-      FileUtils.listStatusRecursively(dirFs, new FileStatus(0, true, 0, 0, 0, dir), dirFiles);
-      return dirFiles;
-    });
-  }
-
-  private static synchronized ExecutorService getThreadPool(int numThreads) {
-    if (threadPool == null) {
-      threadPool = Executors.newFixedThreadPool(numThreads,
-          new ThreadFactoryBuilder()
-              .setDaemon(true)
-              .setNameFormat("PARQUET_GET_SPLITS #%d")
-              .build());
-    }
-    return threadPool;
-  }
-
-  private static <T> void cancelFutures(List<Future<T>> futures) {
-    for (Future<T> future : futures) {
-      future.cancel(true);
-    }
+    job.setInt(LIST_STATUS_NUM_THREADS,
+        HiveConf.getIntVar(job, HiveConf.ConfVars.HIVE_COMPUTE_SPLITS_NUM_THREADS));
+    return super.listStatus(job);
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/MapredParquetInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/MapredParquetInputFormat.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -60,6 +61,8 @@ public class MapredParquetInputFormat extends FileInputFormat<NullWritable, Arra
 
   private static final Logger LOG = LoggerFactory.getLogger(MapredParquetInputFormat.class);
 
+  private static ExecutorService threadPool;
+
   private final ParquetInputFormat<ArrayWritable> realInput;
 
   private final transient VectorizedParquetInputFormat vectorizedSelf;
@@ -94,35 +97,35 @@ public class MapredParquetInputFormat extends FileInputFormat<NullWritable, Arra
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
 
     int numThreads = Math.max(2, HiveConf.getIntVar(job, HiveConf.ConfVars.HIVE_COMPUTE_SPLITS_NUM_THREADS));
-    ExecutorService pool = newWorkerPool(numThreads);
+    ExecutorService pool = getThreadPool(numThreads);
     CompletionService<List<FileStatus>> completionService = new ExecutorCompletionService<>(pool);
 
+    List<Future<List<FileStatus>>> pathFutures = new ArrayList<>(dirs.length);
     List<FileStatus> files = new ArrayList<>();
     try {
       for (Path dir : dirs) {
-        completionService.submit(() -> ugi.doAs(
-            (PrivilegedExceptionAction<List<FileStatus>>) () -> {
-              FileSystem dirFs = dir.getFileSystem(job);
-              List<FileStatus> dirFiles = new ArrayList<>();
-              FileUtils.listStatusRecursively(dirFs, new FileStatus(0, true, 0, 0, 0, dir), dirFiles);
-              return dirFiles;
-            }));
+        pathFutures.add(completionService.submit(() -> listDirectory(job, dir, ugi)));
       }
       for (int resultsLeft = dirs.length; resultsLeft > 0; resultsLeft--) {
         files.addAll(completionService.take().get());
       }
     } catch (InterruptedException e) {
+      cancelFutures(pathFutures);
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while listing input directories", e);
 
     } catch (ExecutionException e) {
+      cancelFutures(pathFutures);
       Throwable cause = e.getCause();
+
+      if (cause instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while listing input directories", cause);
+      }
       if (cause instanceof IOException) {
         throw (IOException) cause;
       }
       throw new IOException("Failed to list input directories", cause);
-    } finally {
-      pool.shutdownNow();
     }
 
     LOG.info("Parquet parallel listStatus: {} files from {} dirs in {} ms ({} threads)",
@@ -130,12 +133,31 @@ public class MapredParquetInputFormat extends FileInputFormat<NullWritable, Arra
     return files.toArray(new FileStatus[0]);
   }
 
-  private static ExecutorService newWorkerPool(int numThreads) {
-    return Executors.newFixedThreadPool(numThreads,
-        new ThreadFactoryBuilder()
-            .setDaemon(true)
-            .setNameFormat("PARQUET_GET_SPLITS #%d")
-            .build());
+  private static List<FileStatus> listDirectory(JobConf job, Path dir, UserGroupInformation ugi)
+      throws IOException, InterruptedException {
+    return ugi.doAs((PrivilegedExceptionAction<List<FileStatus>>) () -> {
+      FileSystem dirFs = dir.getFileSystem(job);
+      List<FileStatus> dirFiles = new ArrayList<>();
+      FileUtils.listStatusRecursively(dirFs, new FileStatus(0, true, 0, 0, 0, dir), dirFiles);
+      return dirFiles;
+    });
+  }
+
+  private static synchronized ExecutorService getThreadPool(int numThreads) {
+    if (threadPool == null) {
+      threadPool = Executors.newFixedThreadPool(numThreads,
+          new ThreadFactoryBuilder()
+              .setDaemon(true)
+              .setNameFormat("PARQUET_GET_SPLITS #%d")
+              .build());
+    }
+    return threadPool;
+  }
+
+  private static <T> void cancelFutures(List<Future<T>> futures) {
+    for (Future<T> future : futures) {
+      future.cancel(true);
+    }
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/MapredParquetInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/MapredParquetInputFormat.java
@@ -14,45 +14,46 @@
 package org.apache.hadoop.hive.ql.io.parquet;
 
 import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.BlobStorageUtils;
+import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.common.io.DataCache;
 import org.apache.hadoop.hive.common.io.FileMetadataCache;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedInputFormatInterface;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedSupport;
-import org.apache.hadoop.hive.ql.io.HiveFileFormatUtils;
 import org.apache.hadoop.hive.ql.io.InputFormatChecker;
 import org.apache.hadoop.hive.ql.io.LlapCacheOnlyInputFormatInterface;
-import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetTableUtils;
-import org.apache.hadoop.hive.ql.plan.MapWork;
-import org.apache.hadoop.hive.ql.plan.PartitionDesc;
-import org.apache.hadoop.mapred.FileSplit;
-import org.apache.hadoop.mapred.JobConf;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.io.parquet.read.DataWritableReadSupport;
 import org.apache.hadoop.hive.ql.io.parquet.read.ParquetRecordReaderWrapper;
 import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
-
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.parquet.hadoop.ParquetInputFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 
 /**
- *
- * A Parquet InputFormat for Hive (with the deprecated package mapred)
- *
- * NOTE: With HIVE-9235 we removed "implements VectorizedParquetInputFormat" since all data types
- *       are not currently supported.  Removing the interface turns off vectorization.
+ * A Parquet InputFormat for Hive (with the deprecated package mapred).
  */
 public class MapredParquetInputFormat extends FileInputFormat<NullWritable, ArrayWritable>
   implements InputFormatChecker, VectorizedInputFormatInterface, LlapCacheOnlyInputFormatInterface {
@@ -70,6 +71,71 @@ public class MapredParquetInputFormat extends FileInputFormat<NullWritable, Arra
   protected MapredParquetInputFormat(final ParquetInputFormat<ArrayWritable> inputFormat) {
     this.realInput = inputFormat;
     vectorizedSelf = new VectorizedParquetInputFormat();
+  }
+
+  /**
+   * On blob storage with multiple recursive input directories, list them in parallel instead of the
+   * default serial per-directory listing that dominates split generation. Listed files flow through
+   * the inherited {@link FileInputFormat#getSplits} unchanged; all other cases defer to the default.
+   */
+  @Override
+  protected FileStatus[] listStatus(JobConf job) throws IOException {
+    Path[] dirs = getInputPaths(job);
+    // Only the recursive case (the Tez default) takes the parallel path; non-recursive listing has
+    // subtler sub-directory semantics, so defer to the default.
+    if (dirs.length <= 1
+        || !job.getBoolean(FileInputFormat.INPUT_DIR_RECURSIVE, false)
+        || !BlobStorageUtils.isBlobStorageFileSystem(job, dirs[0].getFileSystem(job))) {
+      return super.listStatus(job);
+    }
+
+    long start = System.currentTimeMillis();
+    // List as the caller's end-user, not the pool threads' login user; FileSystem.get is UGI-keyed.
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+
+    int numThreads = Math.max(2, HiveConf.getIntVar(job, HiveConf.ConfVars.HIVE_COMPUTE_SPLITS_NUM_THREADS));
+    ExecutorService pool = newWorkerPool(numThreads);
+    CompletionService<List<FileStatus>> completionService = new ExecutorCompletionService<>(pool);
+
+    List<FileStatus> files = new ArrayList<>();
+    try {
+      for (Path dir : dirs) {
+        completionService.submit(() -> ugi.doAs(
+            (PrivilegedExceptionAction<List<FileStatus>>) () -> {
+              FileSystem dirFs = dir.getFileSystem(job);
+              List<FileStatus> dirFiles = new ArrayList<>();
+              FileUtils.listStatusRecursively(dirFs, new FileStatus(0, true, 0, 0, 0, dir), dirFiles);
+              return dirFiles;
+            }));
+      }
+      for (int resultsLeft = dirs.length; resultsLeft > 0; resultsLeft--) {
+        files.addAll(completionService.take().get());
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while listing input directories", e);
+
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      throw new IOException("Failed to list input directories", cause);
+    } finally {
+      pool.shutdownNow();
+    }
+
+    LOG.info("Parquet parallel listStatus: {} files from {} dirs in {} ms ({} threads)",
+        files.size(), dirs.length, System.currentTimeMillis() - start, numThreads);
+    return files.toArray(new FileStatus[0]);
+  }
+
+  private static ExecutorService newWorkerPool(int numThreads) {
+    return Executors.newFixedThreadPool(numThreads,
+        new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("PARQUET_GET_SPLITS #%d")
+            .build());
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Override `MapredParquetInputFormat.listStatus` and configure `mapreduce.input.fileinputformat.list-status.num-threads` to enable parallel listing of input directories.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
 Parquet split generation lists each input directory (typically one per partition) serially, which dominates planning time on object stores where every listing is a network round trip.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Cluster (10 workers) TPC-DS scale 1Tb, external, parquet
query2 150sec (before) / 70 (after) # without the semijoins (see https://github.com/apache/hive/pull/6525)
