### PR TITLE
HIVE-29687:Build on aarch64 along with mac in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,19 +31,22 @@ env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
-  macos-jdk21:
-    name: 'macOS (JDK 21)'
-    runs-on: macos-latest
+  build:
+    name: '${{ matrix.os }} (JDK 21)'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: 'Set up JDK 21'
-        uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5
         with:
-            java-version: '21'
-            distribution: temurin
-            cache: maven
-      - name: 'Build project'
-        run: |
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: >
           mvn clean install -DskipTests -Pitests
       - name: 'Dependency tree'
         run: mvn dependency:tree -Pitests


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1.Refactored .github/workflows/build.yml from a single macOS job into a matrix-based build job that runs on:
a.)macos-latest b.)ubuntu-24.04-arm
2.Renamed the job from macos-jdk21 to build
3.Added fail-fast: false so one platform failure does not cancel the other
4.Added dynamic job names: ${{ matrix.os }} (JDK 21)
5.No module exclusions (-pl) or Maven flag changes were introduced.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Hive was previously compiled in GitHub Actions only on macos-latest. While macOS runners are ARM64 (Apple Silicon), that does not cover Linux aarch64, where OS-specific Maven profiles and native dependencies can behave differently (for example, Kudu-related profiles on Unix/Linux).
Adding a Linux ARM64 CI leg catches platform-specific compile and dependency issues early, before they affect users or release builds on ARM64 Linux.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
CI workflow validation on GitHub Actions:
1.Pushed the branch and verified the Build CI with different platforms/configs workflow runs both matrix legs:
a.)macos-latest (JDK 21) b.)ubuntu-24.04-arm (JDK 21)
2.No unit tests were added because this change only updates GitHub Actions workflow configuration.