### PR TITLE
HIVE-29709: Add health check to docker

### DIFF
--- a/packaging/src/docker/conf/tez-site.xml.template
+++ b/packaging/src/docker/conf/tez-site.xml.template
@@ -34,6 +34,10 @@
         <value>${TEZ_AM_REGISTRY_NAMESPACE}</value>
     </property>
     <property>
+        <name>tez.am.rpc.port</name>
+        <value>${TEZ_AM_RPC_PORT}</value>
+    </property>
+    <property>
         <name>tez.local.mode</name>
         <value>false</value>
     </property>

--- a/packaging/src/docker/docker-compose.yml
+++ b/packaging/src/docker/docker-compose.yml
@@ -156,12 +156,14 @@ services:
       - '2181:2181'
     networks:
       - hive
+    environment:
+      ZOO_4LW_COMMANDS_WHITELIST: ruok
     volumes:
       - zookeeper_data:/data
       - zookeeper_datalog:/datalog
       - zookeeper_logs:/logs
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo ruok > /dev/tcp/localhost/2181'"]
+      test: ["CMD-SHELL", "echo ruok | nc -w 2 127.0.0.1 2181 | grep imok"]
       interval: 5s
       timeout: 3s
       retries: 30
@@ -182,6 +184,7 @@ services:
 
       TEZ_FRAMEWORK_MODE: STANDALONE_ZOOKEEPER
       TEZ_AM_ZOOKEEPER_QUORUM: zookeeper:2181
+      TEZ_AM_RPC_PORT: '15100'
 
       # LLAP daemon discovery
       HIVE_ZOOKEEPER_QUORUM: zookeeper:2181
@@ -196,6 +199,12 @@ services:
       - scratch:/opt/hive/scratch
     networks:
       - hive
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/$${TEZ_AM_RPC_PORT}'"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
 
   llapdaemon:
     profiles:

--- a/packaging/src/docker/docker-compose.yml
+++ b/packaging/src/docker/docker-compose.yml
@@ -32,11 +32,17 @@ services:
       - hive-db:/var/lib/postgresql
     networks:
       - hive
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hive -d metastore_db"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
 
   metastore:
     image: apache/hive:${HIVE_VERSION}
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
     container_name: metastore
     hostname: metastore
@@ -67,11 +73,18 @@ services:
         - ./jars:/tmp/ext-jars:ro
     networks:
       - hive
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/9083'"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
 
   hiveserver2:
     image: apache/hive:${HIVE_VERSION}
     depends_on:
-      - metastore
+      metastore:
+        condition: service_healthy
     restart: unless-stopped
     container_name: hiveserver2
     hostname: hiveserver2
@@ -125,6 +138,12 @@ services:
       - ./jars:/tmp/ext-jars:ro
     networks:
       - hive
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/10000'"]
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 40s
 
   zookeeper:
     profiles:
@@ -141,6 +160,11 @@ services:
       - zookeeper_data:/data
       - zookeeper_datalog:/datalog
       - zookeeper_logs:/logs
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo ruok > /dev/tcp/localhost/2181'"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
 
   tezam:
     profiles:
@@ -149,7 +173,8 @@ services:
     container_name: tezam
     hostname: tezam
     depends_on:
-      - zookeeper
+      zookeeper:
+        condition: service_healthy
     restart: on-failure:3
     environment:
       USER: hive
@@ -177,7 +202,8 @@ services:
       - llap
     image: apache/hive:${HIVE_VERSION}
     depends_on:
-      - zookeeper
+      zookeeper:
+        condition: service_healthy
     restart: unless-stopped
     environment:
       USER: hive
@@ -205,6 +231,12 @@ services:
       - scratch:/opt/hive/scratch
     networks:
       - hive
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/15001'"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
 
 volumes:
   hive-db:

--- a/packaging/src/docker/entrypoint.sh
+++ b/packaging/src/docker/entrypoint.sh
@@ -48,6 +48,7 @@ export HIVE_SERVER2_TEZ_USE_EXTERNAL_SESSIONS="${HIVE_SERVER2_TEZ_USE_EXTERNAL_S
 export TEZ_FRAMEWORK_MODE="${TEZ_FRAMEWORK_MODE:-}"
 export TEZ_AM_REGISTRY_NAMESPACE="${TEZ_AM_REGISTRY_NAMESPACE:-/tez_am/server}"
 export TEZ_AM_ZOOKEEPER_QUORUM="${TEZ_AM_ZOOKEEPER_QUORUM:-${HIVE_ZOOKEEPER_QUORUM}}"
+export TEZ_AM_RPC_PORT="${TEZ_AM_RPC_PORT:-0}"
 
 envsubst < $HIVE_HOME/conf/core-site.xml.template > $HIVE_HOME/conf/core-site.xml
 envsubst < $HIVE_HOME/conf/hive-site.xml.template > $HIVE_HOME/conf/hive-site.xml

--- a/packaging/src/docker/start-hive.sh
+++ b/packaging/src/docker/start-hive.sh
@@ -58,4 +58,6 @@ export COMPOSE_FILE="$COMPOSE_FILES"
 
 echo "Starting Hive cluster (mode=$HIVE_EXECUTION_MODE)"
 
-docker compose $PROFILE up -d $SCALE
+docker compose $PROFILE up -d --wait $SCALE
+
+echo "Hive cluster is ready."


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add health check to Hive docker startup

### Why are the changes needed?

Better user experiance 


### Does this PR introduce _any_ user-facing change?

Yes, post hive cluster startup, you need not to wait randomly 

### How was this patch tested?

Manually 

#### Before
```
[+] Building 0.0s (0/0)
[+] Running 7/7
 ✔ Network hive             Created                                                                                                                                                     0.0s
 ✔ Volume "hive_hive-db"    Created                                                                                                                                                     0.0s
 ✔ Volume "hive_warehouse"  Created                                                                                                                                                     0.0s
 ✔ Volume "hive_scratch"    Created                                                                                                                                                     0.0s
 ✔ Container postgres       Started                                                                                                                                                     1.4s
 ✔ Container metastore      Started                                                                                                                                                     1.1s
 ✔ Container hiveserver2    Started                                                                                                                                                     1.1s
ayushsaxena@Q3NW54Y0C5 docker % docker exec -it hiveserver2 beeline -u 'jdbc:hive2://hiveserver2:10000/'
Connecting to jdbc:hive2://hiveserver2:10000/
26/07/06 14:22:15 [main]: WARN jdbc.HiveConnection: Failed to connect to hiveserver2:10000
Could not open connection to the HS2 server. Please check the server URI and if the URI is correct, then ask the administrator to check the server status. Enable verbose error messages (--verbose=true) for more information.
Error: Could not open client transport with JDBC Uri: jdbc:hive2://hiveserver2:10000/: java.net.ConnectException: Connection refused (state=08S01,code=0)
ayushsaxena@Q3NW54Y0C5 docker % docker exec -it hiveserver2 beeline -u 'jdbc:hive2://hiveserver2:10000/'
Connecting to jdbc:hive2://hiveserver2:10000/
26/07/06 14:22:20 [main]: WARN jdbc.HiveConnection: Failed to connect to hiveserver2:10000
Could not open connection to the HS2 server. Please check the server URI and if the URI is correct, then ask the administrator to check the server status. Enable verbose error messages (--verbose=true) for more information.
Error: Could not open client transport with JDBC Uri: jdbc:hive2://hiveserver2:10000/: java.net.ConnectException: Connection refused (state=08S01,code=0)
ayushsaxena@Q3NW54Y0C5 docker % docker exec -it hiveserver2 beeline -u 'jdbc:hive2://hiveserver2:10000/'
Connecting to jdbc:hive2://hiveserver2:10000/
26/07/06 14:22:25 [main]: WARN jdbc.HiveConnection: Failed to connect to hiveserver2:10000
Could not open connection to the HS2 server. Please check the server URI and if the URI is correct, then ask the administrator to check the server status. Enable verbose error messages (--verbose=true) for more information.
Error: Could not open client transport with JDBC Uri: jdbc:hive2://hiveserver2:10000/: java.net.ConnectException: Connection refused (state=08S01,code=0)
ayushsaxena@Q3NW54Y0C5 docker % docker exec -it hiveserver2 beeline -u 'jdbc:hive2://hiveserver2:10000/'
Connecting to jdbc:hive2://hiveserver2:10000/
26/07/06 14:22:37 [main]: WARN jdbc.HiveConnection: Failed to connect to hiveserver2:10000
Could not open connection to the HS2 server. Please check the server URI and if the URI is correct, then ask the administrator to check the server status. Enable verbose error messages (--verbose=true) for more information.
Error: Could not open client transport with JDBC Uri: jdbc:hive2://hiveserver2:10000/: java.net.ConnectException: Connection refused (state=08S01,code=0)
```

#### After - Non-LLAP
```
[+] Building 0.0s (0/0)
[+] Running 7/7
 ✔ Network hive             Created                                                                                                                                                     0.0s
 ✔ Volume "hive_scratch"    Created                                                                                                                                                     0.0s
 ✔ Volume "hive_hive-db"    Created                                                                                                                                                     0.0s
 ✔ Volume "hive_warehouse"  Created                                                                                                                                                     0.0s
 ✔ Container postgres       Healthy                                                                                                                                                    17.2s
 ✔ Container metastore      Healthy                                                                                                                                                    17.2s
 ✔ Container hiveserver2    Healthy                                                                                                                                                    27.2s
Hive cluster is ready.
ayushsaxena@Q3NW54Y0C5 docker % docker exec -it hiveserver2 beeline -u 'jdbc:hive2://hiveserver2:10000/'
Connecting to jdbc:hive2://hiveserver2:10000/
Connected to: Apache Hive (version 4.3.0-SNAPSHOT)
Driver: Hive JDBC (version 4.3.0-SNAPSHOT)
Transaction isolation: TRANSACTION_REPEATABLE_READ
Beeline version 4.3.0-SNAPSHOT by Apache Hive
0: jdbc:hive2://hiveserver2:10000/>
```

#### After - LLAP
```
+] Building 0.0s (0/0)
[+] Running 14/14
 ✔ Network hive                 Created                                                                                                                                                 0.0s
 ✔ Volume "zookeeper_datalog"   Created                                                                                                                                                 0.0s
 ✔ Volume "zookeeper_logs"      Created                                                                                                                                                 0.0s
 ✔ Volume "hive_hive-db"        Created                                                                                                                                                 0.0s
 ✔ Volume "hive_warehouse"      Created                                                                                                                                                 0.0s
 ✔ Volume "hive_scratch"        Created                                                                                                                                                 0.0s
 ✔ Volume "zookeeper_data"      Created                                                                                                                                                 0.0s
 ✔ Container zookeeper          Healthy                                                                                                                                                17.5s
 ✔ Container postgres           Healthy                                                                                                                                                17.5s
 ✔ Container hive-llapdaemon-2  Healthy                                                                                                                                                17.4s
 ✔ Container tezam              Healthy                                                                                                                                                17.4s
 ✔ Container hive-llapdaemon-1  Healthy                                                                                                                                                17.4s
 ✔ Container metastore          Healthy                                                                                                                                                17.4s
 ✔ Container hiveserver2        Healthy                                                                                                                                                27.4s
Hive cluster is ready.
ayushsaxena@Q3NW54Y0C5 docker % docker exec -it hiveserver2 beeline -u 'jdbc:hive2://hiveserver2:10000/'
Connecting to jdbc:hive2://hiveserver2:10000/
Connected to: Apache Hive (version 4.3.0-SNAPSHOT)
Driver: Hive JDBC (version 4.3.0-SNAPSHOT)
Transaction isolation: TRANSACTION_REPEATABLE_READ
Beeline version 4.3.0-SNAPSHOT by Apache Hive
0: jdbc:hive2://hiveserver2:10000/>
```

