### PR TITLE
HIVE-29654: Provide an easy way to execute a query and get the CBO plan at the same time

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -643,9 +643,19 @@ public class CalcitePlanner extends SemanticAnalyzer {
           LOG.info("CBO Succeeded; optimized logical plan.");
           this.ctx.setCboInfo(getOptimizedByCboInfo());
           this.ctx.setCboSucceeded(true);
-          if (this.ctx.isExplainPlan()) {
+
+          boolean needExplainPlan = this.ctx.isExplainPlan() || this.conf.getBoolVar(ConfVars.HIVE_LOG_EXPLAIN_OUTPUT);
+          if (needExplainPlan) {
             // Enrich explain with information derived from CBO
+            // ensure the context gets a CBO plan if HIVE_LOG_EXPLAIN_OUTPUT is true
             ExplainConfiguration explainConfig = this.ctx.getExplainConfig();
+            if (explainConfig == null) {
+              explainConfig = new ExplainConfiguration();
+              explainConfig.setCbo(true);
+              explainConfig.setCboJoinCost(true);
+              explainConfig.setFormatted(true);
+            }
+
             if (explainConfig.isCbo()) {
               if (!explainConfig.isCboJoinCost()) {
                 // Include cost as provided by Calcite

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -635,9 +635,19 @@ public class CalcitePlanner extends SemanticAnalyzer {
           LOG.info("CBO Succeeded; optimized logical plan.");
           this.ctx.setCboInfo(getOptimizedByCboInfo());
           this.ctx.setCboSucceeded(true);
-          if (this.ctx.isExplainPlan()) {
+
+          boolean needExplainPlan = this.ctx.isExplainPlan() || this.conf.getBoolVar(ConfVars.HIVE_LOG_EXPLAIN_OUTPUT);
+          if (needExplainPlan) {
             // Enrich explain with information derived from CBO
+            // ensure the context gets a CBO plan if HIVE_LOG_EXPLAIN_OUTPUT is true
             ExplainConfiguration explainConfig = this.ctx.getExplainConfig();
+            if (explainConfig == null) {
+              explainConfig = new ExplainConfiguration();
+              explainConfig.setCbo(true);
+              explainConfig.setCboJoinCost(true);
+              explainConfig.setFormatted(true);
+            }
+
             if (explainConfig.isCbo()) {
               if (!explainConfig.isCboJoinCost()) {
                 // Include cost as provided by Calcite

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -636,37 +636,36 @@ public class CalcitePlanner extends SemanticAnalyzer {
           this.ctx.setCboInfo(getOptimizedByCboInfo());
           this.ctx.setCboSucceeded(true);
 
-          boolean needExplainPlan = this.ctx.isExplainPlan() || this.conf.getBoolVar(ConfVars.HIVE_LOG_EXPLAIN_OUTPUT);
-          if (needExplainPlan) {
-            // Enrich explain with information derived from CBO
-            // ensure the context gets a CBO plan if HIVE_LOG_EXPLAIN_OUTPUT is true
-            ExplainConfiguration explainConfig = this.ctx.getExplainConfig();
-            if (explainConfig == null) {
-              explainConfig = new ExplainConfiguration();
-              explainConfig.setCbo(true);
-              explainConfig.setCboJoinCost(true);
-              explainConfig.setFormatted(true);
-            }
-
-            if (explainConfig.isCbo()) {
-              if (!explainConfig.isCboJoinCost()) {
-                // Include cost as provided by Calcite
-                newPlan.getCluster().invalidateMetadataQuery();
-                RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.DEFAULT);
-              }
-              if (explainConfig.isFormatted()) {
+          ExplainConfiguration explainConfig = this.getExplainConfiguration();
+          if (explainConfig != null) {
+            try {
+              if (explainConfig.isCbo()) {
+                if (!explainConfig.isCboJoinCost()) {
+                  // Include cost as provided by Calcite
+                  newPlan.getCluster().invalidateMetadataQuery();
+                  RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.DEFAULT);
+                }
+                if (explainConfig.isFormatted()) {
+                  this.ctx.setCalcitePlan(HiveRelOptUtil.toJsonString(newPlan));
+                } else if (explainConfig.isCboCost() || explainConfig.isCboJoinCost()) {
+                  this.ctx.setCalcitePlan(RelOptUtil.toString(newPlan, SqlExplainLevel.ALL_ATTRIBUTES));
+                } else {
+                  // Do not include join cost
+                  this.ctx.setCalcitePlan(RelOptUtil.toString(newPlan));
+                }
+              } else if (explainConfig.isFormatted()) {
                 this.ctx.setCalcitePlan(HiveRelOptUtil.toJsonString(newPlan));
-              } else if (explainConfig.isCboCost() || explainConfig.isCboJoinCost()) {
-                this.ctx.setCalcitePlan(RelOptUtil.toString(newPlan, SqlExplainLevel.ALL_ATTRIBUTES));
-              } else {
-                // Do not include join cost
-                this.ctx.setCalcitePlan(RelOptUtil.toString(newPlan));
+                this.ctx.setOptimizedSql(getOptimizedSql(newPlan));
+              } else if (explainConfig.isExtended()) {
+                this.ctx.setOptimizedSql(getOptimizedSql(newPlan));
               }
-            } else if (explainConfig.isFormatted()) {
-              this.ctx.setCalcitePlan(HiveRelOptUtil.toJsonString(newPlan));
-              this.ctx.setOptimizedSql(getOptimizedSql(newPlan));
-            } else if (explainConfig.isExtended()) {
-              this.ctx.setOptimizedSql(getOptimizedSql(newPlan));
+            } catch (RuntimeException ex) {
+              if (!this.ctx.isExplainPlan()) {
+                // logging the plan failed; log the exception instead
+                LOG.warn("Exception generating explain output: " + ex, ex);
+              } else {
+                throw ex;
+              }
             }
           }
           if (LOG.isTraceEnabled()) {
@@ -722,6 +721,20 @@ public class CalcitePlanner extends SemanticAnalyzer {
     }
 
     return sinkOp;
+  }
+
+  private ExplainConfiguration getExplainConfiguration() {
+    if (this.ctx.isExplainPlan()) {
+      return this.ctx.getExplainConfig();
+    }
+    if (this.conf.getBoolVar(ConfVars.HIVE_LOG_EXPLAIN_OUTPUT)) {
+      ExplainConfiguration explainConfig = new ExplainConfiguration();
+      explainConfig.setCbo(true);
+      explainConfig.setCboJoinCost(true);
+      explainConfig.setFormatted(true);
+      return explainConfig;
+    }
+    return null;
   }
 
   protected ASTNode handlePostCboRewriteContext(PreCboCtx cboCtx, ASTNode newAST)

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -636,38 +636,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
           this.ctx.setCboInfo(getOptimizedByCboInfo());
           this.ctx.setCboSucceeded(true);
 
-          ExplainConfiguration explainConfig = this.getExplainConfiguration();
-          if (explainConfig != null) {
-            try {
-              if (explainConfig.isCbo()) {
-                if (!explainConfig.isCboJoinCost()) {
-                  // Include cost as provided by Calcite
-                  newPlan.getCluster().invalidateMetadataQuery();
-                  RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.DEFAULT);
-                }
-                if (explainConfig.isFormatted()) {
-                  this.ctx.setCalcitePlan(HiveRelOptUtil.toJsonString(newPlan));
-                } else if (explainConfig.isCboCost() || explainConfig.isCboJoinCost()) {
-                  this.ctx.setCalcitePlan(RelOptUtil.toString(newPlan, SqlExplainLevel.ALL_ATTRIBUTES));
-                } else {
-                  // Do not include join cost
-                  this.ctx.setCalcitePlan(RelOptUtil.toString(newPlan));
-                }
-              } else if (explainConfig.isFormatted()) {
-                this.ctx.setCalcitePlan(HiveRelOptUtil.toJsonString(newPlan));
-                this.ctx.setOptimizedSql(getOptimizedSql(newPlan));
-              } else if (explainConfig.isExtended()) {
-                this.ctx.setOptimizedSql(getOptimizedSql(newPlan));
-              }
-            } catch (RuntimeException ex) {
-              if (!this.ctx.isExplainPlan()) {
-                // logging the plan failed; log the exception instead
-                LOG.warn("Exception generating explain output: " + ex, ex);
-              } else {
-                throw ex;
-              }
-            }
-          }
+          handleExplainConfiguration(newPlan);
           if (LOG.isTraceEnabled()) {
             LOG.trace(getOptimizedSql(newPlan));
           }
@@ -721,6 +690,43 @@ public class CalcitePlanner extends SemanticAnalyzer {
     }
 
     return sinkOp;
+  }
+
+  private void handleExplainConfiguration(RelNode newPlan) {
+    ExplainConfiguration explainConfig = this.getExplainConfiguration();
+    if (explainConfig == null) {
+      return;
+    }
+
+    try {
+      if (explainConfig.isCbo()) {
+        if (!explainConfig.isCboJoinCost()) {
+          // Include cost as provided by Calcite
+          newPlan.getCluster().invalidateMetadataQuery();
+          RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.DEFAULT);
+        }
+        if (explainConfig.isFormatted()) {
+          this.ctx.setCalcitePlan(HiveRelOptUtil.toJsonString(newPlan));
+        } else if (explainConfig.isCboCost() || explainConfig.isCboJoinCost()) {
+          this.ctx.setCalcitePlan(RelOptUtil.toString(newPlan, SqlExplainLevel.ALL_ATTRIBUTES));
+        } else {
+          // Do not include join cost
+          this.ctx.setCalcitePlan(RelOptUtil.toString(newPlan));
+        }
+      } else if (explainConfig.isFormatted()) {
+        this.ctx.setCalcitePlan(HiveRelOptUtil.toJsonString(newPlan));
+        this.ctx.setOptimizedSql(getOptimizedSql(newPlan));
+      } else if (explainConfig.isExtended()) {
+        this.ctx.setOptimizedSql(getOptimizedSql(newPlan));
+      }
+    } catch (RuntimeException ex) {
+      if (!this.ctx.isExplainPlan()) {
+        // logging the plan failed; log the exception instead
+        LOG.warn("Exception generating explain output: " + ex, ex);
+      } else {
+        throw ex;
+      }
+    }
   }
 
   private ExplainConfiguration getExplainConfiguration() {

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestCalcitePlanner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestCalcitePlanner.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
+import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdConfOnlyAuthorizerFactory;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Note: this test is not thread-safe!
+ */
+public class TestCalcitePlanner {
+  static QueryState queryState;
+
+  ParseDriver pd;
+  CalcitePlanner planner;
+
+  @BeforeClass
+  public static void initialize() throws Exception {
+    HiveConf conf = new HiveConfForTest(TestCalcitePlanner.class);
+    conf.set(HiveConf.ConfVars.HIVE_AUTHORIZATION_ENABLED.varname, "false");
+    conf.set(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER.varname,
+        SQLStdConfOnlyAuthorizerFactory.class.getCanonicalName());
+    queryState = new QueryState.Builder().withHiveConf(conf).build();
+    SessionState.start(conf);
+  }
+
+  @Before
+  public void setup() throws SemanticException {
+    pd = new ParseDriver();
+    planner = new CalcitePlanner(queryState);
+  }
+
+  ASTNode parse(String query) throws ParseException {
+    ASTNode nd = pd.parse(query).getTree();
+    return (ASTNode) nd.getChild(0);
+  }
+
+  private Context getContext(String sql) throws ParseException, SemanticException {
+    ASTNode ast = parse(sql);
+    Context ctx = new Context(queryState.getConf());
+    planner.init(false);
+    planner.initCtx(ctx);
+    SemanticAnalyzer.PlannerContext pctx = new CalcitePlanner.PreCboCtx();
+    planner.genResolvedParseTree(ast, pctx);
+    Operator<?> operator = planner.genOPTree(ast, pctx);
+    assertNotNull(operator);
+    return ctx;
+  }
+
+  /**
+   * The planner should store the Calcite plan in the context when HIVE_LOG_EXPLAIN_OUTPUT is enabled.
+   */
+  @Test
+  public void testCBOLogging() throws Exception {
+    queryState.getConf().setBoolVar(HiveConf.ConfVars.HIVE_LOG_EXPLAIN_OUTPUT, true);
+    Context ctx = getContext("select 1");
+    String calcitePlan = ctx.getCalcitePlan();
+    assertNotNull(calcitePlan);
+    assertTrue("Expected a RelNode plan containing \"HiveProject\", but was:\n" + calcitePlan,
+        calcitePlan.contains("HiveProject"));
+  }
+
+  /**
+   * The planner shall not store the Calcite plan in the context when HIVE_LOG_EXPLAIN_OUTPUT is disabled.
+   */
+  @Test
+  public void testNoCBOLogging() throws Exception {
+    queryState.getConf().setBoolVar(HiveConf.ConfVars.HIVE_LOG_EXPLAIN_OUTPUT, false);
+    Context ctx = getContext("select 1");
+    String calcitePlan = ctx.getCalcitePlan();
+    assertNull(calcitePlan);
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestCalcitePlanner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestCalcitePlanner.java
@@ -30,6 +30,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -62,10 +65,16 @@ public class TestCalcitePlanner {
   }
 
   private Context getContext(String sql) throws ParseException, SemanticException {
+    return getContext(sql, ctx -> {
+    });
+  }
+
+  private Context getContext(String sql, Consumer<Context> prepare) throws ParseException, SemanticException {
     ASTNode ast = parse(sql);
     Context ctx = new Context(queryState.getConf());
     planner.init(false);
     planner.initCtx(ctx);
+    prepare.accept(ctx);
     SemanticAnalyzer.PlannerContext pctx = new CalcitePlanner.PreCboCtx();
     planner.genResolvedParseTree(ast, pctx);
     Operator<?> operator = planner.genOPTree(ast, pctx);
@@ -79,11 +88,49 @@ public class TestCalcitePlanner {
   @Test
   public void testCBOLogExplainEnabled() throws ParseException, SemanticException {
     queryState.getConf().setBoolVar(HiveConf.ConfVars.HIVE_LOG_EXPLAIN_OUTPUT, true);
-    Context ctx = getContext("select 1");
-    String calcitePlan = ctx.getCalcitePlan();
+    Context context = getContext("select 1");
+    String calcitePlan = context.getCalcitePlan();
     assertNotNull(calcitePlan);
     assertTrue("Expected a RelNode plan containing \"HiveProject\", but was:\n" + calcitePlan,
         calcitePlan.contains("HiveProject"));
+  }
+
+  /**
+   * The planner shall not overwrite the explain configuration.
+   */
+  @Test
+  public void testCBOLogExplainEnabledExplainFormatted() throws ParseException, SemanticException {
+    queryState.getConf().setBoolVar(HiveConf.ConfVars.HIVE_LOG_EXPLAIN_OUTPUT, true);
+    Context context = getContext("explain formatted cbo select 1", ctx -> {
+      ExplainConfiguration explConf = new ExplainConfiguration();
+      explConf.setFormatted(true);
+      explConf.setCbo(true);
+      explConf.setCboJoinCost(false);
+      ctx.setExplainConfig(explConf);
+      ctx.setExplainPlan(true);
+    });
+    String calcitePlan = context.getCalcitePlan();
+    assertNotNull(calcitePlan);
+    assertTrue("Expected a JSON plan, but was\n" + calcitePlan, calcitePlan.trim().startsWith("{"));
+  }
+
+  /**
+   * The planner shall not overwrite the explain configuration.
+   */
+  @Test
+  public void testCBOLogExplainEnabledExplainNotFormatted() throws ParseException, SemanticException {
+    queryState.getConf().setBoolVar(HiveConf.ConfVars.HIVE_LOG_EXPLAIN_OUTPUT, true);
+    Context context = getContext("explain cbo select 1", ctx -> {
+      ExplainConfiguration explConf = new ExplainConfiguration();
+      explConf.setFormatted(false);
+      explConf.setCbo(true);
+      explConf.setCboJoinCost(false);
+      ctx.setExplainConfig(explConf);
+      ctx.setExplainPlan(true);
+    });
+    String calcitePlan = context.getCalcitePlan();
+    assertNotNull(calcitePlan);
+    assertFalse("Expected a non-JSON plan, but was\n" + calcitePlan, calcitePlan.trim().startsWith("{"));
   }
 
   /**
@@ -92,8 +139,8 @@ public class TestCalcitePlanner {
   @Test
   public void testCBOLogExplainDisabled() throws ParseException, SemanticException {
     queryState.getConf().setBoolVar(HiveConf.ConfVars.HIVE_LOG_EXPLAIN_OUTPUT, false);
-    Context ctx = getContext("select 1");
-    String calcitePlan = ctx.getCalcitePlan();
+    Context context = getContext("select 1");
+    String calcitePlan = context.getCalcitePlan();
     assertNull(calcitePlan);
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestCalcitePlanner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestCalcitePlanner.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
+import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdConfOnlyAuthorizerFactory;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestCalcitePlanner {
+  static QueryState queryState;
+
+  ParseDriver pd;
+  CalcitePlanner planner;
+
+  @BeforeClass
+  public static void initialize() {
+    HiveConf conf = new HiveConfForTest(TestCalcitePlanner.class);
+    conf.set(HiveConf.ConfVars.HIVE_AUTHORIZATION_ENABLED.varname, "false");
+    conf.set(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER.varname,
+        SQLStdConfOnlyAuthorizerFactory.class.getCanonicalName());
+    queryState = new QueryState.Builder().withHiveConf(conf).build();
+    SessionState.start(conf);
+  }
+
+  @Before
+  public void setup() throws SemanticException {
+    pd = new ParseDriver();
+    planner = new CalcitePlanner(queryState);
+  }
+
+  ASTNode parse(String query) throws ParseException {
+    ASTNode nd = pd.parse(query).getTree();
+    return (ASTNode) nd.getChild(0);
+  }
+
+  private Context getContext(String sql) throws ParseException, SemanticException {
+    ASTNode ast = parse(sql);
+    Context ctx = new Context(queryState.getConf());
+    planner.init(false);
+    planner.initCtx(ctx);
+    SemanticAnalyzer.PlannerContext pctx = new CalcitePlanner.PreCboCtx();
+    planner.genResolvedParseTree(ast, pctx);
+    Operator<?> operator = planner.genOPTree(ast, pctx);
+    assertNotNull(operator);
+    return ctx;
+  }
+
+  /**
+   * The planner should store the Calcite plan in the context when HIVE_LOG_EXPLAIN_OUTPUT is enabled.
+   */
+  @Test
+  public void testCBOLogExplainEnabled() throws ParseException, SemanticException {
+    queryState.getConf().setBoolVar(HiveConf.ConfVars.HIVE_LOG_EXPLAIN_OUTPUT, true);
+    Context ctx = getContext("select 1");
+    String calcitePlan = ctx.getCalcitePlan();
+    assertNotNull(calcitePlan);
+    assertTrue("Expected a RelNode plan containing \"HiveProject\", but was:\n" + calcitePlan,
+        calcitePlan.contains("HiveProject"));
+  }
+
+  /**
+   * The planner shall not store the Calcite plan in the context when HIVE_LOG_EXPLAIN_OUTPUT is disabled.
+   */
+  @Test
+  public void testCBOLogExplainDisabled() throws ParseException, SemanticException {
+    queryState.getConf().setBoolVar(HiveConf.ConfVars.HIVE_LOG_EXPLAIN_OUTPUT, false);
+    Context ctx = getContext("select 1");
+    String calcitePlan = ctx.getCalcitePlan();
+    assertNull(calcitePlan);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Include the Calcite plan when enabling `hive.log.explain.output`, as discussed in [HIVE-29654](https://issues.apache.org/jira/browse/HIVE-29654).

### Why are the changes needed?
Make it easier to get the exact Calcite plan that has been used for an executed query.

### Does this PR introduce _any_ user-facing change?
Just adding the Calcite plan to the logging of `hive.log.explain.output`.

### How was this patch tested?
Unit test and manual execution of a query in beeline.