### PR TITLE
HIVE-29227: Apply masking in memory instead of rewriting the file in QOutProcessor#maskPatterns

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/io/CachingPrintStream.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/CachingPrintStream.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.common.io;
 
 import java.io.FileNotFoundException;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +44,12 @@ public class CachingPrintStream extends SessionStream {
   @Override
   public void println(String out) {
     output.add(out);
-    super.println(out);
+    // Delegate to a wrapped PrintStream so downstream transforms (e.g. QTestFetchConverter) apply.
+    if (this.out instanceof PrintStream ps && ps != this) {
+      ps.println(out);
+    } else {
+      super.println(out);
+    }
   }
 
   @Override

--- a/common/src/java/org/apache/hadoop/hive/common/io/CachingPrintStream.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/CachingPrintStream.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.common.io;
 
 import java.io.FileNotFoundException;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +45,12 @@ public class CachingPrintStream extends SessionStream {
   @Override
   public void println(String out) {
     output.add(out);
-    super.println(out);
+    // Delegate to a wrapped PrintStream so downstream transforms (e.g. QTestFetchConverter) apply.
+    if (this.out instanceof PrintStream ps && ps != this) {
+      ps.println(out);
+    } else {
+      super.println(out);
+    }
   }
 
   @Override

--- a/common/src/java/org/apache/hadoop/hive/common/io/FetchConverter.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/FetchConverter.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.common.io;
 
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 
 public abstract class FetchConverter extends SessionStream implements FetchCallback {
@@ -48,8 +49,14 @@ public abstract class FetchConverter extends SessionStream implements FetchCallb
     }
   }
 
-  protected final void printDirect(String out) {
-    super.println(out);
+  protected final void printDirect(String line) {
+    // Delegate to a wrapped PrintStream so downstream transforms (e.g. QTestFetchConverter) apply
+    // when this converter is stacked above them (sort/hash then mask).
+    if (this.out instanceof PrintStream ps && ps != this) {
+      ps.println(line);
+    } else {
+      super.println(line);
+    }
   }
 
   protected final boolean byPass() {

--- a/common/src/java/org/apache/hadoop/hive/common/io/FetchConverter.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/FetchConverter.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hive.common.io;
 
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 
 public abstract class FetchConverter extends SessionStream implements FetchCallback {
@@ -49,8 +50,14 @@ public abstract class FetchConverter extends SessionStream implements FetchCallb
     }
   }
 
-  protected final void printDirect(String out) {
-    super.println(out);
+  protected final void printDirect(String line) {
+    // Delegate to a wrapped PrintStream so downstream transforms (e.g. QTestFetchConverter) apply
+    // when this converter is stacked above them (sort/hash then mask).
+    if (this.out instanceof PrintStream ps && ps != this) {
+      ps.println(line);
+    } else {
+      super.println(line);
+    }
   }
 
   protected final boolean byPass() {

--- a/common/src/java/org/apache/hadoop/hive/common/io/QTestFetchConverter.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/QTestFetchConverter.java
@@ -43,7 +43,26 @@ public class QTestFetchConverter extends SessionStream implements FetchCallback 
 
   @Override
   public void println(String str) {
-    inner.println(transformation.apply(str));
+    // PREHOOK/POSTHOOK may send multiple lines separated by \n in one println, mask each separately.
+    if (str.indexOf('\n') < 0) {
+      writeTransformedLine(str);
+      return;
+    }
+    int start = 0;
+    for (int i = 0; i < str.length(); i++) {
+      if (str.charAt(i) == '\n') {
+        writeTransformedLine(str.substring(start, i));
+        start = i + 1;
+      }
+    }
+    writeTransformedLine(str.substring(start));
+  }
+
+  private void writeTransformedLine(String line) {
+    String transformed = transformation.apply(line);
+    if (transformed != null) {
+      inner.println(transformed);
+    }
   }
 
   @Override

--- a/common/src/java/org/apache/hadoop/hive/common/io/QTestFetchConverter.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/QTestFetchConverter.java
@@ -43,19 +43,27 @@ public class QTestFetchConverter extends SessionStream implements FetchCallback 
 
   @Override
   public void println(String str) {
-    // PREHOOK/POSTHOOK may send multiple lines separated by \n in one println, mask each separately.
-    if (str.indexOf('\n') < 0) {
-      writeTransformedLine(str);
+    // PREHOOK/POSTHOOK may send multiple lines separated by \n in one println, mask each
+    // separately. Query fetch rows must stay intact so SORT_QUERY_RESULTS keeps row order.
+    if (str.indexOf('\n') >= 0 && shouldSplitMultiline()) {
+      int start = 0;
+      for (int i = 0; i < str.length(); i++) {
+        if (str.charAt(i) == '\n') {
+          writeTransformedLine(str.substring(start, i));
+          start = i + 1;
+        }
+      }
+      writeTransformedLine(str.substring(start));
       return;
     }
-    int start = 0;
-    for (int i = 0; i < str.length(); i++) {
-      if (str.charAt(i) == '\n') {
-        writeTransformedLine(str.substring(start, i));
-        start = i + 1;
-      }
+    writeTransformedLine(str);
+  }
+
+  private boolean shouldSplitMultiline() {
+    if (inner instanceof FetchConverter fetchConverter) {
+      return !(fetchConverter.queryfound && fetchConverter.fetchStarted);
     }
-    writeTransformedLine(str.substring(start));
+    return true;
   }
 
   private void writeTransformedLine(String line) {

--- a/common/src/java/org/apache/hadoop/hive/common/io/QTestFetchConverter.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/QTestFetchConverter.java
@@ -44,7 +44,26 @@ public class QTestFetchConverter extends SessionStream implements FetchCallback 
 
   @Override
   public void println(String str) {
-    inner.println(transformation.apply(str));
+    // PREHOOK/POSTHOOK may send multiple lines separated by \n in one println, mask each separately.
+    if (str.indexOf('\n') < 0) {
+      writeTransformedLine(str);
+      return;
+    }
+    int start = 0;
+    for (int i = 0; i < str.length(); i++) {
+      if (str.charAt(i) == '\n') {
+        writeTransformedLine(str.substring(start, i));
+        start = i + 1;
+      }
+    }
+    writeTransformedLine(str.substring(start));
+  }
+
+  private void writeTransformedLine(String line) {
+    String transformed = transformation.apply(line);
+    if (transformed != null) {
+      inner.println(transformed);
+    }
   }
 
   @Override

--- a/common/src/java/org/apache/hadoop/hive/common/io/QTestFetchConverter.java
+++ b/common/src/java/org/apache/hadoop/hive/common/io/QTestFetchConverter.java
@@ -44,19 +44,27 @@ public class QTestFetchConverter extends SessionStream implements FetchCallback 
 
   @Override
   public void println(String str) {
-    // PREHOOK/POSTHOOK may send multiple lines separated by \n in one println, mask each separately.
-    if (str.indexOf('\n') < 0) {
-      writeTransformedLine(str);
+    // PREHOOK/POSTHOOK may send multiple lines separated by \n in one println, mask each
+    // separately. Query fetch rows must stay intact so SORT_QUERY_RESULTS keeps row order.
+    if (str.indexOf('\n') >= 0 && shouldSplitMultiline()) {
+      int start = 0;
+      for (int i = 0; i < str.length(); i++) {
+        if (str.charAt(i) == '\n') {
+          writeTransformedLine(str.substring(start, i));
+          start = i + 1;
+        }
+      }
+      writeTransformedLine(str.substring(start));
       return;
     }
-    int start = 0;
-    for (int i = 0; i < str.length(); i++) {
-      if (str.charAt(i) == '\n') {
-        writeTransformedLine(str.substring(start, i));
-        start = i + 1;
-      }
+    writeTransformedLine(str);
+  }
+
+  private boolean shouldSplitMultiline() {
+    if (inner instanceof FetchConverter fetchConverter) {
+      return !(fetchConverter.queryfound && fetchConverter.fetchStarted);
     }
-    writeTransformedLine(str.substring(start));
+    return true;
   }
 
   private void writeTransformedLine(String line) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreBeeLineDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreBeeLineDriver.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.conf.HiveConfUtil;
 import org.apache.hadoop.hive.ql.QTestProcessExecResult;
 import org.apache.hadoop.hive.ql.QTestUtil;
@@ -227,6 +229,11 @@ public class CoreBeeLineDriver extends CliAdapter {
       long startTime = System.currentTimeMillis();
       System.err.println(">>> STARTED " + qFile.getName());
 
+      qOutProcessor.initMasks(FileUtils.readFileToString(qFile.getInputFile(), StandardCharsets.UTF_8));
+      setupAdditionalPartialMasks();
+      QOutProcessor.MaskingFoldState maskingFoldState = new QOutProcessor.MaskingFoldState();
+      beeLineClient.setOutputMasking(qOutProcessor, maskingFoldState);
+
       beeLineClient.execute(qFile, preCommands);
 
       long queryEndTime = System.currentTimeMillis();
@@ -239,7 +246,6 @@ public class CoreBeeLineDriver extends CliAdapter {
           + "ms");
 
       if (!overwrite) {
-        qOutProcessor.maskPatterns(qFile.getOutputFile().getPath());
         QTestProcessExecResult result = qFile.compareResults();
 
         long compareEndTime = System.currentTimeMillis();
@@ -259,11 +265,38 @@ public class CoreBeeLineDriver extends CliAdapter {
         qFile.overwriteResults();
         System.err.println(">>> PASSED " + qFile.getName());
       }
+      resetAdditionalPartialMasks();
     } catch (Exception e) {
+      resetAdditionalPartialMasks();
       throw new Exception("Exception running or analyzing the results of the query file: " + qFile
           + "\n" + qFile.getDebugHint(), e);
     }
 
+  }
+
+  private void setupAdditionalPartialMasks() {
+    if (miniHS2 == null) {
+      return;
+    }
+    HiveConf conf = miniHS2.getHiveConf();
+    String patternStr = HiveConf.getVar(conf, ConfVars.HIVE_ADDITIONAL_PARTIAL_MASKS_PATTERN);
+    String replacementStr = HiveConf.getVar(conf, ConfVars.HIVE_ADDITIONAL_PARTIAL_MASKS_REPLACEMENT_TEXT);
+    if (patternStr != null && replacementStr != null && !replacementStr.isEmpty()
+        && !patternStr.isEmpty()) {
+      String[] patterns = patternStr.split(",");
+      String[] replacements = replacementStr.split(",");
+      if (patterns.length != replacements.length) {
+        throw new RuntimeException("Count mismatch for additional partial masks and their replacements");
+      }
+      for (int i = 0; i < patterns.length; i++) {
+        qOutProcessor.addPatternWithMaskComment(patterns[i],
+            String.format("### %s ###", replacements[i]));
+      }
+    }
+  }
+
+  private void resetAdditionalPartialMasks() {
+    qOutProcessor.resetPatternwithMaskComments();
   }
 
   public void runTest(QFile qFile) throws Exception {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreBeeLineDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreBeeLineDriver.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +37,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.conf.HiveConfUtil;
 import org.apache.hadoop.hive.ql.QTestProcessExecResult;
 import org.apache.hadoop.hive.ql.QTestUtil;
@@ -228,6 +230,11 @@ public class CoreBeeLineDriver extends CliAdapter {
       long startTime = System.currentTimeMillis();
       System.err.println(">>> STARTED " + qFile.getName());
 
+      qOutProcessor.initMasks(FileUtils.readFileToString(qFile.getInputFile(), StandardCharsets.UTF_8));
+      setupAdditionalPartialMasks();
+      QOutProcessor.MaskingFoldState maskingFoldState = new QOutProcessor.MaskingFoldState();
+      beeLineClient.setOutputMasking(qOutProcessor, maskingFoldState);
+
       beeLineClient.execute(qFile, preCommands);
 
       long queryEndTime = System.currentTimeMillis();
@@ -238,7 +245,6 @@ public class CoreBeeLineDriver extends CliAdapter {
       long filterEndTime = System.currentTimeMillis();
       System.err.println(">>> FILTERED " + qFile.getName() + ": " + (filterEndTime - queryEndTime)
           + "ms");
-      qOutProcessor.maskPatterns(qFile.getOutputFile().getPath());
 
       if (!overwrite) {
         QTestProcessExecResult result = qFile.compareResults();
@@ -260,11 +266,38 @@ public class CoreBeeLineDriver extends CliAdapter {
         qFile.overwriteResults();
         System.err.println(">>> PASSED " + qFile.getName());
       }
+      resetAdditionalPartialMasks();
     } catch (Exception e) {
+      resetAdditionalPartialMasks();
       throw new Exception("Exception running or analyzing the results of the query file: " + qFile
           + "\n" + qFile.getDebugHint(), e);
     }
 
+  }
+
+  private void setupAdditionalPartialMasks() {
+    if (miniHS2 == null) {
+      return;
+    }
+    HiveConf conf = miniHS2.getHiveConf();
+    String patternStr = HiveConf.getVar(conf, ConfVars.HIVE_ADDITIONAL_PARTIAL_MASKS_PATTERN);
+    String replacementStr = HiveConf.getVar(conf, ConfVars.HIVE_ADDITIONAL_PARTIAL_MASKS_REPLACEMENT_TEXT);
+    if (patternStr != null && replacementStr != null && !replacementStr.isEmpty()
+        && !patternStr.isEmpty()) {
+      String[] patterns = patternStr.split(",");
+      String[] replacements = replacementStr.split(",");
+      if (patterns.length != replacements.length) {
+        throw new RuntimeException("Count mismatch for additional partial masks and their replacements");
+      }
+      for (int i = 0; i < patterns.length; i++) {
+        qOutProcessor.addPatternWithMaskComment(patterns[i],
+            String.format("### %s ###", replacements[i]));
+      }
+    }
+  }
+
+  private void resetAdditionalPartialMasks() {
+    qOutProcessor.resetPatternwithMaskComments();
   }
 
   public void runTest(QFile qFile) throws Exception {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
@@ -109,6 +109,7 @@ public class CoreCliDriver extends CliAdapter {
       System.err.println("Begin query: " + fname);
 
       qt.setInputFile(fpath);
+      setupAdditionalPartialMasks();
       qt.cliInit();
 
       try {
@@ -118,7 +119,6 @@ public class CoreCliDriver extends CliAdapter {
         qt.failedQuery(e.getCause(), e.getResponseCode(), fname, QTestUtil.DEBUG_HINT);
       }
 
-      setupAdditionalPartialMasks();
       QTestProcessExecResult result = qt.checkCliDriverResults();
       resetAdditionalPartialMasks();
       if (result.getReturnCode() != 0) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
@@ -110,6 +110,7 @@ public class CoreCliDriver extends CliAdapter {
       System.err.println("Begin query: " + fname);
 
       qt.setInputFile(fpath);
+      setupAdditionalPartialMasks();
       qt.cliInit();
 
       try {
@@ -119,7 +120,6 @@ public class CoreCliDriver extends CliAdapter {
         qt.failedQuery(e.getCause(), e.getResponseCode(), fname, QTestUtil.DEBUG_HINT);
       }
 
-      setupAdditionalPartialMasks();
       QTestProcessExecResult result = qt.checkCliDriverResults();
       resetAdditionalPartialMasks();
       if (result.getReturnCode() != 0) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QOutProcessor.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QOutProcessor.java
@@ -18,12 +18,8 @@
 package org.apache.hadoop.hive.ql;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -31,7 +27,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.FsType;
@@ -89,6 +84,11 @@ public class QOutProcessor {
     public String get() {
       return line;
     }
+  }
+
+  public static final class MaskingFoldState {
+    private boolean lastWasMasked;
+    private boolean lastWasVertexKilled;
   }
 
   private final Pattern[] planMask = toPattern(new String[] {
@@ -184,55 +184,66 @@ public class QOutProcessor {
     return patterns;
   }
 
-  public void maskPatterns(String fname) throws Exception {
+  /**
+   * Applies {@link #processLine(String)} and consecutive-line folding.
+   *
+   * @return the line to emit, or {@code null} if the line should be suppressed
+   */
+  public String maskAndFoldLine(String line, MaskingFoldState state) {
+    LineProcessingResult result = processLine(line);
 
-    String line;
-    BufferedReader in;
-    BufferedWriter out;
+    if (result.line.equals(MASK_PATTERN)) {
+      // We're folding multiple masked lines into one.
+      if (state.lastWasMasked) {
+        state.lastWasVertexKilled = false;
+        return null;
+      }
+      state.lastWasMasked = true;
+      state.lastWasVertexKilled = false;
+      return result.line;
+    }
+    if (result.line.equals(MASKED_VERTEX_KILLED_PATTERN)) {
+      // Deduplicate consecutive standalone vertex-killed lines — the number of sibling
+      // vertices still alive when the kill propagates is non-deterministic.
+      if (state.lastWasVertexKilled) {
+        state.lastWasMasked = false;
+        return null;
+      }
+      state.lastWasVertexKilled = true;
+      state.lastWasMasked = false;
+      return result.line;
+    }
+    state.lastWasMasked = false;
+    state.lastWasVertexKilled = false;
+    return result.line;
+  }
 
-    File file = new File(fname);
-    File fileOrig = new File(fname + ".orig");
-    FileUtils.copyFile(file, fileOrig);
-
-    in = new BufferedReader(new InputStreamReader(new FileInputStream(fileOrig), "UTF-8"));
-    out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
-
-    boolean lastWasMasked = false;
-    boolean lastWasVertexKilled = false;
-
-    while (null != (line = in.readLine())) {
-      LineProcessingResult result = processLine(line);
-
-      if (result.line.equals(MASK_PATTERN)) {
-        // We're folding multiple masked lines into one.
-        if (!lastWasMasked) {
-          out.write(result.line);
-          out.write("\n");
-          lastWasMasked = true;
-          result.partialMaskWasMatched = false;
-        }
-        lastWasVertexKilled = false;
-      } else if (result.line.equals(MASKED_VERTEX_KILLED_PATTERN)) {
-        // Deduplicate consecutive standalone vertex-killed lines — the number of sibling
-        // vertices still alive when the kill propagates is non-deterministic.
-        if (!lastWasVertexKilled) {
-          out.write(result.line);
-          out.write("\n");
-          lastWasVertexKilled = true;
-        }
-        lastWasMasked = false;
-        result.partialMaskWasMatched = false;
-      } else {
-        out.write(result.line);
-        out.write("\n");
-        lastWasMasked = false;
-        lastWasVertexKilled = false;
-        result.partialMaskWasMatched = false;
+  public List<String> maskLines(List<String> lines) {
+    MaskingFoldState state = new MaskingFoldState();
+    List<String> masked = new ArrayList<>(lines.size());
+    for (String line : lines) {
+      String folded = maskAndFoldLine(line, state);
+      if (folded != null) {
+        masked.add(folded);
       }
     }
+    return masked;
+  }
 
-    in.close();
-    out.close();
+  /** Applies masking and folding to multiline text */
+  public String maskContent(String content) throws IOException {
+    List<String> lines = new ArrayList<>();
+    try (BufferedReader reader = new BufferedReader(new StringReader(content))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        lines.add(line);
+      }
+    }
+    StringBuilder out = new StringBuilder();
+    for (String line : maskLines(lines)) {
+      out.append(line).append('\n');
+    }
+    return out.toString();
   }
 
   LineProcessingResult processLine(String line) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QOutProcessor.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QOutProcessor.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.hive.ql;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -245,6 +248,13 @@ public class QOutProcessor {
       out.append(line).append('\n');
     }
     return out.toString();
+  }
+
+  /** Applies {@link #maskContent(String)} to a q test output file in place. */
+  public void maskOutputFile(String fname) throws IOException {
+    Path path = Path.of(fname);
+    String masked = maskContent(Files.readString(path, StandardCharsets.UTF_8));
+    Files.writeString(path, masked, StandardCharsets.UTF_8);
   }
 
   LineProcessingResult processLine(String line) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QOutProcessor.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QOutProcessor.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.hive.ql;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -244,6 +247,13 @@ public class QOutProcessor {
       out.append(line).append('\n');
     }
     return out.toString();
+  }
+
+  /** Applies {@link #maskContent(String)} to a q test output file in place. */
+  public void maskOutputFile(String fname) throws IOException {
+    Path path = Path.of(fname);
+    String masked = maskContent(Files.readString(path, StandardCharsets.UTF_8));
+    Files.writeString(path, masked, StandardCharsets.UTF_8);
   }
 
   LineProcessingResult processLine(String line) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QOutProcessor.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QOutProcessor.java
@@ -19,12 +19,8 @@
 package org.apache.hadoop.hive.ql;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -32,7 +28,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.FsType;
@@ -90,6 +85,11 @@ public class QOutProcessor {
     public String get() {
       return line;
     }
+  }
+
+  public static final class MaskingFoldState {
+    private boolean lastWasMasked;
+    private boolean lastWasVertexKilled;
   }
 
   private final Pattern[] planMask = toPattern(new String[] {
@@ -185,55 +185,66 @@ public class QOutProcessor {
     return patterns;
   }
 
-  public void maskPatterns(String fname) throws Exception {
+  /**
+   * Applies {@link #processLine(String)} and consecutive-line folding.
+   *
+   * @return the line to emit, or {@code null} if the line should be suppressed
+   */
+  public String maskAndFoldLine(String line, MaskingFoldState state) {
+    LineProcessingResult result = processLine(line);
 
-    String line;
-    BufferedReader in;
-    BufferedWriter out;
+    if (result.line.equals(MASK_PATTERN)) {
+      // We're folding multiple masked lines into one.
+      if (state.lastWasMasked) {
+        state.lastWasVertexKilled = false;
+        return null;
+      }
+      state.lastWasMasked = true;
+      state.lastWasVertexKilled = false;
+      return result.line;
+    }
+    if (result.line.equals(MASKED_VERTEX_KILLED_PATTERN)) {
+      // Deduplicate consecutive standalone vertex-killed lines — the number of sibling
+      // vertices still alive when the kill propagates is non-deterministic.
+      if (state.lastWasVertexKilled) {
+        state.lastWasMasked = false;
+        return null;
+      }
+      state.lastWasVertexKilled = true;
+      state.lastWasMasked = false;
+      return result.line;
+    }
+    state.lastWasMasked = false;
+    state.lastWasVertexKilled = false;
+    return result.line;
+  }
 
-    File file = new File(fname);
-    File fileOrig = new File(fname + ".orig");
-    FileUtils.copyFile(file, fileOrig);
-
-    in = new BufferedReader(new InputStreamReader(new FileInputStream(fileOrig), "UTF-8"));
-    out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
-
-    boolean lastWasMasked = false;
-    boolean lastWasVertexKilled = false;
-
-    while (null != (line = in.readLine())) {
-      LineProcessingResult result = processLine(line);
-
-      if (result.line.equals(MASK_PATTERN)) {
-        // We're folding multiple masked lines into one.
-        if (!lastWasMasked) {
-          out.write(result.line);
-          out.write("\n");
-          lastWasMasked = true;
-          result.partialMaskWasMatched = false;
-        }
-        lastWasVertexKilled = false;
-      } else if (result.line.equals(MASKED_VERTEX_KILLED_PATTERN)) {
-        // Deduplicate consecutive standalone vertex-killed lines — the number of sibling
-        // vertices still alive when the kill propagates is non-deterministic.
-        if (!lastWasVertexKilled) {
-          out.write(result.line);
-          out.write("\n");
-          lastWasVertexKilled = true;
-        }
-        lastWasMasked = false;
-        result.partialMaskWasMatched = false;
-      } else {
-        out.write(result.line);
-        out.write("\n");
-        lastWasMasked = false;
-        lastWasVertexKilled = false;
-        result.partialMaskWasMatched = false;
+  public List<String> maskLines(List<String> lines) {
+    MaskingFoldState state = new MaskingFoldState();
+    List<String> masked = new ArrayList<>(lines.size());
+    for (String line : lines) {
+      String folded = maskAndFoldLine(line, state);
+      if (folded != null) {
+        masked.add(folded);
       }
     }
+    return masked;
+  }
 
-    in.close();
-    out.close();
+  /** Applies masking and folding to multiline text */
+  public String maskContent(String content) throws IOException {
+    List<String> lines = new ArrayList<>();
+    try (BufferedReader reader = new BufferedReader(new StringReader(content))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        lines.add(line);
+      }
+    }
+    StringBuilder out = new StringBuilder();
+    for (String line : maskLines(lines)) {
+      out.append(line).append('\n');
+    }
+    return out.toString();
   }
 
   LineProcessingResult processLine(String line) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestResultProcessor.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestResultProcessor.java
@@ -94,7 +94,7 @@ public class QTestResultProcessor {
     // specified below. This ensures the behavior remains the same as before this
     // refactoring.
     // It would be better to throw an error than silently pick one and ignore the
-    // rest but it is out of the scope of the current change. 
+    // rest but it is out of the scope of the current change.
     if (operations.contains(Operation.SORT)) {
       ss.out = new SortPrintStream(fo, "UTF-8");
     } else if (operations.contains(Operation.HASH)) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestResultProcessor.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestResultProcessor.java
@@ -93,7 +93,7 @@ public class QTestResultProcessor {
     // specified below. This ensures the behavior remains the same as before this
     // refactoring.
     // It would be better to throw an error than silently pick one and ignore the
-    // rest but it is out of the scope of the current change. 
+    // rest but it is out of the scope of the current change.
     if (operations.contains(Operation.SORT)) {
       ss.out = new SortPrintStream(fo, "UTF-8");
     } else if (operations.contains(Operation.HASH)) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
@@ -143,6 +143,8 @@ public class QTestUtil {
   QTestOptionDispatcher dispatcher = new QTestOptionDispatcher();
 
   private boolean isSessionStateStarted = false;
+  private QOutProcessor.MaskingFoldState outMaskingFoldState;
+  private QOutProcessor.MaskingFoldState errMaskingFoldState;
 
   public CliDriver getCliDriver() {
     if (cliDriver == null) {
@@ -688,16 +690,24 @@ public class QTestUtil {
 
     qTestResultProcessor.setOutputs(ss, fo);
 
+    outMaskingFoldState = new QOutProcessor.MaskingFoldState();
     ss.out = new QTestFetchConverter(ss.out, false, "UTF-8", line -> {
       notifyOutputLine(line);
       if (qOutProcessor != null) {
         // ensure that the masking is done before the sorting of the query results
-        return qOutProcessor.processLine(line).get();
+        return qOutProcessor.maskAndFoldLine(line, outMaskingFoldState);
       }
       return line;
     });
 
+    errMaskingFoldState = new QOutProcessor.MaskingFoldState();
     ss.err = new CachingPrintStream(fo, true, "UTF-8");
+    ss.err = new QTestFetchConverter(ss.err, false, "UTF-8", line ->{
+      if (qOutProcessor != null) {
+        return qOutProcessor.maskAndFoldLine(line, errMaskingFoldState);
+      }
+      return line;
+    });
     ss.setIsSilent(true);
     ss.setIsQtestLogging(true);
   }
@@ -1014,7 +1024,6 @@ public class QTestUtil {
     String outFileName = outPath(outDir, tname + outFileExtension);
 
     File f = new File(logDir, tname + outFileExtension);
-    qOutProcessor.maskPatterns(f.getPath());
 
     if (QTestSystemProperties.shouldOverwriteResults()) {
       qTestResultProcessor.overwriteResults(f.getPath(), outFileName);

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
@@ -144,6 +144,8 @@ public class QTestUtil {
   QTestOptionDispatcher dispatcher = new QTestOptionDispatcher();
 
   private boolean isSessionStateStarted = false;
+  private QOutProcessor.MaskingFoldState outMaskingFoldState;
+  private QOutProcessor.MaskingFoldState errMaskingFoldState;
 
   public CliDriver getCliDriver() {
     if (cliDriver == null) {
@@ -689,16 +691,24 @@ public class QTestUtil {
 
     qTestResultProcessor.setOutputs(ss, fo);
 
+    outMaskingFoldState = new QOutProcessor.MaskingFoldState();
     ss.out = new QTestFetchConverter(ss.out, false, "UTF-8", line -> {
       notifyOutputLine(line);
       if (qOutProcessor != null) {
         // ensure that the masking is done before the sorting of the query results
-        return qOutProcessor.processLine(line).get();
+        return qOutProcessor.maskAndFoldLine(line, outMaskingFoldState);
       }
       return line;
     });
 
+    errMaskingFoldState = new QOutProcessor.MaskingFoldState();
     ss.err = new CachingPrintStream(fo, true, "UTF-8");
+    ss.err = new QTestFetchConverter(ss.err, false, "UTF-8", line ->{
+      if (qOutProcessor != null) {
+        return qOutProcessor.maskAndFoldLine(line, errMaskingFoldState);
+      }
+      return line;
+    });
     ss.setIsSilent(true);
     ss.setIsQtestLogging(true);
   }
@@ -1015,7 +1025,6 @@ public class QTestUtil {
     String outFileName = outPath(outDir, tname + outFileExtension);
 
     File f = new File(logDir, tname + outFileExtension);
-    qOutProcessor.maskPatterns(f.getPath());
 
     if (QTestSystemProperties.shouldOverwriteResults()) {
       qTestResultProcessor.overwriteResults(f.getPath(), outFileName);

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
@@ -143,8 +143,6 @@ public class QTestUtil {
   QTestOptionDispatcher dispatcher = new QTestOptionDispatcher();
 
   private boolean isSessionStateStarted = false;
-  private QOutProcessor.MaskingFoldState outMaskingFoldState;
-  private QOutProcessor.MaskingFoldState errMaskingFoldState;
 
   public CliDriver getCliDriver() {
     if (cliDriver == null) {
@@ -690,24 +688,16 @@ public class QTestUtil {
 
     qTestResultProcessor.setOutputs(ss, fo);
 
-    outMaskingFoldState = new QOutProcessor.MaskingFoldState();
     ss.out = new QTestFetchConverter(ss.out, false, "UTF-8", line -> {
       notifyOutputLine(line);
       if (qOutProcessor != null) {
-        // ensure that the masking is done before the sorting of the query results
-        return qOutProcessor.maskAndFoldLine(line, outMaskingFoldState);
+        // Mask before sort/hash (HIVE-29226); folding runs in maskOutputFile().
+        return qOutProcessor.processLine(line).get();
       }
       return line;
     });
 
-    errMaskingFoldState = new QOutProcessor.MaskingFoldState();
     ss.err = new CachingPrintStream(fo, true, "UTF-8");
-    ss.err = new QTestFetchConverter(ss.err, false, "UTF-8", line ->{
-      if (qOutProcessor != null) {
-        return qOutProcessor.maskAndFoldLine(line, errMaskingFoldState);
-      }
-      return line;
-    });
     ss.setIsSilent(true);
     ss.setIsQtestLogging(true);
   }
@@ -1024,6 +1014,8 @@ public class QTestUtil {
     String outFileName = outPath(outDir, tname + outFileExtension);
 
     File f = new File(logDir, tname + outFileExtension);
+
+    qOutProcessor.maskOutputFile(f.getPath());
 
     if (QTestSystemProperties.shouldOverwriteResults()) {
       qTestResultProcessor.overwriteResults(f.getPath(), outFileName);

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
@@ -144,8 +144,6 @@ public class QTestUtil {
   QTestOptionDispatcher dispatcher = new QTestOptionDispatcher();
 
   private boolean isSessionStateStarted = false;
-  private QOutProcessor.MaskingFoldState outMaskingFoldState;
-  private QOutProcessor.MaskingFoldState errMaskingFoldState;
 
   public CliDriver getCliDriver() {
     if (cliDriver == null) {
@@ -691,24 +689,16 @@ public class QTestUtil {
 
     qTestResultProcessor.setOutputs(ss, fo);
 
-    outMaskingFoldState = new QOutProcessor.MaskingFoldState();
     ss.out = new QTestFetchConverter(ss.out, false, "UTF-8", line -> {
       notifyOutputLine(line);
       if (qOutProcessor != null) {
-        // ensure that the masking is done before the sorting of the query results
-        return qOutProcessor.maskAndFoldLine(line, outMaskingFoldState);
+        // Mask before sort/hash (HIVE-29226); folding runs in maskOutputFile().
+        return qOutProcessor.processLine(line).get();
       }
       return line;
     });
 
-    errMaskingFoldState = new QOutProcessor.MaskingFoldState();
     ss.err = new CachingPrintStream(fo, true, "UTF-8");
-    ss.err = new QTestFetchConverter(ss.err, false, "UTF-8", line ->{
-      if (qOutProcessor != null) {
-        return qOutProcessor.maskAndFoldLine(line, errMaskingFoldState);
-      }
-      return line;
-    });
     ss.setIsSilent(true);
     ss.setIsQtestLogging(true);
   }
@@ -1025,6 +1015,8 @@ public class QTestUtil {
     String outFileName = outPath(outDir, tname + outFileExtension);
 
     File f = new File(logDir, tname + outFileExtension);
+
+    qOutProcessor.maskOutputFile(f.getPath());
 
     if (QTestSystemProperties.shouldOverwriteResults()) {
       qTestResultProcessor.overwriteResults(f.getPath(), outFileName);

--- a/itests/util/src/main/java/org/apache/hive/beeline/ConvertedOutputFile.java
+++ b/itests/util/src/main/java/org/apache/hive/beeline/ConvertedOutputFile.java
@@ -20,8 +20,10 @@ package org.apache.hive.beeline;
 
 import org.apache.hadoop.hive.common.io.DigestPrintStream;
 import org.apache.hadoop.hive.common.io.FetchCallback;
+import org.apache.hadoop.hive.common.io.QTestFetchConverter;
 import org.apache.hadoop.hive.common.io.SortAndDigestPrintStream;
 import org.apache.hadoop.hive.common.io.SortPrintStream;
+import org.apache.hadoop.hive.ql.QOutProcessor;
 
 import java.io.PrintStream;
 
@@ -33,8 +35,28 @@ public class ConvertedOutputFile extends OutputFile {
   private final boolean hasFetchCallback;
 
   public ConvertedOutputFile(OutputFile inner, Converter converter) throws Exception {
-    super(converter.getConvertedPrintStream(inner.getOut()), inner.getFilename());
+    this(inner, converter, null, null);
+  }
+
+  public ConvertedOutputFile(OutputFile inner, Converter converter, QOutProcessor qOutProcessor,
+      QOutProcessor.MaskingFoldState maskingFoldState) throws Exception {
+    super(wrapStream(inner.getOut(), converter, qOutProcessor, maskingFoldState), inner.getFilename());
     hasFetchCallback = (getOut() instanceof FetchCallback);
+  }
+
+  private static PrintStream wrapStream(PrintStream inner, Converter converter,
+      QOutProcessor qOutProcessor, QOutProcessor.MaskingFoldState maskingFoldState) throws Exception {
+    if (qOutProcessor == null || maskingFoldState == null) {
+      return converter.getConvertedPrintStream(inner);
+    }
+    // Sort before mask: identical MASK lines must not be created by sorting already-masked rows.
+    PrintStream masked = new QTestFetchConverter(inner, false, "UTF-8", line -> {
+      if (line.startsWith("Reading log file:")) {
+        return null;
+      }
+      return qOutProcessor.maskAndFoldLine(line, maskingFoldState);
+    });
+    return converter.getConvertedPrintStream(masked);
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hive/beeline/ConvertedOutputFile.java
+++ b/itests/util/src/main/java/org/apache/hive/beeline/ConvertedOutputFile.java
@@ -21,8 +21,10 @@ package org.apache.hive.beeline;
 
 import org.apache.hadoop.hive.common.io.DigestPrintStream;
 import org.apache.hadoop.hive.common.io.FetchCallback;
+import org.apache.hadoop.hive.common.io.QTestFetchConverter;
 import org.apache.hadoop.hive.common.io.SortAndDigestPrintStream;
 import org.apache.hadoop.hive.common.io.SortPrintStream;
+import org.apache.hadoop.hive.ql.QOutProcessor;
 
 import java.io.PrintStream;
 
@@ -34,8 +36,28 @@ public class ConvertedOutputFile extends OutputFile {
   private final boolean hasFetchCallback;
 
   public ConvertedOutputFile(OutputFile inner, Converter converter) throws Exception {
-    super(converter.getConvertedPrintStream(inner.getOut()), inner.getFilename());
+    this(inner, converter, null, null);
+  }
+
+  public ConvertedOutputFile(OutputFile inner, Converter converter, QOutProcessor qOutProcessor,
+      QOutProcessor.MaskingFoldState maskingFoldState) throws Exception {
+    super(wrapStream(inner.getOut(), converter, qOutProcessor, maskingFoldState), inner.getFilename());
     hasFetchCallback = (getOut() instanceof FetchCallback);
+  }
+
+  private static PrintStream wrapStream(PrintStream inner, Converter converter,
+      QOutProcessor qOutProcessor, QOutProcessor.MaskingFoldState maskingFoldState) throws Exception {
+    if (qOutProcessor == null || maskingFoldState == null) {
+      return converter.getConvertedPrintStream(inner);
+    }
+    // Sort before mask: identical MASK lines must not be created by sorting already-masked rows.
+    PrintStream masked = new QTestFetchConverter(inner, false, "UTF-8", line -> {
+      if (line.startsWith("Reading log file:")) {
+        return null;
+      }
+      return qOutProcessor.maskAndFoldLine(line, maskingFoldState);
+    });
+    return converter.getConvertedPrintStream(masked);
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hive/beeline/QFile.java
+++ b/itests/util/src/main/java/org/apache/hive/beeline/QFile.java
@@ -331,26 +331,12 @@ public final class QFile {
     }
   }
 
-  // These are the filters which are common for every QTest.
-  // Check specificFilterSet for QTest specific ones.
+  // BeeLine-specific filters. Volatile-value masking is applied in-stream via QOutProcessor.
   private static RegexFilterSet getStaticFilterSet() {
-    // Pattern to remove the timestamp and other infrastructural info from the out file
     return new RegexFilterSet()
         .addFilter("Reading log file: .*\n", "")
         .addFilter("INFO  : ", "")
-        .addFilter(".*/tmp/.*\n", MASK_PATTERN)
-        .addFilter(".*file:.*\n", MASK_PATTERN)
-        .addFilter(".*file\\..*\n", MASK_PATTERN)
-        .addFilter(".*Location.*\n", MASK_PATTERN)
-        .addFilter(".*LOCATION '.*\n", MASK_PATTERN)
-        .addFilter(".*Output:.*/data/files/.*\n", MASK_PATTERN)
-        .addFilter(".*CreateTime.*\n", MASK_PATTERN)
-        .addFilter(".*last_modified_.*\n", MASK_PATTERN)
-        .addFilter(".*transient_lastDdlTime.*\n", MASK_PATTERN)
-        .addFilter(".*lastUpdateTime.*\n", MASK_PATTERN)
-        .addFilter(".*lastAccessTime.*\n", MASK_PATTERN)
-        .addFilter(".*[Oo]wner.*\n", MASK_PATTERN)
-        .addFilter("(?s)(" + MASK_PATTERN + ")+", MASK_PATTERN);
+        .addFilter(".*Output:.*/data/files/.*\n", MASK_PATTERN);
   }
 
   /**

--- a/itests/util/src/main/java/org/apache/hive/beeline/QFile.java
+++ b/itests/util/src/main/java/org/apache/hive/beeline/QFile.java
@@ -332,26 +332,12 @@ public final class QFile {
     }
   }
 
-  // These are the filters which are common for every QTest.
-  // Check specificFilterSet for QTest specific ones.
+  // BeeLine-specific filters. Volatile-value masking is applied in-stream via QOutProcessor.
   private static RegexFilterSet getStaticFilterSet() {
-    // Pattern to remove the timestamp and other infrastructural info from the out file
     return new RegexFilterSet()
         .addFilter("Reading log file: .*\n", "")
         .addFilter("INFO  : ", "")
-        .addFilter(".*/tmp/.*\n", MASK_PATTERN)
-        .addFilter(".*file:.*\n", MASK_PATTERN)
-        .addFilter(".*file\\..*\n", MASK_PATTERN)
-        .addFilter(".*Location.*\n", MASK_PATTERN)
-        .addFilter(".*LOCATION '.*\n", MASK_PATTERN)
-        .addFilter(".*Output:.*/data/files/.*\n", MASK_PATTERN)
-        .addFilter(".*CreateTime.*\n", MASK_PATTERN)
-        .addFilter(".*last_modified_.*\n", MASK_PATTERN)
-        .addFilter(".*transient_lastDdlTime.*\n", MASK_PATTERN)
-        .addFilter(".*lastUpdateTime.*\n", MASK_PATTERN)
-        .addFilter(".*lastAccessTime.*\n", MASK_PATTERN)
-        .addFilter(".*[Oo]wner.*\n", MASK_PATTERN)
-        .addFilter("(?s)(" + MASK_PATTERN + ")+", MASK_PATTERN);
+        .addFilter(".*Output:.*/data/files/.*\n", MASK_PATTERN);
   }
 
   /**

--- a/itests/util/src/main/java/org/apache/hive/beeline/QFileBeeLineClient.java
+++ b/itests/util/src/main/java/org/apache/hive/beeline/QFileBeeLineClient.java
@@ -19,7 +19,7 @@
 package org.apache.hive.beeline;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.hadoop.hive.ql.QTestUtil;
+import org.apache.hadoop.hive.ql.QOutProcessor;
 import org.apache.hadoop.hive.ql.dataset.QTestDatasetHandler;
 import org.apache.hive.beeline.ConvertedOutputFile.Converter;
 
@@ -43,6 +43,8 @@ public class QFileBeeLineClient implements AutoCloseable {
   private BeeLine beeLine;
   private PrintStream beelineOutputStream;
   private File logFile;
+  private QOutProcessor qOutProcessor;
+  private QOutProcessor.MaskingFoldState maskingFoldState;
   private String[] TEST_FIRST_COMMANDS = new String[] {
     "!set outputformat tsv2",
     "!set verbose false",
@@ -126,13 +128,30 @@ public class QFileBeeLineClient implements AutoCloseable {
     return views;
   }
 
+  public void setOutputMasking(QOutProcessor qOutProcessor,
+      QOutProcessor.MaskingFoldState maskingFoldState) {
+    this.qOutProcessor = qOutProcessor;
+    this.maskingFoldState = maskingFoldState;
+  }
+
   public void execute(String[] commands, File resultFile, Converter converter)
+      throws Exception {
+    execute(commands, resultFile, converter, false);
+  }
+
+  private void execute(String[] commands, File resultFile, Converter converter, boolean applyMasking)
       throws Exception {
     beeLine.runCommands(
         new String[] {
           "!record " + resultFile.getAbsolutePath()
         });
-    beeLine.setRecordOutputFile(new ConvertedOutputFile(beeLine.getRecordOutputFile(), converter));
+    OutputFile recordOutputFile = beeLine.getRecordOutputFile();
+    if (applyMasking) {
+      beeLine.setRecordOutputFile(
+          new ConvertedOutputFile(recordOutputFile, converter, qOutProcessor, maskingFoldState));
+    } else {
+      beeLine.setRecordOutputFile(new ConvertedOutputFile(recordOutputFile, converter));
+    }
 
     int lastSuccessfulCommand = beeLine.runCommands(commands);
     if (commands.length != lastSuccessfulCommand) {
@@ -208,7 +227,7 @@ public class QFileBeeLineClient implements AutoCloseable {
     }
 
     String[] commands = beeLine.getCommands(qFile.getInputFile());
-    execute(qFile.filterCommands(commands), qFile.getRawOutputFile(), qFile.getConverter());
+    execute(qFile.filterCommands(commands), qFile.getRawOutputFile(), qFile.getConverter(), true);
     afterExecute(qFile);
   }
 

--- a/itests/util/src/main/java/org/apache/hive/beeline/QFileBeeLineClient.java
+++ b/itests/util/src/main/java/org/apache/hive/beeline/QFileBeeLineClient.java
@@ -20,7 +20,7 @@
 package org.apache.hive.beeline;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.hadoop.hive.ql.QTestUtil;
+import org.apache.hadoop.hive.ql.QOutProcessor;
 import org.apache.hadoop.hive.ql.dataset.QTestDatasetHandler;
 import org.apache.hive.beeline.ConvertedOutputFile.Converter;
 
@@ -44,6 +44,8 @@ public class QFileBeeLineClient implements AutoCloseable {
   private BeeLine beeLine;
   private PrintStream beelineOutputStream;
   private File logFile;
+  private QOutProcessor qOutProcessor;
+  private QOutProcessor.MaskingFoldState maskingFoldState;
   private String[] TEST_FIRST_COMMANDS = new String[] {
     "!set outputformat tsv2",
     "!set verbose false",
@@ -127,13 +129,30 @@ public class QFileBeeLineClient implements AutoCloseable {
     return views;
   }
 
+  public void setOutputMasking(QOutProcessor qOutProcessor,
+      QOutProcessor.MaskingFoldState maskingFoldState) {
+    this.qOutProcessor = qOutProcessor;
+    this.maskingFoldState = maskingFoldState;
+  }
+
   public void execute(String[] commands, File resultFile, Converter converter)
+      throws Exception {
+    execute(commands, resultFile, converter, false);
+  }
+
+  private void execute(String[] commands, File resultFile, Converter converter, boolean applyMasking)
       throws Exception {
     beeLine.runCommands(
         new String[] {
           "!record " + resultFile.getAbsolutePath()
         });
-    beeLine.setRecordOutputFile(new ConvertedOutputFile(beeLine.getRecordOutputFile(), converter));
+    OutputFile recordOutputFile = beeLine.getRecordOutputFile();
+    if (applyMasking) {
+      beeLine.setRecordOutputFile(
+          new ConvertedOutputFile(recordOutputFile, converter, qOutProcessor, maskingFoldState));
+    } else {
+      beeLine.setRecordOutputFile(new ConvertedOutputFile(recordOutputFile, converter));
+    }
 
     int lastSuccessfulCommand = beeLine.runCommands(commands);
     if (commands.length != lastSuccessfulCommand) {
@@ -209,7 +228,7 @@ public class QFileBeeLineClient implements AutoCloseable {
     }
 
     String[] commands = beeLine.getCommands(qFile.getInputFile());
-    execute(qFile.filterCommands(commands), qFile.getRawOutputFile(), qFile.getConverter());
+    execute(qFile.filterCommands(commands), qFile.getRawOutputFile(), qFile.getConverter(), true);
     afterExecute(qFile);
   }
 

--- a/itests/util/src/test/java/org/apache/hadoop/hive/ql/TestQOutProcessor.java
+++ b/itests/util/src/test/java/org/apache/hadoop/hive/ql/TestQOutProcessor.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hive.ql;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -26,19 +26,64 @@ import java.util.List;
 
 import org.apache.hadoop.hive.ql.QTestMiniClusters.FsType;
 import org.apache.hadoop.hive.ql.qoption.QTestReplaceHandler;
+import org.apache.hadoop.hive.common.io.QTestFetchConverter;
+import org.apache.hadoop.hive.common.io.SortPrintStream;
+import org.apache.hive.beeline.ConvertedOutputFile;
+import org.apache.hive.beeline.ConvertedOutputFile.Converter;
+import org.apache.hive.beeline.OutputFile;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /**
- * This class contains unit tests for QTestUtil
+ * Unit tests for {@link QOutProcessor} in-memory masking APIs and qtest capture streams.
  */
 public class TestQOutProcessor {
   QOutProcessor qOutProcessor = new QOutProcessor(FsType.LOCAL, new QTestReplaceHandler());
 
   @Rule
   public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  /**
+   * Query fetch rows (-- SORT_QUERY_RESULTS) are one line per println; identity transform passes through.
+   */
+  @Test
+  public void testSingleLineQueryRowPassThrough() throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    QTestFetchConverter converter = new QTestFetchConverter(buf, true, "UTF-8", line -> line);
+    converter.println("0\tabc");
+    Assert.assertEquals("0\tabc\n", buf.toString(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Transform returning null suppresses the line (BeeLine "Reading log file:" and mask folding).
+   */
+  @Test
+  public void testNullTransformSuppressesLine() throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    QTestFetchConverter converter = new QTestFetchConverter(buf, true, "UTF-8",
+        line -> line.startsWith("Reading log file:") ? null : line);
+    converter.println("Reading log file: /tmp/op.log");
+    converter.println("PREHOOK: query: SELECT 1");
+    Assert.assertEquals("PREHOOK: query: SELECT 1\n", buf.toString(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Consecutive full-mask lines fold to one via {@link QOutProcessor#maskLines(List)}.
+   */
+  @Test
+  public void testConsecutiveMaskPatternFoldsInMemory() {
+    List<String> input = Arrays.asList(
+        "line before",
+        QOutProcessor.MASK_PATTERN,
+        QOutProcessor.MASK_PATTERN,
+        QOutProcessor.MASK_PATTERN,
+        "line after");
+    Assert.assertEquals(
+        Arrays.asList("line before", QOutProcessor.MASK_PATTERN, "line after"),
+        qOutProcessor.maskLines(input));
+  }
 
   /**
    * A raw vertex-killed log line must be replaced with MASKED_VERTEX_KILLED_PATTERN.
@@ -103,46 +148,38 @@ public class TestQOutProcessor {
 
   /**
    * Multiple consecutive standalone MASKED_VERTEX_KILLED_PATTERN lines must be
-   * collapsed to a single line by maskPatterns().
+   * collapsed to a single line by maskLines().
    */
   @Test
-  public void testConsecutiveVertexKilledLinesDeduplicatedInFile() throws Exception {
-    File f = tmpFile(
+  public void testConsecutiveVertexKilledLinesDeduplicatedInMemory() {
+    List<String> input = Arrays.asList(
         "line before",
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         "line after");
-
-    qOutProcessor.maskPatterns(f.getAbsolutePath());
-
-    List<String> lines = readLines(f);
     Assert.assertEquals(
         Arrays.asList("line before", QOutProcessor.MASKED_VERTEX_KILLED_PATTERN, "line after"),
-        lines);
+        qOutProcessor.maskLines(input));
   }
 
   /**
    * Two separate (non-consecutive) vertex-killed blocks must each produce one line.
    */
   @Test
-  public void testNonConsecutiveVertexKilledLinesKeptSeparately() throws Exception {
-    File f = tmpFile(
+  public void testNonConsecutiveVertexKilledLinesKeptSeparatelyInMemory() {
+    List<String> input = Arrays.asList(
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         "some other line",
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN);
-
-    qOutProcessor.maskPatterns(f.getAbsolutePath());
-
-    List<String> lines = readLines(f);
     Assert.assertEquals(
         Arrays.asList(
             QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
             "some other line",
             QOutProcessor.MASKED_VERTEX_KILLED_PATTERN),
-        lines);
+        qOutProcessor.maskLines(input));
   }
 
   /**
@@ -150,23 +187,178 @@ public class TestQOutProcessor {
    * the run of vertex-killed lines.
    */
   @Test
-  public void testVertexKilledRunResetByMaskedLine() throws Exception {
-    // "Deleted something" starts with "Deleted" → gets replaced by MASK_PATTERN
-    File f = tmpFile(
+  public void testVertexKilledRunResetByMaskedLineInMemory() {
+    List<String> input = Arrays.asList(
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
-        "Deleted /tmp/something",        // will be masked → MASK_PATTERN
+        "Deleted /tmp/something",
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN);
-
-    qOutProcessor.maskPatterns(f.getAbsolutePath());
-
-    List<String> lines = readLines(f);
-    // MASK_PATTERN lines fold duplicates; but here there is only one occurrence
     Assert.assertEquals(
         Arrays.asList(
             QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
             QOutProcessor.MASK_PATTERN,
             QOutProcessor.MASKED_VERTEX_KILLED_PATTERN),
-        lines);
+        qOutProcessor.maskLines(input));
+  }
+
+  @Test
+  public void testMaskContentFoldsConsecutiveVertexKilledLines() throws Exception {
+    String input = String.join("\n",
+        QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
+        QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
+        "line after") + "\n";
+    Assert.assertEquals(
+        QOutProcessor.MASKED_VERTEX_KILLED_PATTERN + "\nline after\n",
+        qOutProcessor.maskContent(input));
+  }
+
+  /**
+   * PREHOOK/POSTHOOK emit multiline query text in one println; stream masking must match
+   * {@link QOutProcessor#maskContent(String)} (including consecutive-line folding).
+   */
+  @Test
+  public void testMultilinePrehookStreamMaskMatchesMaskContent() throws Exception {
+    String multiline =
+        "PREHOOK: query: CREATE TABLE alter_table_location2 (id int, name string, dept string)\n"
+            + "  PARTITIONED BY (year int)\n"
+            + "  STORED AS ORC\n"
+            + "  LOCATION 'pfile://${system:test.tmp.dir}/alter_table_location2'\n"
+            + "  TBLPROPERTIES (\"transactional\"=\"true\")";
+    String expected = qOutProcessor.maskContent(multiline + "\n");
+
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    QTestFetchConverter converter = new QTestFetchConverter(buf, true, "UTF-8",
+        line -> qOutProcessor.maskAndFoldLine(line, state));
+    converter.println(multiline);
+
+    Assert.assertEquals(expected, buf.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testBeeLineRecordMaskingAppliedWhenProcessorProvided() throws Exception {
+    File out = tmpFolder.newFile("test.out");
+    OutputFile inner = new OutputFile(out.getAbsolutePath());
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+
+    ConvertedOutputFile record =
+        new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
+    record.println("hdfs://localhost:51594/tmp/other text");
+    record.close();
+
+    String content = Files.readString(out.toPath(), StandardCharsets.UTF_8);
+    Assert.assertTrue(content.contains(QOutProcessor.HDFS_MASK));
+    Assert.assertFalse(content.contains("localhost:51594"));
+  }
+
+  /**
+   * BeeLine fetches HS2 operation logs in test mode; the "Reading log file:" header must be dropped
+   * (same as {@link org.apache.hive.beeline.QFile#getStaticFilterSet()}).
+   */
+  @Test
+  public void testBeeLineRecordReadingLogFileLineIsSuppressed() throws Exception {
+    File out = tmpFolder.newFile("test.out");
+    OutputFile inner = new OutputFile(out.getAbsolutePath());
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    ConvertedOutputFile record =
+        new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
+
+    record.println("Reading log file: /tmp/cyanzheng/operation_logs/query.test");
+    record.println("PREHOOK: query: SELECT 1");
+    record.close();
+
+    Assert.assertEquals("PREHOOK: query: SELECT 1\n",
+        Files.readString(out.toPath(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testBeeLineRecordNoMaskingWithoutProcessor() throws Exception {
+    File out = tmpFolder.newFile("test.out");
+    OutputFile inner = new OutputFile(out.getAbsolutePath());
+
+    ConvertedOutputFile record = new ConvertedOutputFile(inner, Converter.NONE);
+    record.println("hdfs://localhost:51594/tmp/other text");
+    record.close();
+
+    Assert.assertEquals("hdfs://localhost:51594/tmp/other text\n",
+        Files.readString(out.toPath(), StandardCharsets.UTF_8));
+  }
+
+  /**
+   * BeeLine PREHOOK/POSTHOOK emit multiline query text in one println; !record output must match
+   * {@link QOutProcessor#maskContent(String)} via {@link ConvertedOutputFile}.
+   */
+  @Test
+  public void testMultilinePrehookBeeLineRecordMaskMatchesMaskContent() throws Exception {
+    String multiline =
+        "PREHOOK: query: CREATE TABLE alter_table_location2 (id int, name string, dept string)\n"
+            + "  PARTITIONED BY (year int)\n"
+            + "  STORED AS ORC\n"
+            + "  LOCATION 'pfile://${system:test.tmp.dir}/alter_table_location2'\n"
+            + "  TBLPROPERTIES (\"transactional\"=\"true\")";
+    String expected = qOutProcessor.maskContent(multiline + "\n");
+
+    File out = tmpFolder.newFile("test.out");
+    OutputFile inner = new OutputFile(out.getAbsolutePath());
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    ConvertedOutputFile record =
+        new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
+
+    record.println(multiline);
+    record.close();
+
+    Assert.assertEquals(expected, Files.readString(out.toPath(), StandardCharsets.UTF_8));
+  }
+
+  /**
+   * With -- SORT_QUERY_RESULTS, sort unmasked rows first then apply masking on output so identical
+   * mask placeholders are not clustered by the sorter (same stream order as ConvertedOutputFile).
+   */
+  @Test
+  public void testSortQueryResultsMasksAfterSort() throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    QTestFetchConverter mask = new QTestFetchConverter(buf, false, "UTF-8",
+        line -> qOutProcessor.maskAndFoldLine(line, state));
+    SortPrintStream sort = new SortPrintStream(mask, "UTF-8");
+
+    sort.fetchStarted();
+    sort.foundQuery(true);
+    sort.println("b\tcol\thdfs://host-b");
+    sort.println("a\tcol\thdfs://host-a");
+    sort.fetchFinished();
+
+    String output = buf.toString(StandardCharsets.UTF_8);
+    Assert.assertFalse(output.contains("host-a"));
+    Assert.assertFalse(output.contains("host-b"));
+    Assert.assertTrue(output.contains(QOutProcessor.HDFS_MASK));
+    Assert.assertEquals(
+        "a\tcol\thdfs://" + QOutProcessor.HDFS_MASK + "\n"
+            + "b\tcol\thdfs://" + QOutProcessor.HDFS_MASK + "\n",
+        output);
+  }
+
+
+  @Test
+  public void testCliDriverMaskBeforeSort() throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    SortPrintStream sort = new SortPrintStream(buf, "UTF-8");
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    QTestFetchConverter mask = new QTestFetchConverter(sort, false, "UTF-8",
+        line -> qOutProcessor.maskAndFoldLine(line, state));
+
+    mask.fetchStarted();
+    mask.foundQuery(true);
+    mask.println("b\tcol\thdfs://host-b");
+    mask.println("a\tcol\thdfs://host-a");
+    mask.fetchFinished();
+
+    String output = buf.toString(StandardCharsets.UTF_8);
+    Assert.assertFalse(output.contains("host-a"));
+    Assert.assertFalse(output.contains("host-b"));
+    Assert.assertEquals(
+        "a\tcol\thdfs://" + QOutProcessor.HDFS_MASK + "\n"
+            + "b\tcol\thdfs://" + QOutProcessor.HDFS_MASK + "\n",
+        output);
   }
 
   @Test
@@ -217,24 +409,6 @@ public class TestQOutProcessor {
 
   private String processLine(String line) {
     return qOutProcessor.processLine(line).get();
-  }
-
-  private File tmpFile(String... lines) throws Exception {
-    File f = tmpFolder.newFile();
-    try (PrintWriter pw = new PrintWriter(Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8))) {
-      for (String l : lines) {
-        pw.println(l);
-      }
-    }
-    return f;
-  }
-
-  private List<String> readLines(File f) throws Exception {
-    List<String> all = Files.readAllLines(f.toPath(), StandardCharsets.UTF_8);
-    while (!all.isEmpty() && all.get(all.size() - 1).isEmpty()) {
-      all.remove(all.size() - 1);
-    }
-    return all;
   }
 
 }

--- a/itests/util/src/test/java/org/apache/hadoop/hive/ql/TestQOutProcessor.java
+++ b/itests/util/src/test/java/org/apache/hadoop/hive/ql/TestQOutProcessor.java
@@ -18,8 +18,8 @@
  */
 package org.apache.hadoop.hive.ql;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -27,19 +27,64 @@ import java.util.List;
 
 import org.apache.hadoop.hive.ql.QTestMiniClusters.FsType;
 import org.apache.hadoop.hive.ql.qoption.QTestReplaceHandler;
+import org.apache.hadoop.hive.common.io.QTestFetchConverter;
+import org.apache.hadoop.hive.common.io.SortPrintStream;
+import org.apache.hive.beeline.ConvertedOutputFile;
+import org.apache.hive.beeline.ConvertedOutputFile.Converter;
+import org.apache.hive.beeline.OutputFile;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /**
- * This class contains unit tests for QTestUtil
+ * Unit tests for {@link QOutProcessor} in-memory masking APIs and qtest capture streams.
  */
 public class TestQOutProcessor {
   QOutProcessor qOutProcessor = new QOutProcessor(FsType.LOCAL, new QTestReplaceHandler());
 
   @Rule
   public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  /**
+   * Query fetch rows (-- SORT_QUERY_RESULTS) are one line per println; identity transform passes through.
+   */
+  @Test
+  public void testSingleLineQueryRowPassThrough() throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    QTestFetchConverter converter = new QTestFetchConverter(buf, true, "UTF-8", line -> line);
+    converter.println("0\tabc");
+    Assert.assertEquals("0\tabc\n", buf.toString(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Transform returning null suppresses the line (BeeLine "Reading log file:" and mask folding).
+   */
+  @Test
+  public void testNullTransformSuppressesLine() throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    QTestFetchConverter converter = new QTestFetchConverter(buf, true, "UTF-8",
+        line -> line.startsWith("Reading log file:") ? null : line);
+    converter.println("Reading log file: /tmp/op.log");
+    converter.println("PREHOOK: query: SELECT 1");
+    Assert.assertEquals("PREHOOK: query: SELECT 1\n", buf.toString(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Consecutive full-mask lines fold to one via {@link QOutProcessor#maskLines(List)}.
+   */
+  @Test
+  public void testConsecutiveMaskPatternFoldsInMemory() {
+    List<String> input = Arrays.asList(
+        "line before",
+        QOutProcessor.MASK_PATTERN,
+        QOutProcessor.MASK_PATTERN,
+        QOutProcessor.MASK_PATTERN,
+        "line after");
+    Assert.assertEquals(
+        Arrays.asList("line before", QOutProcessor.MASK_PATTERN, "line after"),
+        qOutProcessor.maskLines(input));
+  }
 
   /**
    * A raw vertex-killed log line must be replaced with MASKED_VERTEX_KILLED_PATTERN.
@@ -104,46 +149,38 @@ public class TestQOutProcessor {
 
   /**
    * Multiple consecutive standalone MASKED_VERTEX_KILLED_PATTERN lines must be
-   * collapsed to a single line by maskPatterns().
+   * collapsed to a single line by maskLines().
    */
   @Test
-  public void testConsecutiveVertexKilledLinesDeduplicatedInFile() throws Exception {
-    File f = tmpFile(
+  public void testConsecutiveVertexKilledLinesDeduplicatedInMemory() {
+    List<String> input = Arrays.asList(
         "line before",
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         "line after");
-
-    qOutProcessor.maskPatterns(f.getAbsolutePath());
-
-    List<String> lines = readLines(f);
     Assert.assertEquals(
         Arrays.asList("line before", QOutProcessor.MASKED_VERTEX_KILLED_PATTERN, "line after"),
-        lines);
+        qOutProcessor.maskLines(input));
   }
 
   /**
    * Two separate (non-consecutive) vertex-killed blocks must each produce one line.
    */
   @Test
-  public void testNonConsecutiveVertexKilledLinesKeptSeparately() throws Exception {
-    File f = tmpFile(
+  public void testNonConsecutiveVertexKilledLinesKeptSeparatelyInMemory() {
+    List<String> input = Arrays.asList(
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         "some other line",
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN);
-
-    qOutProcessor.maskPatterns(f.getAbsolutePath());
-
-    List<String> lines = readLines(f);
     Assert.assertEquals(
         Arrays.asList(
             QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
             "some other line",
             QOutProcessor.MASKED_VERTEX_KILLED_PATTERN),
-        lines);
+        qOutProcessor.maskLines(input));
   }
 
   /**
@@ -151,23 +188,178 @@ public class TestQOutProcessor {
    * the run of vertex-killed lines.
    */
   @Test
-  public void testVertexKilledRunResetByMaskedLine() throws Exception {
-    // "Deleted something" starts with "Deleted" → gets replaced by MASK_PATTERN
-    File f = tmpFile(
+  public void testVertexKilledRunResetByMaskedLineInMemory() {
+    List<String> input = Arrays.asList(
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
-        "Deleted /tmp/something",        // will be masked → MASK_PATTERN
+        "Deleted /tmp/something",
         QOutProcessor.MASKED_VERTEX_KILLED_PATTERN);
-
-    qOutProcessor.maskPatterns(f.getAbsolutePath());
-
-    List<String> lines = readLines(f);
-    // MASK_PATTERN lines fold duplicates; but here there is only one occurrence
     Assert.assertEquals(
         Arrays.asList(
             QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
             QOutProcessor.MASK_PATTERN,
             QOutProcessor.MASKED_VERTEX_KILLED_PATTERN),
-        lines);
+        qOutProcessor.maskLines(input));
+  }
+
+  @Test
+  public void testMaskContentFoldsConsecutiveVertexKilledLines() throws Exception {
+    String input = String.join("\n",
+        QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
+        QOutProcessor.MASKED_VERTEX_KILLED_PATTERN,
+        "line after") + "\n";
+    Assert.assertEquals(
+        QOutProcessor.MASKED_VERTEX_KILLED_PATTERN + "\nline after\n",
+        qOutProcessor.maskContent(input));
+  }
+
+  /**
+   * PREHOOK/POSTHOOK emit multiline query text in one println; stream masking must match
+   * {@link QOutProcessor#maskContent(String)} (including consecutive-line folding).
+   */
+  @Test
+  public void testMultilinePrehookStreamMaskMatchesMaskContent() throws Exception {
+    String multiline =
+        "PREHOOK: query: CREATE TABLE alter_table_location2 (id int, name string, dept string)\n"
+            + "  PARTITIONED BY (year int)\n"
+            + "  STORED AS ORC\n"
+            + "  LOCATION 'pfile://${system:test.tmp.dir}/alter_table_location2'\n"
+            + "  TBLPROPERTIES (\"transactional\"=\"true\")";
+    String expected = qOutProcessor.maskContent(multiline + "\n");
+
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    QTestFetchConverter converter = new QTestFetchConverter(buf, true, "UTF-8",
+        line -> qOutProcessor.maskAndFoldLine(line, state));
+    converter.println(multiline);
+
+    Assert.assertEquals(expected, buf.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testBeeLineRecordMaskingAppliedWhenProcessorProvided() throws Exception {
+    File out = tmpFolder.newFile("test.out");
+    OutputFile inner = new OutputFile(out.getAbsolutePath());
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+
+    ConvertedOutputFile record =
+        new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
+    record.println("hdfs://localhost:51594/tmp/other text");
+    record.close();
+
+    String content = Files.readString(out.toPath(), StandardCharsets.UTF_8);
+    Assert.assertTrue(content.contains(QOutProcessor.HDFS_MASK));
+    Assert.assertFalse(content.contains("localhost:51594"));
+  }
+
+  /**
+   * BeeLine fetches HS2 operation logs in test mode; the "Reading log file:" header must be dropped
+   * (same as {@link org.apache.hive.beeline.QFile#getStaticFilterSet()}).
+   */
+  @Test
+  public void testBeeLineRecordReadingLogFileLineIsSuppressed() throws Exception {
+    File out = tmpFolder.newFile("test.out");
+    OutputFile inner = new OutputFile(out.getAbsolutePath());
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    ConvertedOutputFile record =
+        new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
+
+    record.println("Reading log file: /tmp/cyanzheng/operation_logs/query.test");
+    record.println("PREHOOK: query: SELECT 1");
+    record.close();
+
+    Assert.assertEquals("PREHOOK: query: SELECT 1\n",
+        Files.readString(out.toPath(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testBeeLineRecordNoMaskingWithoutProcessor() throws Exception {
+    File out = tmpFolder.newFile("test.out");
+    OutputFile inner = new OutputFile(out.getAbsolutePath());
+
+    ConvertedOutputFile record = new ConvertedOutputFile(inner, Converter.NONE);
+    record.println("hdfs://localhost:51594/tmp/other text");
+    record.close();
+
+    Assert.assertEquals("hdfs://localhost:51594/tmp/other text\n",
+        Files.readString(out.toPath(), StandardCharsets.UTF_8));
+  }
+
+  /**
+   * BeeLine PREHOOK/POSTHOOK emit multiline query text in one println; !record output must match
+   * {@link QOutProcessor#maskContent(String)} via {@link ConvertedOutputFile}.
+   */
+  @Test
+  public void testMultilinePrehookBeeLineRecordMaskMatchesMaskContent() throws Exception {
+    String multiline =
+        "PREHOOK: query: CREATE TABLE alter_table_location2 (id int, name string, dept string)\n"
+            + "  PARTITIONED BY (year int)\n"
+            + "  STORED AS ORC\n"
+            + "  LOCATION 'pfile://${system:test.tmp.dir}/alter_table_location2'\n"
+            + "  TBLPROPERTIES (\"transactional\"=\"true\")";
+    String expected = qOutProcessor.maskContent(multiline + "\n");
+
+    File out = tmpFolder.newFile("test.out");
+    OutputFile inner = new OutputFile(out.getAbsolutePath());
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    ConvertedOutputFile record =
+        new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
+
+    record.println(multiline);
+    record.close();
+
+    Assert.assertEquals(expected, Files.readString(out.toPath(), StandardCharsets.UTF_8));
+  }
+
+  /**
+   * With -- SORT_QUERY_RESULTS, sort unmasked rows first then apply masking on output so identical
+   * mask placeholders are not clustered by the sorter (same stream order as ConvertedOutputFile).
+   */
+  @Test
+  public void testSortQueryResultsMasksAfterSort() throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    QTestFetchConverter mask = new QTestFetchConverter(buf, false, "UTF-8",
+        line -> qOutProcessor.maskAndFoldLine(line, state));
+    SortPrintStream sort = new SortPrintStream(mask, "UTF-8");
+
+    sort.fetchStarted();
+    sort.foundQuery(true);
+    sort.println("b\tcol\thdfs://host-b");
+    sort.println("a\tcol\thdfs://host-a");
+    sort.fetchFinished();
+
+    String output = buf.toString(StandardCharsets.UTF_8);
+    Assert.assertFalse(output.contains("host-a"));
+    Assert.assertFalse(output.contains("host-b"));
+    Assert.assertTrue(output.contains(QOutProcessor.HDFS_MASK));
+    Assert.assertEquals(
+        "a\tcol\thdfs://" + QOutProcessor.HDFS_MASK + "\n"
+            + "b\tcol\thdfs://" + QOutProcessor.HDFS_MASK + "\n",
+        output);
+  }
+
+
+  @Test
+  public void testCliDriverMaskBeforeSort() throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    SortPrintStream sort = new SortPrintStream(buf, "UTF-8");
+    QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
+    QTestFetchConverter mask = new QTestFetchConverter(sort, false, "UTF-8",
+        line -> qOutProcessor.maskAndFoldLine(line, state));
+
+    mask.fetchStarted();
+    mask.foundQuery(true);
+    mask.println("b\tcol\thdfs://host-b");
+    mask.println("a\tcol\thdfs://host-a");
+    mask.fetchFinished();
+
+    String output = buf.toString(StandardCharsets.UTF_8);
+    Assert.assertFalse(output.contains("host-a"));
+    Assert.assertFalse(output.contains("host-b"));
+    Assert.assertEquals(
+        "a\tcol\thdfs://" + QOutProcessor.HDFS_MASK + "\n"
+            + "b\tcol\thdfs://" + QOutProcessor.HDFS_MASK + "\n",
+        output);
   }
 
   @Test
@@ -218,24 +410,6 @@ public class TestQOutProcessor {
 
   private String processLine(String line) {
     return qOutProcessor.processLine(line).get();
-  }
-
-  private File tmpFile(String... lines) throws Exception {
-    File f = tmpFolder.newFile();
-    try (PrintWriter pw = new PrintWriter(Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8))) {
-      for (String l : lines) {
-        pw.println(l);
-      }
-    }
-    return f;
-  }
-
-  private List<String> readLines(File f) throws Exception {
-    List<String> all = Files.readAllLines(f.toPath(), StandardCharsets.UTF_8);
-    while (!all.isEmpty() && all.get(all.size() - 1).isEmpty()) {
-      all.remove(all.size() - 1);
-    }
-    return all;
   }
 
 }

--- a/itests/util/src/test/java/org/apache/hadoop/hive/ql/TestQOutProcessor.java
+++ b/itests/util/src/test/java/org/apache/hadoop/hive/ql/TestQOutProcessor.java
@@ -240,10 +240,10 @@ public class TestQOutProcessor {
     OutputFile inner = new OutputFile(out.getAbsolutePath());
     QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
 
-    ConvertedOutputFile record =
+    ConvertedOutputFile convertedOutput =
         new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
-    record.println("hdfs://localhost:51594/tmp/other text");
-    record.close();
+    convertedOutput.println("hdfs://localhost:51594/tmp/other text");
+    convertedOutput.close();
 
     String content = Files.readString(out.toPath(), StandardCharsets.UTF_8);
     Assert.assertTrue(content.contains(QOutProcessor.HDFS_MASK));
@@ -259,12 +259,12 @@ public class TestQOutProcessor {
     File out = tmpFolder.newFile("test.out");
     OutputFile inner = new OutputFile(out.getAbsolutePath());
     QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
-    ConvertedOutputFile record =
+    ConvertedOutputFile convertedOutput =
         new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
 
-    record.println("Reading log file: /tmp/cyanzheng/operation_logs/query.test");
-    record.println("PREHOOK: query: SELECT 1");
-    record.close();
+    convertedOutput.println("Reading log file: /tmp/cyanzheng/operation_logs/query.test");
+    convertedOutput.println("PREHOOK: query: SELECT 1");
+    convertedOutput.close();
 
     Assert.assertEquals("PREHOOK: query: SELECT 1\n",
         Files.readString(out.toPath(), StandardCharsets.UTF_8));
@@ -275,16 +275,16 @@ public class TestQOutProcessor {
     File out = tmpFolder.newFile("test.out");
     OutputFile inner = new OutputFile(out.getAbsolutePath());
 
-    ConvertedOutputFile record = new ConvertedOutputFile(inner, Converter.NONE);
-    record.println("hdfs://localhost:51594/tmp/other text");
-    record.close();
+    ConvertedOutputFile convertedOutput = new ConvertedOutputFile(inner, Converter.NONE);
+    convertedOutput.println("hdfs://localhost:51594/tmp/other text");
+    convertedOutput.close();
 
     Assert.assertEquals("hdfs://localhost:51594/tmp/other text\n",
         Files.readString(out.toPath(), StandardCharsets.UTF_8));
   }
 
   /**
-   * BeeLine PREHOOK/POSTHOOK emit multiline query text in one println; !record output must match
+   * BeeLine PREHOOK/POSTHOOK emit multiline query text in one println; converted output must match
    * {@link QOutProcessor#maskContent(String)} via {@link ConvertedOutputFile}.
    */
   @Test
@@ -300,11 +300,11 @@ public class TestQOutProcessor {
     File out = tmpFolder.newFile("test.out");
     OutputFile inner = new OutputFile(out.getAbsolutePath());
     QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
-    ConvertedOutputFile record =
+    ConvertedOutputFile convertedOutput =
         new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
 
-    record.println(multiline);
-    record.close();
+    convertedOutput.println(multiline);
+    convertedOutput.close();
 
     Assert.assertEquals(expected, Files.readString(out.toPath(), StandardCharsets.UTF_8));
   }

--- a/itests/util/src/test/java/org/apache/hadoop/hive/ql/TestQOutProcessor.java
+++ b/itests/util/src/test/java/org/apache/hadoop/hive/ql/TestQOutProcessor.java
@@ -241,10 +241,10 @@ public class TestQOutProcessor {
     OutputFile inner = new OutputFile(out.getAbsolutePath());
     QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
 
-    ConvertedOutputFile record =
+    ConvertedOutputFile convertedOutput =
         new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
-    record.println("hdfs://localhost:51594/tmp/other text");
-    record.close();
+    convertedOutput.println("hdfs://localhost:51594/tmp/other text");
+    convertedOutput.close();
 
     String content = Files.readString(out.toPath(), StandardCharsets.UTF_8);
     Assert.assertTrue(content.contains(QOutProcessor.HDFS_MASK));
@@ -260,12 +260,12 @@ public class TestQOutProcessor {
     File out = tmpFolder.newFile("test.out");
     OutputFile inner = new OutputFile(out.getAbsolutePath());
     QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
-    ConvertedOutputFile record =
+    ConvertedOutputFile convertedOutput =
         new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
 
-    record.println("Reading log file: /tmp/cyanzheng/operation_logs/query.test");
-    record.println("PREHOOK: query: SELECT 1");
-    record.close();
+    convertedOutput.println("Reading log file: /tmp/cyanzheng/operation_logs/query.test");
+    convertedOutput.println("PREHOOK: query: SELECT 1");
+    convertedOutput.close();
 
     Assert.assertEquals("PREHOOK: query: SELECT 1\n",
         Files.readString(out.toPath(), StandardCharsets.UTF_8));
@@ -276,16 +276,16 @@ public class TestQOutProcessor {
     File out = tmpFolder.newFile("test.out");
     OutputFile inner = new OutputFile(out.getAbsolutePath());
 
-    ConvertedOutputFile record = new ConvertedOutputFile(inner, Converter.NONE);
-    record.println("hdfs://localhost:51594/tmp/other text");
-    record.close();
+    ConvertedOutputFile convertedOutput = new ConvertedOutputFile(inner, Converter.NONE);
+    convertedOutput.println("hdfs://localhost:51594/tmp/other text");
+    convertedOutput.close();
 
     Assert.assertEquals("hdfs://localhost:51594/tmp/other text\n",
         Files.readString(out.toPath(), StandardCharsets.UTF_8));
   }
 
   /**
-   * BeeLine PREHOOK/POSTHOOK emit multiline query text in one println; !record output must match
+   * BeeLine PREHOOK/POSTHOOK emit multiline query text in one println; converted output must match
    * {@link QOutProcessor#maskContent(String)} via {@link ConvertedOutputFile}.
    */
   @Test
@@ -301,11 +301,11 @@ public class TestQOutProcessor {
     File out = tmpFolder.newFile("test.out");
     OutputFile inner = new OutputFile(out.getAbsolutePath());
     QOutProcessor.MaskingFoldState state = new QOutProcessor.MaskingFoldState();
-    ConvertedOutputFile record =
+    ConvertedOutputFile convertedOutput =
         new ConvertedOutputFile(inner, Converter.NONE, qOutProcessor, state);
 
-    record.println(multiline);
-    record.close();
+    convertedOutput.println(multiline);
+    convertedOutput.close();
 
     Assert.assertEquals(expected, Files.readString(out.toPath(), StandardCharsets.UTF_8));
   }


### PR DESCRIPTION

Refactored masking from QOutProcessor#maskPatterns that involves file rewrite to in-memory implementation  for CliDriver and BeeLine.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Removed `QOutProcessor#maskPatterns() `which rewrites the whole file when masking.
Added in-stream masking methods and states, including `maskAndFoldLine()`, `maskLines()`, `maskContent()`, and `MaskingFoldState` while retaining the original semantics. Splitted multiline `println()` on \n for PREHOOK/POSTHOOK text
Wrapped both stdout and stderr with QTestFetchConverter to perform mask before sort for CliDriver. For BeeLine retained original sort before mask behaviour and applied masking on the `!record` stream.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently masking is scattered across multiple locations and also involves re-writing the q.out files after test execution. This change centralises rules in `QOutProcessor`, applies them in memory on the
capture path where possible, and preserves existing golden semantics.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested and validated with multiple existing qfiles with `TestMiniLlapLocalCliDriver`, `TestMiniLlapCliDriver`, `TestCliDriver`, `TestMiniTezCliDriver`, `TestBeeLineDriver`
Also added unit test under `TestQOutProcessor`