### PR TITLE
HIVE-29416: optimise extrapolation by fetching matched partition col rows with one query

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/directsql/DirectSqlAggrStats.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/directsql/DirectSqlAggrStats.java
@@ -296,10 +296,8 @@ public class DirectSqlAggrStats {
         IExtrapolatePartStatus extrapolateMethod = new LinearExtrapolatePartStatus();
         // fill in colstatus
         Integer[] index;
-        boolean decimal = false;
         if (colType.toLowerCase().startsWith("decimal")) {
           index = IExtrapolatePartStatus.indexMaps.get("decimal");
-          decimal = true;
         } else {
           index = IExtrapolatePartStatus.indexMaps.get(colType.toLowerCase());
         }
@@ -309,8 +307,8 @@ public class DirectSqlAggrStats {
           index = IExtrapolatePartStatus.indexMaps.get("default");
         }
 
+        List<Integer> minMaxStatIndices = new ArrayList<>();
         for (int colStatIndex : index) {
-          String colStatName = IExtrapolatePartStatus.colStatNames[colStatIndex];
           // if the aggregation type is sum, we do a scale-up
           if (
               IExtrapolatePartStatus.aggrTypes[colStatIndex] == IExtrapolatePartStatus.AggrType.Sum
@@ -325,51 +323,31 @@ public class DirectSqlAggrStats {
               IExtrapolatePartStatus.aggrTypes[colStatIndex] == IExtrapolatePartStatus.AggrType.Min ||
                   IExtrapolatePartStatus.aggrTypes[colStatIndex] == IExtrapolatePartStatus.AggrType.Max
           ) {
-            // if the aggregation type is min/max, we extrapolate from the
-            // left/right borders
-            String orderByExpr =
-                decimal ? "cast(\"" + colStatName + "\" as decimal)" : "\"" + colStatName + "\"";
-
-            queryText = "select \"" + colStatName + "\",\"PART_NAME\" from " + PART_COL_STATS
-                + " inner join " + PARTITIONS + " on " + PART_COL_STATS + ".\"PART_ID\" = " + PARTITIONS + ".\"PART_ID\""
-                + " inner join " + TBLS + " on " + PARTITIONS + ".\"TBL_ID\" = " + TBLS + ".\"TBL_ID\""
-                + " inner join " + DBS + " on " + TBLS + ".\"DB_ID\" = " + DBS + ".\"DB_ID\""
-                + " where " + DBS + ".\"CTLG_NAME\" = ? and " + DBS + ".\"NAME\" = ? and " + TBLS + ".\"TBL_NAME\" = ? "
-                + " and " + PART_COL_STATS + ".\"COLUMN_NAME\" in (%1$s)"
-                + " and " + PARTITIONS + ".\"PART_NAME\" in (%2$s)"
-                + " and " + PART_COL_STATS + ".\"ENGINE\" = ? "
-                + " order by " + orderByExpr;
-
-            Batchable<String, Object[]> columnWisePartitionBatches =
-                columnWisePartitionBatcher(queryText, catName, dbName, tableName, partNames, engine, doTrace);
-            try {
-              List<Object[]> list =
-                  Batchable.runBatched(batchSize, Collections.singletonList(colName), columnWisePartitionBatches);
-              Object[] min = list.getFirst();
-              Object[] max = list.getLast();
-              if (batchSize > 0) {
-                for (int i = Math.min(batchSize - 1, list.size() - 1); i < list.size(); i += batchSize) {
-                  Object[] posMax = list.get(i);
-                  if (new BigDecimal(max[0].toString()).compareTo(new BigDecimal(posMax[0].toString())) < 0) {
-                    max = posMax;
-                  }
-                  int j = i + 1;
-                  if (j < list.size()) {
-                    Object[] posMin = list.get(j);
-                    if (new BigDecimal(min[0].toString()).compareTo(new BigDecimal(posMin[0].toString())) > 0) {
-                      min = posMin;
-                    }
-                  }
-                }
-              }
-              if (min[0] == null || max[0] == null) {
+            minMaxStatIndices.add(colStatIndex);
+          }
+        }
+        if (!minMaxStatIndices.isEmpty()) {
+          queryText = createQueryString(minMaxStatIndices);
+          Batchable<String, Object[]> columnWisePartitionBatches =
+              columnWisePartitionBatcher(queryText, catName, dbName, tableName, partNames, engine, doTrace);
+          try {
+            List<Object[]> partitionStatRows =
+                Batchable.runBatched(batchSize, Collections.singletonList(colName), columnWisePartitionBatches);
+            for (int i = 0; i < minMaxStatIndices.size(); i++) {
+              int colStatIndex = minMaxStatIndices.get(i);
+              // row[0] is PART_NAME; stat columns follow in minMaxStatIndices order
+              int statColIdx = i + 1;
+              Object[] minBorder = findStatBorder(partitionStatRows, statColIdx, indexMap, true);
+              Object[] maxBorder = findStatBorder(partitionStatRows, statColIdx, indexMap, false);
+              if (minBorder[0] == null || maxBorder[0] == null) {
                 row[2 + colStatIndex] = null;
               } else {
-                row[2 + colStatIndex] = extrapolateMethod.extrapolate(min, max, colStatIndex, indexMap);
+                row[2 + colStatIndex] =
+                    extrapolateMethod.extrapolate(minBorder, maxBorder, colStatIndex, indexMap);
               }
-            } finally {
-              columnWisePartitionBatches.closeAllQueries();
             }
+          } finally {
+            columnWisePartitionBatches.closeAllQueries();
           }
         }
         colStats.add(prepareCSObjWithAdjustedNDV
@@ -379,6 +357,61 @@ public class DirectSqlAggrStats {
     }
     return colStats;
   }
+
+  private String createQueryString(List<Integer> minMaxStatIndices) {
+    StringBuilder selectClause = new StringBuilder("\"PART_NAME\"");
+    for (int colStatIndex : minMaxStatIndices) {
+      String colStatName = IExtrapolatePartStatus.colStatNames[colStatIndex];
+      selectClause.append(", ");
+      if (IExtrapolatePartStatus.colStatTypes[colStatIndex]
+          == IExtrapolatePartStatus.ColStatType.Decimal) {
+        selectClause.append("cast(\"").append(colStatName).append("\" as decimal)");
+      } else {
+        selectClause.append("\"").append(colStatName).append("\"");
+      }
+    }
+    return "select " + selectClause + " from " + PART_COL_STATS
+        + " inner join " + PARTITIONS + " on " + PART_COL_STATS + ".\"PART_ID\" = " + PARTITIONS + ".\"PART_ID\""
+        + " inner join " + TBLS + " on " + PARTITIONS + ".\"TBL_ID\" = " + TBLS + ".\"TBL_ID\""
+        + " inner join " + DBS + " on " + TBLS + ".\"DB_ID\" = " + DBS + ".\"DB_ID\""
+        + " where " + DBS + ".\"CTLG_NAME\" = ? and " + DBS + ".\"NAME\" = ? and " + TBLS + ".\"TBL_NAME\" = ? "
+        + " and " + PART_COL_STATS + ".\"COLUMN_NAME\" in (%1$s)"
+        + " and " + PARTITIONS + ".\"PART_NAME\" in (%2$s)"
+        + " and " + PART_COL_STATS + ".\"ENGINE\" = ? ";
+  }
+
+  /*
+   * Find the min/max border of the column partitionStatRows[statColIdx] in the partitionStatRows
+   */
+  private Object[] findStatBorder(
+      List<Object[]> partitionStatRows, int statColIdx, Map<String, Integer> indexMap, boolean findMin) {
+    Object[] bestBorder = new Object[] { null, null };
+    for (Object[] partitionStatRow : partitionStatRows) {
+      Object statValue = partitionStatRow[statColIdx];
+      if (statValue == null) {
+        continue;
+      }
+      Object[] currentBorder = new Object[] { statValue, partitionStatRow[0] };
+      if (bestBorder[0] == null || isBetterBorder(currentBorder, bestBorder, indexMap, findMin)) {
+        bestBorder = currentBorder;
+      }
+    }
+    return bestBorder;
+  }
+
+  private boolean isBetterBorder(
+      Object[] currentBorder, Object[] currentBestBorder, Map<String, Integer> indexMap, boolean findMin) {
+    int valueComparison = new BigDecimal(currentBorder[0].toString())
+        .compareTo(new BigDecimal(currentBestBorder[0].toString()));
+    if (valueComparison != 0) {
+      return findMin ? valueComparison < 0 : valueComparison > 0;
+    }
+    int partitionComparison = Integer.compare(
+        indexMap.get(currentBorder[1].toString()),
+        indexMap.get(currentBestBorder[1].toString()));
+    return findMin ? partitionComparison < 0 : partitionComparison > 0;
+  }
+
 
   private void columnWiseStatsMerger(
       final String queryText, final String catName, final String dbName,

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -34,7 +34,9 @@ import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.CreationMetadata;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.Decimal;
 import org.apache.hadoop.hive.metastore.api.DecimalColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.utils.DecimalUtils;
 import org.apache.hadoop.hive.metastore.api.AddPackageRequest;
 import org.apache.hadoop.hive.metastore.api.AggrStats;
 import org.apache.hadoop.hive.metastore.api.DropPackageRequest;
@@ -1201,6 +1203,62 @@ public class TestObjectStore {
     statsAggrResourceCleanup();
   }
 
+  @Test
+  public void testMissingPartsStatsAggrWithBackendDBDistinctBorders() throws Exception {
+    setAggrConf(false, false, 2);
+    List<ColumnStatisticsData> statsPerPartition = Arrays.asList(
+        new ColStatsBuilder<>(long.class).numNulls(1).numDVs(2).low(1L).high(5L).build(),
+        new ColStatsBuilder<>(long.class).numNulls(1).numDVs(2).low(3L).high(7L).build(),
+        new ColStatsBuilder<>(long.class).numNulls(1).numDVs(2).low(3L).high(7L).build());
+    createPartitionedTable(true, true, new HashSet<>(Collections.singletonList(1)), "int", statsPerPartition);
+    AggrStats aggrStats = runStatsAggregation();
+    ColumnStatisticsData computedStats = aggrStats.getColStats().get(0).getStatsData();
+    Assert.assertEquals(2, aggrStats.getPartsFound());
+    ColumnStatisticsData expectedStats = new ColStatsBuilder<>(long.class).numNulls(3).numDVs(2)
+        .low(1L).high(7L).build();
+    assertEqualStatistics(expectedStats, computedStats);
+    statsAggrResourceCleanup();
+  }
+
+  @Test
+  public void testMissingPartsStatsAggrWithBackendDBDecimal() throws Exception {
+    setAggrConf(false, false, 2);
+    Decimal one = DecimalUtils.createThriftDecimal("1.0");
+    Decimal three = DecimalUtils.createThriftDecimal("3.0");
+    Decimal four = DecimalUtils.createThriftDecimal("4.0");
+    Decimal seven = DecimalUtils.createThriftDecimal("7.0");
+    List<ColumnStatisticsData> statsPerPartition = Arrays.asList(
+        new ColStatsBuilder<>(Decimal.class).numNulls(1).numDVs(2).low(one).high(four).build(),
+        new ColStatsBuilder<>(Decimal.class).numNulls(1).numDVs(2).low(three).high(seven).build(),
+        new ColStatsBuilder<>(Decimal.class).numNulls(1).numDVs(2).low(three).high(seven).build());
+    createPartitionedTable(true, true, new HashSet<>(Collections.singletonList(1)),
+        "decimal(10,2)", statsPerPartition);
+    AggrStats aggrStats = runStatsAggregation();
+    ColumnStatisticsData computedStats = aggrStats.getColStats().get(0).getStatsData();
+    Assert.assertEquals(2, aggrStats.getPartsFound());
+    ColumnStatisticsData expectedStats = new ColStatsBuilder<>(Decimal.class).numNulls(3).numDVs(2)
+        .low(one).high(seven).build();
+    assertEqualStatistics(expectedStats, computedStats);
+    statsAggrResourceCleanup();
+  }
+
+  @Test
+  public void testMissingPartsStatsAggrWithBackendDBMissingLastPartition() throws Exception {
+    setAggrConf(false, false, 2);
+    List<ColumnStatisticsData> statsPerPartition = Arrays.asList(
+        new ColStatsBuilder<>(long.class).numNulls(1).numDVs(2).low(1L).high(5L).build(),
+        new ColStatsBuilder<>(long.class).numNulls(1).numDVs(2).low(3L).high(7L).build(),
+        new ColStatsBuilder<>(long.class).numNulls(1).numDVs(2).low(3L).high(7L).build());
+    createPartitionedTable(true, true, new HashSet<>(Collections.singletonList(2)), "int", statsPerPartition);
+    AggrStats aggrStats = runStatsAggregation();
+    ColumnStatisticsData computedStats = aggrStats.getColStats().get(0).getStatsData();
+    Assert.assertEquals(2, aggrStats.getPartsFound());
+    ColumnStatisticsData expectedStats = new ColStatsBuilder<>(long.class).numNulls(3).numDVs(2)
+        .low(1L).high(9L).build();
+    assertEqualStatistics(expectedStats, computedStats);
+    statsAggrResourceCleanup();
+  }
+
   /**
    * Creates DB1 database, TABLE1 table with 3 partitions.
    * @param withPrivileges Should we create privileges as well
@@ -1208,6 +1266,12 @@ public class TestObjectStore {
    */
   private void createPartitionedTable(boolean withPrivileges, boolean withStatistics, Set<Integer> statsMissingIndices)
       throws Exception {
+    createPartitionedTable(withPrivileges, withStatistics, statsMissingIndices, "int", null);
+  }
+
+  private void createPartitionedTable(boolean withPrivileges, boolean withStatistics,
+      Set<Integer> statsMissingIndices, String statsColumnType,
+      List<ColumnStatisticsData> statsDataPerPartition) throws Exception {
     Database db1 = new DatabaseBuilder()
                        .setName(DB1)
                        .setDescription("description")
@@ -1285,10 +1349,15 @@ public class TestObjectStore {
         stats.setStatsObj(statsObjList);
         stats.setEngine(ENGINE);
 
-        ColumnStatisticsData data = new ColStatsBuilder<>(long.class).numNulls(1).numDVs(2)
-            .low(3L).high(4L).hll(3, 4).kll(3, 4).build();
+        ColumnStatisticsData data;
+        if (statsDataPerPartition != null) {
+          data = statsDataPerPartition.get(i);
+        } else {
+          data = new ColStatsBuilder<>(long.class).numNulls(1).numDVs(2)
+              .low(3L).high(4L).hll(3, 4).kll(3, 4).build();
+        }
 
-        ColumnStatisticsObj partStats = new ColumnStatisticsObj("test_part_col", "int", data);
+        ColumnStatisticsObj partStats = new ColumnStatisticsObj("test_part_col", statsColumnType, data);
         statsObjList.add(partStats);
 
         try (AutoCloseable c = deadline()) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Replace per min/max col query used for min/max extrapolation in `DirectSqlAggrStats.aggrStatsUseDB` with a single query that fetches `PART_NAME` and all relevant min/max stat columns. Scan all returned partition rows to find the global min/max borders before linear extrapolation.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When aggregating column stats over partitions with partial stats, min/max values need to be extrapolated from partitions with stats. Previous implementation runs the same query to db per min/max column required for extrapolation, same query is executed multiple times in this case.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests under `TestObjectStore.java` for extrapolation with partial partition stats