### PR TITLE
HIVE-29719: NegativeArraySizeException in HybridGrace HashJoin due to integer overflow

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/persistence/HybridHashTableContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/persistence/HybridHashTableContainer.java
@@ -701,12 +701,17 @@ public class HybridHashTableContainer
       int minWbSize) throws IOException {
     int numPartitions = minNumParts;
 
-    if (memoryThreshold < minNumParts * minWbSize) {
+    if (memoryThreshold < (long) minNumParts * minWbSize) {
       LOG.warn("Available memory is not enough to create a HybridHashTableContainer!");
     }
 
     if (memoryThreshold / 2 < dataSize) { // The divided-by-2 logic is consistent to MapJoinOperator.reloadHashTable
       while (dataSize / numPartitions > memoryThreshold / 2) {
+        // Prevent integer overflow
+        if (numPartitions > Integer.MAX_VALUE / 2) {
+          throw new IOException("Cannot create a Hybrid Grace Hash Join with a table size this large ("
+              + dataSize + " bytes) against a memory threshold of " + memoryThreshold + " bytes");
+        }
         numPartitions *= 2;
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a check for Integer overflow. Check [HIVE-29719](https://issues.apache.org/jira/browse/HIVE-29719) 

### Why are the changes needed?
To fix NegativeArraySizeException when running hybridgrace hash join


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Will see CI output