### PR TITLE
HIVE-29761: Upgrade jackson to 2.21.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <httpcomponents5.core.version>5.3.4</httpcomponents5.core.version>
     <httpcomponents5.client.version>5.5</httpcomponents5.client.version>
     <ivy.version>2.5.2</ivy.version>
-    <jackson.version>2.18.6</jackson.version>
+    <jackson.version>2.21.5</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <javax-servlet.version>3.1.0</javax-servlet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <httpcomponents5.core.version>5.3.4</httpcomponents5.core.version>
     <httpcomponents5.client.version>5.5</httpcomponents5.client.version>
     <ivy.version>2.5.2</ivy.version>
-    <jackson.version>2.18.6</jackson.version>
+    <jackson.version>2.21.5</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <javax-servlet.version>3.1.0</javax-servlet.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -88,7 +88,7 @@
     <hadoop.version>3.4.2</hadoop.version>
     <hikaricp.version>4.0.3</hikaricp.version>
     <iceberg.version>1.11.0</iceberg.version>
-    <jackson.version>2.18.6</jackson.version>
+    <jackson.version>2.21.5</jackson.version>
     <jexl.version>3.3</jexl.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13.2</junit.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -92,8 +92,8 @@
     <hadoop.version>3.4.2</hadoop.version>
     <hikaricp.version>4.0.3</hikaricp.version>
     <iceberg.version>1.11.0</iceberg.version>
-    <jackson.version>2.18.6</jackson.version>
     <jexl.version>3.7.0</jexl.version>
+    <jackson.version>2.21.5</jackson.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.13.3</junit.jupiter.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -36,6 +36,7 @@
     <netty.version>4.1.127.Final</netty.version>
     <guava.version>22.0</guava.version>
     <hadoop.version>3.4.2</hadoop.version>
+    <jackson.version>2.21.5</jackson.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.13.3</junit.jupiter.version>
     <junit.vintage.version>5.13.3</junit.vintage.version>
@@ -59,6 +60,13 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
         <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION

### What changes were proposed in this pull request?
Upgrade Jackson to 2.21.5 to resolve CVEs:
[CVE-2026-54515](https://www.cve.org/CVERecord?id=CVE-2026-54515): affectedat >= 2.8.0, < 2.18.9, >= 2.19.0, < 2.21.5, >= 3.1.0, < 3.1.4, 
[CVE-2026-54514](https://www.cve.org/CVERecord?id=CVE-2026-54514): affectedat >= 2.0.0, < 2.18.8, >= 2.19.0, < 2.21.4, >= 3.0.0, < 3.1.4
[CVE-2026-54513](https://www.cve.org/CVERecord?id=CVE-2026-54513): affectedat >= 2.10.0, < 2.18.8, >= 2.19.0, < 2.21.4, >= 3.0.0, < 3.1.4
[CVE-2026-54512](https://www.cve.org/CVERecord?id=CVE-2026-54512): affectedat >= 2.10.0, < 2.18.8, >= 2.19.0, < 2.21.4, >= 3.0.0, < 3.1.4


### Dependency Tree
[jackson.txt](https://github.com/user-attachments/files/31165007/jackson_st-api.txt)


### Why are the changes needed?
version upgrade

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
CI
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
