### PR TITLE
HIVE-29741:Update GitHub Actions to use ASF allowed Docker action ver…

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -118,7 +118,7 @@ jobs:
           ls ./standalone-metastore/packaging/src/docker/
 
       - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -127,7 +127,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Build Hive Image locally
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./packaging/src/docker/
           file: ./packaging/src/docker/Dockerfile
@@ -142,7 +142,7 @@ jobs:
             BUILD_ENV=${{ env.BUILD_ENV }}
 
       - name: Build Standalone Metastore Image locally
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./standalone-metastore/packaging/src/docker/
           file: ./standalone-metastore/packaging/src/docker/Dockerfile
@@ -184,7 +184,7 @@ jobs:
           kind delete cluster --name chart-testing
 
       - name: Build and push Hive Image to docker hub
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./packaging/src/docker/
           file: ./packaging/src/docker/Dockerfile
@@ -199,7 +199,7 @@ jobs:
             BUILD_ENV=${{ env.BUILD_ENV }}
 
       - name: Build and push Standalone Metastore Image to docker hub
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./standalone-metastore/packaging/src/docker/
           file: ./standalone-metastore/packaging/src/docker/Dockerfile

--- a/.github/workflows/hive-postgres-tpcds-metastore.yml
+++ b/.github/workflows/hive-postgres-tpcds-metastore.yml
@@ -45,13 +45,13 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.event.inputs.pushImage == 'true' }}
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and optionally push Docker image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./standalone-metastore/metastore-server/docker/hive-postgres-tpcds-metastore/
           file: ./standalone-metastore/metastore-server/docker/hive-postgres-tpcds-metastore/Dockerfile


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR updates the GitHub Actions workflow files to use ASF allowlisted versions of docker/build-push-action and docker/login-action.

The changes update the action versions in:

a).github/workflows/docker-images.yml
b).github/workflows/hive-postgres-tpcds-metastore.yml

No workflow logic or functionality has been modified; only the action references have been updated to approved versions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The ASF Allowlist Check currently fails because the versions of docker/build-push-action and docker/login-action used by Hive are not present in the ASF approved allowlist.

Updating these actions to approved versions resolves the allowlist check failure while preserving the existing workflow behavior.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1.Verified that the workflow files reference the updated ASF allowlisted versions of docker/build-push-action and docker/login-action.
2.Verified that no workflow logic or build steps were changed beyond the action version updates.
3.Validation will be performed by the GitHub Actions CI, including the ASF Allowlist Check, on the pull request.