### PR TITLE
HIVE-29750: Iceberg: Move Iceberg REST catalog client code to a new m…

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/IcebergCatalogProperties.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/IcebergCatalogProperties.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
-import org.apache.iceberg.hive.client.RestAccessDelegationMode;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class IcebergCatalogProperties {
@@ -39,7 +38,6 @@ public class IcebergCatalogProperties {
   public static final String ICEBERG_HADOOP_TABLE_NAME = "location_based_table";
   public static final String ICEBERG_DEFAULT_CATALOG_NAME = "default_iceberg";
   public static final String NO_CATALOG_TYPE = "no catalog";
-  public static final String REST_ACCESS_DELEGATION_HEADER_PROPERTY = "header.X-Iceberg-Access-Delegation";
 
   private IcebergCatalogProperties() {
 
@@ -104,19 +102,6 @@ public class IcebergCatalogProperties {
    */
   public static String catalogPropertyConfigKey(String catalogName, String catalogProperty) {
     return String.format("%s%s.%s", CATALOG_CONFIG_PREFIX, catalogName, catalogProperty);
-  }
-
-  /**
-   * Returns true when the catalog is configured to request REST vended storage credentials via
-   * {@link #REST_ACCESS_DELEGATION_HEADER_PROPERTY}.
-   */
-  public static boolean requestsVendedCredentials(String catalogName, Configuration conf) {
-    if (conf == null || StringUtils.isEmpty(catalogName)) {
-      return false;
-    }
-    String headerValue =
-        conf.get(catalogPropertyConfigKey(catalogName, REST_ACCESS_DELEGATION_HEADER_PROPERTY));
-    return RestAccessDelegationMode.headerRequestsVendedCredentials(headerValue);
   }
 
   /**

--- a/iceberg/iceberg-handler/pom.xml
+++ b/iceberg/iceberg-handler/pom.xml
@@ -35,6 +35,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-rest-catalog-client</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <!-- compile-time only, for S3FileIOProperties/AwsClientProperties string constants
            (inlined by javac); the classes are not referenced at runtime -->
       <groupId>org.apache.iceberg</groupId>
@@ -176,6 +181,14 @@
                 <artifactItem>
                   <groupId>org.apache.hive</groupId>
                   <artifactId>hive-iceberg-catalog</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.hive</groupId>
+                  <artifactId>hive-iceberg-rest-catalog-client</artifactId>
                   <version>${project.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergVendedCredentialUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergVendedCredentialUtil.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hive.IcebergCatalogProperties;
+import org.apache.iceberg.hive.rest.catalog.RestCatalogAccessDelegation;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.io.SupportsStorageCredentials;
@@ -214,7 +215,7 @@ public final class IcebergVendedCredentialUtil {
    */
   private static boolean shouldSkipApplyFromJobConf(String tableName, String catalogName, Configuration conf) {
     return StringUtils.isBlank(conf.get(InputFormatConfig.vendedCredentialsKey(tableName))) &&
-        !IcebergCatalogProperties.requestsVendedCredentials(catalogName, conf);
+        !RestCatalogAccessDelegation.requestsVendedCredentials(catalogName, conf);
   }
 
   /**
@@ -247,7 +248,7 @@ public final class IcebergVendedCredentialUtil {
     if (properties == null) {
       return false;
     }
-    return IcebergCatalogProperties.requestsVendedCredentials(
+    return RestCatalogAccessDelegation.requestsVendedCredentials(
         properties.getProperty(InputFormatConfig.CATALOG_NAME), configuration);
   }
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_rest_catalog_gravitino.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_rest_catalog_gravitino.q
@@ -25,7 +25,7 @@
 --! qt:replace:/(\S\"iceberg-version\\\":\\\")(\w+\s\w+\s\d+\.\d+\.\d+\s\(\w+\s\w+\))(\\\")/$1#Masked#$3/
 
 set hive.stats.autogather=false;
-set metastore.client.impl=org.apache.iceberg.hive.client.HiveRESTCatalogClient;
+set metastore.client.impl=org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient;
 set metastore.catalog.default=ice01;
 set iceberg.catalog.ice01.type=rest;
 set iceberg.catalog.ice01.header.X-Iceberg-Access-Delegation=vended-credentials;

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_rest_catalog_hms.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_rest_catalog_hms.q
@@ -21,7 +21,7 @@
 --! qt:replace:/(\S\"iceberg-version\\\":\\\")(\w+\s\w+\s\d+\.\d+\.\d+\s\(\w+\s\w+\))(\\\")/$1#Masked#$3/
 
 set hive.stats.autogather=false;
-set metastore.client.impl=org.apache.iceberg.hive.client.HiveRESTCatalogClient;
+set metastore.client.impl=org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient;
 set metastore.catalog.default=ice01;
 set iceberg.catalog.ice01.type=rest;
 

--- a/iceberg/iceberg-rest-catalog-client/pom.xml
+++ b/iceberg/iceberg-rest-catalog-client/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.apache.hive</groupId>
+    <artifactId>hive-iceberg</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>hive-iceberg-rest-catalog-client</artifactId>
+  <packaging>jar</packaging>
+  <name>Hive Iceberg REST Catalog Client</name>
+  <properties>
+    <hive.path.to.root>../..</hive.path.to.root>
+    <path.to.iceberg.root>..</path.to.iceberg.root>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-shading</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-catalog</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-standalone-metastore-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-catalog</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-core</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/RestAccessDelegationMode.java
+++ b/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/RestAccessDelegationMode.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Values for the Iceberg REST catalog {@code X-Iceberg-Access-Delegation} request header. The header
  * accepts a comma-separated list of these modes; configure via
- * {@link RestCatalogAccessDelegation#ACCESS_DELEGATION_HEADER_PROPERTY}.
+ * {@link RestCatalogAccessDelegation#ACCESS_DELEGATION_PROPERTY}.
  *
  * @see <a href="https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml">REST catalog spec</a>
  */
@@ -45,7 +45,7 @@ public enum RestAccessDelegationMode {
     return modeName;
   }
 
-  /** Comma-separated list suitable for {@link RestCatalogAccessDelegation#ACCESS_DELEGATION_HEADER_PROPERTY}. */
+  /** Comma-separated list suitable for {@link RestCatalogAccessDelegation#ACCESS_DELEGATION_PROPERTY}. */
   public static String toHeaderValue(RestAccessDelegationMode... modes) {
     return Arrays.stream(modes).map(RestAccessDelegationMode::modeName).collect(Collectors.joining(","));
   }

--- a/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/RestAccessDelegationMode.java
+++ b/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/RestAccessDelegationMode.java
@@ -17,17 +17,16 @@
  * under the License.
  */
 
-package org.apache.iceberg.hive.client;
+package org.apache.iceberg.hive.rest.catalog;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.iceberg.hive.IcebergCatalogProperties;
 
 /**
  * Values for the Iceberg REST catalog {@code X-Iceberg-Access-Delegation} request header. The header
  * accepts a comma-separated list of these modes; configure via
- * {@link IcebergCatalogProperties#REST_ACCESS_DELEGATION_HEADER_PROPERTY}.
+ * {@link RestCatalogAccessDelegation#ACCESS_DELEGATION_HEADER_PROPERTY}.
  *
  * @see <a href="https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml">REST catalog spec</a>
  */
@@ -46,7 +45,7 @@ public enum RestAccessDelegationMode {
     return modeName;
   }
 
-  /** Comma-separated list suitable for {@link IcebergCatalogProperties#REST_ACCESS_DELEGATION_HEADER_PROPERTY}. */
+  /** Comma-separated list suitable for {@link RestCatalogAccessDelegation#ACCESS_DELEGATION_HEADER_PROPERTY}. */
   public static String toHeaderValue(RestAccessDelegationMode... modes) {
     return Arrays.stream(modes).map(RestAccessDelegationMode::modeName).collect(Collectors.joining(","));
   }

--- a/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/RestCatalogAccessDelegation.java
+++ b/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/RestCatalogAccessDelegation.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hive.rest.catalog;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hive.IcebergCatalogProperties;
+
+/**
+ * REST catalog access-delegation configuration for Hive, including the
+ * {@code X-Iceberg-Access-Delegation} catalog property and vended-credential opt-in.
+ */
+public final class RestCatalogAccessDelegation {
+
+  /** Iceberg REST catalog property prefix for {@code X-Iceberg-Access-Delegation}. */
+  public static final String ACCESS_DELEGATION_HEADER_PROPERTY = "header.X-Iceberg-Access-Delegation";
+
+  private RestCatalogAccessDelegation() {
+  }
+
+  /**
+   * Returns true when the catalog is configured to request REST vended storage credentials via
+   * {@link #ACCESS_DELEGATION_HEADER_PROPERTY}.
+   */
+  public static boolean requestsVendedCredentials(String catalogName, Configuration conf) {
+    if (conf == null || StringUtils.isEmpty(catalogName)) {
+      return false;
+    }
+    String headerValue =
+        conf.get(IcebergCatalogProperties.catalogPropertyConfigKey(catalogName, ACCESS_DELEGATION_HEADER_PROPERTY));
+    return RestAccessDelegationMode.headerRequestsVendedCredentials(headerValue);
+  }
+}

--- a/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/RestCatalogAccessDelegation.java
+++ b/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/RestCatalogAccessDelegation.java
@@ -24,27 +24,27 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hive.IcebergCatalogProperties;
 
 /**
- * REST catalog access-delegation configuration for Hive, including the
- * {@code X-Iceberg-Access-Delegation} catalog property and vended-credential opt-in.
+ * Utilities for Iceberg REST catalog access delegation, including the {@code X-Iceberg-Access-Delegation}
+ * catalog property and vended-credential configuration.
  */
 public final class RestCatalogAccessDelegation {
 
   /** Iceberg REST catalog property prefix for {@code X-Iceberg-Access-Delegation}. */
-  public static final String ACCESS_DELEGATION_HEADER_PROPERTY = "header.X-Iceberg-Access-Delegation";
+  public static final String ACCESS_DELEGATION_PROPERTY = "header.X-Iceberg-Access-Delegation";
 
   private RestCatalogAccessDelegation() {
   }
 
   /**
    * Returns true when the catalog is configured to request REST vended storage credentials via
-   * {@link #ACCESS_DELEGATION_HEADER_PROPERTY}.
+   * {@link #ACCESS_DELEGATION_PROPERTY}.
    */
   public static boolean requestsVendedCredentials(String catalogName, Configuration conf) {
     if (conf == null || StringUtils.isEmpty(catalogName)) {
       return false;
     }
     String headerValue =
-        conf.get(IcebergCatalogProperties.catalogPropertyConfigKey(catalogName, ACCESS_DELEGATION_HEADER_PROPERTY));
+        conf.get(IcebergCatalogProperties.catalogPropertyConfigKey(catalogName, ACCESS_DELEGATION_PROPERTY));
     return RestAccessDelegationMode.headerRequestsVendedCredentials(headerValue);
   }
 }

--- a/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/client/HiveRESTCatalogClient.java
+++ b/iceberg/iceberg-rest-catalog-client/src/main/java/org/apache/iceberg/hive/rest/catalog/client/HiveRESTCatalogClient.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.hive.client;
+package org.apache.iceberg.hive.rest.catalog.client;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/iceberg/iceberg-rest-catalog-client/src/test/java/org/apache/iceberg/hive/rest/catalog/TestRestAccessDelegationMode.java
+++ b/iceberg/iceberg-rest-catalog-client/src/test/java/org/apache/iceberg/hive/rest/catalog/TestRestAccessDelegationMode.java
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-package org.apache.iceberg.hive.client;
+package org.apache.iceberg.hive.rest.catalog;
 
-import org.apache.iceberg.hive.IcebergCatalogProperties;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,11 +64,11 @@ class TestRestAccessDelegationMode {
   @Test
   void requestsVendedCredentialsFromConfiguration() {
     org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
-    assertThat(IcebergCatalogProperties.requestsVendedCredentials("ice01", conf)).isFalse();
+    assertThat(RestCatalogAccessDelegation.requestsVendedCredentials("ice01", conf)).isFalse();
 
     conf.set(
         "iceberg.catalog.ice01.header.X-Iceberg-Access-Delegation",
         RestAccessDelegationMode.VENDED_CREDENTIALS.modeName());
-    assertThat(IcebergCatalogProperties.requestsVendedCredentials("ice01", conf)).isTrue();
+    assertThat(RestCatalogAccessDelegation.requestsVendedCredentials("ice01", conf)).isTrue();
   }
 }

--- a/iceberg/iceberg-rest-catalog-client/src/test/java/org/apache/iceberg/hive/rest/catalog/client/TestHiveRESTCatalogClient.java
+++ b/iceberg/iceberg-rest-catalog-client/src/test/java/org/apache/iceberg/hive/rest/catalog/client/TestHiveRESTCatalogClient.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.hive.client;
+package org.apache.iceberg.hive.rest.catalog.client;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -41,6 +41,7 @@
     <module>patched-iceberg-core</module>
     <module>iceberg-shading</module>
     <module>iceberg-catalog</module>
+    <module>iceberg-rest-catalog-client</module>
     <module>iceberg-handler</module>
   </modules>
   <dependencies>
@@ -96,6 +97,11 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-iceberg-catalog</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hive</groupId>
+        <artifactId>hive-iceberg-rest-catalog-client</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/itests/hive-iceberg/pom.xml
+++ b/itests/hive-iceberg/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
-      <artifactId>hive-iceberg-catalog</artifactId>
+      <artifactId>hive-iceberg-rest-catalog-client</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/itests/hive-iceberg/src/test/java/org/apache/hive/TestHiveRESTCatalogClientITBase.java
+++ b/itests/hive-iceberg/src/test/java/org/apache/hive/TestHiveRESTCatalogClientITBase.java
@@ -92,7 +92,7 @@ public abstract class TestHiveRESTCatalogClientITBase {
     conf = restCatalogExtension.getConf();
 
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_IMPL,
-        "org.apache.iceberg.hive.client.HiveRESTCatalogClient");
+        "org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient");
     conf.set(MetastoreConf.ConfVars.CATALOG_DEFAULT.getVarname(), CATALOG_NAME);
     conf.set(REST_CATALOG_PREFIX + "uri", restCatalogExtension.getRestEndpoint());
     conf.set(REST_CATALOG_PREFIX + "type", CatalogUtil.ICEBERG_CATALOG_TYPE_REST);

--- a/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergRESTCatalogGravitinoLlapLocalCliDriver.java
+++ b/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergRESTCatalogGravitinoLlapLocalCliDriver.java
@@ -28,8 +28,9 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.hive.IcebergCatalogProperties;
-import org.apache.iceberg.hive.client.RestAccessDelegationMode;
-import org.apache.iceberg.hive.client.HiveRESTCatalogClient;
+import org.apache.iceberg.hive.rest.catalog.RestAccessDelegationMode;
+import org.apache.iceberg.hive.rest.catalog.RestCatalogAccessDelegation;
+import org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient;
 import org.apache.iceberg.rest.extension.OAuth2AuthorizationServer;
 import org.junit.After;
 import org.junit.Before;
@@ -149,7 +150,7 @@ public class TestIcebergRESTCatalogGravitinoLlapLocalCliDriver {
     conf.set(restCatalogPrefix + "oauth2-server-uri", oAuth2AuthorizationServer.getTokenEndpoint());
     conf.set(restCatalogPrefix + "credential", oAuth2AuthorizationServer.getClientCredential());
     conf.set(
-        restCatalogPrefix + IcebergCatalogProperties.REST_ACCESS_DELEGATION_HEADER_PROPERTY,
+        restCatalogPrefix + RestCatalogAccessDelegation.ACCESS_DELEGATION_HEADER_PROPERTY,
         RestAccessDelegationMode.VENDED_CREDENTIALS.modeName());
 
     applyHostS3FilesystemSettings(conf);

--- a/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergRESTCatalogGravitinoLlapLocalCliDriver.java
+++ b/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergRESTCatalogGravitinoLlapLocalCliDriver.java
@@ -150,7 +150,7 @@ public class TestIcebergRESTCatalogGravitinoLlapLocalCliDriver {
     conf.set(restCatalogPrefix + "oauth2-server-uri", oAuth2AuthorizationServer.getTokenEndpoint());
     conf.set(restCatalogPrefix + "credential", oAuth2AuthorizationServer.getClientCredential());
     conf.set(
-        restCatalogPrefix + RestCatalogAccessDelegation.ACCESS_DELEGATION_HEADER_PROPERTY,
+        restCatalogPrefix + RestCatalogAccessDelegation.ACCESS_DELEGATION_PROPERTY,
         RestAccessDelegationMode.VENDED_CREDENTIALS.modeName());
 
     applyHostS3FilesystemSettings(conf);

--- a/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergRESTCatalogHMSLlapLocalCliDriver.java
+++ b/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergRESTCatalogHMSLlapLocalCliDriver.java
@@ -80,7 +80,7 @@ public class TestIcebergRESTCatalogHMSLlapLocalCliDriver {
 
     Configuration conf = SessionState.get().getConf();
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_IMPL,
-        "org.apache.iceberg.hive.client.HiveRESTCatalogClient");
+        "org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient");
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.CATALOG_DEFAULT, CATALOG_NAME);
     conf.set(restCatalogPrefix + "uri", REST_CATALOG_EXTENSION.getRestEndpoint());
     conf.set(restCatalogPrefix + "type", CatalogUtil.ICEBERG_CATALOG_TYPE_REST);

--- a/packaging/src/docker/thirdparties/gravitino/README.md
+++ b/packaging/src/docker/thirdparties/gravitino/README.md
@@ -193,7 +193,7 @@ docker-compose down -v
     
     <property>
       <name>metastore.client.impl</name>
-      <value>org.apache.iceberg.hive.client.HiveRESTCatalogClient</value>
+      <value>org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient</value>
       <description>Specifies the client implementation to use for accessing Iceberg via REST.</description>
     </property>
     

--- a/packaging/src/docker/thirdparties/gravitino/hive/hive-site.xml
+++ b/packaging/src/docker/thirdparties/gravitino/hive/hive-site.xml
@@ -90,7 +90,7 @@
 
   <property>
     <name>metastore.client.impl</name>
-    <value>org.apache.iceberg.hive.client.HiveRESTCatalogClient</value>
+    <value>org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient</value>
   </property>
 
   <property>

--- a/packaging/src/docker/thirdparties/polaris/README.md
+++ b/packaging/src/docker/thirdparties/polaris/README.md
@@ -124,7 +124,7 @@ docker-compose down -v
     
     <property>
       <name>metastore.client.impl</name>
-      <value>org.apache.iceberg.hive.client.HiveRESTCatalogClient</value>
+      <value>org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient</value>
       <description>Specifies the client implementation to use for accessing Iceberg via REST.</description>
     </property>
     

--- a/packaging/src/docker/thirdparties/polaris/hive/hive-site.xml
+++ b/packaging/src/docker/thirdparties/polaris/hive/hive-site.xml
@@ -90,7 +90,7 @@
 
   <property>
     <name>metastore.client.impl</name>
-    <value>org.apache.iceberg.hive.client.HiveRESTCatalogClient</value>
+    <value>org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient</value>
   </property>
 
   <property>

--- a/packaging/src/main/assembly/src.xml
+++ b/packaging/src/main/assembly/src.xml
@@ -119,6 +119,7 @@
         <include>parser/**/*</include>
         <include>udf/**/*</include>
         <include>iceberg/iceberg-catalog/**/*</include>
+        <include>iceberg/iceberg-rest-catalog-client/**/*</include>
         <include>iceberg/iceberg-handler/**/*</include>
         <include>iceberg/iceberg-shading/**/*</include>
         <include>iceberg/patched-iceberg-api/**/*</include>


### PR DESCRIPTION
…odule

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Extract Iceberg REST catalog client code from `hive-iceberg-catalog` into new module `iceberg/iceberg-rest-catalog-client`. Moves `HiveRESTCatalogClient` and REST access-delegation support to `org.apache.iceberg.hive.rest.catalog.*`, updates handler unpack/dependencies, and renames `metastore.client.impl` references accordingly.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
REST catalog client code was embedded in `hive-iceberg-catalog` alongside HMS catalog logic. Extracting it into a dedicated module improves separation of concerns, clarifies dependencies, and makes the REST metastore client easier to maintain and consume without pulling in unrelated HMS catalog code.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Users who set `metastore.client.impl` to o`rg.apache.iceberg.hive.client.HiveRESTCatalogClient` must update it to `org.apache.iceberg.hive.rest.catalog.client.HiveRESTCatalogClient`. No other user-facing behavior or catalog configuration keys change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing precommit tests that cover Iceberg REST Catalog client.