### PR TITLE
HIVE-29686: Env variables for substitution are not propagated to entrypoint.sh from start-hive.sh

### DIFF
--- a/packaging/src/docker/README.md
+++ b/packaging/src/docker/README.md
@@ -212,9 +212,9 @@ docker compose logs -f llapdaemon
 To stop and remove the LLAP stack:
 
 ```shell
-./stop-hive.sh --llap # to stop and delete containers
+./stop-hive.sh # to stop and delete containers
 #OR
-./stop-hive.sh --llap --cleanup # to remove volumes also
+./stop-hive.sh --cleanup # to remove volumes also
 ```
 
 #### Usage

--- a/packaging/src/docker/docker-compose.yml
+++ b/packaging/src/docker/docker-compose.yml
@@ -84,6 +84,16 @@ services:
       HIVE_SCRATCH_DIR: /opt/hive/scratch
       HIVE_QUERY_RESULTS_CACHE_DIRECTORY: /opt/hive/scratch/_resultscache_
 
+      # LLAP / external Tez session wiring — consumed by envsubst against
+      # hive-site.xml.template and tez-site.xml.template in entrypoint.sh.
+      # Without these, the templates fall back to the defaults in
+      # entrypoint.sh (external sessions disabled) even when start-hive.sh
+      # was invoked with --llap.
+      HIVE_ZOOKEEPER_QUORUM: "${HIVE_ZOOKEEPER_QUORUM:-}"
+      HIVE_LLAP_DAEMON_SERVICE_HOSTS: "${HIVE_LLAP_DAEMON_SERVICE_HOSTS:-}"
+      HIVE_SERVER2_TEZ_USE_EXTERNAL_SESSIONS: "${HIVE_SERVER2_TEZ_USE_EXTERNAL_SESSIONS:-false}"
+      TEZ_FRAMEWORK_MODE: "${TEZ_FRAMEWORK_MODE:-}"
+
       DB_DRIVER: postgres
       SERVICE_OPTS: >-
         -Xmx1G


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add env variables to hiveserver2 configuration in the docker-compose file.


### Why are the changes needed?
See jira description.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Build and start hive cluster according to README under packaging/src/docker. Without the patch, the queries still passed flawlessly and silently, but never reached tezam and llapdaemons. With the patch, DAG activity was present:
```
docker compose logs -f tezam
...

tezam  | 2026-06-26T10:27:11,512 INFO  DAGAppMaster - Completed cleanup for DAG: name=insert into test_part values (1, '1') (Stage-1), with id=dag_1782468450563_0003_2
```
