### PR TITLE
HIVE-29776: Remove obsolete Java 8 detection 

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/JavaVersionUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/JavaVersionUtils.java
@@ -24,44 +24,29 @@ public class JavaVersionUtils {
   }
 
   /**
-   * Returns the detected Java major version (e.g., 8, 11, 17).
+   * Returns JVM --add-opens flags for Tez/MR child processes.
    */
-  public static int getJavaMajorVersion() {
-    return Math.max(8, Integer.parseInt(
-        System.getProperty("java.specification.version").split("\\.")[0]));
-  }
-
-  /**
-   * Returns the full --add-opens string if Java 9, or an empty string if Java 8 or below.
-   */
-  public static String getAddOpensFlagsIfNeeded() {
-    //TODO: Please remove this once the codebase has been migrated to JDK 9 or a higher version.
-    int javaVersion = getJavaMajorVersion();
-    if (javaVersion >= 9) {
-      return " --add-opens=java.base/java.net=ALL-UNNAMED" +
-          " --add-opens=java.base/java.util=ALL-UNNAMED" +
-          " --add-opens=java.base/java.util.concurrent=ALL-UNNAMED" +
-          " --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED" +
-          " --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED" +
-          " --add-opens=java.base/java.lang=ALL-UNNAMED" +
-          " --add-opens=java.base/java.io=ALL-UNNAMED" +
-          " --add-opens=java.base/java.lang=ALL-UNNAMED" +
-          " --add-opens=java.base/java.lang.invoke=ALL-UNNAMED" +
-          " --add-opens=java.base/java.lang.reflect=ALL-UNNAMED" +
-          " --add-opens=java.base/java.math=ALL-UNNAMED" +
-          " --add-opens=java.base/java.nio=ALL-UNNAMED" +
-          " --add-opens=java.base/java.text=ALL-UNNAMED" +
-          " --add-opens=java.base/java.time=ALL-UNNAMED" +
-          " --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED" +
-          " --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED" +
-          " --add-opens=java.sql/java.sql=ALL-UNNAMED" +
-          " --add-opens=java.base/sun.nio.ch=ALL-UNNAMED" +
-          " --add-opens=java.base/sun.nio.cs=ALL-UNNAMED" +
-          " --add-opens=java.base/java.util.regex=ALL-UNNAMED" +
-          " --add-opens=java.base/java.security=ALL-UNNAMED" +
-          " --add-opens=java.base/sun.security.provider=ALL-UNNAMED";
-    } else {
-      return ""; // Java 8 or lower does not need add-opens
-    }
+  public static String getAddOpensFlags() {
+    return " --add-opens=java.base/java.net=ALL-UNNAMED" +
+        " --add-opens=java.base/java.util=ALL-UNNAMED" +
+        " --add-opens=java.base/java.util.concurrent=ALL-UNNAMED" +
+        " --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED" +
+        " --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED" +
+        " --add-opens=java.base/java.lang=ALL-UNNAMED" +
+        " --add-opens=java.base/java.io=ALL-UNNAMED" +
+        " --add-opens=java.base/java.lang.invoke=ALL-UNNAMED" +
+        " --add-opens=java.base/java.lang.reflect=ALL-UNNAMED" +
+        " --add-opens=java.base/java.math=ALL-UNNAMED" +
+        " --add-opens=java.base/java.nio=ALL-UNNAMED" +
+        " --add-opens=java.base/java.text=ALL-UNNAMED" +
+        " --add-opens=java.base/java.time=ALL-UNNAMED" +
+        " --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED" +
+        " --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED" +
+        " --add-opens=java.sql/java.sql=ALL-UNNAMED" +
+        " --add-opens=java.base/sun.nio.ch=ALL-UNNAMED" +
+        " --add-opens=java.base/sun.nio.cs=ALL-UNNAMED" +
+        " --add-opens=java.base/java.util.regex=ALL-UNNAMED" +
+        " --add-opens=java.base/java.security=ALL-UNNAMED" +
+        " --add-opens=java.base/sun.security.provider=ALL-UNNAMED";
   }
 }

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/TempletonControllerJob.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/TempletonControllerJob.java
@@ -124,7 +124,7 @@ public class TempletonControllerJob extends Configured implements Tool, JobSubmi
       conf.set(AppConfig.HADOOP_MR_AM_MEMORY_MB, amMemoryMB);
     }
     String amJavaOpts = StringUtils.defaultString(appConf.controllerAMChildOpts());
-    amJavaOpts += JavaVersionUtils.getAddOpensFlagsIfNeeded();
+    amJavaOpts += JavaVersionUtils.getAddOpensFlags();
     if (!amJavaOpts.isEmpty()) {
       conf.set(AppConfig.HADOOP_MR_AM_JAVA_OPTS, amJavaOpts);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
@@ -374,7 +374,7 @@ public class ExecDriver extends Task<MapredWork> implements Serializable, Hadoop
         }
       }
 
-      addOpensFlagsIfNeeded(job);
+      addOpensFlags(job);
       jc = new JobClient(job);
       // make this client wait if job tracker is not behaving well.
       Throttle.checkJobTracker(job, LOG);
@@ -493,13 +493,11 @@ public class ExecDriver extends Task<MapredWork> implements Serializable, Hadoop
     return (returnVal);
   }
 
-  private static void addOpensFlagsIfNeeded(JobConf job) {
-    String addOpens = JavaVersionUtils.getAddOpensFlagsIfNeeded();
-    if(!addOpens.isEmpty()) {
-      addJavaOpts(job, "mapreduce.map.java.opts", addOpens);
-      addJavaOpts(job, "mapreduce.reduce.java.opts", addOpens);
-      addJavaOpts(job, "yarn.app.mapreduce.am.command-opts", addOpens);
-    }
+  private static void addOpensFlags(JobConf job) {
+    String addOpens = JavaVersionUtils.getAddOpensFlags();
+    addJavaOpts(job, "mapreduce.map.java.opts", addOpens);
+    addJavaOpts(job, "mapreduce.reduce.java.opts", addOpens);
+    addJavaOpts(job, "yarn.app.mapreduce.am.command-opts", addOpens);
   }
   private static void addJavaOpts(JobConf job, String conf, String extraOpts) {
     String javaOpts = StringUtils.defaultString(job.get(conf));

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -728,7 +728,7 @@ public class DagUtils {
       }
       finalOpts = logLevel + " " + MRHelpers.getJavaOptsForMRMapper(conf);
     }
-    finalOpts += JavaVersionUtils.getAddOpensFlagsIfNeeded();
+    finalOpts += JavaVersionUtils.getAddOpensFlags();
     LOG.debug("Tez container final opts: {}", finalOpts);
     return finalOpts;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -582,7 +582,7 @@ public class TezSessionState implements TezSession {
     }
 
     String mrAmJavaOpts = conf.get(TezConfiguration.TEZ_AM_LAUNCH_CMD_OPTS, MRHelpers.getJavaOptsForMRAM(conf));
-    conf.set(TezConfiguration.TEZ_AM_LAUNCH_CMD_OPTS, mrAmJavaOpts + JavaVersionUtils.getAddOpensFlagsIfNeeded());
+    conf.set(TezConfiguration.TEZ_AM_LAUNCH_CMD_OPTS, mrAmJavaOpts + JavaVersionUtils.getAddOpensFlags());
 
     String queueName = conf.get(JobContext.QUEUE_NAME, YarnConfiguration.DEFAULT_QUEUE_NAME);
     conf.setIfUnset(TezConfiguration.TEZ_QUEUE_NAME, queueName);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removed the old Java 8 checks from JavaVersionUtils. Since Hive 4.2.x requires JDK 21, the utility no longer needs to detect the Java version and always returns the required --add-opens flags.

### Why are the changes needed?
Java 8 is no longer supported in Hive 4.2.x. Removing the old compatibility code makes JavaVersionUtils simpler and easier to maintain.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI 

