### PR TITLE
 HIVE-29768: Fix ClassNotFoundException(SQLStdHiveAuthorizerFactoryForTest) in compactor tests

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
@@ -155,12 +155,11 @@ public abstract class CompactorTest {
     }
     // Set this config to true in the base class, there are extended test classes which set this config to false.
     MetastoreConf.setBoolVar(conf, ConfVars.COMPACTOR_CLEAN_ABORTS_USING_CLEANER, true);
-    // Post-compaction stats gathering runs an ANALYZE TABLE query through the Driver,
-    // which triggers SessionState.setupAuth() and fails here with a ClassNotFoundException:
-    // data/conf/hive-site.xml points hive.security.authorization.manager at
-    // SQLStdHiveAuthorizerFactoryForTest, but that class lives in itests/util which
-    // isn't on the ql test classpath. StatsUpdater swallows the failure so tests still pass.
-    // Disable stats by default as these tests do not assert on the stats that StatsUpdater.gatherStats produces.
+    // Disable stats by default as these tests do not assert on the stats that
+    // StatsUpdater.gatherStats produces.
+    // Note: Enabling it requires a properly configured authorizer,
+    // since post-compaction stats gathering runs ANALYZE TABLE through
+    // the Driver and triggers SessionState.setupAuth().
     HiveConf.setBoolVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
     TestTxnDbUtil.setConfValues(conf);
     TestTxnDbUtil.cleanDb(conf);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
@@ -155,6 +155,13 @@ public abstract class CompactorTest {
     }
     // Set this config to true in the base class, there are extended test classes which set this config to false.
     MetastoreConf.setBoolVar(conf, ConfVars.COMPACTOR_CLEAN_ABORTS_USING_CLEANER, true);
+    // Post-compaction stats gathering runs an ANALYZE TABLE query through the Driver,
+    // which triggers SessionState.setupAuth() and fails here with a ClassNotFoundException:
+    // data/conf/hive-site.xml points hive.security.authorization.manager at
+    // SQLStdHiveAuthorizerFactoryForTest, but that class lives in itests/util which
+    // isn't on the ql test classpath. StatsUpdater swallows the failure so tests still pass.
+    // Disable stats by default as these tests do not assert on the stats that StatsUpdater.gatherStats produces.
+    HiveConf.setBoolVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
     TestTxnDbUtil.setConfValues(conf);
     TestTxnDbUtil.cleanDb(conf);
     TestTxnDbUtil.prepDb(conf);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestDeltaFilesMetrics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestDeltaFilesMetrics.java
@@ -63,7 +63,6 @@ public class TestDeltaFilesMetrics extends CompactorTest  {
         TimeUnit.SECONDS);
     MetastoreConf.setDoubleVar(conf, MetastoreConf.ConfVars.METASTORE_DELTAMETRICS_DELTA_PCT_THRESHOLD, 0.15f);
     MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.METRICS_ENABLED, true);
-    HiveConf.setBoolVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
   }
 
   @Override


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Disables `hive.compactor.gather.stats` by default in the compactor test base class (CompactorTest)  
so post-compaction stats gathering no longer runs during unit tests. 
These tests do not assert on the stats that **StatsUpdater.gatherStats** produces.


### Why are the changes needed?
 Every TestWorker run (and every other test extending CompactorTest) emits a loud stack trace(CNFE) after each successful compaction.
```
  ERROR session.SessionState: Error setting up authorization:                                       
    java.lang.ClassNotFoundException:                                                                                                                                                 
  org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactoryForTest 
```


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existed UT
