### PR TITLE
HIVE-29756: maven shade plugin fixed to make beeline-standalone.jar

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -143,60 +143,60 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
-  <!-- test intra-project -->
-  <!--
+    <!-- test intra-project -->
+    <!--
     hive-exec, hive-llap-server, and hive-hplsql are declared test scope here so that
     are all needed to run BeelineCli test to manage the embedded HS2 session.
   -->
-  <dependency>
-    <groupId>org.apache.hive</groupId>
-    <artifactId>hive-exec</artifactId>
-    <version>${project.version}</version>
-    <scope>test</scope>
-    <exclusions>
-      <exclusion>
-        <groupId>*</groupId>
-        <artifactId>*</artifactId>
-      </exclusion>
-    </exclusions>
-  </dependency>
-  <dependency>
-    <groupId>org.apache.hive</groupId>
-    <artifactId>hive-exec</artifactId>
-    <version>${project.version}</version>
-    <classifier>tests</classifier>
-    <scope>test</scope>
-    <exclusions>
-      <exclusion>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-      </exclusion>
-    </exclusions>
-  </dependency>
-  <dependency>
-    <groupId>org.apache.hive</groupId>
-    <artifactId>hive-llap-server</artifactId>
-    <version>${project.version}</version>
-    <scope>test</scope>
-    <exclusions>
-      <exclusion>
-        <groupId>*</groupId>
-        <artifactId>*</artifactId>
-      </exclusion>
-    </exclusions>
-  </dependency>
-  <dependency>
-    <groupId>org.apache.hive</groupId>
-    <artifactId>hive-hplsql</artifactId>
-    <version>${project.version}</version>
-    <scope>test</scope>
-    <exclusions>
-      <exclusion>
-        <groupId>*</groupId>
-        <artifactId>*</artifactId>
-      </exclusion>
-    </exclusions>
-  </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-llap-server</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-hplsql</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -66,6 +66,22 @@
       <artifactId>hive-standalone-metastore-server</artifactId>
       <version>${standalone-metastore.version}</version>
     </dependency>
+    <dependency>
+      <!--
+        Since the compile-time hive-jdbc dependency contains Utils.java,
+        which directly imports HiveSQLException from hive-service,
+        hive-service is also required at runtime and should therefore be declared as a compile-time dependency.
+        -->
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-service</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!-- inter-project -->
     <dependency>
       <groupId>commons-cli</groupId>
@@ -127,7 +143,60 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
-    <!-- test intra-project -->
+  <!-- test intra-project -->
+  <!--
+    hive-exec, hive-llap-server, and hive-hplsql are declared test scope here so that
+    are all needed to run BeelineCli test to manage the embedded HS2 session.
+  -->
+  <dependency>
+    <groupId>org.apache.hive</groupId>
+    <artifactId>hive-exec</artifactId>
+    <version>${project.version}</version>
+    <scope>test</scope>
+    <exclusions>
+      <exclusion>
+        <groupId>*</groupId>
+        <artifactId>*</artifactId>
+      </exclusion>
+    </exclusions>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.hive</groupId>
+    <artifactId>hive-exec</artifactId>
+    <version>${project.version}</version>
+    <classifier>tests</classifier>
+    <scope>test</scope>
+    <exclusions>
+      <exclusion>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+      </exclusion>
+    </exclusions>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.hive</groupId>
+    <artifactId>hive-llap-server</artifactId>
+    <version>${project.version}</version>
+    <scope>test</scope>
+    <exclusions>
+      <exclusion>
+        <groupId>*</groupId>
+        <artifactId>*</artifactId>
+      </exclusion>
+    </exclusions>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.hive</groupId>
+    <artifactId>hive-hplsql</artifactId>
+    <version>${project.version}</version>
+    <scope>test</scope>
+    <exclusions>
+      <exclusion>
+        <groupId>*</groupId>
+        <artifactId>*</artifactId>
+      </exclusion>
+    </exclusions>
+  </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
@@ -138,22 +207,6 @@
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <!--
-        Since the compile-time hive-jdbc dependency contains Utils.java,
-        which directly imports HiveSQLException from hive-service,
-        hive-service is also required at runtime and should therefore be declared as a compile-time dependency.
-        -->
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-service</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -197,19 +197,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-exec</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- test inter-project -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -142,6 +142,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <!--
+        Since hive-jdbc dependecy that is compile time has Utils.java
+        that directly imports HiveSQLException from hive-service, so hive-service should is needed at runtime and should
+        be a compile time dependecy also.
+        -->
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
       <version>${project.version}</version>
@@ -253,7 +258,7 @@
                   </manifestEntries>
                 </transformer>
                 <!--
-                  Without this, the java.sql.Driver service file ends up containing only one implementation of the
+                  Without this, the META-INF/services/java.sql.Driver service file ends up with only one implementation of the
                   interface (the last writer wins) and HiveDriver is never registered, causing:
                     "No known driver to handle jdbc:hive2://..."
                 -->

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -145,11 +145,10 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
       <exclusions>
         <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -244,12 +243,21 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
-              <finalName>jar-with-dependencies</finalName>
+              <finalName>beeline-standalone</finalName>
               <transformers>
                 <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.apache.hive.beeline.BeeLine</mainClass>
+                  <manifestEntries>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
                 </transformer>
+                <!--
+                  Without this, the java.sql.Driver service file ends up containing only one implementation of the
+                  interface (the last writer wins) and HiveDriver is never registered, causing:
+                    "No known driver to handle jdbc:hive2://..."
+                -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <filters>
                 <filter>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <!--
         Since hive-jdbc dependecy that is compile time has Utils.java
-        that directly imports HiveSQLException from hive-service, so hive-service should is needed at runtime and should
+        that directly imports HiveSQLException from hive-service, so hive-service is needed at runtime and should
         be a compile time dependecy also.
         -->
       <groupId>org.apache.hive</groupId>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -143,9 +143,9 @@
     </dependency>
     <dependency>
       <!--
-        Since hive-jdbc dependecy that is compile time has Utils.java
-        that directly imports HiveSQLException from hive-service, so hive-service is needed at runtime and should
-        be a compile time dependecy also.
+        Since the compile-time hive-jdbc dependency contains Utils.java,
+        which directly imports HiveSQLException from hive-service,
+        hive-service is also required at runtime and should therefore be declared as a compile-time dependency.
         -->
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -68,10 +68,10 @@
     </dependency>
     <dependency>
       <!--
-        Since the compile-time hive-jdbc dependency contains Utils.java,
-        which directly imports HiveSQLException from hive-service,
-        hive-service is also required at runtime and should therefore be declared as a compile-time dependency.
-        -->
+      Since the compile-time hive-jdbc dependency contains Utils.java,
+      which directly imports HiveSQLException from hive-service,
+      hive-service is also required at runtime and should therefore be declared as a compile-time dependency.
+      -->
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
       <version>${project.version}</version>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -147,7 +147,7 @@
     <!--
     hive-exec, hive-llap-server, and hive-hplsql are declared test scope here so that
     are all needed to run BeelineCli test to manage the embedded HS2 session.
-  -->
+    -->
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
1. The beeline pom/xml was missing Multi-Release: true.
dnsjava is a Multi-Release JAR. Its DnsjavaInetAddressResolverProvider class lives at META-INF/versions/18/org/xbill/DNS/spi/DnsjavaInetAddressResolverProvider.class (Java 18+ only) which caused 
Class not found exception for jdk18+ without multi-release
2. hive-service is declared as compile scope in beeline/pom.xml now, Since hive-jdbc's Utils.java directly imports HiveSQLException from hive-service, so it's needed at runtime.
3. hive-exec dependency along with hive-llap-server and hive-hplsql were added to the test scope of the beeline module.
4. ServicesResourceTransformer added to shade configuration, to merge all the implementations of java.sql.Driver
Otherwise only one implementation could be present in the final jar. (No hive driver exception fix)
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  5. If there is design documentation, please add the link.
  6. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
1. To distribute beeline as a standalone jar without any additional dependencies.  
2. Since hive-service was in the test scope, it didn't exclude any transitive dependencies and beeline tests relied on packages that weren't in the pom.xml. After we moved hive-service into compile scope we had to exclude all the transitive dependencies to keep the standalone jar lean. But the test scope changed and it was needed to declare all the test dependencies for beeline explicitly to make beeline cli tests run.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
1. No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?
1. No tests were added, as it's a build configuration change
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
