### PR TITLE
HIVE-28757: Preserve partition create time

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -2751,7 +2751,7 @@ public class Hive implements AutoCloseable {
     }
 
     if (oldPart == null) {
-      addPartitionToMetastore(newTPart, resetStatistics, tbl, tableSnapshot);
+      newTPart = addPartitionToMetastore(newTPart, resetStatistics, tbl, tableSnapshot);
       // For acid table, add the acid_write event with file list at the time of load itself. But
       // it should be done after partition is created.
       if (isTxnTable && (null != newFiles)) {
@@ -2986,11 +2986,11 @@ public class Hive implements AutoCloseable {
     }
   }
 
-  private void addPartitionToMetastore(Partition newTPart, boolean resetStatistics,
-                                       Table tbl, TableSnapshot tableSnapshot) throws HiveException{
+  private Partition addPartitionToMetastore(Partition newTPart, boolean resetStatistics,
+                                            Table tbl, TableSnapshot tableSnapshot) throws HiveException {
     try {
       LOG.debug("Adding new partition " + newTPart.getSpec());
-      getMSC().add_partition(newTPart.getTPartition());
+      return new Partition(tbl, getMSC().add_partition(newTPart.getTPartition()));
     } catch (AlreadyExistsException aee) {
       // With multiple users concurrently issuing insert statements on the same partition has
       // a side effect that some queries may not see a partition at the time when they're issued,
@@ -3006,6 +3006,7 @@ public class Hive implements AutoCloseable {
       LOG.debug("Caught AlreadyExistsException, trying to alter partition instead");
       try {
         setStatsPropAndAlterPartition(resetStatistics, tbl, newTPart, tableSnapshot);
+        return getPartition(tbl, newTPart.getSpec(), false);
       } catch (TException e) {
         LOG.error("Error setStatsPropAndAlterPartition", e);
         throw new HiveException(e);
@@ -3024,21 +3025,27 @@ public class Hive implements AutoCloseable {
     }
   }
 
-  private void addPartitionsToMetastore(List<Partition> partitions,
-                                        boolean resetStatistics, Table tbl,
-                                        List<AcidUtils.TableSnapshot> tableSnapshots)
-                                        throws HiveException {
+  private List<Partition> addPartitionsToMetastore(List<Partition> partitions,
+                                                   boolean resetStatistics, Table tbl,
+                                                   List<AcidUtils.TableSnapshot> tableSnapshots)
+                                                   throws HiveException {
     try {
       if (partitions.isEmpty() || tableSnapshots.isEmpty()) {
-        return;
+        return partitions;
       }
       if (LOG.isDebugEnabled()) {
         StringBuffer debugMsg = new StringBuffer("Adding new partitions ");
         partitions.forEach(partition -> debugMsg.append(partition.getSpec() + " "));
         LOG.debug(debugMsg.toString());
       }
-      getMSC().add_partitions(partitions.stream().map(Partition::getTPartition)
-              .collect(Collectors.toList()));
+      List<org.apache.hadoop.hive.metastore.api.Partition> addedPartitions =
+          getMSC().add_partitions(partitions.stream().map(Partition::getTPartition)
+              .collect(Collectors.toList()), false, true);
+      List<Partition> result = new ArrayList<>(addedPartitions.size());
+      for (org.apache.hadoop.hive.metastore.api.Partition partition : addedPartitions) {
+        result.add(new Partition(tbl, partition));
+      }
+      return result;
     } catch(AlreadyExistsException aee) {
       // With multiple users concurrently issuing insert statements on the same partition has
       // a side effect that some queries may not see a partition at the time when they're issued,
@@ -3053,10 +3060,12 @@ public class Hive implements AutoCloseable {
       // In that case, we want to retry with alterPartition.
       LOG.debug("Caught AlreadyExistsException, trying to add partitions one by one.");
       assert partitions.size() == tableSnapshots.size();
+      List<Partition> addedPartitions = new ArrayList<>(partitions.size());
       for (int i = 0; i < partitions.size(); i++) {
-        addPartitionToMetastore(partitions.get(i), resetStatistics, tbl,
-                tableSnapshots.get(i));
+        addedPartitions.add(addPartitionToMetastore(partitions.get(i), resetStatistics, tbl,
+                tableSnapshots.get(i)));
       }
+      return addedPartitions;
     } catch (Exception e) {
       try {
         for (Partition partition : partitions) {
@@ -3447,12 +3456,13 @@ private void constructOneLBLocationMap(FileStatus fSta,
       }
       // add new partitions in batch
 
-      addPartitionsToMetastore(
-              partitionDetailsMap.entrySet()
-                      .stream()
-                      .filter(entry -> !entry.getValue().hasOldPartition)
-                      .map(entry -> entry.getValue().partition)
-                      .collect(Collectors.toList()),
+      List<Partition> partitionsToAdd = partitionDetailsMap.entrySet()
+              .stream()
+              .filter(entry -> !entry.getValue().hasOldPartition)
+              .map(entry -> entry.getValue().partition)
+              .collect(Collectors.toList());
+      List<Partition> addedPartitions = addPartitionsToMetastore(
+              partitionsToAdd,
               resetStatistics,
               tbl,
               partitionDetailsMap.entrySet()
@@ -3460,6 +3470,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
                       .filter(entry -> !entry.getValue().hasOldPartition)
                       .map(entry -> entry.getValue().tableSnapshot)
                       .collect(Collectors.toList()));
+      addedPartitions.forEach(partition -> result.put(partition.getSpec(), partition));
       // For acid table, add the acid_write event with file list at the time of load itself. But
       // it should be done after partition is created.
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveLoadPartitionKeepExisting.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveLoadPartitionKeepExisting.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.metadata;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -37,7 +38,10 @@ import org.apache.hadoop.hive.conf.HiveConfForTest;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.ql.exec.Utilities.PartitionDetails;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
+import org.apache.hadoop.hive.ql.plan.LoadTableDesc;
 import org.apache.hadoop.hive.ql.plan.LoadTableDesc.LoadFileType;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.mapred.TextInputFormat;
@@ -139,6 +143,57 @@ public class TestHiveLoadPartitionKeepExisting {
         fs.exists(new Path(partPath, "000000_0_old")));
     assertTrue("REPLACE_ALL loadPartition should publish staged data",
         fs.exists(new Path(partPath, "000000_0_new")));
+  }
+
+  @Test
+  public void testLoadPartitionReturnsMetastoreCreateTime() throws Exception {
+    Table table = hive.getTable(tableName);
+    Map<String, String> partSpec = partitionSpec("2026-07-22");
+    FileSystem fs = table.getDataLocation().getFileSystem(hiveConf);
+    Path staging = createStagingDir(fs, table.getDataLocation(), "create_time");
+    try (OutputStream out = fs.create(new Path(staging, "000000_0"))) {
+      out.write("data\n".getBytes());
+    }
+
+    Partition loaded = hive.loadPartition(staging, table, partSpec, LoadFileType.REPLACE_ALL,
+        true, false, false, false, false, false, null, 0, true, false);
+    Partition stored = hive.getPartition(table, partSpec, false);
+
+    assertTrue("loadPartition should return the createTime assigned by HMS",
+        loaded.getTPartition().getCreateTime() > 0);
+    assertEquals(stored.getTPartition().getCreateTime(), loaded.getTPartition().getCreateTime());
+  }
+
+  @Test
+  public void testLoadDynamicPartitionsReturnsMetastoreCreateTime() throws Exception {
+    Table table = hive.getTable(tableName);
+    FileSystem fs = table.getDataLocation().getFileSystem(hiveConf);
+    Map<Path, PartitionDetails> partitionDetails = new LinkedHashMap<>();
+
+    for (String loadDate : Arrays.asList("2026-07-23", "2026-07-24")) {
+      Map<String, String> partSpec = partitionSpec(loadDate);
+      Path staging = createStagingDir(fs, table.getDataLocation(), loadDate);
+      try (OutputStream out = fs.create(new Path(staging, "000000_0"))) {
+        out.write(loadDate.getBytes());
+      }
+      PartitionDetails details = new PartitionDetails();
+      details.fullSpec = partSpec;
+      partitionDetails.put(staging, details);
+    }
+
+    LoadTableDesc loadTableDesc = new LoadTableDesc(table.getDataLocation(), table,
+        false, true, new LinkedHashMap<>());
+    Map<Map<String, String>, Partition> loaded = hive.loadDynamicPartitions(loadTableDesc,
+        0, false, 0, 0, false, AcidUtils.Operation.NOT_ACID, partitionDetails);
+
+    assertEquals(2, loaded.size());
+    for (Partition partition : loaded.values()) {
+      Partition stored = hive.getPartition(table, partition.getSpec(), false);
+      assertTrue("loadDynamicPartitions should return the createTime assigned by HMS",
+          partition.getTPartition().getCreateTime() > 0);
+      assertEquals(stored.getTPartition().getCreateTime(),
+          partition.getTPartition().getCreateTime());
+    }
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -588,6 +588,7 @@ public class HiveAlterHandler implements AlterHandler {
               "Unable to alter partition because table or database does not exist.");
         }
         oldPart = msdb.getPartition(catName, dbname, name, new_part.getValues());
+        preservePartitionCreateTime(oldPart, new_part);
         if (MetaStoreServerUtils.requireCalStats(oldPart, new_part, tbl, environmentContext)) {
           // if stats are same, no need to update
           if (MetaStoreServerUtils.isFastStatsSame(oldPart, new_part)) {
@@ -666,6 +667,7 @@ public class HiveAlterHandler implements AlterHandler {
         throw new InvalidObjectException(
             "Unable to rename partition because old partition does not exist");
       }
+      preservePartitionCreateTime(oldPart, new_part);
 
       // when renaming a partition, we should update
       // 1) partition SD Location
@@ -848,6 +850,7 @@ public class HiveAlterHandler implements AlterHandler {
         }
 
         Partition oldTmpPart = oldPartMap.get(tmpPart.getValues());
+        preservePartitionCreateTime(oldTmpPart, tmpPart);
         oldParts.add(oldTmpPart);
         partValsList.add(tmpPart.getValues());
 
@@ -895,6 +898,13 @@ public class HiveAlterHandler implements AlterHandler {
     }
 
     return oldParts;
+  }
+
+  private static void preservePartitionCreateTime(Partition oldPart, Partition newPart) {
+    if ((!newPart.isSetCreateTime() || newPart.getCreateTime() <= 0)
+        && oldPart.isSetCreateTime()) {
+      newPart.setCreateTime(oldPart.getCreateTime());
+    }
   }
 
   // Validate changes to partition's location to protect against errors on migration during

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAlterPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAlterPartitions.java
@@ -259,6 +259,22 @@ public class TestAlterPartitions extends MetaStoreClientTest {
   }
 
   @Test
+  public void testAlterPartitionPreservesCreateTimeWhenUnset() throws Exception {
+    createTable4PartColsParts(client);
+    Partition partition = client.listPartitions(DB_NAME, TABLE_NAME, (short)-1).get(0);
+    int createTime = partition.getCreateTime();
+    assertTrue(createTime > 0);
+
+    partition.setCreateTime(0);
+    partition.putToParameters("test_key", "test_value");
+    client.alter_partition(DB_NAME, TABLE_NAME, partition);
+
+    Partition altered = client.getPartition(DB_NAME, TABLE_NAME, partition.getValues());
+    assertEquals(createTime, altered.getCreateTime());
+    assertEquals("test_value", altered.getParameters().get("test_key"));
+  }
+
+  @Test
   @ConditionalIgnoreOnSessionHiveMetastoreClient
   public void otherCatalog() throws TException {
     String catName = "alter_partition_catalog";
@@ -655,6 +671,27 @@ public class TestAlterPartitions extends MetaStoreClientTest {
       assertPartitionChanged(oldParts.get(i), testValues.get(i), PARTCOL_SCHEMA);
     }
     assertPartitionsHaveCorrectValues(newParts, testValues);
+  }
+
+  @Test
+  public void testAlterPartitionsPreserveCreateTimeWhenUnset() throws Exception {
+    createTable4PartColsParts(client);
+    List<Partition> partitions = client.listPartitions(DB_NAME, TABLE_NAME, (short)-1);
+    List<Integer> createTimes = new ArrayList<>();
+    for (Partition partition : partitions) {
+      assertTrue(partition.getCreateTime() > 0);
+      createTimes.add(partition.getCreateTime());
+      partition.setCreateTime(0);
+      partition.putToParameters("test_key", "test_value");
+    }
+
+    client.alter_partitions(DB_NAME, TABLE_NAME, partitions);
+
+    List<Partition> altered = client.listPartitions(DB_NAME, TABLE_NAME, (short)-1);
+    for (int i = 0; i < altered.size(); ++i) {
+      assertEquals(createTimes.get(i).intValue(), altered.get(i).getCreateTime());
+      assertEquals("test_value", altered.get(i).getParameters().get("test_key"));
+    }
   }
 
   @Test(expected = InvalidOperationException.class)


### PR DESCRIPTION
Supersedes #6628. GitHub closed the earlier PR automatically when its source branch was renamed; the commit itself is unchanged.

### What changes were proposed in this pull request?

Keep the `Partition` objects returned by HMS in the single-partition and batch dynamic-partition load paths. The batch path now requests the partitions returned by `add_partitions` and uses them in the result map.

On the metastore side, preserve the existing partition `createTime` when an alter request carries an unset or non-positive value. This covers single, rename, and batch alter paths.

Regression tests were added for both the load and alter cases.

### Why are the changes needed?

HMS assigns server-owned fields such as `createTime` when a partition is added. The load path currently discards the partition returned by HMS and keeps using the request-side object, whose `createTime` is still zero. A later statistics update can send that object through `alter_partition` and overwrite the value stored by HMS with zero.

This makes the partition creation time unreliable for retention and lifecycle management.

### Does this PR introduce _any_ user-facing change?

Yes. A newly created partition keeps the creation time assigned by HMS instead of having it reset to zero by a later alter operation. There is no public API change.

### How was this patch tested?

- `TestHiveLoadPartitionKeepExisting`: 5 tests passed, including the new static and dynamic partition cases.
- `TestAlterPartitions`: 154 tests passed, including the new single and batch alter cases.
- The related 21-module Maven reactor completed successfully with JDK 21.

JIRA: https://issues.apache.org/jira/browse/HIVE-28757