### PR TITLE
HIVE-29685: Fix LLAP UI status for non-YARN deployments

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceDriver.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceDriver.java
@@ -244,8 +244,11 @@ public class LlapStatusServiceDriver {
         return ret;
       }
 
+      if (appStatusBuilder.getState() == State.APP_NOT_FOUND) {
+        return ExitCode.SUCCESS;
+      }
+
       if (NO_YARN_SERVICE_INFO_STATES.contains(appStatusBuilder.getState())) {
-        updateRunningThresholdAchieved(appStatusBuilder, cl.getRunningNodesThreshold());
         return ExitCode.SUCCESS;
       }
 
@@ -420,15 +423,10 @@ public class LlapStatusServiceDriver {
 
   /**
    * Populate additional information for containers from the LLAP registry. Must be invoked
-   * after YARN Service status and diagnostics.
+   * after YARN Service status and diagnostics when {@code registryOnly} is false.
    * @return an ExitCode. An ExitCode other than ExitCode.SUCCESS implies future progress not possible
    * @throws LlapStatusCliException
    */
-  private ExitCode populateAppStatusFromLlapRegistry(AppStatusBuilder appStatusBuilder, long watchTimeoutMs)
-      throws LlapStatusCliException {
-    return populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, false);
-  }
-
   private ExitCode populateAppStatusFromLlapRegistry(AppStatusBuilder appStatusBuilder, long watchTimeoutMs,
       boolean registryOnly) throws LlapStatusCliException {
 

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceDriver.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceDriver.java
@@ -71,7 +71,7 @@ public class LlapStatusServiceDriver {
   private static final Logger CONSOLE_LOGGER = LoggerFactory.getLogger("LlapStatusServiceDriverConsole");
 
   private static final EnumSet<State> NO_YARN_SERVICE_INFO_STATES = EnumSet.of(
-      State.APP_NOT_FOUND, State.COMPLETE, State.LAUNCHING);
+      State.COMPLETE, State.LAUNCHING);
   private static final EnumSet<State> LAUNCHING_STATES = EnumSet.of(
       State.LAUNCHING, State.RUNNING_PARTIAL, State.RUNNING_ALL);
 
@@ -107,6 +107,10 @@ public class LlapStatusServiceDriver {
 
   private static final long LOG_SUMMARY_INTERVAL = 15000L; // Log summary every ~15 seconds.
   private static final String LLAP_KEY = "llap";
+  private static final String TEZ_AM_FRAMEWORK_MODE = "tez.am.framework.mode";
+  private static final String TEZ_FRAMEWORK_MODE_STANDALONE_ZOOKEEPER = "STANDALONE_ZOOKEEPER";
+  /** When set, overrides auto-detection for registry vs YARN status lookup. */
+  private static final String CONFIG_STATUS_USE_REGISTRY = CONF_PREFIX + "status.use-registry";
 
   private final Configuration conf;
   private String appName = null;
@@ -194,18 +198,31 @@ public class LlapStatusServiceDriver {
         llapRegistryConf.set(HiveConf.ConfVars.LLAP_DAEMON_SERVICE_HOSTS.varname, "@" + appName);
       }
 
+      if (usesRegistryBasedLlapStatus(conf)) {
+        LOG.info("Non-YARN LLAP deployment detected; using LLAP registry for status");
+        try {
+          ExitCode ret = populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, true);
+          if (ret == ExitCode.SUCCESS) {
+            updateRunningThresholdAchieved(appStatusBuilder, cl.getRunningNodesThreshold());
+          }
+          return ret;
+        } catch (LlapStatusCliException e) {
+          logError(e);
+          return e.getExitCode();
+        }
+      }
+
       try {
         if (serviceClient == null) {
           serviceClient = LlapSliderUtils.createServiceClient(conf);
         }
       } catch (Exception e) {
-        LlapStatusCliException le = new LlapStatusCliException(
-            ExitCode.SERVICE_CLIENT_ERROR_CREATE_FAILED, "Failed to create service client", e);
+        LlapStatusCliException le = new LlapStatusCliException(ExitCode.SERVICE_CLIENT_ERROR_CREATE_FAILED,
+            "Failed to create YARN Service client", e);
         logError(le);
         return le.getExitCode();
       }
 
-      // Get the App report from YARN
       ApplicationReport appReport;
       try {
         appReport = getAppReport(appName, cl.getFindAppTimeoutMs());
@@ -214,7 +231,6 @@ public class LlapStatusServiceDriver {
         return e.getExitCode();
       }
 
-      // Process the report
       ExitCode ret;
       try {
         ret = processAppReport(appReport, appStatusBuilder);
@@ -225,30 +241,35 @@ public class LlapStatusServiceDriver {
 
       if (ret != ExitCode.SUCCESS) {
         return ret;
-      } else if (NO_YARN_SERVICE_INFO_STATES.contains(appStatusBuilder.getState())) {
+      }
+
+      if (NO_YARN_SERVICE_INFO_STATES.contains(appStatusBuilder.getState())) {
+        updateRunningThresholdAchieved(appStatusBuilder, cl.getRunningNodesThreshold());
         return ExitCode.SUCCESS;
-      } else {
-        // Get information from YARN Service
-        try {
-          ret = populateAppStatusFromServiceStatus(appName, serviceClient, appStatusBuilder);
-        } catch (LlapStatusCliException e) {
-          // In case of failure, send back whatever is constructed so far - which would be from the AppReport
-          logError(e);
-          return e.getExitCode();
-        }
+      }
+
+      // Get information from YARN Service
+      try {
+        ret = populateAppStatusFromServiceStatus(appName, serviceClient, appStatusBuilder);
+      } catch (LlapStatusCliException e) {
+        // In case of failure, send back whatever is constructed so far - which would be from the AppReport
+        logError(e);
+        return e.getExitCode();
       }
 
       if (ret != ExitCode.SUCCESS) {
         return ret;
-      } else {
-        try {
-          ret = populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs);
-        } catch (LlapStatusCliException e) {
-          logError(e);
-          return e.getExitCode();
-        }
       }
 
+      try {
+        ret = populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, false);
+      } catch (LlapStatusCliException e) {
+        logError(e);
+        return e.getExitCode();
+      }
+      if (ret == ExitCode.SUCCESS) {
+        updateRunningThresholdAchieved(appStatusBuilder, cl.getRunningNodesThreshold());
+      }
       return ret;
     } finally {
       LOG.debug("Final AppState: " + appStatusBuilder.toString());
@@ -404,6 +425,11 @@ public class LlapStatusServiceDriver {
    */
   private ExitCode populateAppStatusFromLlapRegistry(AppStatusBuilder appStatusBuilder, long watchTimeoutMs)
       throws LlapStatusCliException {
+    return populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, false);
+  }
+
+  private ExitCode populateAppStatusFromLlapRegistry(AppStatusBuilder appStatusBuilder, long watchTimeoutMs,
+      boolean registryOnly) throws LlapStatusCliException {
 
     if (llapRegistry == null) {
       try {
@@ -426,6 +452,23 @@ public class LlapStatusServiceDriver {
       appStatusBuilder.setLiveInstances(0);
       appStatusBuilder.setState(State.LAUNCHING);
       appStatusBuilder.clearRunningLlapInstances();
+      return ExitCode.SUCCESS;
+    }
+
+    if (registryOnly) {
+      List<LlapInstance> registryInstances = new LinkedList<>();
+      for (LlapServiceInstance serviceInstance : serviceInstances) {
+        registryInstances.add(createLlapInstanceFromRegistry(serviceInstance));
+      }
+      if (appStatusBuilder.getAmInfo() == null) {
+        appStatusBuilder.setAmInfo(new AmInfo().setAppName(appName));
+      }
+      appStatusBuilder.clearAndAddPreviouslyKnownRunningInstances(registryInstances);
+      appStatusBuilder.setLiveInstances(registryInstances.size());
+      if (appStatusBuilder.getDesiredInstances() == null) {
+        appStatusBuilder.setDesiredInstances(registryInstances.size());
+      }
+      updateStateFromInstanceCounts(appStatusBuilder, registryInstances.size());
       return ExitCode.SUCCESS;
     } else {
       // Tracks instances known by both YARN Service and llap.
@@ -455,18 +498,10 @@ public class LlapStatusServiceDriver {
 
       appStatusBuilder.setLiveInstances(validatedInstances.size());
       appStatusBuilder.setLaunchingInstances(llapExtraInstances.size());
-      if (appStatusBuilder.getDesiredInstances() != null &&
-          validatedInstances.size() >= appStatusBuilder.getDesiredInstances()) {
-        appStatusBuilder.setState(State.RUNNING_ALL);
-        if (validatedInstances.size() > appStatusBuilder.getDesiredInstances()) {
-          LOG.warn("Found more entries in LLAP registry, as compared to desired entries");
-        }
-      } else {
-        if (validatedInstances.size() > 0) {
-          appStatusBuilder.setState(State.RUNNING_PARTIAL);
-        } else {
-          appStatusBuilder.setState(State.LAUNCHING);
-        }
+      updateStateFromInstanceCounts(appStatusBuilder, validatedInstances.size());
+      if (appStatusBuilder.getDesiredInstances() != null
+          && validatedInstances.size() > appStatusBuilder.getDesiredInstances()) {
+        LOG.warn("Found more entries in LLAP registry, as compared to desired entries");
       }
 
       // At this point, everything that can be consumed from AppStatusBuilder has been consumed.
@@ -485,6 +520,63 @@ public class LlapStatusServiceDriver {
 
     }
     return ExitCode.SUCCESS;
+  }
+
+  static LlapInstance createLlapInstanceFromRegistry(LlapServiceInstance serviceInstance) {
+    String containerId = serviceInstance.getProperties().get(
+        HiveConf.ConfVars.LLAP_DAEMON_CONTAINER_ID.varname);
+    if (StringUtils.isBlank(containerId)) {
+      containerId = serviceInstance.getWorkerIdentity();
+    }
+    LlapInstance llapInstance = new LlapInstance(serviceInstance.getHost(), containerId);
+    llapInstance.setMgmtPort(serviceInstance.getManagementPort());
+    llapInstance.setRpcPort(serviceInstance.getRpcPort());
+    llapInstance.setShufflePort(serviceInstance.getShufflePort());
+    llapInstance.setWebUrl(serviceInstance.getServicesAddress());
+    llapInstance.setStatusUrl(serviceInstance.getServicesAddress() + "/status");
+    return llapInstance;
+  }
+
+  static void updateStateFromInstanceCounts(AppStatusBuilder appStatusBuilder, int liveInstances) {
+    Integer desiredInstances = appStatusBuilder.getDesiredInstances();
+    if (desiredInstances != null && liveInstances >= desiredInstances) {
+      appStatusBuilder.setState(State.RUNNING_ALL);
+    } else if (liveInstances > 0) {
+      appStatusBuilder.setState(State.RUNNING_PARTIAL);
+    } else {
+      appStatusBuilder.setState(State.LAUNCHING);
+    }
+  }
+
+  /**
+   * Non-YARN LLAP (e.g. Kubernetes, standalone Tez) uses the ZK registry for daemon discovery.
+   * YARN Service LLAP uses the YARN APIs. Detection follows deployment config set by the operator.
+   */
+  static boolean usesRegistryBasedLlapStatus(Configuration conf) {
+    if (conf.get(CONFIG_STATUS_USE_REGISTRY) != null) {
+      return conf.getBoolean(CONFIG_STATUS_USE_REGISTRY, false);
+    }
+    if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_SERVER2_TEZ_USE_EXTERNAL_SESSIONS)) {
+      return true;
+    }
+    String tezFrameworkMode = conf.get(TEZ_AM_FRAMEWORK_MODE, "");
+    return TEZ_FRAMEWORK_MODE_STANDALONE_ZOOKEEPER.equalsIgnoreCase(tezFrameworkMode);
+  }
+
+  static void updateRunningThresholdAchieved(AppStatusBuilder appStatusBuilder, float runningNodesThreshold) {
+    Integer desiredInstances = appStatusBuilder.getDesiredInstances();
+    Integer liveInstances = appStatusBuilder.getLiveInstances();
+    if (desiredInstances == null || desiredInstances <= 0 || liveInstances == null) {
+      return;
+    }
+    if (!(appStatusBuilder.getState() == State.RUNNING_PARTIAL
+        || appStatusBuilder.getState() == State.RUNNING_ALL)) {
+      return;
+    }
+    float ratio = (float) liveInstances / (float) desiredInstances;
+    if (ratio >= runningNodesThreshold) {
+      appStatusBuilder.setRunningThresholdAchieved(true);
+    }
   }
 
   private void close() {

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceDriver.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceDriver.java
@@ -72,7 +72,7 @@ public class LlapStatusServiceDriver {
   private static final Logger CONSOLE_LOGGER = LoggerFactory.getLogger("LlapStatusServiceDriverConsole");
 
   private static final EnumSet<State> NO_YARN_SERVICE_INFO_STATES = EnumSet.of(
-      State.APP_NOT_FOUND, State.COMPLETE, State.LAUNCHING);
+      State.COMPLETE, State.LAUNCHING);
   private static final EnumSet<State> LAUNCHING_STATES = EnumSet.of(
       State.LAUNCHING, State.RUNNING_PARTIAL, State.RUNNING_ALL);
 
@@ -108,6 +108,10 @@ public class LlapStatusServiceDriver {
 
   private static final long LOG_SUMMARY_INTERVAL = 15000L; // Log summary every ~15 seconds.
   private static final String LLAP_KEY = "llap";
+  private static final String TEZ_AM_FRAMEWORK_MODE = "tez.am.framework.mode";
+  private static final String TEZ_FRAMEWORK_MODE_STANDALONE_ZOOKEEPER = "STANDALONE_ZOOKEEPER";
+  /** When set, overrides auto-detection for registry vs YARN status lookup. */
+  private static final String CONFIG_STATUS_USE_REGISTRY = CONF_PREFIX + "status.use-registry";
 
   private final Configuration conf;
   private String appName = null;
@@ -195,18 +199,31 @@ public class LlapStatusServiceDriver {
         llapRegistryConf.set(HiveConf.ConfVars.LLAP_DAEMON_SERVICE_HOSTS.varname, "@" + appName);
       }
 
+      if (usesRegistryBasedLlapStatus(conf)) {
+        LOG.info("Non-YARN LLAP deployment detected; using LLAP registry for status");
+        try {
+          ExitCode ret = populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, true);
+          if (ret == ExitCode.SUCCESS) {
+            updateRunningThresholdAchieved(appStatusBuilder, cl.getRunningNodesThreshold());
+          }
+          return ret;
+        } catch (LlapStatusCliException e) {
+          logError(e);
+          return e.getExitCode();
+        }
+      }
+
       try {
         if (serviceClient == null) {
           serviceClient = LlapSliderUtils.createServiceClient(conf);
         }
       } catch (Exception e) {
-        LlapStatusCliException le = new LlapStatusCliException(
-            ExitCode.SERVICE_CLIENT_ERROR_CREATE_FAILED, "Failed to create service client", e);
+        LlapStatusCliException le = new LlapStatusCliException(ExitCode.SERVICE_CLIENT_ERROR_CREATE_FAILED,
+            "Failed to create YARN Service client", e);
         logError(le);
         return le.getExitCode();
       }
 
-      // Get the App report from YARN
       ApplicationReport appReport;
       try {
         appReport = getAppReport(appName, cl.getFindAppTimeoutMs());
@@ -215,7 +232,6 @@ public class LlapStatusServiceDriver {
         return e.getExitCode();
       }
 
-      // Process the report
       ExitCode ret;
       try {
         ret = processAppReport(appReport, appStatusBuilder);
@@ -226,30 +242,35 @@ public class LlapStatusServiceDriver {
 
       if (ret != ExitCode.SUCCESS) {
         return ret;
-      } else if (NO_YARN_SERVICE_INFO_STATES.contains(appStatusBuilder.getState())) {
+      }
+
+      if (NO_YARN_SERVICE_INFO_STATES.contains(appStatusBuilder.getState())) {
+        updateRunningThresholdAchieved(appStatusBuilder, cl.getRunningNodesThreshold());
         return ExitCode.SUCCESS;
-      } else {
-        // Get information from YARN Service
-        try {
-          ret = populateAppStatusFromServiceStatus(appName, serviceClient, appStatusBuilder);
-        } catch (LlapStatusCliException e) {
-          // In case of failure, send back whatever is constructed so far - which would be from the AppReport
-          logError(e);
-          return e.getExitCode();
-        }
+      }
+
+      // Get information from YARN Service
+      try {
+        ret = populateAppStatusFromServiceStatus(appName, serviceClient, appStatusBuilder);
+      } catch (LlapStatusCliException e) {
+        // In case of failure, send back whatever is constructed so far - which would be from the AppReport
+        logError(e);
+        return e.getExitCode();
       }
 
       if (ret != ExitCode.SUCCESS) {
         return ret;
-      } else {
-        try {
-          ret = populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs);
-        } catch (LlapStatusCliException e) {
-          logError(e);
-          return e.getExitCode();
-        }
       }
 
+      try {
+        ret = populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, false);
+      } catch (LlapStatusCliException e) {
+        logError(e);
+        return e.getExitCode();
+      }
+      if (ret == ExitCode.SUCCESS) {
+        updateRunningThresholdAchieved(appStatusBuilder, cl.getRunningNodesThreshold());
+      }
       return ret;
     } finally {
       LOG.debug("Final AppState: " + appStatusBuilder.toString());
@@ -405,6 +426,11 @@ public class LlapStatusServiceDriver {
    */
   private ExitCode populateAppStatusFromLlapRegistry(AppStatusBuilder appStatusBuilder, long watchTimeoutMs)
       throws LlapStatusCliException {
+    return populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, false);
+  }
+
+  private ExitCode populateAppStatusFromLlapRegistry(AppStatusBuilder appStatusBuilder, long watchTimeoutMs,
+      boolean registryOnly) throws LlapStatusCliException {
 
     if (llapRegistry == null) {
       try {
@@ -427,6 +453,23 @@ public class LlapStatusServiceDriver {
       appStatusBuilder.setLiveInstances(0);
       appStatusBuilder.setState(State.LAUNCHING);
       appStatusBuilder.clearRunningLlapInstances();
+      return ExitCode.SUCCESS;
+    }
+
+    if (registryOnly) {
+      List<LlapInstance> registryInstances = new LinkedList<>();
+      for (LlapServiceInstance serviceInstance : serviceInstances) {
+        registryInstances.add(createLlapInstanceFromRegistry(serviceInstance));
+      }
+      if (appStatusBuilder.getAmInfo() == null) {
+        appStatusBuilder.setAmInfo(new AmInfo().setAppName(appName));
+      }
+      appStatusBuilder.clearAndAddPreviouslyKnownRunningInstances(registryInstances);
+      appStatusBuilder.setLiveInstances(registryInstances.size());
+      if (appStatusBuilder.getDesiredInstances() == null) {
+        appStatusBuilder.setDesiredInstances(registryInstances.size());
+      }
+      updateStateFromInstanceCounts(appStatusBuilder, registryInstances.size());
       return ExitCode.SUCCESS;
     } else {
       // Tracks instances known by both YARN Service and llap.
@@ -456,18 +499,10 @@ public class LlapStatusServiceDriver {
 
       appStatusBuilder.setLiveInstances(validatedInstances.size());
       appStatusBuilder.setLaunchingInstances(llapExtraInstances.size());
-      if (appStatusBuilder.getDesiredInstances() != null &&
-          validatedInstances.size() >= appStatusBuilder.getDesiredInstances()) {
-        appStatusBuilder.setState(State.RUNNING_ALL);
-        if (validatedInstances.size() > appStatusBuilder.getDesiredInstances()) {
-          LOG.warn("Found more entries in LLAP registry, as compared to desired entries");
-        }
-      } else {
-        if (validatedInstances.size() > 0) {
-          appStatusBuilder.setState(State.RUNNING_PARTIAL);
-        } else {
-          appStatusBuilder.setState(State.LAUNCHING);
-        }
+      updateStateFromInstanceCounts(appStatusBuilder, validatedInstances.size());
+      if (appStatusBuilder.getDesiredInstances() != null
+          && validatedInstances.size() > appStatusBuilder.getDesiredInstances()) {
+        LOG.warn("Found more entries in LLAP registry, as compared to desired entries");
       }
 
       // At this point, everything that can be consumed from AppStatusBuilder has been consumed.
@@ -486,6 +521,63 @@ public class LlapStatusServiceDriver {
 
     }
     return ExitCode.SUCCESS;
+  }
+
+  static LlapInstance createLlapInstanceFromRegistry(LlapServiceInstance serviceInstance) {
+    String containerId = serviceInstance.getProperties().get(
+        HiveConf.ConfVars.LLAP_DAEMON_CONTAINER_ID.varname);
+    if (StringUtils.isBlank(containerId)) {
+      containerId = serviceInstance.getWorkerIdentity();
+    }
+    LlapInstance llapInstance = new LlapInstance(serviceInstance.getHost(), containerId);
+    llapInstance.setMgmtPort(serviceInstance.getManagementPort());
+    llapInstance.setRpcPort(serviceInstance.getRpcPort());
+    llapInstance.setShufflePort(serviceInstance.getShufflePort());
+    llapInstance.setWebUrl(serviceInstance.getServicesAddress());
+    llapInstance.setStatusUrl(serviceInstance.getServicesAddress() + "/status");
+    return llapInstance;
+  }
+
+  static void updateStateFromInstanceCounts(AppStatusBuilder appStatusBuilder, int liveInstances) {
+    Integer desiredInstances = appStatusBuilder.getDesiredInstances();
+    if (desiredInstances != null && liveInstances >= desiredInstances) {
+      appStatusBuilder.setState(State.RUNNING_ALL);
+    } else if (liveInstances > 0) {
+      appStatusBuilder.setState(State.RUNNING_PARTIAL);
+    } else {
+      appStatusBuilder.setState(State.LAUNCHING);
+    }
+  }
+
+  /**
+   * Non-YARN LLAP (e.g. Kubernetes, standalone Tez) uses the ZK registry for daemon discovery.
+   * YARN Service LLAP uses the YARN APIs. Detection follows deployment config set by the operator.
+   */
+  static boolean usesRegistryBasedLlapStatus(Configuration conf) {
+    if (conf.get(CONFIG_STATUS_USE_REGISTRY) != null) {
+      return conf.getBoolean(CONFIG_STATUS_USE_REGISTRY, false);
+    }
+    if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_SERVER2_TEZ_USE_EXTERNAL_SESSIONS)) {
+      return true;
+    }
+    String tezFrameworkMode = conf.get(TEZ_AM_FRAMEWORK_MODE, "");
+    return TEZ_FRAMEWORK_MODE_STANDALONE_ZOOKEEPER.equalsIgnoreCase(tezFrameworkMode);
+  }
+
+  static void updateRunningThresholdAchieved(AppStatusBuilder appStatusBuilder, float runningNodesThreshold) {
+    Integer desiredInstances = appStatusBuilder.getDesiredInstances();
+    Integer liveInstances = appStatusBuilder.getLiveInstances();
+    if (desiredInstances == null || desiredInstances <= 0 || liveInstances == null) {
+      return;
+    }
+    if (!(appStatusBuilder.getState() == State.RUNNING_PARTIAL
+        || appStatusBuilder.getState() == State.RUNNING_ALL)) {
+      return;
+    }
+    float ratio = (float) liveInstances / (float) desiredInstances;
+    if (ratio >= runningNodesThreshold) {
+      appStatusBuilder.setRunningThresholdAchieved(true);
+    }
   }
 
   private void close() {

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceDriver.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceDriver.java
@@ -224,6 +224,7 @@ public class LlapStatusServiceDriver {
         return le.getExitCode();
       }
 
+      // Get the App report from YARN
       ApplicationReport appReport;
       try {
         appReport = getAppReport(appName, cl.getFindAppTimeoutMs());
@@ -232,6 +233,7 @@ public class LlapStatusServiceDriver {
         return e.getExitCode();
       }
 
+      // Process the report
       ExitCode ret;
       try {
         ret = processAppReport(appReport, appStatusBuilder);
@@ -242,34 +244,29 @@ public class LlapStatusServiceDriver {
 
       if (ret != ExitCode.SUCCESS) {
         return ret;
-      }
-
-      if (appStatusBuilder.getState() == State.APP_NOT_FOUND) {
+      } else if (appStatusBuilder.getState() == State.APP_NOT_FOUND
+          || NO_YARN_SERVICE_INFO_STATES.contains(appStatusBuilder.getState())) {
         return ExitCode.SUCCESS;
-      }
-
-      if (NO_YARN_SERVICE_INFO_STATES.contains(appStatusBuilder.getState())) {
-        return ExitCode.SUCCESS;
-      }
-
-      // Get information from YARN Service
-      try {
-        ret = populateAppStatusFromServiceStatus(appName, serviceClient, appStatusBuilder);
-      } catch (LlapStatusCliException e) {
-        // In case of failure, send back whatever is constructed so far - which would be from the AppReport
-        logError(e);
-        return e.getExitCode();
+      } else {
+        // Get information from YARN Service
+        try {
+          ret = populateAppStatusFromServiceStatus(appName, serviceClient, appStatusBuilder);
+        } catch (LlapStatusCliException e) {
+          // In case of failure, send back whatever is constructed so far - which would be from the AppReport
+          logError(e);
+          return e.getExitCode();
+        }
       }
 
       if (ret != ExitCode.SUCCESS) {
         return ret;
-      }
-
-      try {
-        ret = populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, false);
-      } catch (LlapStatusCliException e) {
-        logError(e);
-        return e.getExitCode();
+      } else {
+        try {
+          ret = populateAppStatusFromLlapRegistry(appStatusBuilder, watchTimeoutMs, false);
+        } catch (LlapStatusCliException e) {
+          logError(e);
+          return e.getExitCode();
+        }
       }
       if (ret == ExitCode.SUCCESS) {
         updateRunningThresholdAchieved(appStatusBuilder, cl.getRunningNodesThreshold());
@@ -548,7 +545,7 @@ public class LlapStatusServiceDriver {
   }
 
   /**
-   * Non-YARN LLAP (e.g. Kubernetes, standalone Tez) uses the ZK registry for daemon discovery.
+   * Non-YARN LLAP (e.g. Kubernetes, standalone Tez) uses the LLAP registry for daemon discovery.
    * YARN Service LLAP uses the YARN APIs. Detection follows deployment config set by the operator.
    */
   static boolean usesRegistryBasedLlapStatus(Configuration conf) {

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/cli/status/TestLlapStatusRegistryFallback.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/cli/status/TestLlapStatusRegistryFallback.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.llap.cli.status;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.llap.registry.LlapServiceInstance;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests registry-only status helpers used when LLAP runs without YARN.
+ */
+public class TestLlapStatusRegistryFallback {
+
+  @Test
+  public void testCreateLlapInstanceFromRegistryUsesWorkerIdentityWhenNoContainerId() {
+    LlapServiceInstance instance = new TestLlapServiceInstance("worker-1", "llap-host-0",
+        "http://llap-host-0:15002", 15004, 15001, 15551, Collections.emptyMap());
+
+    LlapInstance llapInstance = LlapStatusServiceDriver.createLlapInstanceFromRegistry(instance);
+
+    assertEquals("llap-host-0", llapInstance.getHostname());
+    assertEquals("worker-1", llapInstance.getContainerId());
+    assertEquals("http://llap-host-0:15002", llapInstance.getWebUrl());
+    assertEquals("http://llap-host-0:15002/status", llapInstance.getStatusUrl());
+    assertEquals(Integer.valueOf(15004), llapInstance.getMgmtPort());
+  }
+
+  @Test
+  public void testCreateLlapInstanceFromRegistryUsesYarnContainerIdWhenPresent() {
+    Map<String, String> props = new HashMap<>();
+    props.put(HiveConf.ConfVars.LLAP_DAEMON_CONTAINER_ID.varname, "container_123_456");
+    LlapServiceInstance instance = new TestLlapServiceInstance("worker-2", "yarn-host",
+        "http://yarn-host:15002", 15004, 15001, 15551, props);
+
+    LlapInstance llapInstance = LlapStatusServiceDriver.createLlapInstanceFromRegistry(instance);
+
+    assertEquals("container_123_456", llapInstance.getContainerId());
+  }
+
+  @Test
+  public void testUpdateStateFromInstanceCounts() {
+    AppStatusBuilder builder = new AppStatusBuilder();
+    builder.setDesiredInstances(2);
+
+    LlapStatusServiceDriver.updateStateFromInstanceCounts(builder, 2);
+    assertEquals(State.RUNNING_ALL, builder.getState());
+
+    LlapStatusServiceDriver.updateStateFromInstanceCounts(builder, 1);
+    assertEquals(State.RUNNING_PARTIAL, builder.getState());
+
+    LlapStatusServiceDriver.updateStateFromInstanceCounts(builder, 0);
+    assertEquals(State.LAUNCHING, builder.getState());
+  }
+
+  @Test
+  public void testUsesRegistryBasedLlapStatusFromExternalSessions() {
+    Configuration conf = new Configuration(false);
+    HiveConf.setBoolVar(conf, HiveConf.ConfVars.HIVE_SERVER2_TEZ_USE_EXTERNAL_SESSIONS, true);
+    assertTrue(LlapStatusServiceDriver.usesRegistryBasedLlapStatus(conf));
+  }
+
+  @Test
+  public void testUsesRegistryBasedLlapStatusFromTezFrameworkMode() {
+    Configuration conf = new Configuration(false);
+    conf.set("tez.am.framework.mode", "STANDALONE_ZOOKEEPER");
+    assertTrue(LlapStatusServiceDriver.usesRegistryBasedLlapStatus(conf));
+  }
+
+  @Test
+  public void testUsesYarnBasedLlapStatusByDefault() {
+    Configuration conf = new Configuration(false);
+    assertFalse(LlapStatusServiceDriver.usesRegistryBasedLlapStatus(conf));
+  }
+
+  @Test
+  public void testUpdateRunningThresholdAchievedWhenFullyRunning() {
+    AppStatusBuilder builder = new AppStatusBuilder();
+    builder.setDesiredInstances(2);
+    builder.setLiveInstances(2);
+    builder.setState(State.RUNNING_ALL);
+
+    LlapStatusServiceDriver.updateRunningThresholdAchieved(builder, 1.0f);
+    assertTrue(builder.isRunningThresholdAchieved());
+  }
+
+  @Test
+  public void testUpdateRunningThresholdAchievedWhenLaunching() {
+    AppStatusBuilder builder = new AppStatusBuilder();
+    builder.setDesiredInstances(2);
+    builder.setLiveInstances(0);
+    builder.setState(State.LAUNCHING);
+
+    LlapStatusServiceDriver.updateRunningThresholdAchieved(builder, 1.0f);
+    assertFalse(builder.isRunningThresholdAchieved());
+  }
+
+  private static final class TestLlapServiceInstance implements LlapServiceInstance {
+    private final String workerIdentity;
+    private final String host;
+    private final String servicesAddress;
+    private final int mgmtPort;
+    private final int rpcPort;
+    private final int shufflePort;
+    private final Map<String, String> properties;
+
+    private TestLlapServiceInstance(String workerIdentity, String host, String servicesAddress,
+        int mgmtPort, int rpcPort, int shufflePort, Map<String, String> properties) {
+      this.workerIdentity = workerIdentity;
+      this.host = host;
+      this.servicesAddress = servicesAddress;
+      this.mgmtPort = mgmtPort;
+      this.rpcPort = rpcPort;
+      this.shufflePort = shufflePort;
+      this.properties = properties;
+    }
+
+    @Override
+    public String getWorkerIdentity() {
+      return workerIdentity;
+    }
+
+    @Override
+    public String getHost() {
+      return host;
+    }
+
+    @Override
+    public int getRpcPort() {
+      return rpcPort;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+      return properties;
+    }
+
+    @Override
+    public int getManagementPort() {
+      return mgmtPort;
+    }
+
+    @Override
+    public int getShufflePort() {
+      return shufflePort;
+    }
+
+    @Override
+    public String getServicesAddress() {
+      return servicesAddress;
+    }
+
+    @Override
+    public int getOutputFormatPort() {
+      return 0;
+    }
+
+    @Override
+    public String getExternalHostname() {
+      return host;
+    }
+
+    @Override
+    public int getExternalClientsRpcPort() {
+      return 0;
+    }
+
+    @Override
+    public Resource getResource() {
+      return null;
+    }
+  }
+}

--- a/service/src/java/org/apache/hive/http/LlapServlet.java
+++ b/service/src/java/org/apache/hive/http/LlapServlet.java
@@ -104,6 +104,7 @@ public class LlapServlet extends HttpServlet {
           driver.outputJson(writer);
         } else {
           response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+          response.setHeader(HttpConstants.CACHE_CONTROL, "no-store");
         }
 
       } finally {

--- a/service/src/java/org/apache/hive/http/LlapServlet.java
+++ b/service/src/java/org/apache/hive/http/LlapServlet.java
@@ -100,6 +100,8 @@ public class LlapServlet extends HttpServlet {
         ExitCode ret = driver.run(LlapStatusServiceCommandLine.parseArguments(new String[] {"-n", clusterName}), 0);
         if (ret == ExitCode.SUCCESS) {
           driver.outputJson(writer);
+        } else {
+          response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
 
       } finally {

--- a/service/src/java/org/apache/hive/http/LlapServlet.java
+++ b/service/src/java/org/apache/hive/http/LlapServlet.java
@@ -102,6 +102,8 @@ public class LlapServlet extends HttpServlet {
         ExitCode ret = driver.run(LlapStatusServiceCommandLine.parseArguments(new String[] {"-n", clusterName}), 0);
         if (ret == ExitCode.SUCCESS) {
           driver.outputJson(writer);
+        } else {
+          response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
 
       } finally {

--- a/service/src/java/org/apache/hive/http/LlapServlet.java
+++ b/service/src/java/org/apache/hive/http/LlapServlet.java
@@ -115,6 +115,7 @@ public class LlapServlet extends HttpServlet {
     } catch (Exception e) {
       LOG.error("Caught exception while processing llap status request", e);
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.setHeader(HttpConstants.CACHE_CONTROL, "no-store");
     }
   }
 }

--- a/service/src/resources/hive-webapps/hiveserver2/llap.html
+++ b/service/src/resources/hive-webapps/hiveserver2/llap.html
@@ -15,8 +15,8 @@
 
     <link rel="stylesheet" type="text/css" href="/static/css/json.human.css">
     <script src="/static/js/jquery.min.js"></script>
-    <script src="/static/js/json.human.js"></script>
-    <script src="/static/js/llap.js"></script>
+    <script src="/static/js/json.human.js?v=1"></script>
+    <script src="/static/js/llap.js?v=2"></script>
   </head>
   <body>
       <div class="navbar  navbar-fixed-top navbar-default">

--- a/service/src/resources/hive-webapps/hiveserver2/llap.html
+++ b/service/src/resources/hive-webapps/hiveserver2/llap.html
@@ -15,8 +15,8 @@
 
     <link rel="stylesheet" type="text/css" href="/static/css/json.human.css">
     <script src="/static/js/jquery.min.js"></script>
-    <script src="/static/js/json.human.js?v=1"></script>
-    <script src="/static/js/llap.js?v=2"></script>
+    <script src="/static/js/json.human.js"></script>
+    <script src="/static/js/llap.js"></script>
   </head>
   <body>
       <div class="navbar  navbar-fixed-top navbar-default">

--- a/service/src/resources/hive-webapps/static/js/json.human.js
+++ b/service/src/resources/hive-webapps/static/js/json.human.js
@@ -139,8 +139,8 @@
             container = document.createElement('div');
 
             if (boolOpt.showImage && boolOpt.img && boolOpt.img.true && boolOpt.img.false
-                && ('' + boolOpt.img.true).startsWith('/static/')
-                && ('' + boolOpt.img.false).startsWith('/static/')) {
+                && ('' + boolOpt.img.true).indexOf('/static/') === 0
+                && ('' + boolOpt.img.false).indexOf('/static/') === 0) {
                 var img = document.createElement('img');
                 img.setAttribute('class', BOOL_IMAGE);
 
@@ -440,8 +440,8 @@
 
             if(boolOptions.showImage){
                 if(!boolOptions.img || !boolOptions.img.true || !boolOptions.img.false
-                    || !('' + boolOptions.img.true).startsWith('/static/')
-                    || !('' + boolOptions.img.false).startsWith('/static/')){
+                    || ('' + boolOptions.img.true).indexOf('/static/') !== 0
+                    || ('' + boolOptions.img.false).indexOf('/static/') !== 0){
                     boolOptions.showImage = false;
                 }
             }

--- a/service/src/resources/hive-webapps/static/js/json.human.js
+++ b/service/src/resources/hive-webapps/static/js/json.human.js
@@ -138,7 +138,9 @@
             var boolOpt = options.bool;
             container = document.createElement('div');
 
-            if (boolOpt.showImage) {
+            if (boolOpt.showImage && boolOpt.img && boolOpt.img.true && boolOpt.img.false
+                && ('' + boolOpt.img.true).startsWith('/static/')
+                && ('' + boolOpt.img.false).startsWith('/static/')) {
                 var img = document.createElement('img');
                 img.setAttribute('class', BOOL_IMAGE);
 
@@ -437,7 +439,9 @@
             }
 
             if(boolOptions.showImage){
-                if(!boolOptions.img.true && !boolOptions.img.false){
+                if(!boolOptions.img || !boolOptions.img.true || !boolOptions.img.false
+                    || !('' + boolOptions.img.true).startsWith('/static/')
+                    || !('' + boolOptions.img.false).startsWith('/static/')){
                     boolOptions.showImage = false;
                 }
             }

--- a/service/src/resources/hive-webapps/static/js/llap.js
+++ b/service/src/resources/hive-webapps/static/js/llap.js
@@ -32,11 +32,7 @@ window.options = {
             true : "true",
             false : "false"
         },
-        showImage : true,
-        img : {
-            true : 'css/true.png',
-            false : 'css/false.png'
-        }
+        showImage : false
     }
 };
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1.This PR fixes the HiveServer2 LLAP status page (/llap.html, backed by GET /llap) on non-YARN deployments such as Kubernetes and Docker. Today LlapServlet delegates to LlapStatusServiceDriver, which only queries YARN for the LLAP application. On K8s/Docker, LLAP daemons register in ZooKeeper instead of YARN, so the driver returns APP_NOT_FOUND and the UI never shows running instances.
2.The main change is config-based routing in LlapStatusServiceDriver: when the deployment is detected as non-YARN (via hive.server2.tez.use.external.sessions=true, tez.am.framework.mode=STANDALONE_ZOOKEEPER, or the override hive.llapcli.status.use-registry), status is populated from the LLAP ZK registry instead of YARN. For those deployments, worker UUIDs are used as container IDs when YARN container IDs are absent. The YARN path is unchanged for classic YARN LLAP.
3.This PR also fixes runningThresholdAchieved not being set for servlet/one-shot callers by calling updateRunningThresholdAchieved() after a successful registry or YARN status lookup. LlapServlet now returns HTTP 500 when status lookup fails. On the UI side, it removes references to missing boolean PNG assets in llap.js, adds a defensive guard in json.human.js so bool icons are only rendered for valid /static/ paths, and adds cache-buster query params in llap.html. Unit tests are added in TestLlapStatus

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
On Kubernetes and Docker, LLAP does not run as a YARN application. Daemons register in ZooKeeper, but the status driver only looked up YARN and returned early with APP_NOT_FOUND before consulting the registry. That broke /llap.html for operators running LLAP on K8s/Docker — they could not see cluster state, instance counts, or daemon web URLs from HiveServer2.
The runningThresholdAchieved field was also never set for the servlet path, so the UI always showed false even when all daemons were up. The broken boolean icon beside runningThresholdAchieved is a separate pre-existing UI bug (missing PNG assets since HIVE-13467); this PR fixes that as well so the page renders cleanly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. On non-YARN LLAP deployments, /llap.html and GET /llap now report the correct state (RUNNING_ALL / RUNNING_PARTIAL instead of APP_NOT_FOUND), show live instance counts and daemon web URLs from the registry, and set runningThresholdAchieved to true when the running threshold is met. On YARN LLAP deployments, behavior is unchanged. When status lookup fails, the servlet returns HTTP 500 instead of 200 with incomplete JSON. The LLAP UI no longer shows a broken image icon before boolean fields; it displays plain true/false text instead.

Before :
<img width="3456" height="1120" alt="image" src="https://github.com/user-attachments/assets/875247ef-e8ca-48a3-8b05-6a57d7b5bbcb" />

After:
<img width="1728" height="318" alt="image" src="https://github.com/user-attachments/assets/79d86e07-070b-438d-bb0e-9e23917812b7" />


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1.Unit tests were added in TestLlapStatusRegistryFallback.java covering registry instance creation (worker identity vs YARN container ID), state updates from instance counts, config-based detection of registry vs YARN status lookup, and runningThresholdAchieved logic. These were run with mvn test -pl llap-server -Dtest=TestLlapStatusRegistryFallback.
2.End-to-end testing used the Docker LLAP stack in packaging/src/docker/ with ./start-hive.sh --llap and a locally built apache/hive:4.3.0-SNAPSHOT image