### PR TITLE
HIVE-29702: Reduce-side merge join can produce NULL values or fail with IllegalStateException under Tez container reuse

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -34,6 +34,7 @@ minitez.query.files=\
   orc_vectorization_ppd.q,\
   partition_default_name_change_numeric.q,\
   tez_complextype_with_null.q,\
+  tez_dummystore_reduce_side_reuse.q,\
   tez_tag.q,\
   tez_union_udtf.q,\
   tez_union_with_udf.q,\

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TezDummyStoreOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TezDummyStoreOperator.java
@@ -18,8 +18,11 @@
 
 package org.apache.hadoop.hive.ql.exec;
 
+import java.util.List;
+
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 
 /**
  * A dummy store operator same as the dummy store operator but for tez. This is required so that we
@@ -59,6 +62,16 @@ public class TezDummyStoreOperator extends DummyStoreOperator {
 
   @Override
   public void closeOp(boolean abort) throws HiveException {
+    List<Operator<? extends OperatorDesc>> children = getChildOperators();
+    if (children != null && !children.isEmpty()) {
+      for (Operator<? extends OperatorDesc> child : children) {
+        List<Operator<? extends OperatorDesc>> parents = child.getParentOperators();
+        if (parents != null) {
+          parents.remove(this);
+        }
+      }
+      children.clear();
+    }
     super.closeOp(abort);
     fetchDone = false;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
@@ -358,13 +358,16 @@ public class ReduceRecordProcessor extends RecordProcessor {
       if (abort) {
         setAborted(true);
       }
-      reducer.close(abort);
+      // Close Tree1 (DummyStore chain) before Tree2 (MergeJoin chain).
+      // DummyStore.closeOp() removes itself from MergeJoin.parentOperators, so that when
+      // Tree2 closes, MergeJoin.allInitializedParentsAreClosed() returns true and
+      // checkAndGenObject() fires to emit the last join group.
       if (mergeWorkList != null) {
         for (BaseWork redWork : mergeWorkList) {
           ((ReduceWork) redWork).getReducer().close(abort);
         }
       }
-
+      reducer.close(abort);
       // Need to close the dummyOps as well. The operator pipeline
       // is not considered "closed/done" unless all operators are
       // done. For broadcast joins that includes the dummy parents.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
@@ -324,16 +324,29 @@ public class ReduceRecordProcessor extends RecordProcessor {
    */
   private List<LogicalInput> getShuffleInputs(Map<String, LogicalInput> inputs) throws Exception {
     // the reduce plan inputs have tags, add all inputs that have tags
-    Map<Integer, String> tagToinput = reduceWork.getTagToInput();
     ArrayList<LogicalInput> shuffleInputs = new ArrayList<LogicalInput>();
-    for (String inpStr : tagToinput.values()) {
+    startTaggedInputs(reduceWork, inputs, shuffleInputs);
+    // Merge-join siblings (e.g. the DummyStore side of a reduce-side merge join) are separate
+    // ReduceWorks with their own tagged inputs. init() later reads from all of them via
+    // tagToReducerMap, so they must be started here as well or getReader() throws
+    // "Must start input before invoking this method".
+    if (mergeWorkList != null) {
+      for (BaseWork mergeWork : mergeWorkList) {
+        startTaggedInputs((ReduceWork) mergeWork, inputs, shuffleInputs);
+      }
+    }
+    return shuffleInputs;
+  }
+
+  private void startTaggedInputs(ReduceWork redWork, Map<String, LogicalInput> inputs,
+      List<LogicalInput> shuffleInputs) throws Exception {
+    for (String inpStr : redWork.getTagToInput().values()) {
       if (inputs.get(inpStr) == null) {
         throw new AssertionError("Cound not find input: " + inpStr);
       }
       inputs.get(inpStr).start();
       shuffleInputs.add(inputs.get(inpStr));
     }
-    return shuffleInputs;
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ddl.DDLUtils;
 import org.apache.hadoop.hive.ql.exec.AbstractFileMergeOperator;
 import org.apache.hadoop.hive.ql.exec.AppMasterEventOperator;
+import org.apache.hadoop.hive.ql.exec.CommonMergeJoinOperator;
 import org.apache.hadoop.hive.ql.exec.FetchTask;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
@@ -110,6 +111,14 @@ public class GenTezUtils {
     assert context.parentOfRoot instanceof ReduceSinkOperator;
     ReduceSinkOperator reduceSink = (ReduceSinkOperator) context.parentOfRoot;
 
+    // If this RS feeds into a CommonMergeJoinOp (possibly via intermediate ops like GroupBy
+    // or DummyStore), normalize all RS inputs to the same numReducers so that every mapper
+    // writes to the same number of partitions and join keys land in the same task. Also
+    // disable Tez's dynamic auto-parallelism for these RS: ShuffleVertexManager can still
+    // shrink the actual task count at runtime independently of our numReducers value, which
+    // would silently break the same-key-same-partition guarantee this normalization relies on.
+    boolean isMergeJoinInput = normalizeMergeJoinReducers(reduceSink);
+
     reduceWork.setNumReduceTasks(reduceSink.getConf().getNumReducers());
     reduceWork.setSlowStart(reduceSink.getConf().isSlowStart());
     float minSrcFraction = context.conf.getFloat(
@@ -127,7 +136,8 @@ public class GenTezUtils {
       reduceSink.getConf().getReducerTraits().remove(AUTOPARALLEL);
     }
 
-    if (isAutoReduceParallelism && reduceSink.getConf().getReducerTraits().contains(AUTOPARALLEL)) {
+    if (isAutoReduceParallelism && !isMergeJoinInput
+        && reduceSink.getConf().getReducerTraits().contains(AUTOPARALLEL)) {
 
       // configured limit for reducers
       final int maxReducers = context.conf.getIntVar(HiveConf.ConfVars.MAX_REDUCERS);
@@ -185,6 +195,87 @@ public class GenTezUtils {
     context.connectedReduceSinks.add(reduceSink);
 
     return reduceWork;
+  }
+
+  /**
+   * If the given RS leads (through child ops) to a CommonMergeJoinOperator, normalizes all RS
+   * ancestors of that MergeJoinOp's parents to use the same maximum numReducers. This is a
+   * last-resort fix: even if earlier optimizer passes failed to align numReducers, we correct
+   * it at edge-creation time so each mapper writes the same partition count.
+   */
+  private static boolean normalizeMergeJoinReducers(ReduceSinkOperator reduceSink) {
+    CommonMergeJoinOperator mergeJoin = findDownstreamMergeJoin(reduceSink, 8);
+    if (mergeJoin == null) {
+      return false;
+    }
+    List<ReduceSinkOperator> allRS = new ArrayList<>();
+    for (Operator<?> parent : mergeJoin.getParentOperators()) {
+      ReduceSinkOperator rsAnc = findUpstreamRS(parent, 8);
+      if (rsAnc != null) {
+        allRS.add(rsAnc);
+      }
+    }
+    if (allRS.isEmpty()) {
+      return true;
+    }
+    int maxNR = 0;
+    for (ReduceSinkOperator rs : allRS) {
+      if (rs.getConf().getNumReducers() > maxNR) {
+        maxNR = rs.getConf().getNumReducers();
+      }
+    }
+    if (maxNR <= 0) {
+      return true;
+    }
+    for (ReduceSinkOperator rs : allRS) {
+      int orig = rs.getConf().getNumReducers();
+      boolean hasAutoParallel = rs.getConf().getReducerTraits().contains(AUTOPARALLEL);
+      boolean hasUniform = rs.getConf().getReducerTraits().contains(UNIFORM);
+      if (orig != maxNR || hasAutoParallel || hasUniform) {
+        rs.getConf().setNumReducers(maxNR);
+        // ReduceSinkDesc.setReducerTraits() is ADDITIVE (this.reduceTraits.addAll(traits)) in
+        // every branch except when the passed set contains FIXED, in which case it explicitly
+        // removes AUTOPARALLEL/UNIFORM first. Passing a traits set with those already removed
+        // is therefore a no-op against the existing (unremoved) traits - FIXED must be passed
+        // to actually clear them.
+        rs.getConf().setReducerTraits(EnumSet.of(ReduceSinkDesc.ReducerTraits.FIXED));
+      }
+    }
+    return true;
+  }
+
+  private static CommonMergeJoinOperator findDownstreamMergeJoin(
+      ReduceSinkOperator rs, int maxDepth) {
+    Operator<?> curr = rs;
+    for (int d = 0; d < maxDepth; d++) {
+      List<Operator<?>> children = curr.getChildOperators();
+      if (children == null || children.isEmpty()) {
+        break;
+      }
+      curr = children.get(0);
+      if (curr instanceof CommonMergeJoinOperator) {
+        return (CommonMergeJoinOperator) curr;
+      }
+    }
+    return null;
+  }
+
+  private static ReduceSinkOperator findUpstreamRS(Operator<?> op, int maxDepth) {
+    if (op instanceof ReduceSinkOperator) {
+      return (ReduceSinkOperator) op;
+    }
+    Operator<?> curr = op;
+    for (int d = 0; d < maxDepth; d++) {
+      List<Operator<?>> parents = curr.getParentOperators();
+      if (parents == null || parents.isEmpty()) {
+        break;
+      }
+      curr = parents.get(0);
+      if (curr instanceof ReduceSinkOperator) {
+        return (ReduceSinkOperator) curr;
+      }
+    }
+    return null;
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.ql.exec.OperatorUtils;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
+import org.apache.hadoop.hive.ql.exec.TezDummyStoreOperator;
 import org.apache.hadoop.hive.ql.exec.UnionOperator;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
@@ -198,14 +199,32 @@ public class GenTezUtils {
   }
 
   /**
-   * If the given RS leads (through child ops) to a CommonMergeJoinOperator, normalizes all RS
-   * ancestors of that MergeJoinOp's parents to use the same maximum numReducers. This is a
-   * last-resort fix: even if earlier optimizer passes failed to align numReducers, we correct
-   * it at edge-creation time so each mapper writes the same partition count.
+   * If the given RS leads (through child ops) to a CommonMergeJoinOperator that also has a
+   * {@link TezDummyStoreOperator} sibling parent, normalizes all RS ancestors of that
+   * MergeJoinOp's parents to use the same maximum numReducers. This is a last-resort fix: even
+   * if earlier optimizer passes failed to align numReducers, we correct it at edge-creation time
+   * so each mapper writes the same partition count.
+   *
+   * <p>The DummyStore check matters: it marks the merge join's sibling as living in its own,
+   * separately auto-parallelized Tez vertex (see ReduceRecordProcessor's mergeWorkList). A merge
+   * join whose parents are just multiple tags of this same ReduceWork (no DummyStore involved)
+   * already shares this vertex's single parallelism setting, so there is no independent-vertex
+   * mismatch to guard against, and forcing FIXED traits there only disables auto-parallelism
+   * without fixing anything.
    */
   private static boolean normalizeMergeJoinReducers(ReduceSinkOperator reduceSink) {
     CommonMergeJoinOperator mergeJoin = findDownstreamMergeJoin(reduceSink, 8);
     if (mergeJoin == null) {
+      return false;
+    }
+    boolean hasDummyStoreSibling = false;
+    for (Operator<?> parent : mergeJoin.getParentOperators()) {
+      if (parent instanceof TezDummyStoreOperator) {
+        hasDummyStoreSibling = true;
+        break;
+      }
+    }
+    if (!hasDummyStoreSibling) {
       return false;
     }
     List<ReduceSinkOperator> allRS = new ArrayList<>();

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestTezDummyStoreOperator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestTezDummyStoreOperator.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link TezDummyStoreOperator#closeOp(boolean)}.
+ *
+ * When a Tez container is reused for a subsequent task of the same reducer vertex, Hive's
+ * per-query ObjectCache (keyed by vertex name) can hand the new task the same already-
+ * initialized DummyStore/MergeJoin operator instances the previous task used. If closeOp()
+ * leaves stale wiring behind (this operator still listed as a parent of its former child,
+ * and/or that child still referenced from childOperators), the reused instances carry over
+ * incorrect state into the next task's execution, causing
+ * ReduceRecordProcessor.getJoinParentOp() to walk into the wrong operator and throw
+ * IllegalStateException("Was expecting dummy store operator but found: ...").
+ */
+public class TestTezDummyStoreOperator {
+
+  private TezDummyStoreOperator dummyStore;
+
+  @Before
+  public void setUp() {
+    dummyStore = new TezDummyStoreOperator();
+  }
+
+  @Test
+  public void testCloseOpRemovesSelfFromChildParents() throws HiveException {
+    CommonMergeJoinOperator mergeJoin = new CommonMergeJoinOperator();
+
+    wireParentChild(dummyStore, mergeJoin);
+
+    Assert.assertTrue("precondition: mergeJoin's parents must contain dummyStore",
+        mergeJoin.getParentOperators().contains(dummyStore));
+    Assert.assertTrue("precondition: dummyStore's children must contain mergeJoin",
+        dummyStore.getChildOperators().contains(mergeJoin));
+
+    dummyStore.closeOp(false);
+
+    Assert.assertFalse("dummyStore must be removed from its former child's parentOperators",
+        mergeJoin.getParentOperators().contains(dummyStore));
+    Assert.assertTrue("dummyStore's own childOperators must be cleared",
+        dummyStore.getChildOperators().isEmpty());
+  }
+
+  @Test
+  public void testCloseOpRemovesSelfFromAllChildrenWhenMultiple() throws HiveException {
+    CommonMergeJoinOperator child1 = new CommonMergeJoinOperator();
+    CommonMergeJoinOperator child2 = new CommonMergeJoinOperator();
+
+    List<Operator<? extends OperatorDesc>> children = new ArrayList<>();
+    children.add(child1);
+    children.add(child2);
+    dummyStore.setChildOperators(children);
+
+    List<Operator<? extends OperatorDesc>> parentsOfChild1 = new ArrayList<>();
+    parentsOfChild1.add(dummyStore);
+    child1.setParentOperators(parentsOfChild1);
+
+    List<Operator<? extends OperatorDesc>> parentsOfChild2 = new ArrayList<>();
+    parentsOfChild2.add(dummyStore);
+    child2.setParentOperators(parentsOfChild2);
+
+    dummyStore.closeOp(false);
+
+    Assert.assertFalse(child1.getParentOperators().contains(dummyStore));
+    Assert.assertFalse(child2.getParentOperators().contains(dummyStore));
+    Assert.assertTrue(dummyStore.getChildOperators().isEmpty());
+  }
+
+  @Test
+  public void testCloseOpWithNoChildrenDoesNotThrow() throws HiveException {
+    dummyStore.setChildOperators(new ArrayList<>());
+    dummyStore.closeOp(false);
+    Assert.assertTrue(dummyStore.getChildOperators().isEmpty());
+  }
+
+  @Test
+  public void testCloseOpWithNullChildrenDoesNotThrow() throws HiveException {
+    dummyStore.setChildOperators(null);
+    // setChildOperators(null) replaces null with an empty list (see Operator#setChildOperators).
+    dummyStore.closeOp(false);
+    Assert.assertTrue(dummyStore.getChildOperators().isEmpty());
+  }
+
+  @Test
+  public void testCloseOpDoesNotAffectUnrelatedParentReferences() throws HiveException {
+    CommonMergeJoinOperator mergeJoin = new CommonMergeJoinOperator();
+    TezDummyStoreOperator otherDummyStore = new TezDummyStoreOperator();
+
+    List<Operator<? extends OperatorDesc>> parents = new ArrayList<>();
+    parents.add(otherDummyStore);
+    parents.add(dummyStore);
+    mergeJoin.setParentOperators(parents);
+
+    List<Operator<? extends OperatorDesc>> children = new ArrayList<>();
+    children.add(mergeJoin);
+    dummyStore.setChildOperators(children);
+
+    dummyStore.closeOp(false);
+
+    Assert.assertFalse(mergeJoin.getParentOperators().contains(dummyStore));
+    Assert.assertTrue("unrelated parent reference must be left untouched",
+        mergeJoin.getParentOperators().contains(otherDummyStore));
+  }
+
+  private static void wireParentChild(
+      Operator<? extends OperatorDesc> parent, Operator<? extends OperatorDesc> child) {
+    List<Operator<? extends OperatorDesc>> children = new ArrayList<>();
+    children.add(child);
+    parent.setChildOperators(children);
+
+    List<Operator<? extends OperatorDesc>> parents = new ArrayList<>();
+    parents.add(parent);
+    child.setParentOperators(parents);
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestGenTezUtilsMergeJoinNumReducers.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestGenTezUtilsMergeJoinNumReducers.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.parse;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Properties;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.exec.CommonMergeJoinOperator;
+import org.apache.hadoop.hive.ql.exec.GroupByOperator;
+import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
+import org.apache.hadoop.hive.ql.exec.Task;
+import org.apache.hadoop.hive.ql.exec.TezDummyStoreOperator;
+import org.apache.hadoop.hive.ql.plan.GroupByDesc;
+import org.apache.hadoop.hive.ql.plan.MapWork;
+import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
+import org.apache.hadoop.hive.ql.plan.ReduceWork;
+import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.hive.ql.plan.TezWork;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Reproduces a reduce-side merge join bug: {@link GenTezUtils#createReduceWork} sets each
+ * {@link ReduceWork}'s numReduceTasks purely from that branch's own ReduceSinkOperator, with no
+ * cross-check against sibling ReduceSinkOperators that feed the same downstream
+ * {@link CommonMergeJoinOperator}. When two such siblings end up with different numReducers
+ * (e.g. because Tez auto-parallelism at runtime shrinks one side's task count but not the
+ * other's), rows with the same join key can land in different reduce tasks on each side,
+ * causing the merge join to silently miss matches.
+ */
+public class TestGenTezUtilsMergeJoinNumReducers {
+
+  private static final int BIG_TABLE_NUM_REDUCERS = 5;
+  private static final int SMALL_TABLE_NUM_REDUCERS = 20;
+
+  private GenTezProcContext ctx;
+  private TezWork tezWork;
+
+  private ReduceSinkOperator rsBigTable;
+  private GroupByOperator groupBy;
+
+  private ReduceSinkOperator rsSmallTable;
+  private TezDummyStoreOperator dummyStore;
+
+  @Before
+  public void setUp() throws Exception {
+    HiveConf conf = new HiveConfForTest(getClass());
+    SessionState.start(conf);
+
+    ParseContext pctx = new ParseContext();
+    pctx.setContext(new Context(conf));
+
+    ctx = new GenTezProcContext(conf, pctx, Collections.EMPTY_LIST,
+        new ArrayList<Task<?>>(), Collections.EMPTY_SET, Collections.EMPTY_SET);
+
+    tezWork = new TezWork("test");
+
+    CompilationOpContext cCtx = new CompilationOpContext();
+
+    rsBigTable = newReduceSink(cCtx, BIG_TABLE_NUM_REDUCERS);
+    groupBy = new GroupByOperator(cCtx);
+    groupBy.setConf(new GroupByDesc());
+    groupBy.getConf().setKeys(new ArrayList<>());
+    wireParentChild(rsBigTable, groupBy);
+
+    rsSmallTable = newReduceSink(cCtx, SMALL_TABLE_NUM_REDUCERS);
+    dummyStore = new TezDummyStoreOperator(cCtx);
+    wireParentChild(rsSmallTable, dummyStore);
+
+    CommonMergeJoinOperator mergeJoin = new CommonMergeJoinOperator(cCtx);
+    groupBy.setChildOperators(newList(mergeJoin));
+    dummyStore.setChildOperators(newList(mergeJoin));
+    mergeJoin.setParentOperators(newList(groupBy, dummyStore));
+  }
+
+  /**
+   * Both ReduceSinkOperators feed the same CommonMergeJoinOperator (one via a GroupBy, one via
+   * a DummyStore), but start out with different numReducers. Today, createReduceWork does not
+   * reconcile them: this assertion fails against unfixed code (5 != 20) and should pass once
+   * GenTezUtils normalizes numReducers across merge-join siblings.
+   */
+  @Test
+  public void testSiblingReduceSinksFeedingMergeJoinGetSameNumReducers() throws Exception {
+    ReduceWork rwBigTable = createReduceWorkFor(rsBigTable, groupBy);
+    ReduceWork rwSmallTable = createReduceWorkFor(rsSmallTable, dummyStore);
+
+    assertEquals("both sides of the merge join must partition into the same number of tasks",
+        rwBigTable.getNumReduceTasks(), rwSmallTable.getNumReduceTasks());
+  }
+
+  private ReduceWork createReduceWorkFor(ReduceSinkOperator rs, Operator<?> root) throws Exception {
+    MapWork preceedingWork = new MapWork("Map for " + rs);
+    tezWork.add(preceedingWork);
+    ctx.preceedingWork = preceedingWork;
+    ctx.parentOfRoot = rs;
+    return GenTezUtils.createReduceWork(ctx, root, tezWork);
+  }
+
+  private static ReduceSinkOperator newReduceSink(CompilationOpContext cCtx, int numReducers) {
+    ReduceSinkOperator rs = new ReduceSinkOperator(cCtx);
+    rs.setConf(new ReduceSinkDesc());
+    TableDesc tableDesc = new TableDesc();
+    tableDesc.setProperties(new Properties());
+    rs.getConf().setKeySerializeInfo(tableDesc);
+    rs.getConf().setValueSerializeInfo(tableDesc);
+    rs.getConf().setNumReducers(numReducers);
+    return rs;
+  }
+
+  private static void wireParentChild(
+      Operator<? extends OperatorDesc> parent, Operator<? extends OperatorDesc> child) {
+    parent.setChildOperators(newList(child));
+    child.setParentOperators(newList(parent));
+  }
+
+  @SafeVarargs
+  private static <T> ArrayList<T> newList(T... items) {
+    ArrayList<T> list = new ArrayList<>();
+    Collections.addAll(list, items);
+    return list;
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestGenTezUtilsMergeJoinNumReducers.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestGenTezUtilsMergeJoinNumReducers.java
@@ -18,9 +18,11 @@
 package org.apache.hadoop.hive.ql.parse;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Properties;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -111,6 +113,39 @@ public class TestGenTezUtilsMergeJoinNumReducers {
 
     assertEquals("both sides of the merge join must partition into the same number of tasks",
         rwBigTable.getNumReduceTasks(), rwSmallTable.getNumReduceTasks());
+  }
+
+  /**
+   * When a CommonMergeJoinOperator's parents are plain ReduceSinkOperators with no
+   * TezDummyStoreOperator sibling, both sides already run as tags of the same single Tez
+   * vertex and share its one parallelism setting. Normalization must be a no-op here: it must
+   * not touch numReducers or strip the AUTOPARALLEL trait, since there is no independent-vertex
+   * mismatch to protect against.
+   */
+  @Test
+  public void testMergeJoinWithoutDummyStoreSiblingIsNotNormalized() throws Exception {
+    CompilationOpContext cCtx = new CompilationOpContext();
+    ReduceSinkOperator rsLeft = newReduceSink(cCtx, BIG_TABLE_NUM_REDUCERS);
+    rsLeft.getConf().setReducerTraits(EnumSet.of(ReduceSinkDesc.ReducerTraits.AUTOPARALLEL));
+    ReduceSinkOperator rsRight = newReduceSink(cCtx, SMALL_TABLE_NUM_REDUCERS);
+    rsRight.getConf().setReducerTraits(EnumSet.of(ReduceSinkDesc.ReducerTraits.AUTOPARALLEL));
+
+    CommonMergeJoinOperator mergeJoin = new CommonMergeJoinOperator(cCtx);
+    rsLeft.setChildOperators(newList(mergeJoin));
+    rsRight.setChildOperators(newList(mergeJoin));
+    mergeJoin.setParentOperators(newList(rsLeft, rsRight));
+
+    ReduceWork rwLeft = createReduceWorkFor(rsLeft, mergeJoin);
+    ReduceWork rwRight = createReduceWorkFor(rsRight, mergeJoin);
+
+    assertEquals("numReducers must be untouched when there is no DummyStore sibling",
+        (long) BIG_TABLE_NUM_REDUCERS, (long) rwLeft.getNumReduceTasks());
+    assertEquals("numReducers must be untouched when there is no DummyStore sibling",
+        (long) SMALL_TABLE_NUM_REDUCERS, (long) rwRight.getNumReduceTasks());
+    assertTrue("AUTOPARALLEL must survive when there is no DummyStore sibling to protect against",
+        rsLeft.getConf().getReducerTraits().contains(ReduceSinkDesc.ReducerTraits.AUTOPARALLEL));
+    assertTrue("AUTOPARALLEL must survive when there is no DummyStore sibling to protect against",
+        rsRight.getConf().getReducerTraits().contains(ReduceSinkDesc.ReducerTraits.AUTOPARALLEL));
   }
 
   private ReduceWork createReduceWorkFor(ReduceSinkOperator rs, Operator<?> root) throws Exception {

--- a/ql/src/test/queries/clientpositive/tez_dummystore_reduce_side_reuse.q
+++ b/ql/src/test/queries/clientpositive/tez_dummystore_reduce_side_reuse.q
@@ -1,0 +1,62 @@
+set hive.mapred.mode=nonstrict;
+set hive.auto.convert.join=false;
+set hive.auto.convert.sortmerge.join=true;
+set hive.auto.convert.sortmerge.join.reduce.side=true;
+set hive.auto.convert.sortmerge.join.to.mapjoin=false;
+set hive.optimize.bucketmapjoin=true;
+-- Force multiple reduce tasks for the SAME vertex, and inflate each task's requested
+-- container memory so only a couple of containers fit in the (small, test-sized)
+-- NodeManager at once. This forces the Tez AM to sequentially REUSE the same container
+-- for multiple tasks of the Reducer vertex within this single query - the ObjectCache
+-- entry (keyed by vertex name, scoped per-query) then hands the second task the SAME
+-- already-initialized operator instances the first task used, exercising
+-- TezDummyStoreOperator's wiring cleanup on closeOp().
+set mapred.reduce.tasks=8;
+set hive.exec.reducers.max=8;
+set hive.tez.container.size=2048;
+set hive.tez.java.opts=-Xmx1600m;
+
+CREATE TABLE dummystore_src (id int, val string, sort_col int);
+
+INSERT INTO dummystore_src VALUES
+  (1,'A',3),(1,'A',1),(1,'A',2),
+  (2,'B',1),(2,'B',3),(2,'B',2),
+  (3,'C',2),(3,'C',1),
+  (4,'D',1),(4,'D',3),(4,'D',2),
+  (5,'E',1),(5,'E',3),(5,'E',2),
+  (6,'F',2),(6,'F',1),
+  (7,'G',1),(7,'G',3),(7,'G',2),
+  (8,'H',1),(8,'H',3),(8,'H',2);
+
+-- Reduce-side merge join with PTF (ROW_NUMBER) + LEFT OUTER JOIN: one side aggregates via
+-- GROUP BY, the other picks the "latest" row per id via ROW_NUMBER. Both sides shuffle into
+-- a Reducer vertex containing a DummyStore + CommonMergeJoinOperator pipeline. With 8
+-- reducer tasks contending for a couple of containers, some containers must sequentially
+-- process more than one task of this vertex, exercising TezDummyStoreOperator's wiring
+-- cleanup on closeOp() and ReduceRecordProcessor's close ordering for the last group in
+-- each task's merge-scan order.
+EXPLAIN
+SELECT b.id, b.max_val, e.enrch_val
+FROM
+  (SELECT id, max(val) AS max_val FROM dummystore_src GROUP BY id) b
+  LEFT JOIN
+  (SELECT id, val AS enrch_val
+   FROM (SELECT id, val, sort_col,
+                ROW_NUMBER() OVER (PARTITION BY id ORDER BY sort_col DESC) AS rn
+         FROM dummystore_src) t
+   WHERE rn = 1) e
+  ON b.id = e.id;
+
+-- SORT_QUERY_RESULTS
+SELECT b.id, b.max_val, e.enrch_val
+FROM
+  (SELECT id, max(val) AS max_val FROM dummystore_src GROUP BY id) b
+  LEFT JOIN
+  (SELECT id, val AS enrch_val
+   FROM (SELECT id, val, sort_col,
+                ROW_NUMBER() OVER (PARTITION BY id ORDER BY sort_col DESC) AS rn
+         FROM dummystore_src) t
+   WHERE rn = 1) e
+  ON b.id = e.id;
+
+DROP TABLE dummystore_src;

--- a/ql/src/test/results/clientpositive/tez/tez_dummystore_reduce_side_reuse.q.out
+++ b/ql/src/test/results/clientpositive/tez/tez_dummystore_reduce_side_reuse.q.out
@@ -1,0 +1,150 @@
+PREHOOK: query: CREATE TABLE dummystore_src (id int, val string, sort_col int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@dummystore_src
+POSTHOOK: query: CREATE TABLE dummystore_src (id int, val string, sort_col int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@dummystore_src
+PREHOOK: query: INSERT INTO dummystore_src VALUES
+  (1,'A',3),(1,'A',1),(1,'A',2),
+  (2,'B',1),(2,'B',3),(2,'B',2),
+  (3,'C',2),(3,'C',1),
+  (4,'D',1),(4,'D',3),(4,'D',2),
+  (5,'E',1),(5,'E',3),(5,'E',2),
+  (6,'F',2),(6,'F',1),
+  (7,'G',1),(7,'G',3),(7,'G',2),
+  (8,'H',1),(8,'H',3),(8,'H',2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@dummystore_src
+POSTHOOK: query: INSERT INTO dummystore_src VALUES
+  (1,'A',3),(1,'A',1),(1,'A',2),
+  (2,'B',1),(2,'B',3),(2,'B',2),
+  (3,'C',2),(3,'C',1),
+  (4,'D',1),(4,'D',3),(4,'D',2),
+  (5,'E',1),(5,'E',3),(5,'E',2),
+  (6,'F',2),(6,'F',1),
+  (7,'G',1),(7,'G',3),(7,'G',2),
+  (8,'H',1),(8,'H',3),(8,'H',2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@dummystore_src
+POSTHOOK: Lineage: dummystore_src.id SCRIPT []
+POSTHOOK: Lineage: dummystore_src.sort_col SCRIPT []
+POSTHOOK: Lineage: dummystore_src.val SCRIPT []
+PREHOOK: query: EXPLAIN
+SELECT b.id, b.max_val, e.enrch_val
+FROM
+  (SELECT id, max(val) AS max_val FROM dummystore_src GROUP BY id) b
+  LEFT JOIN
+  (SELECT id, val AS enrch_val
+   FROM (SELECT id, val, sort_col,
+                ROW_NUMBER() OVER (PARTITION BY id ORDER BY sort_col DESC) AS rn
+         FROM dummystore_src) t
+   WHERE rn = 1) e
+  ON b.id = e.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@dummystore_src
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: EXPLAIN
+SELECT b.id, b.max_val, e.enrch_val
+FROM
+  (SELECT id, max(val) AS max_val FROM dummystore_src GROUP BY id) b
+  LEFT JOIN
+  (SELECT id, val AS enrch_val
+   FROM (SELECT id, val, sort_col,
+                ROW_NUMBER() OVER (PARTITION BY id ORDER BY sort_col DESC) AS rn
+         FROM dummystore_src) t
+   WHERE rn = 1) e
+  ON b.id = e.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@dummystore_src
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+Plan optimized by CBO.
+
+Vertex dependency in root stage
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Stage-1
+      Reducer 2
+      File Output Operator [FS_19]
+        Select Operator [SEL_18] (rows=11 width=273)
+          Output:["_col0","_col1","_col2"]
+          Merge Join Operator [MERGEJOIN_23] (rows=11 width=273)
+            Conds:GBY_4._col0=DUMMY_STORE_24._col0(Left Outer),Output:["_col0","_col1","_col3"]
+          <-Dummy Store [DUMMY_STORE_24]
+              Select Operator [SEL_11] (rows=11 width=89)
+                Output:["_col0","_col1"]
+                Filter Operator [FIL_21] (rows=11 width=93)
+                  predicate:(ROW_NUMBER_window_0 = 1)
+                  PTF Operator [PTF_10] (rows=22 width=93)
+                    Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col2 DESC NULLS FIRST","partition by:":"_col0"}]
+                    Select Operator [SEL_9] (rows=22 width=93)
+                      Output:["_col0","_col1","_col2"]
+          <-Group By Operator [GBY_4] (rows=8 width=188)
+              Output:["_col0","_col1"],aggregations:["max(VALUE._col0)"],keys:KEY._col0
+            <-Map 1 [SIMPLE_EDGE] vectorized
+              SHUFFLE [RS_27]
+                PartitionCols:_col0
+                Group By Operator [GBY_26] (rows=8 width=188)
+                  Output:["_col0","_col1"],aggregations:["max(val)"],keys:id
+                  Select Operator [SEL_25] (rows=22 width=89)
+                    Output:["id","val"]
+                    TableScan [TS_0] (rows=22 width=89)
+                      default@dummystore_src,dummystore_src,Tbl:COMPLETE,Col:COMPLETE,Output:["id","val"]
+            <-Map 3 [SIMPLE_EDGE] vectorized
+              SHUFFLE [RS_29]
+                PartitionCols:id
+                Filter Operator [FIL_28] (rows=22 width=93)
+                  predicate:id is not null
+                  TableScan [TS_6] (rows=22 width=93)
+                    default@dummystore_src,dummystore_src,Tbl:COMPLETE,Col:COMPLETE,Output:["id","val","sort_col"]
+
+PREHOOK: query: SELECT b.id, b.max_val, e.enrch_val
+FROM
+  (SELECT id, max(val) AS max_val FROM dummystore_src GROUP BY id) b
+  LEFT JOIN
+  (SELECT id, val AS enrch_val
+   FROM (SELECT id, val, sort_col,
+                ROW_NUMBER() OVER (PARTITION BY id ORDER BY sort_col DESC) AS rn
+         FROM dummystore_src) t
+   WHERE rn = 1) e
+  ON b.id = e.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@dummystore_src
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT b.id, b.max_val, e.enrch_val
+FROM
+  (SELECT id, max(val) AS max_val FROM dummystore_src GROUP BY id) b
+  LEFT JOIN
+  (SELECT id, val AS enrch_val
+   FROM (SELECT id, val, sort_col,
+                ROW_NUMBER() OVER (PARTITION BY id ORDER BY sort_col DESC) AS rn
+         FROM dummystore_src) t
+   WHERE rn = 1) e
+  ON b.id = e.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@dummystore_src
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	A	A
+2	B	B
+3	C	C
+4	D	D
+5	E	E
+6	F	F
+7	G	G
+8	H	H
+PREHOOK: query: DROP TABLE dummystore_src
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@dummystore_src
+PREHOOK: Output: database:default
+PREHOOK: Output: default@dummystore_src
+POSTHOOK: query: DROP TABLE dummystore_src
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@dummystore_src
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@dummystore_src


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes two related defects in Hive's reduce-side merge join (SMB / DummyStore + `CommonMergeJoinOperator` pipeline) on Tez:

1. **`TezDummyStoreOperator#closeOp`** did not remove itself from its child's `parentOperators`, nor clear its own `childOperators`, when closing. When Hive's per-query `ObjectCache` hands a subsequent task the same `DummyStoreOperator`/`CommonMergeJoinOperator` instances a previous task (sharing the same JVM/container) already used, the stale child reference causes `ReduceRecordProcessor#getJoinParentOp` to walk into the wrong operator subtree and throw `IllegalStateException: Was expecting dummy store operator but found: ...`.

   `ReduceRecordProcessor#close()` also closed the main `reducer` before the `mergeWorkList` (DummyStore chain). Since `DummyStoreOperator#closeOp` is what removes the stale parent reference from the `CommonMergeJoinOperator` side, closing the main reducer first could prevent `CommonMergeJoinOperator#allInitializedParentsAreClosed()` from detecting all parents as closed in the correct order to flush the final join group.

2. **`GenTezUtils#createReduceWork`** sets each `ReduceWork`'s `numReduceTasks` purely from that branch's own `ReduceSinkOperator`, with no cross-check against sibling `ReduceSinkOperator`s that feed the same downstream `CommonMergeJoinOperator`. `SetReducerParallelism` assigns each `ReduceSinkOperator`'s reducer count/traits independently, so two siblings feeding the same merge join can end up with different `numReducers` (and different partitioning behavior, since the `UNIFORM` trait also affects `ReduceWork#setUniformDistribution`), with no reconciliation between them.

A new `normalizeMergeJoinReducers` helper walks from a `ReduceSinkOperator` downstream to find a `CommonMergeJoinOperator`, then walks upstream from each of the merge join's parents to find their originating `ReduceSinkOperator`s, and normalizes all of them to the same (maximum) `numReducers`, clearing `AUTOPARALLEL`/`UNIFORM` traits so Tez's dynamic auto-parallelism cannot independently shrink one side's task count at runtime.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- (1) causes a task failure (`IllegalStateException`) when Tez reuses a container across multiple tasks of the same reducer vertex.
- (2) causes rows with the same join key to be routed to different partitions on each side of the join (since the two sides no longer agree on the same partition count/hash strategy), silently producing incomplete join results (e.g. missing matches in a LEFT JOIN) with no error reported to the user.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- Added `TestTezDummyStoreOperator` (unit test) for (1): verifies `closeOp` correctly removes stale parent/child references. Fails against the pre-fix code (3/5 assertions), passes after the fix.
- Added `tez_dummystore_reduce_side_reuse.q` (`TestMiniTezCliDriver`) for (1): forces Tez to reuse a container across multiple tasks of the same reducer vertex. Reproduces the exact `IllegalStateException` against the pre-fix code; passes cleanly after the fix.
- Added `TestGenTezUtilsMergeJoinNumReducers` (unit test) for (2): drives `GenTezUtils#createReduceWork` directly for two synthetic `ReduceSinkOperator`s (one feeding the merge join through a `GroupByOperator`, the other through a `DummyStoreOperator`) with different `numReducers`. Fails against the pre-fix code (the two resulting `ReduceWork`s keep their original, mismatched `numReduceTasks`), passes after the fix.
- No `.q` test was added for (2): the mismatch only manifests through Tez's *runtime* dynamic-parallelism shrinking (`ShuffleVertexManager`) at realistic data volumes, which could not be reproduced deterministically at qtest scale without either breaking the reduce-side-merge-join plan shape or triggering unrelated flush-ordering issues in synthetic query shapes tried. The unit test above exercises the exact defect directly and deterministically instead.