### PR TITLE
HIVE-29349: upgrade testcontainers to support docker desktop 29+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <tez.version>0.10.5</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
     <tempus-fugit.version>1.1</tempus-fugit.version>
-    <testcontainers.version>1.21.3</testcontainers.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
     <snappy.version>1.1.10.4</snappy.version>
     <jersey-wadl-doclet.version>4.0.0-M2</jersey-wadl-doclet.version>
     <jaxb-runtime.version>4.0.0-M2</jaxb-runtime.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -129,7 +129,7 @@
     <spring.version>5.3.39</spring.version>
     <spring-boot.version>2.7.18</spring-boot.version>
     <spring.ldap.version>2.4.4</spring.ldap.version>
-    <testcontainers.version>1.21.3</testcontainers.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
     <!-- Thrift properties -->
     <thrift.home>you-must-set-this-to-run-thrift</thrift.home>
     <thrift.gen.dir>${basedir}/src/gen/thrift</thrift.gen.dir>


### PR DESCRIPTION
The current version of docker testcontainers doesn't suppport docker versions from 29. 

There were a previous attempt to fix the problem by doing a major upgrade: https://github.com/apache/hive/pull/6220
That attempt failed as it requires upgrades in the CI pipeline as well. 

This change is only a minor upgrade change that means it can be done without touching Jenkins at all. And also, with that change, it is possible to run dockerized metastore tests with never docker versions. 

### What changes were proposed in this pull request?
Upgrade docker testcontainers from 1.21.3 to 1.21.4


### Why are the changes needed?
To be able to run metastorecheckin tests with never docker versions.
Here is the current output with docker version 29.4.0: 
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hive.metastore.dbinstall.TestPostgres
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.341 s <<< FAILURE! -- in org.apache.hadoop.hive.metastore.dbinstall.TestPostgres
[ERROR] org.apache.hadoop.hive.metastore.dbinstall.TestPostgres.upgrade -- Time elapsed: 0.328 s <<< ERROR!
java.lang.IllegalStateException: Could not find a valid Docker environment. Please see logs and check configuration
    at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$getFirstValidStrategy$7(DockerClientProviderStrategy.java:274)
    at java.base/java.util.Optional.orElseThrow(Optional.java:403)
    at org.testcontainers.dockerclient.DockerClientProviderStrategy.getFirstValidStrategy(DockerClientProviderStrategy.java:265)
    at org.testcontainers.DockerClientFactory.getOrInitializeStrategy(DockerClientFactory.java:154)
    at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:196)
    at org.testcontainers.DockerClientFactory$1.getDockerClient(DockerClientFactory.java:108)
    at com.github.dockerjava.api.DockerClientDelegate.authConfig(DockerClientDelegate.java:109)
    at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:321)
    at org.apache.hadoop.hive.metastore.dbinstall.rules.Postgres.before(Postgres.java:39)[ERROR] org.apache.hadoop.hive.metastore.dbinstall.TestPostgres.install -- Time elapsed: 0.005 s <<< ERROR!
java.lang.IllegalStateException: Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration
    at org.testcontainers.dockerclient.DockerClientProviderStrategy.getFirstValidStrategy(DockerClientProviderStrategy.java:229)
    at org.testcontainers.DockerClientFactory.getOrInitializeStrategy(DockerClientFactory.java:154)
    at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:196)
    at org.testcontainers.DockerClientFactory$1.getDockerClient(DockerClientFactory.java:108)
    at com.github.dockerjava.api.DockerClientDelegate.authConfig(DockerClientDelegate.java:109)
    at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:321)
    at org.apache.hadoop.hive.metastore.dbinstall.rules.Postgres.before(Postgres.java:39)[INFO]
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   TestPostgres.install » IllegalState Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration
[ERROR]   TestPostgres.upgrade » IllegalState Could not find a valid Docker environment. Please see logs and check configuration
[INFO]
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0 
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`mvn install -Dtest.groups= -Dtest=TestMysql`
