### PR TITLE
HIVE-29703: LLAP: Parquet footer larger than alloc.max throws RuntimeException during caching

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/metadata/MetadataCache.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/metadata/MetadataCache.java
@@ -287,8 +287,9 @@ public class MetadataCache implements LlapIoDebugDump, FileMetadataCache {
       largeBuffers[i] = new LlapMetadataBuffer<>(fileKey, tag);
     }
     // allocateMultiple is all-or-nothing: on success every chunk is allocated; on failure it
-    // releases whatever it reserved, so a throw here needs no cleanup from us.
+    // releases whatever it reserved.
     allocator.allocateMultiple(largeBuffers, maxAlloc, null, isStopped);
+
     LlapMetadataBuffer<Object> smallBuffer = null;
     boolean done = false;
     try {

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/metadata/MetadataCache.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/metadata/MetadataCache.java
@@ -257,39 +257,43 @@ public class MetadataCache implements LlapIoDebugDump, FileMetadataCache {
   }
 
 
-  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SuppressWarnings("unchecked")
   private LlapBufferOrBuffers wrapBbForFile(LlapBufferOrBuffers result,
       Object fileKey, int length, InputStream stream, CacheTag tag, AtomicBoolean isStopped) throws IOException {
-    if (result != null) return result;
+    if (result != null) {
+      return result;
+    }
     int maxAlloc = allocator.getMaxAllocation();
-    LlapMetadataBuffer<Object>[] largeBuffers = null;
-    if (maxAlloc < length) {
-      largeBuffers = new LlapMetadataBuffer[length / maxAlloc];
-      for (int i = 0; i < largeBuffers.length; ++i) {
-        largeBuffers[i] = new LlapMetadataBuffer<>(fileKey, tag);
-      }
-      allocator.allocateMultiple(largeBuffers, maxAlloc, null, isStopped);
-      for (int i = 0; i < largeBuffers.length; ++i) {
-        readIntoCacheBuffer(stream, maxAlloc, largeBuffers[i]);
-      }
+    if (length <= maxAlloc) {
+      // The whole footer fits in a single buffer - the overwhelmingly common case.
+      LlapMetadataBuffer<Object> buffer = new LlapMetadataBuffer<>(fileKey, tag);
+      allocator.allocateMultiple(new MemoryBuffer[] { buffer }, length, null, isStopped);
+      readIntoCacheBuffer(stream, length, buffer);
+      return buffer;
+    }
+    // Larger footers are split across maxAlloc-sized chunks, the last one holding the remainder.
+    LlapMetadataBuffer<Object>[] largeBuffers = new LlapMetadataBuffer[length / maxAlloc];
+    for (int i = 0; i < largeBuffers.length; ++i) {
+      largeBuffers[i] = new LlapMetadataBuffer<>(fileKey, tag);
+    }
+    allocator.allocateMultiple(largeBuffers, maxAlloc, null, isStopped);
+    for (int i = 0; i < largeBuffers.length; ++i) {
+      readIntoCacheBuffer(stream, maxAlloc, largeBuffers[i]);
     }
     int smallSize = length % maxAlloc;
     if (smallSize == 0) {
-      return new LlapMetadataBuffers(largeBuffers);
-    } else {
-      LlapMetadataBuffer<Object>[] smallBuffer = new LlapMetadataBuffer[1];
-      smallBuffer[0] = new LlapMetadataBuffer(fileKey, tag);
-      allocator.allocateMultiple(smallBuffer, length, null, isStopped);
-      readIntoCacheBuffer(stream, smallSize, smallBuffer[0]);
-      if (largeBuffers == null) {
-        return smallBuffer[0]; // This is the overwhelmingly common case.
-      } else {
-        LlapMetadataBuffer<Object>[] cacheData = new LlapMetadataBuffer[largeBuffers.length + 1];
-        System.arraycopy(largeBuffers, 0, cacheData, 0, largeBuffers.length);
-        cacheData[largeBuffers.length] = smallBuffer[0];
-        return new LlapMetadataBuffers<>(cacheData);
-      }
+      return new LlapMetadataBuffers<>(largeBuffers);
     }
+    // Allocate the remainder only; the last chunk is smaller than maxAlloc.
+    LlapMetadataBuffer<Object> smallBuffer = new LlapMetadataBuffer<>(fileKey, tag);
+    allocator.allocateMultiple(new MemoryBuffer[] { smallBuffer }, smallSize, null, isStopped);
+    readIntoCacheBuffer(stream, smallSize, smallBuffer);
+
+    LlapMetadataBuffer<Object>[] cacheData = new LlapMetadataBuffer[largeBuffers.length + 1];
+    System.arraycopy(largeBuffers, 0, cacheData, 0, largeBuffers.length);
+    cacheData[largeBuffers.length] = smallBuffer;
+
+    return new LlapMetadataBuffers<>(cacheData);
   }
 
   private static void readIntoCacheBuffer(

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/metadata/MetadataCache.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/metadata/MetadataCache.java
@@ -264,36 +264,76 @@ public class MetadataCache implements LlapIoDebugDump, FileMetadataCache {
       return result;
     }
     int maxAlloc = allocator.getMaxAllocation();
+    // Buffers are locked and handed to the cache only after this returns, so release whatever we
+    // allocated if a later read or allocation throws - otherwise it leaks (nothing else reclaims it).
     if (length <= maxAlloc) {
       // The whole footer fits in a single buffer - the overwhelmingly common case.
       LlapMetadataBuffer<Object> buffer = new LlapMetadataBuffer<>(fileKey, tag);
       allocator.allocateMultiple(new MemoryBuffer[] { buffer }, length, null, isStopped);
-      readIntoCacheBuffer(stream, length, buffer);
-      return buffer;
+      boolean done = false;
+      try {
+        readIntoCacheBuffer(stream, length, buffer);
+        done = true;
+        return buffer;
+      } finally {
+        if (!done) {
+          deallocateQuietly(buffer);
+        }
+      }
     }
     // Larger footers are split across maxAlloc-sized chunks, the last one holding the remainder.
     LlapMetadataBuffer<Object>[] largeBuffers = new LlapMetadataBuffer[length / maxAlloc];
     for (int i = 0; i < largeBuffers.length; ++i) {
       largeBuffers[i] = new LlapMetadataBuffer<>(fileKey, tag);
     }
+    // allocateMultiple is all-or-nothing: on success every chunk is allocated; on failure it
+    // releases whatever it reserved, so a throw here needs no cleanup from us.
     allocator.allocateMultiple(largeBuffers, maxAlloc, null, isStopped);
-    for (int i = 0; i < largeBuffers.length; ++i) {
-      readIntoCacheBuffer(stream, maxAlloc, largeBuffers[i]);
-    }
-    int smallSize = length % maxAlloc;
-    if (smallSize == 0) {
-      return new LlapMetadataBuffers<>(largeBuffers);
-    }
-    // Allocate the remainder only; the last chunk is smaller than maxAlloc.
-    LlapMetadataBuffer<Object> smallBuffer = new LlapMetadataBuffer<>(fileKey, tag);
-    allocator.allocateMultiple(new MemoryBuffer[] { smallBuffer }, smallSize, null, isStopped);
-    readIntoCacheBuffer(stream, smallSize, smallBuffer);
+    LlapMetadataBuffer<Object> smallBuffer = null;
+    boolean done = false;
+    try {
+      for (int i = 0; i < largeBuffers.length; ++i) {
+        readIntoCacheBuffer(stream, maxAlloc, largeBuffers[i]);
+      }
+      int smallSize = length % maxAlloc;
+      if (smallSize == 0) {
+        done = true;
+        return new LlapMetadataBuffers<>(largeBuffers);
+      }
+      // Allocate the remainder only; the last chunk is smaller than maxAlloc.
+      LlapMetadataBuffer<Object> remainder = new LlapMetadataBuffer<>(fileKey, tag);
+      allocator.allocateMultiple(new MemoryBuffer[] { remainder }, smallSize, null, isStopped);
+      smallBuffer = remainder; // Registered for cleanup only now that allocation succeeded.
+      readIntoCacheBuffer(stream, smallSize, remainder);
 
-    LlapMetadataBuffer<Object>[] cacheData = new LlapMetadataBuffer[largeBuffers.length + 1];
-    System.arraycopy(largeBuffers, 0, cacheData, 0, largeBuffers.length);
-    cacheData[largeBuffers.length] = smallBuffer;
+      LlapMetadataBuffer<Object>[] cacheData = new LlapMetadataBuffer[largeBuffers.length + 1];
+      System.arraycopy(largeBuffers, 0, cacheData, 0, largeBuffers.length);
+      cacheData[largeBuffers.length] = remainder;
 
-    return new LlapMetadataBuffers<>(cacheData);
+      done = true;
+      return new LlapMetadataBuffers<>(cacheData);
+    } finally {
+      if (!done) {
+        for (LlapMetadataBuffer<Object> buffer : largeBuffers) {
+          deallocateQuietly(buffer);
+        }
+        if (smallBuffer != null) {
+          deallocateQuietly(smallBuffer);
+        }
+      }
+    }
+  }
+
+  /**
+   * Releases a footer buffer that was allocated but not yet published to the cache. The buffer must
+   * be unlocked (refCount 0, as deallocate asserts); callers here run before it is ever locked.
+   */
+  private void deallocateQuietly(MemoryBuffer buffer) {
+    try {
+      allocator.deallocate(buffer);
+    } catch (Throwable t) {
+      LlapIoImpl.LOG.error("Ignoring the cleanup error after another error", t);
+    }
   }
 
   private static void readIntoCacheBuffer(

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/cache/TestMetadataCache.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/cache/TestMetadataCache.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.common.io.CacheTag;
 import org.apache.hadoop.hive.common.io.DataCache;
 import org.apache.hadoop.hive.common.io.DiskRange;
 import org.apache.hadoop.hive.common.io.DiskRangeList;
+import org.apache.hadoop.hive.common.io.encoded.MemoryBuffer;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.llap.IllegalCacheConfigurationException;
@@ -97,10 +98,12 @@ public class TestMetadataCache {
 
   private static class DummyMemoryManager implements MemoryManager {
     private int allocs;
+    private long reservedBytes;
 
     @Override
     public void reserveMemory(long memoryToReserve, AtomicBoolean isStopped) {
       ++allocs;
+      reservedBytes += memoryToReserve;
     }
 
     @Override public long evictMemory(long memoryToEvict) {
@@ -109,10 +112,15 @@ public class TestMetadataCache {
 
     @Override
     public void releaseMemory(long memUsage) {
+      reservedBytes -= memUsage;
     }
 
     @Override
     public void updateMaxSize(long maxSize) {
+    }
+
+    long reservedBytes() {
+      return reservedBytes;
     }
   }
 
@@ -196,6 +204,45 @@ public class TestMetadataCache {
     MetadataCache cache = newMetadataCache();
     verifyFooterFromStream(cache, 2 * MAX_ALLOC, false);
     verifyFooterFromStream(cache, 2 * MAX_ALLOC + 3, false);
+  }
+
+  /**
+   * If reading the footer stream fails after some buffers were already allocated, every allocated
+   * buffer must be released back to the allocator. Otherwise the long-lived LLAP daemon leaks arena
+   * memory on every failed footer read (a truncated file, an IO error, or an oversized chunk).
+   */
+  @Test
+  public void testStreamFooterReadFailureReleasesBuffers() {
+    assertFooterReadFailureReleasesBuffers(MAX_ALLOC);         // single-buffer path
+    assertFooterReadFailureReleasesBuffers(2 * MAX_ALLOC);     // multi-buffer, exact multiple
+    assertFooterReadFailureReleasesBuffers(2 * MAX_ALLOC + 3); // multi-buffer, with remainder
+  }
+
+  private void assertFooterReadFailureReleasesBuffers(int length) {
+    final int arenaSize = 4096;
+    DummyMemoryManager mm = new DummyMemoryManager();
+    LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
+    BuddyAllocator alloc = new BuddyAllocator(
+        false, false, 8, MAX_ALLOC, 1, arenaSize, 0, null, mm, metrics, null, true);
+    MetadataCache cache = new MetadataCache(alloc, mm, new DummyCachePolicy(), true, metrics);
+
+    Object fileKey = new Object();
+    // One byte short of the footer, so reading the last chunk hits EOF part-way through.
+    ByteArrayInputStream truncated = new ByteArrayInputStream(new byte[length - 1]);
+    try {
+      cache.putFileMetadata(fileKey, length, truncated, null, null);
+      fail("Expected an EOFException for a truncated footer stream of length " + length);
+    } catch (IOException expected) {
+      // expected
+    }
+    assertEquals("Allocated buffers must be released after a failed footer read (length " + length + ")",
+        0, mm.reservedBytes());
+    assertNull("A failed put must not leave a cache entry", cache.getFileMetadata(fileKey));
+
+    // Independent check against the real allocator: leaked buffers keep FLAG_NEW_ALLOC and can never
+    // be force-discarded, so re-filling the whole arena succeeds only if nothing leaked.
+    MemoryBuffer[] wholeArena = new MemoryBuffer[arenaSize / MAX_ALLOC];
+    alloc.allocateMultiple(wholeArena, MAX_ALLOC);
   }
 
   private MetadataCache newMetadataCache() {

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/cache/TestMetadataCache.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/cache/TestMetadataCache.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.llap.cache;
 import static org.apache.hadoop.hive.llap.cache.LlapCacheableBuffer.INVALIDATE_OK;
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
@@ -51,7 +52,9 @@ import org.apache.orc.impl.OrcTail;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestOrcMetadataCache {
+public class TestMetadataCache {
+  private static final int MAX_ALLOC = 64;
+
   private static class DummyCachePolicy implements LowLevelCachePolicy {
     int lockCount = 0, unlockCount = 0;
 
@@ -115,12 +118,7 @@ public class TestOrcMetadataCache {
 
   @Test
   public void testCaseSomePartialBuffersAreEvicted() {
-    final DummyMemoryManager mm = new DummyMemoryManager();
-    final DummyCachePolicy cp = new DummyCachePolicy();
-    final int MAX_ALLOC = 64;
-    final LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
-    final BuddyAllocator alloc = new BuddyAllocator(false, false, 8, MAX_ALLOC, 1, 4096, 0, null, mm, metrics, null, true);
-    final MetadataCache cache = new MetadataCache(alloc, mm, cp, true, metrics);
+    final MetadataCache cache = newMetadataCache();
     final Object fileKey1 = new Object();
     final Random rdm = new Random();
     final ByteBuffer smallBuffer = ByteBuffer.allocate(2 * MAX_ALLOC);
@@ -138,14 +136,8 @@ public class TestOrcMetadataCache {
   }
 
   @Test
-  public void testBuffers() throws Exception {
-    DummyMemoryManager mm = new DummyMemoryManager();
-    DummyCachePolicy cp = new DummyCachePolicy();
-    final int MAX_ALLOC = 64;
-    LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
-    BuddyAllocator alloc = new BuddyAllocator(
-        false, false, 8, MAX_ALLOC, 1, 4096, 0, null, mm, metrics, null, true);
-    MetadataCache cache = new MetadataCache(alloc, mm, cp, true, metrics);
+  public void testBuffers() {
+    MetadataCache cache = newMetadataCache();
     Object fileKey1 = new Object();
     Random rdm = new Random();
 
@@ -185,6 +177,65 @@ public class TestOrcMetadataCache {
     assertFalse(b0.incRef() > 0); // Should have also been thrown out.
   }
 
+  /**
+   * A footer of exactly maxAlloc: the split condition used a strict {@code <}, so no buffer was
+   * allocated and the InputStream put path returned an empty wrapper (NPE on lock).
+   */
+  @Test
+  public void testStreamFooterEqualToMaxAlloc() throws Exception {
+    verifyFooterFromStream(newMetadataCache(), MAX_ALLOC, true);
+  }
+
+  /**
+   * A footer larger than maxAlloc is split into a multi-buffer wrapper: an exact multiple of maxAlloc
+   * (only full chunks) and a multiple plus a remainder (full chunks + a smaller last chunk). The
+   * remainder buffer used to be allocated with the full footer length, exceeding the max allocation.
+   */
+  @Test
+  public void testStreamFooterLargerThanMaxAlloc() throws Exception {
+    MetadataCache cache = newMetadataCache();
+    verifyFooterFromStream(cache, 2 * MAX_ALLOC, false);
+    verifyFooterFromStream(cache, 2 * MAX_ALLOC + 3, false);
+  }
+
+  private MetadataCache newMetadataCache() {
+    return newMetadataCache(4096);
+  }
+
+  private MetadataCache newMetadataCache(int arenaSize) {
+    return newMetadataCache(arenaSize, new DummyCachePolicy());
+  }
+
+  private MetadataCache newMetadataCache(int arenaSize, DummyCachePolicy cp) {
+    DummyMemoryManager mm = new DummyMemoryManager();
+    LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
+    BuddyAllocator alloc = new BuddyAllocator(
+        false, false, 8, MAX_ALLOC, 1, arenaSize, 0, null, mm, metrics, null, true);
+    return new MetadataCache(alloc, mm, cp, true, metrics);
+  }
+
+  private void verifyFooterFromStream(MetadataCache cache, int length, boolean expectSingleBuffer)
+      throws IOException {
+    Object fileKey = new Object();
+    ByteBuffer footer = ByteBuffer.allocate(length);
+    new Random().nextBytes(footer.array());
+
+    LlapBufferOrBuffers result = cache.putFileMetadata(
+        fileKey, length, new ByteArrayInputStream(footer.array()), null, null);
+    cache.decRefBuffer(result);
+    assertEquals(expectSingleBuffer, result.getSingleLlapBuffer() != null);
+    assertEquals(footer, reassemble(result));
+
+    result = cache.getFileMetadata(fileKey);
+    assertEquals(footer, reassemble(result));
+    cache.decRefBuffer(result);
+  }
+
+  private ByteBuffer reassemble(LlapBufferOrBuffers result) {
+    LlapAllocatorBuffer single = result.getSingleLlapBuffer();
+    return single != null ? single.getByteBufferDup() : extractResultBbs(result);
+  }
+
   public ByteBuffer extractResultBbs(LlapBufferOrBuffers result) {
     int totalLen = 0;
     for (LlapAllocatorBuffer buf : result.getMultipleLlapBuffers()) {
@@ -199,14 +250,9 @@ public class TestOrcMetadataCache {
   }
 
   @Test
-  public void testIncompleteCbs() throws Exception {
-    DummyMemoryManager mm = new DummyMemoryManager();
+  public void testIncompleteCbs() {
     DummyCachePolicy cp = new DummyCachePolicy();
-    final int MAX_ALLOC = 64;
-    LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
-    BuddyAllocator alloc = new BuddyAllocator(
-        false, false, 8, MAX_ALLOC, 1, 4096, 0, null, mm, metrics, null, true);
-    MetadataCache cache = new MetadataCache(alloc, mm, cp, true, metrics);
+    MetadataCache cache = newMetadataCache(4096, cp);
     DataCache.BooleanRef gotAllData = new DataCache.BooleanRef();
     Object fileKey1 = new Object();
 
@@ -239,13 +285,7 @@ public class TestOrcMetadataCache {
 
   @Test
   public void testGetOrcTailForPath() throws Exception {
-    DummyMemoryManager mm = new DummyMemoryManager();
-    DummyCachePolicy cp = new DummyCachePolicy();
-    final int MAX_ALLOC = 64;
-    LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
-    BuddyAllocator alloc = new BuddyAllocator(
-        false, false, 8, MAX_ALLOC, 1, 4 * 4096, 0, null, mm, metrics, null, true);
-    MetadataCache cache = new MetadataCache(alloc, mm, cp, true, metrics);
+    MetadataCache cache = newMetadataCache(4 * 4096);
 
     Path path = new Path("../data/files/alltypesorc");
     Configuration jobConf = new Configuration();
@@ -260,13 +300,7 @@ public class TestOrcMetadataCache {
 
   @Test
   public void testGetOrcTailForPathWithFileId() throws Exception {
-    DummyMemoryManager mm = new DummyMemoryManager();
-    DummyCachePolicy cp = new DummyCachePolicy();
-    final int MAX_ALLOC = 64;
-    LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
-    BuddyAllocator alloc = new BuddyAllocator(
-        false, false, 8, MAX_ALLOC, 1, 4 * 4096, 0, null, mm, metrics, null, true);
-    MetadataCache cache = new MetadataCache(alloc, mm, cp, true, metrics);
+    MetadataCache cache = newMetadataCache(4 * 4096);
 
     Path path = new Path("../data/files/alltypesorc");
     Configuration jobConf = new Configuration();
@@ -284,13 +318,7 @@ public class TestOrcMetadataCache {
 
   @Test
   public void testGetOrcTailForPathWithFileIdChange() throws Exception {
-    DummyMemoryManager mm = new DummyMemoryManager();
-    DummyCachePolicy cp = new DummyCachePolicy();
-    final int MAX_ALLOC = 64;
-    LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
-    BuddyAllocator alloc = new BuddyAllocator(
-        false, false, 8, MAX_ALLOC, 1, 4 * 4096, 0, null, mm, metrics, null, true);
-    MetadataCache cache = new MetadataCache(alloc, mm, cp, true, metrics);
+    MetadataCache cache = newMetadataCache(4 * 4096);
 
     Path path = new Path("../data/files/alltypesorc");
     Configuration jobConf = new Configuration();
@@ -317,14 +345,8 @@ public class TestOrcMetadataCache {
   }
 
   @Test
-  public void testProactiveEvictionMark() throws Exception {
-    DummyMemoryManager mm = new DummyMemoryManager();
-    DummyCachePolicy cp = new DummyCachePolicy();
-    final int MAX_ALLOC = 64;
-    LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
-    BuddyAllocator alloc = new BuddyAllocator(
-        false, false, 8, MAX_ALLOC, 1, 4096, 0, null, mm, metrics, null, true);
-    MetadataCache cache = new MetadataCache(alloc, mm, cp, true, metrics);
+  public void testProactiveEvictionMark() {
+    MetadataCache cache = newMetadataCache();
 
     long fn1 = 1;
     long fn2 = 2;

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/cache/TestMetadataCache.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/cache/TestMetadataCache.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hive.llap.cache.LlapCacheableBuffer.INVALIDATE_O
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
@@ -212,13 +213,13 @@ public class TestMetadataCache {
    * memory on every failed footer read (a truncated file, an IO error, or an oversized chunk).
    */
   @Test
-  public void testStreamFooterReadFailureReleasesBuffers() {
+  public void testStreamFooterReadFailureReleasesBuffers() throws IOException {
     assertFooterReadFailureReleasesBuffers(MAX_ALLOC);         // single-buffer path
     assertFooterReadFailureReleasesBuffers(2 * MAX_ALLOC);     // multi-buffer, exact multiple
     assertFooterReadFailureReleasesBuffers(2 * MAX_ALLOC + 3); // multi-buffer, with remainder
   }
 
-  private void assertFooterReadFailureReleasesBuffers(int length) {
+  private void assertFooterReadFailureReleasesBuffers(int length) throws IOException {
     final int arenaSize = 4096;
     DummyMemoryManager mm = new DummyMemoryManager();
     LlapDaemonCacheMetrics metrics = LlapDaemonCacheMetrics.create("", "");
@@ -232,7 +233,7 @@ public class TestMetadataCache {
     try {
       cache.putFileMetadata(fileKey, length, truncated, null, null);
       fail("Expected an EOFException for a truncated footer stream of length " + length);
-    } catch (IOException expected) {
+    } catch (EOFException expected) {
       // expected
     }
     assertEquals("Allocated buffers must be released after a failed footer read (length " + length + ")",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
  - Allocate the remainder buffer with smallSize, not length.                                                                                                                                                    
  - Use maxAlloc <= length so a footer of exactly maxAlloc is held in one full buffer.                                                                                                                                                                                                                            

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When LLAP caches a Parquet file footer whose size exceeds hive.llap.io.allocator.alloc.max, the query fails with:     
````                                                                                         
  java.lang.RuntimeException: Trying to allocate 35405479; max is 33554432
````

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
````
mvn test -pl llap-server -Dtest='TestOrcMetadataCache#testStreamFooterEqualToMaxAlloc+testStreamFooterLargerThanMaxAlloc
````
