### PR TITLE
HIVE-28400: Refactor QueryProperties feature flags to use QueryFeature enum

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/hooks/CheckQueryPropertiesHook.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/hooks/CheckQueryPropertiesHook.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.ql.hooks;
 
 import org.apache.hadoop.hive.ql.QueryProperties;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 
@@ -41,13 +42,14 @@ public class CheckQueryPropertiesHook implements ExecuteWithHookContext {
 
     if (queryProps != null) {
       console.printError("Has Join: " + queryProps.hasJoin());
-      console.printError("Has Group By: " + queryProps.hasGroupBy());
-      console.printError("Has Sort By: " + queryProps.hasSortBy());
-      console.printError("Has Order By: " + queryProps.hasOrderBy());
-      console.printError("Has Group By After Join: " + queryProps.hasJoinFollowedByGroupBy());
-      console.printError("Uses Script: " + queryProps.usesScript());
-      console.printError("Has Distribute By: " + queryProps.hasDistributeBy());
-      console.printError("Has Cluster By: " + queryProps.hasClusterBy());
+      console.printError("Has Group By: " + queryProps.hasFeature(QueryFeature.GROUP_BY));
+      console.printError("Has Sort By: " + queryProps.hasFeature(QueryFeature.SORT_BY));
+      console.printError("Has Order By: " + queryProps.hasFeature(QueryFeature.ORDER_BY));
+      console.printError("Has Group By After Join: "
+          + queryProps.hasFeature(QueryFeature.JOIN_FOLLOWED_BY_GROUP_BY));
+      console.printError("Uses Script: " + queryProps.hasFeature(QueryFeature.USES_SCRIPT));
+      console.printError("Has Distribute By: " + queryProps.hasFeature(QueryFeature.DISTRIBUTE_BY));
+      console.printError("Has Cluster By: " + queryProps.hasFeature(QueryFeature.CLUSTER_BY));
     }
   }
 }

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/hooks/CheckQueryPropertiesHook.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/hooks/CheckQueryPropertiesHook.java
@@ -41,7 +41,7 @@ public class CheckQueryPropertiesHook implements ExecuteWithHookContext {
     QueryProperties queryProps = hookContext.getQueryPlan().getQueryProperties();
 
     if (queryProps != null) {
-      console.printError("Has Join: " + queryProps.hasJoin());
+      console.printError("Has Join: " + queryProps.hasFeature(QueryFeature.JOIN));
       console.printError("Has Group By: " + queryProps.hasFeature(QueryFeature.GROUP_BY));
       console.printError("Has Sort By: " + queryProps.hasFeature(QueryFeature.SORT_BY));
       console.printError("Has Order By: " + queryProps.hasFeature(QueryFeature.ORDER_BY));

--- a/ql/src/java/org/apache/hadoop/hive/ql/HiveQueryLifeTimeHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/HiveQueryLifeTimeHook.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.CompactionRequest;
 import org.apache.hadoop.hive.metastore.api.CompactionType;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.hooks.PrivateHookContext;
 import org.apache.hadoop.hive.ql.hooks.QueryLifeTimeHook;
 import org.apache.hadoop.hive.ql.hooks.QueryLifeTimeHookContext;
@@ -70,7 +71,7 @@ public class HiveQueryLifeTimeHook implements QueryLifeTimeHook {
     HiveConf conf = ctx.getHiveConf();
     QueryPlan queryPlan = ctx.getHookContext().getQueryPlan();
     boolean isCTAS = Optional.ofNullable(queryPlan.getQueryProperties())
-        .map(queryProps -> queryProps.isCTAS()).orElse(false);
+        .map(queryProps -> queryProps.hasFeature(QueryFeature.CTAS)).orElse(false);
 
     PrivateHookContext pCtx = (PrivateHookContext) ctx.getHookContext();
     Path tblPath = pCtx.getContext().getLocation();

--- a/ql/src/java/org/apache/hadoop/hive/ql/QueryProperties.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/QueryProperties.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql;
 
 
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -56,6 +57,24 @@ public class QueryProperties {
     }
   }
 
+  public enum QueryFeature {
+    GROUP_BY,
+    ORDER_BY,
+    OUTER_ORDER_BY,
+    SORT_BY,
+    LIMIT,
+    JOIN_FOLLOWED_BY_GROUP_BY,
+    PTF,
+    WINDOWING,
+    QUALIFY,
+    EXCEPT,
+    INTERSECT,
+    USES_SCRIPT,
+    DISTRIBUTE_BY,
+    CLUSTER_BY,
+    MAP_GROUP_BY
+  }
+
   boolean query;
   boolean analyzeCommand;
   boolean noScanAnalyzeCommand;
@@ -64,25 +83,8 @@ public class QueryProperties {
   int outerQueryLimit;
 
   boolean hasJoin = false;
-  boolean hasGroupBy = false;
-  boolean hasOrderBy = false;
-  boolean hasOuterOrderBy = false;
-  boolean hasSortBy = false;
-  boolean hasLimit = false;
-  boolean hasJoinFollowedByGroupBy = false;
-  boolean hasPTF = false;
-  boolean hasWindowing = false;
-  boolean hasQualify = false;
-  boolean hasExcept = false;
-  boolean hasIntersect = false;
-
-  // does the query have a using clause
-  boolean usesScript = false;
-
-  boolean hasDistributeBy = false;
-  boolean hasClusterBy = false;
+  private final EnumSet<QueryFeature> features = EnumSet.noneOf(QueryFeature.class);
   boolean mapJoinRemoved = false;
-  boolean hasMapGroupBy = false;
 
   private boolean hasLateralViews = false;
   private boolean cboSupportedLateralViews = true;
@@ -196,116 +198,124 @@ public class QueryProperties {
     return cboSupportedLateralViews;
   }
 
+  public void addFeature(QueryFeature feature) {
+    features.add(feature);
+  }
+
+  public boolean hasFeature(QueryFeature feature) {
+    return features.contains(feature);
+  }
+
   public boolean hasGroupBy() {
-    return hasGroupBy;
+    return hasFeature(QueryFeature.GROUP_BY);
   }
 
   public void setHasGroupBy(boolean hasGroupBy) {
-    this.hasGroupBy = hasGroupBy;
+    setFeature(QueryFeature.GROUP_BY, hasGroupBy);
   }
 
   public boolean hasOrderBy() {
-    return hasOrderBy;
+    return hasFeature(QueryFeature.ORDER_BY);
   }
 
   public void setHasOrderBy(boolean hasOrderBy) {
-    this.hasOrderBy = hasOrderBy;
+    setFeature(QueryFeature.ORDER_BY, hasOrderBy);
   }
 
   public boolean hasOuterOrderBy() {
-    return hasOuterOrderBy;
+    return hasFeature(QueryFeature.OUTER_ORDER_BY);
   }
 
   public void setHasOuterOrderBy(boolean hasOuterOrderBy) {
-    this.hasOuterOrderBy = hasOuterOrderBy;
+    setFeature(QueryFeature.OUTER_ORDER_BY, hasOuterOrderBy);
   }
 
   public boolean hasSortBy() {
-    return hasSortBy;
+    return hasFeature(QueryFeature.SORT_BY);
   }
 
   public void setHasSortBy(boolean hasSortBy) {
-    this.hasSortBy = hasSortBy;
+    setFeature(QueryFeature.SORT_BY, hasSortBy);
   }
 
   public void setHasLimit(boolean hasLimit) {
-    this.hasLimit = hasLimit;
+    setFeature(QueryFeature.LIMIT, hasLimit);
   }
 
   public boolean hasLimit() {
-    return hasLimit;
+    return hasFeature(QueryFeature.LIMIT);
   }
 
   public boolean hasJoinFollowedByGroupBy() {
-    return hasJoinFollowedByGroupBy;
+    return hasFeature(QueryFeature.JOIN_FOLLOWED_BY_GROUP_BY);
   }
 
   public void setHasJoinFollowedByGroupBy(boolean hasJoinFollowedByGroupBy) {
-    this.hasJoinFollowedByGroupBy = hasJoinFollowedByGroupBy;
+    setFeature(QueryFeature.JOIN_FOLLOWED_BY_GROUP_BY, hasJoinFollowedByGroupBy);
   }
 
   public boolean usesScript() {
-    return usesScript;
+    return hasFeature(QueryFeature.USES_SCRIPT);
   }
 
   public void setUsesScript(boolean usesScript) {
-    this.usesScript = usesScript;
+    setFeature(QueryFeature.USES_SCRIPT, usesScript);
   }
 
   public boolean hasDistributeBy() {
-    return hasDistributeBy;
+    return hasFeature(QueryFeature.DISTRIBUTE_BY);
   }
 
   public void setHasDistributeBy(boolean hasDistributeBy) {
-    this.hasDistributeBy = hasDistributeBy;
+    setFeature(QueryFeature.DISTRIBUTE_BY, hasDistributeBy);
   }
 
   public boolean hasClusterBy() {
-    return hasClusterBy;
+    return hasFeature(QueryFeature.CLUSTER_BY);
   }
 
   public void setHasClusterBy(boolean hasClusterBy) {
-    this.hasClusterBy = hasClusterBy;
+    setFeature(QueryFeature.CLUSTER_BY, hasClusterBy);
   }
 
   public boolean hasPTF() {
-    return hasPTF;
+    return hasFeature(QueryFeature.PTF);
   }
 
   public void setHasPTF(boolean hasPTF) {
-    this.hasPTF = hasPTF;
+    setFeature(QueryFeature.PTF, hasPTF);
   }
 
   public boolean hasWindowing() {
-    return hasWindowing;
+    return hasFeature(QueryFeature.WINDOWING);
   }
 
   public void setHasWindowing(boolean hasWindowing) {
-    this.hasWindowing = hasWindowing;
+    setFeature(QueryFeature.WINDOWING, hasWindowing);
   }
 
   public boolean hasQualify() {
-    return hasQualify;
+    return hasFeature(QueryFeature.QUALIFY);
   }
 
   public void setHasQualify(boolean hasQualify) {
-    this.hasQualify = hasQualify;
+    setFeature(QueryFeature.QUALIFY, hasQualify);
   }
 
   public boolean hasExcept() {
-    return hasExcept;
+    return hasFeature(QueryFeature.EXCEPT);
   }
 
   public void setHasExcept(boolean hasExcept) {
-    this.hasExcept = hasExcept;
+    setFeature(QueryFeature.EXCEPT, hasExcept);
   }
 
   public boolean hasIntersect() {
-    return hasIntersect;
+    return hasFeature(QueryFeature.INTERSECT);
   }
 
   public void setHasIntersect(boolean hasIntersect) {
-    this.hasIntersect = hasIntersect;
+    setFeature(QueryFeature.INTERSECT, hasIntersect);
   }
 
   public boolean isMapJoinRemoved() {
@@ -317,11 +327,11 @@ public class QueryProperties {
   }
 
   public boolean isHasMapGroupBy() {
-    return hasMapGroupBy;
+    return hasFeature(QueryFeature.MAP_GROUP_BY);
   }
 
   public void setHasMapGroupBy(boolean hasMapGroupBy) {
-    this.hasMapGroupBy = hasMapGroupBy;
+    setFeature(QueryFeature.MAP_GROUP_BY, hasMapGroupBy);
   }
 
   public boolean hasMultiDestQuery() {
@@ -386,24 +396,8 @@ public class QueryProperties {
     isMaterializedView = false;
 
     hasJoin = false;
-    hasGroupBy = false;
-    hasOrderBy = false;
-    hasOuterOrderBy = false;
-    hasSortBy = false;
-    hasJoinFollowedByGroupBy = false;
-    hasPTF = false;
-    hasWindowing = false;
-    hasQualify = false;
-    hasExcept = false;
-    hasIntersect = false;
-
-    // does the query have a using clause
-    usesScript = false;
-
-    hasDistributeBy = false;
-    hasClusterBy = false;
+    features.clear();
     mapJoinRemoved = false;
-    hasMapGroupBy = false;
 
     noOfJoins = 0;
     noOfOuterJoins = 0;
@@ -412,5 +406,13 @@ public class QueryProperties {
     filterWithSubQuery = false;
 
     usedTables.clear();
+  }
+
+  private void setFeature(QueryFeature feature, boolean enabled) {
+    if (enabled) {
+      addFeature(feature);
+    } else {
+      features.remove(feature);
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/QueryProperties.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/QueryProperties.java
@@ -58,6 +58,8 @@ public class QueryProperties {
   }
 
   public enum QueryFeature {
+    QUERY,
+    JOIN,
     GROUP_BY,
     ORDER_BY,
     OUTER_ORDER_BY,
@@ -72,88 +74,31 @@ public class QueryProperties {
     USES_SCRIPT,
     DISTRIBUTE_BY,
     CLUSTER_BY,
-    MAP_GROUP_BY
+    MAP_GROUP_BY,
+    LATERAL_VIEW,
+    MULTI_DEST_QUERY,
+    FILTER_WITH_SUBQUERY,
+    MATERIALIZED_VIEW,
+    VIEW,
+    CTAS,
+    ANALYZE,
+    NO_SCAN,
+    REWRITE
   }
 
-  boolean query;
-  boolean analyzeCommand;
-  boolean noScanAnalyzeCommand;
-  boolean analyzeRewrite;
-  boolean ctas;
   int outerQueryLimit;
 
-  boolean hasJoin = false;
   private final EnumSet<QueryFeature> features = EnumSet.noneOf(QueryFeature.class);
-  boolean mapJoinRemoved = false;
 
-  private boolean hasLateralViews = false;
   private boolean cboSupportedLateralViews = true;
 
   private int noOfJoins = 0;
   private int noOfOuterJoins = 0;
 
-  private boolean multiDestQuery;
-  private boolean filterWithSubQuery;
-
-  // True if this statement creates or replaces a materialized view
-  private boolean isMaterializedView;
-  private boolean isView;
-
   private QueryType queryType = null;
 
   // set of used tables, aliases are resolved to real table names
   private Set<String> usedTables = new HashSet<>();
-
-  public boolean isQuery() {
-    return query;
-  }
-
-  public void setQuery(boolean query) {
-    this.query = query;
-  }
-
-  /**
-   * The return value of either isAnalyzeCommand() or isAnalyzeRewrite() is always true for analyze commands:
-   * isAnalyzeCommand=true for "compute statistics",
-   * isAnalyzeRewrite=true for "compute statistics for columns".
-   *
-   * @return whether the query is an ANALYZE TABLE query
-   */
-  public boolean isAnalyze() {
-    return isAnalyzeCommand() || isAnalyzeRewrite();
-  }
-
-  public boolean isAnalyzeCommand() {
-    return analyzeCommand;
-  }
-
-  public void setAnalyzeCommand(boolean analyzeCommand) {
-    this.analyzeCommand = analyzeCommand;
-  }
-
-  public boolean isNoScanAnalyzeCommand() {
-    return noScanAnalyzeCommand;
-  }
-
-  public void setNoScanAnalyzeCommand(boolean noScanAnalyzeCommand) {
-    this.noScanAnalyzeCommand = noScanAnalyzeCommand;
-  }
-
-  public boolean isAnalyzeRewrite() {
-    return analyzeRewrite;
-  }
-
-  public void setAnalyzeRewrite(boolean analyzeRewrite) {
-    this.analyzeRewrite = analyzeRewrite;
-  }
-
-  public boolean isCTAS() {
-    return ctas;
-  }
-
-  public void setCTAS(boolean ctas) {
-    this.ctas = ctas;
-  }
 
   public int getOuterQueryLimit() {
     return outerQueryLimit;
@@ -163,11 +108,8 @@ public class QueryProperties {
     this.outerQueryLimit = outerQueryLimit;
   }
 
-  public boolean hasJoin() {
-    return (noOfJoins > 0);
-  }
-
   public void incrementJoinCount(boolean outerJoin) {
+    addFeature(QueryFeature.JOIN);
     noOfJoins++;
     if (outerJoin) {
       noOfOuterJoins++;
@@ -182,16 +124,8 @@ public class QueryProperties {
     return noOfOuterJoins;
   }
 
-  public void setHasLateralViews(boolean hasLateralViews) {
-    this.hasLateralViews = hasLateralViews;
-  }
-
-  public boolean hasLateralViews() {
-    return hasLateralViews;
-  }
-
-  public void setCBOSupportedLateralViews(boolean cboSupportedLateralViews) {
-    this.cboSupportedLateralViews = cboSupportedLateralViews;
+  public void markUnsupportedLateralViewsForCBO() {
+    this.cboSupportedLateralViews = false;
   }
 
   public boolean isCBOSupportedLateralViews() {
@@ -204,170 +138,6 @@ public class QueryProperties {
 
   public boolean hasFeature(QueryFeature feature) {
     return features.contains(feature);
-  }
-
-  public boolean hasGroupBy() {
-    return hasFeature(QueryFeature.GROUP_BY);
-  }
-
-  public void setHasGroupBy(boolean hasGroupBy) {
-    setFeature(QueryFeature.GROUP_BY, hasGroupBy);
-  }
-
-  public boolean hasOrderBy() {
-    return hasFeature(QueryFeature.ORDER_BY);
-  }
-
-  public void setHasOrderBy(boolean hasOrderBy) {
-    setFeature(QueryFeature.ORDER_BY, hasOrderBy);
-  }
-
-  public boolean hasOuterOrderBy() {
-    return hasFeature(QueryFeature.OUTER_ORDER_BY);
-  }
-
-  public void setHasOuterOrderBy(boolean hasOuterOrderBy) {
-    setFeature(QueryFeature.OUTER_ORDER_BY, hasOuterOrderBy);
-  }
-
-  public boolean hasSortBy() {
-    return hasFeature(QueryFeature.SORT_BY);
-  }
-
-  public void setHasSortBy(boolean hasSortBy) {
-    setFeature(QueryFeature.SORT_BY, hasSortBy);
-  }
-
-  public void setHasLimit(boolean hasLimit) {
-    setFeature(QueryFeature.LIMIT, hasLimit);
-  }
-
-  public boolean hasLimit() {
-    return hasFeature(QueryFeature.LIMIT);
-  }
-
-  public boolean hasJoinFollowedByGroupBy() {
-    return hasFeature(QueryFeature.JOIN_FOLLOWED_BY_GROUP_BY);
-  }
-
-  public void setHasJoinFollowedByGroupBy(boolean hasJoinFollowedByGroupBy) {
-    setFeature(QueryFeature.JOIN_FOLLOWED_BY_GROUP_BY, hasJoinFollowedByGroupBy);
-  }
-
-  public boolean usesScript() {
-    return hasFeature(QueryFeature.USES_SCRIPT);
-  }
-
-  public void setUsesScript(boolean usesScript) {
-    setFeature(QueryFeature.USES_SCRIPT, usesScript);
-  }
-
-  public boolean hasDistributeBy() {
-    return hasFeature(QueryFeature.DISTRIBUTE_BY);
-  }
-
-  public void setHasDistributeBy(boolean hasDistributeBy) {
-    setFeature(QueryFeature.DISTRIBUTE_BY, hasDistributeBy);
-  }
-
-  public boolean hasClusterBy() {
-    return hasFeature(QueryFeature.CLUSTER_BY);
-  }
-
-  public void setHasClusterBy(boolean hasClusterBy) {
-    setFeature(QueryFeature.CLUSTER_BY, hasClusterBy);
-  }
-
-  public boolean hasPTF() {
-    return hasFeature(QueryFeature.PTF);
-  }
-
-  public void setHasPTF(boolean hasPTF) {
-    setFeature(QueryFeature.PTF, hasPTF);
-  }
-
-  public boolean hasWindowing() {
-    return hasFeature(QueryFeature.WINDOWING);
-  }
-
-  public void setHasWindowing(boolean hasWindowing) {
-    setFeature(QueryFeature.WINDOWING, hasWindowing);
-  }
-
-  public boolean hasQualify() {
-    return hasFeature(QueryFeature.QUALIFY);
-  }
-
-  public void setHasQualify(boolean hasQualify) {
-    setFeature(QueryFeature.QUALIFY, hasQualify);
-  }
-
-  public boolean hasExcept() {
-    return hasFeature(QueryFeature.EXCEPT);
-  }
-
-  public void setHasExcept(boolean hasExcept) {
-    setFeature(QueryFeature.EXCEPT, hasExcept);
-  }
-
-  public boolean hasIntersect() {
-    return hasFeature(QueryFeature.INTERSECT);
-  }
-
-  public void setHasIntersect(boolean hasIntersect) {
-    setFeature(QueryFeature.INTERSECT, hasIntersect);
-  }
-
-  public boolean isMapJoinRemoved() {
-    return mapJoinRemoved;
-  }
-
-  public void setMapJoinRemoved(boolean mapJoinRemoved) {
-    this.mapJoinRemoved = mapJoinRemoved;
-  }
-
-  public boolean isHasMapGroupBy() {
-    return hasFeature(QueryFeature.MAP_GROUP_BY);
-  }
-
-  public void setHasMapGroupBy(boolean hasMapGroupBy) {
-    setFeature(QueryFeature.MAP_GROUP_BY, hasMapGroupBy);
-  }
-
-  public boolean hasMultiDestQuery() {
-    return this.multiDestQuery;
-  }
-
-  public void setMultiDestQuery(boolean multiDestQuery) {
-    this.multiDestQuery = multiDestQuery;
-  }
-
-  public void setFilterWithSubQuery(boolean filterWithSubQuery) {
-    this.filterWithSubQuery = filterWithSubQuery;
-  }
-
-  public boolean hasFilterWithSubQuery() {
-    return this.filterWithSubQuery;
-  }
-
-  /**
-   * True indicates this statement create or replaces a materialized view, not that it is a query
-   * against a materialized view.
-   */
-  public boolean isMaterializedView() {
-    return isMaterializedView;
-  }
-
-  public void setMaterializedView(boolean isMaterializedView) {
-    this.isMaterializedView = isMaterializedView;
-  }
-
-  public boolean isView() {
-    return isView;
-  }
-
-  public void setView(boolean view) {
-    isView = view;
   }
 
   public QueryType getQueryType() {
@@ -387,32 +157,14 @@ public class QueryProperties {
   }
 
   public void clear() {
-    query = false;
-    analyzeCommand = false;
-    noScanAnalyzeCommand = false;
-    analyzeRewrite = false;
-    ctas = false;
     outerQueryLimit = -1;
-    isMaterializedView = false;
 
-    hasJoin = false;
     features.clear();
-    mapJoinRemoved = false;
+    cboSupportedLateralViews = true;
 
     noOfJoins = 0;
     noOfOuterJoins = 0;
 
-    multiDestQuery = false;
-    filterWithSubQuery = false;
-
     usedTables.clear();
-  }
-
-  private void setFeature(QueryFeature feature, boolean enabled) {
-    if (enabled) {
-      addFeature(feature);
-    } else {
-      features.remove(feature);
-    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRTableScan1.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRTableScan1.java
@@ -84,7 +84,8 @@ public class GenMRTableScan1 implements SemanticNodeProcessor {
         ctx.setCurrAliasId(currAliasId);
         mapCurrCtx.put(op, new GenMapRedCtx(currTask, currAliasId));
 
-        if (parseCtx.getQueryProperties().hasFeature(QueryFeature.ANALYZE)) {
+        if (parseCtx.getQueryProperties().hasFeature(QueryFeature.ANALYZE)
+            && !parseCtx.getQueryProperties().hasFeature(QueryFeature.REWRITE)) {
           boolean noScan = parseCtx.getQueryProperties().hasFeature(QueryFeature.NO_SCAN);
           if (BasicStatsNoJobTask.canUseBasicStats(table, inputFormat)) {
             // For ORC and Parquet, all the following statements are the same

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRTableScan1.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRTableScan1.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
 import org.apache.hadoop.hive.ql.exec.Task;
@@ -83,8 +84,8 @@ public class GenMRTableScan1 implements SemanticNodeProcessor {
         ctx.setCurrAliasId(currAliasId);
         mapCurrCtx.put(op, new GenMapRedCtx(currTask, currAliasId));
 
-        if (parseCtx.getQueryProperties().isAnalyzeCommand()) {
-          boolean noScan = parseCtx.getQueryProperties().isNoScanAnalyzeCommand();
+        if (parseCtx.getQueryProperties().hasFeature(QueryFeature.ANALYZE)) {
+          boolean noScan = parseCtx.getQueryProperties().hasFeature(QueryFeature.NO_SCAN);
           if (BasicStatsNoJobTask.canUseBasicStats(table, inputFormat)) {
             // For ORC and Parquet, all the following statements are the same
             // ANALYZE TABLE T [PARTITION (...)] COMPUTE STATISTICS

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GroupByOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GroupByOptimizer.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -212,7 +213,7 @@ public class GroupByOptimizer extends Transform {
         convertGroupByMapSideSortedGroupBy(hiveConf, groupByOp, depth);
       }
       else if (optimizeDistincts && !HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED)) {
-        pGraphContext.getQueryProperties().setHasMapGroupBy(true);
+        pGraphContext.getQueryProperties().addFeature(QueryFeature.MAP_GROUP_BY);
         ReduceSinkOperator reduceSinkOp =
             (ReduceSinkOperator)groupByOp.getChildOperators().get(0);
         GroupByDesc childGroupByDesc =
@@ -514,7 +515,7 @@ public class GroupByOptimizer extends Transform {
     // The operators specified by depth and removed from the tree.
     protected void convertGroupByMapSideSortedGroupBy(
         HiveConf conf, GroupByOperator groupByOp, int depth) {
-      pGraphContext.getQueryProperties().setHasMapGroupBy(true);
+      pGraphContext.getQueryProperties().addFeature(QueryFeature.MAP_GROUP_BY);
 
       if (removeChildren(groupByOp, depth)) {
         // Use bucketized hive input format - that makes sure that one mapper reads the entire file

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchAggregation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchAggregation.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Stack;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -55,8 +56,9 @@ public class SimpleFetchAggregation extends Transform {
 
   @Override
   public ParseContext transform(ParseContext pctx) throws SemanticException {
-    if (pctx.getFetchTask() != null || !pctx.getQueryProperties().isQuery() ||
-        pctx.getQueryProperties().isAnalyzeRewrite() || pctx.getQueryProperties().isCTAS() ||
+    if (pctx.getFetchTask() != null || !pctx.getQueryProperties().hasFeature(QueryFeature.QUERY) ||
+        pctx.getQueryProperties().hasFeature(QueryFeature.REWRITE) ||
+        pctx.getQueryProperties().hasFeature(QueryFeature.CTAS) ||
         pctx.getLoadFileWork().size() > 1 || !pctx.getLoadTableWork().isEmpty()) {
       return pctx;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.exec.CommonJoinOperator;
 import org.apache.hadoop.hive.ql.exec.FetchTask;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
@@ -105,8 +106,9 @@ public class SimpleFetchOptimizer extends Transform {
   @Override
   public ParseContext transform(ParseContext pctx) throws SemanticException {
     Map<String, TableScanOperator> topOps = pctx.getTopOps();
-    if ((pctx.getQueryProperties().isQuery() || pctx.getQueryProperties().isView())
-        && !pctx.getQueryProperties().isAnalyzeCommand()
+    if ((pctx.getQueryProperties().hasFeature(QueryFeature.QUERY)
+        || pctx.getQueryProperties().hasFeature(QueryFeature.VIEW))
+        && !pctx.getQueryProperties().hasFeature(QueryFeature.ANALYZE)
         && topOps.size() == 1) {
       // no join, no groupby, no distinct, no lateral view, no subq,
       // no CTAS or insert, not analyze command, and single sourced.

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
@@ -106,9 +106,11 @@ public class SimpleFetchOptimizer extends Transform {
   @Override
   public ParseContext transform(ParseContext pctx) throws SemanticException {
     Map<String, TableScanOperator> topOps = pctx.getTopOps();
+    boolean isAnalyzeCommand = pctx.getQueryProperties().hasFeature(QueryFeature.ANALYZE)
+        && !pctx.getQueryProperties().hasFeature(QueryFeature.REWRITE);
     if ((pctx.getQueryProperties().hasFeature(QueryFeature.QUERY)
         || pctx.getQueryProperties().hasFeature(QueryFeature.VIEW))
-        && !pctx.getQueryProperties().hasFeature(QueryFeature.ANALYZE)
+        && !isAnalyzeCommand
         && topOps.size() == 1) {
       // no join, no groupby, no distinct, no lateral view, no subq,
       // no CTAS or insert, not analyze command, and single sourced.

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionOptimizer.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Order;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
@@ -732,7 +733,7 @@ public class SortedDynPartitionOptimizer extends Transform {
       // should honor the ordering of records provided by ORDER BY in SELECT statement
       ReduceSinkOperator parentRSOp = OperatorUtils.findSingleOperatorUpstream(parent,
           ReduceSinkOperator.class);
-      if (parentRSOp != null && parseCtx.getQueryProperties().hasOuterOrderBy()) {
+      if (parentRSOp != null && parseCtx.getQueryProperties().hasFeature(QueryFeature.OUTER_ORDER_BY)) {
         String parentRSOpOrder = parentRSOp.getConf().getOrder();
         String parentRSOpNullOrder = parentRSOp.getConf().getNullOrder();
         if (parentRSOpOrder != null && !parentRSOpOrder.isEmpty() && sortPositions.isEmpty()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionTimeGranularityOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionTimeGranularityOptimizer.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -137,7 +138,7 @@ public class SortedDynPartitionTimeGranularityOptimizer extends Transform {
       // introduce RS and EX before FS
       FileSinkOperator fsOp = (FileSinkOperator) nd;
       final String sh = fsOp.getConf().getTableInfo().getOutputFileFormatClassName();
-      if (parseCtx.getQueryProperties().isQuery() || sh == null || !sh
+      if (parseCtx.getQueryProperties().hasFeature(QueryFeature.QUERY) || sh == null || !sh
               .equals(Constants.DRUID_HIVE_OUTPUT_FORMAT)) {
         // Bail out, nothing to do
         return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/StatsOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/StatsOptimizer.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.DoubleColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.LongColumnStatsData;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FetchTask;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
@@ -108,8 +109,9 @@ public class StatsOptimizer extends Transform {
   @Override
   public ParseContext transform(ParseContext pctx) throws SemanticException {
 
-    if (pctx.getFetchTask() != null || !pctx.getQueryProperties().isQuery()
-        || pctx.getQueryProperties().isAnalyzeRewrite() || pctx.getQueryProperties().isCTAS()
+    if (pctx.getFetchTask() != null || !pctx.getQueryProperties().hasFeature(QueryFeature.QUERY)
+        || pctx.getQueryProperties().hasFeature(QueryFeature.REWRITE)
+        || pctx.getQueryProperties().hasFeature(QueryFeature.CTAS)
         || pctx.getLoadFileWork().size() > 1 || !pctx.getLoadTableWork().isEmpty()
         // If getNameToSplitSample is not empty, at least one of the source
         // tables is being sampled and we can not optimize.

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/Generator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/Generator.java
@@ -28,6 +28,7 @@ import java.util.function.Predicate;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.exec.CommonJoinOperator;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
@@ -68,11 +69,12 @@ public class Generator extends Transform {
 
   enum LineageInfoFilter {
     CREATE_TABLE(parseContext -> parseContext.getCreateTable() != null),
-    CREATE_TABLE_AS_SELECT(parseContext -> parseContext.getQueryProperties().isCTAS()),
-    CREATE_VIEW(parseContext -> parseContext.getQueryProperties().isView()),
-    CREATE_MATERIALIZED_VIEW(parseContext -> parseContext.getQueryProperties().isMaterializedView()),
+    CREATE_TABLE_AS_SELECT(parseContext -> parseContext.getQueryProperties().hasFeature(QueryFeature.CTAS)),
+    CREATE_VIEW(parseContext -> parseContext.getQueryProperties().hasFeature(QueryFeature.VIEW)),
+    CREATE_MATERIALIZED_VIEW(parseContext ->
+        parseContext.getQueryProperties().hasFeature(QueryFeature.MATERIALIZED_VIEW)),
     LOAD(parseContext -> !(parseContext.getLoadTableWork() == null || parseContext.getLoadTableWork().isEmpty())),
-    QUERY(parseContext -> parseContext.getQueryProperties().isQuery()),
+    QUERY(parseContext -> parseContext.getQueryProperties().hasFeature(QueryFeature.QUERY)),
     ALL(parseContext -> true),
     NONE(parseContext -> false);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -141,6 +141,7 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryProperties;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FunctionInfo;
@@ -689,9 +690,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
           this.ctx.setCboInfo(cboMsg);
 
           // Determine if we should re-throw the exception OR if we try to mark the query to retry as non-CBO.
-          final boolean requiresCBO = queryProperties.hasQualify()
-              || queryProperties.hasExcept()
-              || queryProperties.hasIntersect();
+          final boolean requiresCBO = queryProperties.hasFeature(QueryFeature.QUALIFY)
+              || queryProperties.hasFeature(QueryFeature.EXCEPT)
+              || queryProperties.hasFeature(QueryFeature.INTERSECT);
           if (requiresCBO || fallbackStrategy.isFatal(e)) {
             if (e instanceof RuntimeException || e instanceof SemanticException) {
               // These types of exceptions do not need wrapped
@@ -1000,13 +1001,13 @@ public class CalcitePlanner extends SemanticAnalyzer {
                                           HiveConf conf, boolean topLevelQB) {
     List<String> reasons = new ArrayList<>();
     // Not ok to run CBO, build error message.
-    if (queryProperties.hasSortBy() && queryProperties.hasLimit()) {
+    if (queryProperties.hasFeature(QueryFeature.SORT_BY) && queryProperties.hasFeature(QueryFeature.LIMIT)) {
       reasons.add("has sort by with limit");
     }
-    if (queryProperties.hasPTF()) {
+    if (queryProperties.hasFeature(QueryFeature.PTF)) {
       reasons.add("has PTF");
     }
-    if (queryProperties.usesScript()) {
+    if (queryProperties.hasFeature(QueryFeature.USES_SCRIPT)) {
       reasons.add("uses scripts");
     }
     if (!queryProperties.isCBOSupportedLateralViews()) {
@@ -1024,7 +1025,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
       profilesCBO.add(ExtendedCBOProfile.JOIN_REORDERING);
     }
     // If the query contains windowing processing
-    if (queryProperties.hasWindowing()) {
+    if (queryProperties.hasFeature(QueryFeature.WINDOWING)) {
       profilesCBO.add(ExtendedCBOProfile.WINDOWING_POSTPROCESSING);
     }
     return profilesCBO;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -568,7 +568,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
       }
       Pair<Boolean, String> canCBOHandleReason = canCBOHandleAst(queryForCbo, getQB(), cboCtx);
       runCBO = canCBOHandleReason.left;
-      if (queryProperties.hasMultiDestQuery()) {
+      if (queryProperties.hasFeature(QueryFeature.MULTI_DEST_QUERY)) {
         handleMultiDestQuery(ast, cboCtx);
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ProcessAnalyzeTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ProcessAnalyzeTable.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
@@ -72,7 +73,7 @@ public class ProcessAnalyzeTable implements SemanticNodeProcessor {
     Table table = tableScan.getConf().getTableMetadata();
     Class<? extends InputFormat> inputFormat = table.getInputFormatClass();
 
-    if (parseContext.getQueryProperties().isAnalyzeCommand()) {
+    if (parseContext.getQueryProperties().hasFeature(QueryFeature.ANALYZE)) {
 
       assert tableScan.getChildOperators() == null || tableScan.getChildOperators().size() == 0;
 
@@ -114,7 +115,7 @@ public class ProcessAnalyzeTable implements SemanticNodeProcessor {
 
         BasicStatsWork basicStatsWork = new BasicStatsWork(table.getTableSpec());
         basicStatsWork.setIsExplicitAnalyze(true);
-        basicStatsWork.setNoScanAnalyzeCommand(parseContext.getQueryProperties().isNoScanAnalyzeCommand());
+        basicStatsWork.setNoScanAnalyzeCommand(parseContext.getQueryProperties().hasFeature(QueryFeature.NO_SCAN));
         StatsWork columnStatsWork = new StatsWork(table, basicStatsWork, parseContext.getConf());
         columnStatsWork.collectStatsFromAggregator(tableScan.getConf());
 
@@ -124,7 +125,7 @@ public class ProcessAnalyzeTable implements SemanticNodeProcessor {
 
         // ANALYZE TABLE T [PARTITION (...)] COMPUTE STATISTICS noscan;
         // The plan consists of a StatsTask only.
-        if (parseContext.getQueryProperties().isNoScanAnalyzeCommand()) {
+        if (parseContext.getQueryProperties().hasFeature(QueryFeature.NO_SCAN)) {
           statsTask.setParentTasks(null);
           context.rootTasks.remove(context.currentTask);
           context.rootTasks.add(statsTask);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ProcessAnalyzeTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ProcessAnalyzeTable.java
@@ -73,7 +73,8 @@ public class ProcessAnalyzeTable implements SemanticNodeProcessor {
     Table table = tableScan.getConf().getTableMetadata();
     Class<? extends InputFormat> inputFormat = table.getInputFormatClass();
 
-    if (parseContext.getQueryProperties().hasFeature(QueryFeature.ANALYZE)) {
+    if (parseContext.getQueryProperties().hasFeature(QueryFeature.ANALYZE)
+        && !parseContext.getQueryProperties().hasFeature(QueryFeature.REWRITE)) {
 
       assert tableScan.getChildOperators() == null || tableScan.getChildOperators().size() == 0;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -111,6 +111,7 @@ import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryProperties;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.cache.results.CacheUsage;
 import org.apache.hadoop.hive.ql.cache.results.QueryResultsCache;
@@ -669,19 +670,19 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         qbexpr.setOpcode(QBExpr.Opcode.UNION);
         break;
       case HiveParser.TOK_INTERSECTALL:
-        queryProperties.setHasIntersect(true);
+        queryProperties.addFeature(QueryFeature.INTERSECT);
         qbexpr.setOpcode(QBExpr.Opcode.INTERSECTALL);
         break;
       case HiveParser.TOK_INTERSECTDISTINCT:
-        queryProperties.setHasIntersect(true);
+        queryProperties.addFeature(QueryFeature.INTERSECT);
         qbexpr.setOpcode(QBExpr.Opcode.INTERSECT);
         break;
       case HiveParser.TOK_EXCEPTALL:
-        queryProperties.setHasExcept(true);
+        queryProperties.addFeature(QueryFeature.EXCEPT);
         qbexpr.setOpcode(QBExpr.Opcode.EXCEPTALL);
         break;
       case HiveParser.TOK_EXCEPTDISTINCT:
-        queryProperties.setHasExcept(true);
+        queryProperties.addFeature(QueryFeature.EXCEPT);
         qbexpr.setOpcode(QBExpr.Opcode.EXCEPT);
         break;
       default:
@@ -724,7 +725,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     for (ASTNode wdwFn : wdwFns) {
       WindowingSpec spec = qb.getWindowingSpec(dest);
       if(spec == null) {
-        queryProperties.setHasWindowing(true);
+        queryProperties.addFeature(QueryFeature.WINDOWING);
         spec = new WindowingSpec();
         qb.addDestToWindowingSpec(dest, spec);
       }
@@ -1674,7 +1675,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       } else if (child.getToken().getType() == HiveParser.TOK_SUBQUERY) {
         processSubQuery(qb, child);
       } else if (child.getToken().getType() == HiveParser.TOK_PTBLFUNCTION) {
-        queryProperties.setHasPTF(true);
+        queryProperties.addFeature(QueryFeature.PTF);
         processPTF(qb, child);
         PTFInvocationSpec ptfInvocationSpec = qb.getPTFInvocationSpec(child);
         String inputAlias = ptfInvocationSpec == null ? null :
@@ -1785,7 +1786,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         }
 
         if ((ast.getChild(posn).getChild(0).getType() == HiveParser.TOK_TRANSFORM)) {
-          queryProperties.setUsesScript(true);
+          queryProperties.addFeature(QueryFeature.USES_SCRIPT);
         }
 
         Map<String, ASTNode> aggregations = doPhase1GetAggregationsFromSelect(ast, qb, ctx_1.dest);
@@ -1894,7 +1895,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           processJoin(qb, frm);
           qbp.setJoinExpr(frm);
         }else if(frm.getToken().getType() == HiveParser.TOK_PTBLFUNCTION){
-          queryProperties.setHasPTF(true);
+          queryProperties.addFeature(QueryFeature.PTF);
           processPTF(qb, frm);
         }
         break;
@@ -1902,14 +1903,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       case HiveParser.TOK_CLUSTERBY:
         // Get the clusterby aliases - these are aliased to the entries in the
         // select list
-        queryProperties.setHasClusterBy(true);
+        queryProperties.addFeature(QueryFeature.CLUSTER_BY);
         qbp.setClusterByExprForClause(ctx_1.dest, ast);
         break;
 
       case HiveParser.TOK_DISTRIBUTEBY:
         // Get the distribute by aliases - these are aliased to the entries in
         // the select list
-        queryProperties.setHasDistributeBy(true);
+        queryProperties.addFeature(QueryFeature.DISTRIBUTE_BY);
         qbp.setDistributeByExprForClause(ctx_1.dest, ast);
         if (qbp.getClusterByForClause(ctx_1.dest) != null) {
           throw new SemanticException(generateErrorMessage(ast,
@@ -1923,7 +1924,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       case HiveParser.TOK_SORTBY:
         // Get the sort by aliases - these are aliased to the entries in the
         // select list
-        queryProperties.setHasSortBy(true);
+        queryProperties.addFeature(QueryFeature.SORT_BY);
         qbp.setSortByExprForClause(ctx_1.dest, ast);
         if (qbp.getClusterByForClause(ctx_1.dest) != null) {
           throw new SemanticException(generateErrorMessage(ast,
@@ -1938,7 +1939,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       case HiveParser.TOK_ORDERBY:
         // Get the order by aliases - these are aliased to the entries in the
         // select list
-        queryProperties.setHasOrderBy(true);
+        queryProperties.addFeature(QueryFeature.ORDER_BY);
         qbp.setOrderByExprForClause(ctx_1.dest, ast);
         if (qbp.getClusterByForClause(ctx_1.dest) != null) {
           throw new SemanticException(generateErrorMessage(ast,
@@ -1955,9 +1956,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       case HiveParser.TOK_GROUPING_SETS:
         // Get the groupby aliases - these are aliased to the entries in the
         // select list
-        queryProperties.setHasGroupBy(true);
+        queryProperties.addFeature(QueryFeature.GROUP_BY);
         if (qbp.getJoinExpr() != null) {
-          queryProperties.setHasJoinFollowedByGroupBy(true);
+          queryProperties.addFeature(QueryFeature.JOIN_FOLLOWED_BY_GROUP_BY);
         }
         qbp.setGroupByExprForClause(ctx_1.dest, ast);
         skipRecursion = true;
@@ -1982,7 +1983,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         break;
 
       case HiveParser.TOK_QUALIFY:
-        queryProperties.setHasQualify(true);
+        queryProperties.addFeature(QueryFeature.QUALIFY);
         qbp.setQualifyExprForClause(ctx_1.dest, ast);
         qbp.addAggregationExprsForClause(ctx_1.dest,
                 doPhase1GetAggregationsFromSelect(ast, qb, ctx_1.dest));
@@ -1997,7 +1998,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         break;
 
       case HiveParser.TOK_LIMIT:
-        queryProperties.setHasLimit(true);
+        queryProperties.addFeature(QueryFeature.LIMIT);
         if (ast.getChildCount() == 2) {
           qbp.setDestLimit(ctx_1.dest,
               Integer.valueOf(ast.getChild(0).getText()), Integer.valueOf(ast.getChild(1).getText()));
@@ -4767,7 +4768,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     boolean isInTransform = (selExprList.getChild(posn).getChild(0).getType() ==
         HiveParser.TOK_TRANSFORM);
     if (isInTransform) {
-      queryProperties.setUsesScript(true);
+      queryProperties.addFeature(QueryFeature.USES_SCRIPT);
       globalLimitCtx.setHasTransformOrUDTF(true);
       trfm = (ASTNode) selExprList.getChild(posn).getChild(0);
     }
@@ -11594,7 +11595,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       curr = genHavingPlan(dest, qb, curr, aliasToOpInfo);
     }
 
-    if(queryProperties.hasWindowing() && qb.getWindowingSpec(dest) != null) {
+    if(queryProperties.hasFeature(QueryFeature.WINDOWING) && qb.getWindowingSpec(dest) != null) {
       curr = genWindowingPlan(qb, qb.getWindowingSpec(dest), curr);
       // GBy for DISTINCT after windowing
       if ((qbp.getAggregationExprsForClause(dest).size() != 0
@@ -12419,7 +12420,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     Operator srcOpInfo = null;
     Operator lastPTFOp = null;
 
-    if(queryProperties.hasPTF()){
+    if(queryProperties.hasFeature(QueryFeature.PTF)){
       //After processing subqueries and source tables, process
       // partitioned table functions
 
@@ -15118,8 +15119,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       if (qb.getParseInfo().hasInsertTables()) {
         queryProperties.setQueryType(QueryProperties.QueryType.DML);
       }
-      queryProperties.setHasOuterOrderBy(!qb.getParseInfo().getIsSubQ() &&
-          !qb.getParseInfo().getDestToOrderBy().isEmpty());
+      if (!qb.getParseInfo().getIsSubQ() && !qb.getParseInfo().getDestToOrderBy().isEmpty()) {
+        queryProperties.addFeature(QueryFeature.OUTER_ORDER_BY);
+      }
       queryProperties.setOuterQueryLimit(qb.getParseInfo().getOuterQueryLimit());
       queryProperties.setView(forViewCreation);
       queryProperties.setMaterializedView(qb.isMaterializedView());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -1714,7 +1714,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     int numChildren = lateralView.getChildCount();
     assert (numChildren == 2);
 
-    queryProperties.setCBOSupportedLateralViews(isCBOSupportedLateralView());
+    if (!isCBOSupportedLateralView()) {
+      queryProperties.markUnsupportedLateralViewsForCBO();
+    }
 
     ASTNode next = (ASTNode) lateralView.getChild(1);
     String alias = null;
@@ -1799,7 +1801,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       case HiveParser.TOK_WHERE:
         qbp.setWhrExprForClause(ctx_1.dest, ast);
         if (!SubQueryUtils.findSubQueries((ASTNode) ast.getChild(0)).isEmpty()) {
-          queryProperties.setFilterWithSubQuery(true);
+          queryProperties.addFeature(QueryFeature.FILTER_WITH_SUBQUERY);
         }
         doPhase1WhereClause(ast, qb);
         break;
@@ -1854,10 +1856,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           // Using qbp.getClauseNamesForDest().size() >= 2 would be
           // equivalent, but we use == to avoid setting the property
           // multiple times
-          queryProperties.setMultiDestQuery(true);
+          queryProperties.addFeature(QueryFeature.MULTI_DEST_QUERY);
         }
 
-        if (plannerCtx != null && !queryProperties.hasMultiDestQuery()) {
+        if (plannerCtx != null && !queryProperties.hasFeature(QueryFeature.MULTI_DEST_QUERY)) {
           plannerCtx.setInsertToken(ast, isTmpFileDest);
         } else if (plannerCtx != null && qbp.getClauseNamesForDest().size() == 2) {
           // For multi-insert query, currently we only optimize the FROM clause.
@@ -1889,7 +1891,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         } else if (frm.getToken().getType() == HiveParser.TOK_SUBQUERY) {
           processSubQuery(qb, frm);
         } else if (isASTNodeLateralView(frm)) {
-          queryProperties.setHasLateralViews(true);
+          queryProperties.addFeature(QueryFeature.LATERAL_VIEW);
           processLateralView(qb, frm);
         } else if (isJoinToken(frm)) {
           processJoin(qb, frm);
@@ -10326,7 +10328,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           }
         }
         else {
-          queryProperties.setMapJoinRemoved(true);
         }
       }
     }
@@ -15111,11 +15112,23 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
   private void copyInfoToQueryProperties(QueryProperties queryProperties) {
     if (qb != null) {
-      queryProperties.setQuery(qb.getIsQuery() && !forViewCreation);
-      queryProperties.setAnalyzeCommand(qb.getParseInfo().isAnalyzeCommand());
-      queryProperties.setNoScanAnalyzeCommand(qb.getParseInfo().isNoScanAnalyzeCommand());
-      queryProperties.setAnalyzeRewrite(qb.isAnalyzeRewrite());
-      queryProperties.setCTAS(qb.getTableDesc() != null);
+      if (qb.getIsQuery() && !forViewCreation) {
+        queryProperties.addFeature(QueryFeature.QUERY);
+      }
+      if (qb.getParseInfo().isAnalyzeCommand()) {
+        queryProperties.addFeature(QueryFeature.ANALYZE);
+      }
+      if (qb.getParseInfo().isNoScanAnalyzeCommand()) {
+        queryProperties.addFeature(QueryFeature.ANALYZE);
+        queryProperties.addFeature(QueryFeature.NO_SCAN);
+      }
+      if (qb.isAnalyzeRewrite()) {
+        queryProperties.addFeature(QueryFeature.ANALYZE);
+        queryProperties.addFeature(QueryFeature.REWRITE);
+      }
+      if (qb.getTableDesc() != null) {
+        queryProperties.addFeature(QueryFeature.CTAS);
+      }
       if (qb.getParseInfo().hasInsertTables()) {
         queryProperties.setQueryType(QueryProperties.QueryType.DML);
       }
@@ -15123,8 +15136,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         queryProperties.addFeature(QueryFeature.OUTER_ORDER_BY);
       }
       queryProperties.setOuterQueryLimit(qb.getParseInfo().getOuterQueryLimit());
-      queryProperties.setView(forViewCreation);
-      queryProperties.setMaterializedView(qb.isMaterializedView());
+      if (forViewCreation) {
+        queryProperties.addFeature(QueryFeature.VIEW);
+      }
+      if (qb.isMaterializedView()) {
+        queryProperties.addFeature(QueryFeature.MATERIALIZED_VIEW);
+      }
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -137,6 +137,7 @@ public abstract class TaskCompiler {
     List<LoadFileDesc> loadFileWork = pCtx.getLoadFileWork();
 
     boolean isCStats = pCtx.getQueryProperties().hasFeature(QueryFeature.REWRITE);
+    boolean isAnalyzeCommand = pCtx.getQueryProperties().hasFeature(QueryFeature.ANALYZE) && !isCStats;
     int outerQueryLimit = pCtx.getQueryProperties().getOuterQueryLimit();
 
     boolean directInsert = false;
@@ -179,7 +180,7 @@ public abstract class TaskCompiler {
       return;
     }
 
-    if (!pCtx.getQueryProperties().hasFeature(QueryFeature.ANALYZE)) {
+    if (!isAnalyzeCommand) {
       LOG.debug("Skipping optimize operator plan for analyze command.");
       optimizeOperatorPlan(pCtx);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.ddl.DDLDesc;
 import org.apache.hadoop.hive.ql.ddl.DDLDescWithTableProperties;
@@ -135,7 +136,7 @@ public abstract class TaskCompiler {
     List<LoadTableDesc> loadTableWork = pCtx.getLoadTableWork();
     List<LoadFileDesc> loadFileWork = pCtx.getLoadFileWork();
 
-    boolean isCStats = pCtx.getQueryProperties().isAnalyzeRewrite();
+    boolean isCStats = pCtx.getQueryProperties().hasFeature(QueryFeature.REWRITE);
     int outerQueryLimit = pCtx.getQueryProperties().getOuterQueryLimit();
 
     boolean directInsert = false;
@@ -178,7 +179,7 @@ public abstract class TaskCompiler {
       return;
     }
 
-    if (!pCtx.getQueryProperties().isAnalyzeCommand()) {
+    if (!pCtx.getQueryProperties().hasFeature(QueryFeature.ANALYZE)) {
       LOG.debug("Skipping optimize operator plan for analyze command.");
       optimizeOperatorPlan(pCtx);
     }
@@ -188,7 +189,7 @@ public abstract class TaskCompiler {
      * If the select is from analyze table column rewrite, don't create a fetch task. Instead create
      * a column stats task later.
      */
-    if (pCtx.getQueryProperties().isQuery() && !isCStats) {
+    if (pCtx.getQueryProperties().hasFeature(QueryFeature.QUERY) && !isCStats) {
       if ((!loadTableWork.isEmpty()) || (loadFileWork.size() != 1)) {
         throw new SemanticException(ErrorMsg.INVALID_LOAD_TABLE_FILE_WORK.getMsg());
       }
@@ -279,14 +280,16 @@ public abstract class TaskCompiler {
     } else if (!isCStats) {
       for (LoadTableDesc ltd : loadTableWork) {
         Task<MoveWork> tsk = TaskFactory
-            .get(new MoveWork(pCtx.getQueryProperties().isCTAS() && pCtx.getCreateTable().isExternal(),
+            .get(new MoveWork(pCtx.getQueryProperties().hasFeature(QueryFeature.CTAS)
+                    && pCtx.getCreateTable().isExternal(),
                     null, null, ltd, null, false));
         mvTask.add(tsk);
       }
 
       boolean oneLoadFileForCtas = true;
       for (LoadFileDesc lfd : loadFileWork) {
-        if (pCtx.getQueryProperties().isCTAS() || pCtx.getQueryProperties().isMaterializedView()) {
+        if (pCtx.getQueryProperties().hasFeature(QueryFeature.CTAS)
+            || pCtx.getQueryProperties().hasFeature(QueryFeature.MATERIALIZED_VIEW)) {
           if (!oneLoadFileForCtas) { // should not have more than 1 load file for CTAS.
             throw new SemanticException(
                 "One query is not expected to contain multiple CTAS loads statements");
@@ -295,7 +298,8 @@ public abstract class TaskCompiler {
           oneLoadFileForCtas = false;
         }
         mvTask.add(TaskFactory.get(
-            new MoveWork(pCtx.getQueryProperties().isCTAS() && pCtx.getCreateTable().isExternal(), null, null, null,
+            new MoveWork(pCtx.getQueryProperties().hasFeature(QueryFeature.CTAS)
+                && pCtx.getCreateTable().isExternal(), null, null, null,
                 lfd, false)));
       }
     }
@@ -408,14 +412,15 @@ public abstract class TaskCompiler {
 
     // for direct insert CTAS, we don't need this table creation DDL task, since the table will be created
     // ahead of time by the non-native table
-    if (pCtx.getQueryProperties().isCTAS() && !pCtx.getCreateTable().isMaterialization() && !directInsert) {
+    if (pCtx.getQueryProperties().hasFeature(QueryFeature.CTAS)
+        && !pCtx.getCreateTable().isMaterialization() && !directInsert) {
       // generate a DDL task and make it a dependent task of the leaf
       CreateTableDesc crtTblDesc = pCtx.getCreateTable();
       crtTblDesc.validate(conf);
       Task<?> crtTblTask = TaskFactory.get(new DDLWork(inputs, outputs, crtTblDesc));
       patchUpAfterCTASorMaterializedView(rootTasks, inputs, outputs, crtTblTask,
           CollectionUtils.isEmpty(crtTblDesc.getPartColNames()));
-    } else if (pCtx.getQueryProperties().isMaterializedView() && !directInsert) {
+    } else if (pCtx.getQueryProperties().hasFeature(QueryFeature.MATERIALIZED_VIEW) && !directInsert) {
       // generate a DDL task and make it a dependent task of the leaf
       CreateMaterializedViewDesc viewDesc = pCtx.getCreateViewDesc();
       Task<?> crtViewTask = TaskFactory.get(new DDLWork(
@@ -495,7 +500,7 @@ public abstract class TaskCompiler {
   private void setLoadFileLocation(
       final ParseContext pCtx, LoadFileDesc lfd) throws SemanticException {
     // CTAS; make the move task's destination directory the table's destination.
-    DDLDescWithTableProperties ddlDesc = pCtx.getQueryProperties().isCTAS() ?
+    DDLDescWithTableProperties ddlDesc = pCtx.getQueryProperties().hasFeature(QueryFeature.CTAS) ?
         pCtx.getCreateTable() : pCtx.getCreateViewDesc();
 
     FileSinkDesc dataSink = ddlDesc.getAndUnsetWriter();
@@ -504,7 +509,7 @@ public abstract class TaskCompiler {
     int stmtId = 0; // CTAS or CMV cannot be part of multi-txn stmt
     
     Path location = (loc == null) ? getDefaultCtasOrCMVLocation(pCtx) : new Path(loc);
-    if (pCtx.getQueryProperties().isCTAS()) {
+    if (pCtx.getQueryProperties().hasFeature(QueryFeature.CTAS)) {
       CreateTableDesc ctd = pCtx.getCreateTable();
       if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.CREATE_TABLE_AS_EXTERNAL)) {
         ctd.getTblProps().put(hive_metastoreConstants.CTAS_LEGACY_CONFIG, "true"); // create as external table
@@ -547,12 +552,12 @@ public abstract class TaskCompiler {
       boolean createTableOrMVUseSuffix = HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_ACID_CREATE_TABLE_USE_SUFFIX)
               || HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_ACID_LOCKLESS_READS_ENABLED);
 
-      if (pCtx.getQueryProperties().isCTAS()) {
+      if (pCtx.getQueryProperties().hasFeature(QueryFeature.CTAS)) {
         protoName = pCtx.getCreateTable().getDbTableName();
         isExternal = pCtx.getCreateTable().isExternal();
         createTableOrMVUseSuffix &= AcidUtils.isTransactionalTable(pCtx.getCreateTable());
         suffix = Utilities.getTableOrMVSuffix(pCtx.getContext(), createTableOrMVUseSuffix);
-      } else if (pCtx.getQueryProperties().isMaterializedView()) {
+      } else if (pCtx.getQueryProperties().hasFeature(QueryFeature.MATERIALIZED_VIEW)) {
         protoName = pCtx.getCreateViewDesc().getViewName();
         createTableOrMVUseSuffix &= AcidUtils.isTransactionalView(pCtx.getCreateViewDesc());
         suffix = Utilities.getTableOrMVSuffix(pCtx.getContext(), createTableOrMVUseSuffix);

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/DisallowTransformHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/DisallowTransformHook.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.security.authorization.plugin;
 import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
 import org.apache.hadoop.hive.ql.hooks.HookContext;
 import org.apache.hadoop.hive.ql.QueryProperties;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 
 public class DisallowTransformHook implements ExecuteWithHookContext {
 
@@ -30,7 +31,7 @@ public class DisallowTransformHook implements ExecuteWithHookContext {
     if (null == qProps) {
       return; // its a ddl query.
     } 
-    if (qProps.usesScript()) {
+    if (qProps.hasFeature(QueryFeature.USES_SCRIPT)) {
        throw new HiveAccessControlException("Query with transform clause is disallowed in"
            + " current configuration.");
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/lineage/TestGenerator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/lineage/TestGenerator.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.optimizer.lineage;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QueryProperties;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
 import org.junit.Test;
@@ -41,19 +42,19 @@ public class TestGenerator {
 
     ParseContext parseContext = new ParseContext();
     QueryProperties queryProperties = new QueryProperties();
-    queryProperties.setCTAS(true);
+    queryProperties.addFeature(QueryFeature.CTAS);
     parseContext.setQueryProperties(queryProperties);
     assertThat(predicate.test(parseContext), is(true));
 
     parseContext = new ParseContext();
     queryProperties = new QueryProperties();
-    queryProperties.setQuery(true);
+    queryProperties.addFeature(QueryFeature.QUERY);
     parseContext.setQueryProperties(queryProperties);
     assertThat(predicate.test(parseContext), is(true));
 
     parseContext = new ParseContext();
     queryProperties = new QueryProperties();
-    queryProperties.setView(true);
+    queryProperties.addFeature(QueryFeature.VIEW);
     parseContext.setQueryProperties(queryProperties);
     assertThat(predicate.test(parseContext), is(false));
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQueryProperties.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQueryProperties.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.QueryProperties;
+import org.apache.hadoop.hive.ql.QueryProperties.QueryFeature;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
@@ -129,7 +130,7 @@ public class TestQueryProperties {
     }
     QueryProperties properties = analyze(
         "SELECT t1 FROM test_db.test_table EXCEPT ALL SELECT t2 FROM test_db.test_table", false);
-    Assert.assertTrue(properties.hasExcept());
+    Assert.assertTrue(properties.hasFeature(QueryFeature.EXCEPT));
   }
 
   @Test
@@ -140,7 +141,7 @@ public class TestQueryProperties {
     }
     QueryProperties properties = analyze(
         "SELECT t1 FROM test_db.test_table EXCEPT DISTINCT SELECT t2 FROM test_db.test_table", false);
-    Assert.assertTrue(properties.hasExcept());
+    Assert.assertTrue(properties.hasFeature(QueryFeature.EXCEPT));
   }
 
   @Test
@@ -151,7 +152,7 @@ public class TestQueryProperties {
     }
     QueryProperties properties = analyze(
         "SELECT t1 FROM test_db.test_table INTERSECT ALL SELECT t2 FROM test_db.test_table", false);
-    Assert.assertTrue(properties.hasIntersect());
+    Assert.assertTrue(properties.hasFeature(QueryFeature.INTERSECT));
   }
 
   @Test
@@ -162,7 +163,7 @@ public class TestQueryProperties {
     }
     QueryProperties properties = analyze(
         "SELECT t1 FROM test_db.test_table INTERSECT DISTINCT SELECT t2 FROM test_db.test_table", false);
-    Assert.assertTrue(properties.hasIntersect());
+    Assert.assertTrue(properties.hasFeature(QueryFeature.INTERSECT));
   }
 
   @Test
@@ -173,7 +174,7 @@ public class TestQueryProperties {
     }
     QueryProperties properties = analyze(
         "SELECT t1 FROM test_db.test_table QUALIFY row_number() OVER (PARTITION BY t1 ORDER BY t2) = 1", false);
-    Assert.assertTrue(properties.hasQualify());
+    Assert.assertTrue(properties.hasFeature(QueryFeature.QUALIFY));
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1.This PR refactors `QueryProperties` feature tracking from multiple boolean fields to an enum-based model.
2.Query feature flags such as `GROUP_BY`, `ORDER_BY`, `LIMIT`, `PTF`, `WINDOWING`, `QUALIFY`, `EXCEPT`, `INTERSECT`, `USES_SCRIPT`, and related clause flags are now represented by `QueryFeature` values stored in an `EnumSet<QueryFeature>`.
3.Relevant feature writer and reader call sites were updated to use `addFeature(QueryFeature.X)` and `hasFeature(QueryFeature.X)`.
4.Compatibility wrapper methods such as `hasGroupBy()` and `setHasGroupBy(boolean)` continue to delegate to the enum-backed storage. Non-feature state such as join counts, query type, lateral view flags, view/materialized view flags, analyze flags, and used tables remains unchanged.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The previous implementation stored query features as many individual boolean fields, which made `QueryProperties` harder to read and extend.Using a `QueryFeature` enum with `EnumSet` keeps related feature state in one place, reduces repeated boolean field management, and makes adding future query features simpler and less error-prone.`EnumSet` is also efficient for enum values and is a good fit for representing query features.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual testing 