### PR TITLE
HIVE-29758: Fix maven warning for duplicate Iceberg dependency

### DIFF
--- a/itests/qtest-iceberg/pom.xml
+++ b/itests/qtest-iceberg/pom.xml
@@ -284,10 +284,6 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-iceberg-handler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-iceberg-handler</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix maven warning while building hive

### Why are the changes needed?

that prints warning and confuses "me"

### Does this PR introduce _any_ user-facing change?
 No

### How was this patch tested?
### Before
```
ayush@ayushpc:~/hive$ mvn clean install -DskipTests -Pitests
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.hive:hive-it-iceberg-qfile:jar:4.3.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.hive:hive-iceberg-handler:jar -> duplicate declaration of version (?) @ line 288, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Hive Storage API                                                   [jar]
[INFO] Hive                                                               [pom]

```


### After
```
ayush@ayushpc:~/hive$ mvn clean install -DskipTests -Pitests
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Hive Storage API                                                   [jar]
```

