### PR TITLE
HIVE-29753: Add configurable WARN logging for slow getFileInfo calls in StorageBasedAuthorizationProvider

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1284,6 +1284,11 @@ public class HiveConf extends Configuration {
         "StorageBasedAuthorization already does this check for managed table. For external table however,\n" +
         "anyone who has read permission of the directory could drop external table, which is surprising.\n" +
         "The flag is set to false by default to maintain backward compatibility."),
+    METASTORE_AUTHORIZATION_FILEINFO_SLOW_WARN_THRESHOLD_MS(
+        "hive.metastore.authorization.fileinfo.slow.warn.threshold.ms", 300L,
+        "Threshold in milliseconds above which a WARN log is emitted for slow HDFS getFileInfo calls\n" +
+        "during storage-based authorization checks. A value of -1 disables the warning entirely.\n" +
+        "Default is 300ms."),
     /**
      * @deprecated Use MetastoreConf.EVENT_CLEAN_FREQ
      */

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/TestStorageBasedAuthorizationSlowFileInfoLog.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/TestStorageBasedAuthorizationSlowFileInfoLog.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.security;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfForTest;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.ql.metadata.StringAppender;
+import org.apache.hadoop.hive.ql.security.authorization.AuthorizationPreEventListener;
+import org.apache.hadoop.hive.ql.security.authorization.StorageBasedAuthorizationProvider;
+import org.apache.logging.log4j.Level;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests for the slow-getFileInfo WARN logging in
+ * StorageBasedAuthorizationProvider.checkPermissions().
+ *
+ * Exercises the real production code path end-to-end:
+ *   msc.getDatabase() -> AuthorizationPreEventListener.authorizeReadDatabase()
+ *   -> StorageBasedAuthorizationProvider.checkPermissions()
+ *   -> FileUtils.getFileStatusOrNull() -> FileSystem.getFileStatus()
+ *
+ * Two scenarios are tested:
+ * 1. threshold=-1 (disabled): no WARN emitted regardless of elapsed time
+ * 2. threshold=10ms + SlowLocalFileSystem (sleeps 30ms): WARN IS emitted
+ *    because elapsed(~30ms) > threshold(10ms) through the real code path
+ *
+ * Each test starts its own metastore instance so System.setProperty values
+ * (threshold, fs.file.impl) are picked up by the metastore's HiveConf at startup.
+ */
+public class TestStorageBasedAuthorizationSlowFileInfoLog {
+
+  private static final String THRESHOLD_KEY =
+      HiveConf.ConfVars.METASTORE_AUTHORIZATION_FILEINFO_SLOW_WARN_THRESHOLD_MS.varname;
+  private static final String LOGGER_NAME =
+      StorageBasedAuthorizationProvider.class.getName();
+
+  private HiveMetaStoreClient msc;
+  private StringAppender appender;
+
+  /**
+   * LocalFileSystem wrapper that sleeps 30ms in getFileStatus to simulate
+   * a slow HDFS NameNode RPC. Registered via fs.file.impl so it is used
+   * by the metastore's StorageBasedAuthorizationProvider when it calls
+   * FileUtils.getFileStatusOrNull(fs, path).
+   */
+  public static class SlowLocalFileSystem extends LocalFileSystem {
+    @Override
+    public FileStatus getFileStatus(Path f) throws IOException {
+      try {
+        Thread.sleep(30); // 30ms > 10ms threshold used in the WARN test
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return super.getFileStatus(f);
+    }
+  }
+
+  @Before
+  public void setUpAppender() {
+    appender = StringAppender.createStringAppender("%m");
+    appender.addToLogger(LOGGER_NAME, Level.WARN);
+    appender.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (appender != null) {
+      appender.removeFromLogger(LOGGER_NAME);
+    }
+    if (msc != null) {
+      msc.close();
+    }
+    InjectableDummyAuthenticator.injectMode(false);
+    System.clearProperty(HiveConf.ConfVars.METASTORE_PRE_EVENT_LISTENERS.varname);
+    System.clearProperty(HiveConf.ConfVars.HIVE_METASTORE_AUTHORIZATION_MANAGER.varname);
+    System.clearProperty(HiveConf.ConfVars.HIVE_METASTORE_AUTHENTICATOR_MANAGER.varname);
+    System.clearProperty(HiveConf.ConfVars.HIVE_METASTORE_AUTHORIZATION_AUTH_READS.varname);
+    System.clearProperty(THRESHOLD_KEY);
+    System.clearProperty("fs.file.impl");
+    System.clearProperty("fs.file.impl.disable.cache");
+  }
+
+  /**
+   * Starts a fresh metastore with all required System properties already set so
+   * the metastore-side HiveConf picks them up at construction time.
+   *
+   * @param thresholdMs value for hive.metastore.authorization.fileinfo.slow.warn.threshold.ms
+   * @param slowFs      if true, registers SlowLocalFileSystem as fs.file.impl
+   */
+  private void startMetaStore(long thresholdMs, boolean slowFs) throws Exception {
+    System.setProperty(HiveConf.ConfVars.METASTORE_PRE_EVENT_LISTENERS.varname,
+        AuthorizationPreEventListener.class.getName());
+    System.setProperty(HiveConf.ConfVars.HIVE_METASTORE_AUTHORIZATION_MANAGER.varname,
+        StorageBasedAuthorizationProvider.class.getName());
+    System.setProperty(HiveConf.ConfVars.HIVE_METASTORE_AUTHENTICATOR_MANAGER.varname,
+        InjectableDummyAuthenticator.class.getName());
+    System.setProperty(HiveConf.ConfVars.HIVE_METASTORE_AUTHORIZATION_AUTH_READS.varname, "true");
+    System.setProperty(THRESHOLD_KEY, String.valueOf(thresholdMs));
+    if (slowFs) {
+      System.setProperty("fs.file.impl", SlowLocalFileSystem.class.getName());
+      System.setProperty("fs.file.impl.disable.cache", "true");
+    }
+
+    int port = MetaStoreTestUtils.startMetaStoreWithRetry();
+
+    HiveConf clientConf = new HiveConfForTest(getClass());
+    clientConf.setVar(HiveConf.ConfVars.METASTORE_URIS, "thrift://localhost:" + port);
+    clientConf.setIntVar(HiveConf.ConfVars.METASTORE_THRIFT_CONNECTION_RETRIES, 3);
+    clientConf.setBoolVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_ENABLED, false);
+
+    msc = new HiveMetaStoreClient(clientConf);
+    InjectableDummyAuthenticator.injectMode(false);
+  }
+
+  /**
+   * threshold=-1 (disabled): no WARN emitted after a real getDatabase() auth check.
+   * Fully deterministic — threshold=-1 suppresses the WARN unconditionally.
+   */
+  @Test
+  public void testNoSlowWarnWhenThresholdDisabled() throws Exception {
+    startMetaStore(-1, false);
+
+    Database db = new Database("slow_log_disabled_db", null, null, null);
+    msc.createDatabase(db);
+    assertNotNull(msc.getDatabase("slow_log_disabled_db"));
+
+    appender.reset();
+    InjectableDummyAuthenticator.injectMode(true);
+    try {
+      msc.getDatabase("slow_log_disabled_db");
+    } catch (Exception ignored) {
+    } finally {
+      InjectableDummyAuthenticator.injectMode(false);
+    }
+
+    String output = appender.getOutput();
+    assertFalse(
+        "No 'Slow getFileInfo' WARN expected when threshold=-1, got: " + output,
+        output.contains("Slow getFileInfo"));
+
+    msc.dropDatabase("slow_log_disabled_db");
+  }
+
+  /**
+   * threshold=10ms + SlowLocalFileSystem (sleeps 30ms): WARN IS emitted.
+   *
+   * SlowLocalFileSystem is registered as fs.file.impl so the metastore's
+   * StorageBasedAuthorizationProvider uses it when calling getFileStatusOrNull().
+   * The 30ms sleep ensures elapsed(~30ms) > threshold(10ms), triggering the real
+   * LOG.warn inside checkPermissions() in the production code.
+   */
+  @Test
+  public void testSlowWarnEmittedWhenFileSystemIsSlow() throws Exception {
+    startMetaStore(10, true); // 10ms threshold, SlowLocalFileSystem enabled
+
+    Database db = new Database("slow_log_slow_db", null, null, null);
+    msc.createDatabase(db);
+    assertNotNull(msc.getDatabase("slow_log_slow_db"));
+
+    appender.reset();
+    InjectableDummyAuthenticator.injectMode(true);
+    try {
+      msc.getDatabase("slow_log_slow_db");
+    } catch (Exception ignored) {
+    } finally {
+      InjectableDummyAuthenticator.injectMode(false);
+    }
+
+    String output = appender.getOutput();
+    assertTrue(
+        "Expected 'Slow getFileInfo' WARN when elapsed(~30ms) > threshold(10ms), got: " + output,
+        output.contains("Slow getFileInfo"));
+
+    msc.dropDatabase("slow_log_slow_db");
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
@@ -401,8 +401,17 @@ public class StorageBasedAuthorizationProvider extends HiveAuthorizationProvider
     }
 
     final FileSystem fs = path.getFileSystem(conf);
+    final long slowWarnThresholdMs = conf.getLong(
+        HiveConf.ConfVars.METASTORE_AUTHORIZATION_FILEINFO_SLOW_WARN_THRESHOLD_MS.varname,
+        HiveConf.ConfVars.METASTORE_AUTHORIZATION_FILEINFO_SLOW_WARN_THRESHOLD_MS.defaultLongVal);
 
+    long t0 = System.currentTimeMillis();
     FileStatus pathStatus = FileUtils.getFileStatusOrNull(fs, path);
+    long elapsed = System.currentTimeMillis() - t0;
+    if (slowWarnThresholdMs >= 0 && elapsed > slowWarnThresholdMs) {
+      LOG.warn("Slow getFileInfo during storage-based authorization check: path={}, elapsed={}ms",
+          path, elapsed);
+    }
     if (pathStatus != null) {
       checkPermissions(fs, pathStatus, actions, authenticator.getUserName());
     } else if (path.getParent() != null) {
@@ -410,7 +419,13 @@ public class StorageBasedAuthorizationProvider extends HiveAuthorizationProvider
       Path par = path.getParent();
       FileStatus parStatus = null;
       while (par != null) {
+        long t1 = System.currentTimeMillis();
         parStatus = FileUtils.getFileStatusOrNull(fs, par);
+        long elapsedPar = System.currentTimeMillis() - t1;
+        if (slowWarnThresholdMs >= 0 && elapsedPar > slowWarnThresholdMs) {
+          LOG.warn("Slow getFileInfo during storage-based authorization check (parent traversal): "
+              + "path={}, elapsed={}ms", par, elapsedPar);
+        }
         if (parStatus != null) {
           break;
         }


### PR DESCRIPTION
**What changes were proposed in this pull request?**

This PR adds configurable WARN-level logging for slow getFileInfo calls performed during storage-based authorization checks.

A new configuration property,
hive.metastore.authorization.fileinfo.slow.warn.threshold.ms (default: 300 ms, -1 to disable), is introduced to control when a WARN log should be emitted.

StorageBasedAuthorizationProvider.checkPermissions() is instrumented to measure the time spent in FileUtils.getFileStatusOrNull() for both:
- the initial path lookup, and
- parent directory traversal when the target path does not exist.

If the elapsed time exceeds the configured threshold, a WARN log containing the path and elapsed time is emitted.

Integration tests have also been added to verify:
- no WARN is emitted when the feature is disabled (threshold = -1), and
- a WARN is emitted when the configured threshold is exceeded using a slow FileSystem implementation.

**Why are the changes needed?**

Storage-based authorization relies on filesystem metadata lookups (getFileInfo), which may become slow due to NameNode latency or filesystem performance issues. These delays are currently not visible in normal logs, making them difficult to diagnose without enabling verbose logging or profiling.

This change provides lightweight observability by logging only operations whose latency exceeds a configurable threshold, helping administrators identify slow filesystem operations while avoiding excessive log noise.

**Does this PR introduce any user-facing change?**
Yes.

A new configuration property has been added:
hive.metastore.authorization.fileinfo.slow.warn.threshold.ms

- Default: 300
- Value -1: disables WARN logging.

When enabled, slow filesystem metadata lookups performed during storage-based authorization checks will generate WARN log entries if they exceed the configured threshold.
No functional behavior of authorization is changed.

**How was this patch tested?**
Added integration tests covering both positive and negative scenarios