### PR TITLE
HIVE-29584: Invalidate RawStore after Direct SQL connection failures

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.hive.metastore;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLTransientConnectionException;
 import java.sql.SQLTransactionRollbackException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -215,6 +218,27 @@ public class DatabaseProduct implements Configurable {
   public static boolean isRecoverableException(Throwable t) {
     return Stream.of(unrecoverableExceptions)
                  .allMatch(ex -> ExceptionUtils.indexOfType(t, ex) < 0);
+  }
+
+  public static boolean isConnectionException(Throwable t) {
+    while (t != null) {
+      if (t instanceof SQLNonTransientConnectionException
+          || t instanceof SQLRecoverableException
+          || t instanceof SQLTransientConnectionException) {
+        return true;
+      }
+      if (t instanceof SQLException sqlException) {
+        for (SQLException current = sqlException; current != null;
+            current = current.getNextException()) {
+          String sqlState = current.getSQLState();
+          if (sqlState != null && sqlState.startsWith("08")) {
+            return true;
+          }
+        }
+      }
+      t = t.getCause();
+    }
+    return false;
   }
 
   public final boolean isDERBY() {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandlerContext.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandlerContext.java
@@ -155,6 +155,21 @@ public final class HMSHandlerContext {
     context.get().rawStore = rawStore;
   }
 
+  /**
+   * Remove and shut down the RawStore associated with the current handler thread.
+   *
+   * @return true if a RawStore was present
+   */
+  public static boolean invalidateRawStore() {
+    RawStore rawStore = context.get().rawStore;
+    context.get().rawStore = null;
+    if (rawStore == null) {
+      return false;
+    }
+    rawStore.shutdown();
+    return true;
+  }
+
   public static void setTxnStore(TxnStore txnStore) {
     context.get().txnStore = txnStore;
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -377,9 +377,13 @@ public class ObjectStore implements RawStore, Configurable {
   @Override
   public void shutdown() {
     LOG.info("RawStore: {}, with PersistenceManager: {} will be shutdown", this, pm);
-    if (pm != null) {
-      pm.close();
-      pm = null;
+    PersistenceManager persistenceManager = pm;
+    pm = null;
+    currentTransaction = null;
+    openTrasactionCalls = 0;
+    transactionStatus = TXN_STATUS.NO_STATE;
+    if (persistenceManager != null) {
+      persistenceManager.close();
     }
   }
 
@@ -548,7 +552,9 @@ public class ObjectStore implements RawStore, Configurable {
       // remove all detached objects from the cache, since the transaction is
       // being rolled back they are no longer relevant, and this prevents them
       // from reattaching in future transactions
-      pm.evictAll();
+      if (pm != null) {
+        pm.evictAll();
+      }
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/directsql/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/directsql/MetaStoreDirectSql.java
@@ -1983,7 +1983,9 @@ public class MetaStoreDirectSql {
       assert pm.currentTransaction().isActive(); // must be inside tx together with queries
       executeNoResult(stmt);
     } catch (SQLException sqlEx) {
-      throw new MetaException("Error setting ansi quotes: " + sqlEx.getMessage());
+      MetaException metaException = new MetaException("Error setting ansi quotes: " + sqlEx.getMessage());
+      metaException.initCause(sqlEx);
+      throw metaException;
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metastore/GetHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metastore/GetHelper.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.metastore.metastore;
 import com.codahale.metrics.Counter;
 import com.google.common.annotations.VisibleForTesting;
 
+import javax.jdo.JDODataStoreException;
 import javax.jdo.JDOException;
 import javax.jdo.PersistenceManager;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.List;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.metastore.DatabaseProduct;
 import org.apache.hadoop.hive.metastore.ExceptionHandler;
+import org.apache.hadoop.hive.metastore.HMSHandlerContext;
 import org.apache.hadoop.hive.metastore.directsql.MetaStoreDirectSql;
 import org.apache.hadoop.hive.metastore.RawStore;
 import org.apache.hadoop.hive.metastore.api.InvalidInputException;
@@ -59,6 +61,7 @@ public abstract class GetHelper<A, T> {
   protected final List<String> partitionFields;
   protected final A argument;
   private boolean success = false;
+  private boolean storeInvalidated = false;
   protected T results = null;
 
   public GetHelper(RawStoreBundle rsb, A args) throws MetaException {
@@ -148,6 +151,14 @@ public abstract class GetHelper<A, T> {
   }
 
   private void handleDirectSqlError(Exception ex, String savePoint) throws MetaException, NoSuchObjectException {
+    if (DatabaseProduct.isConnectionException(ex)) {
+      LOG.warn("Direct SQL failed because the metastore database connection is not usable", ex);
+      directSqlErrors.inc();
+      invalidateRawStore(ex);
+      throw ExceptionHandler.newMetaException(new JDODataStoreException(
+          "Direct SQL failed because the metastore database connection is not usable", ex));
+    }
+
     String message = null;
     try {
       message = generateShorterMessage(ex);
@@ -193,6 +204,18 @@ public abstract class GetHelper<A, T> {
 
     directSqlErrors.inc();
     doUseDirectSql = false;
+  }
+
+  private void invalidateRawStore(Exception originalException) {
+    storeInvalidated = true;
+    try {
+      if (!HMSHandlerContext.invalidateRawStore()) {
+        baseStore.shutdown();
+      }
+    } catch (Exception cleanupException) {
+      originalException.addSuppressed(cleanupException);
+      LOG.warn("Failed to shut down RawStore after a Direct SQL connection error", cleanupException);
+    }
   }
 
   public void setTransactionSavePoint(String savePoint) {
@@ -252,7 +275,7 @@ public abstract class GetHelper<A, T> {
   }
 
   private void close() {
-    if (!success) {
+    if (!success && !storeInvalidated) {
       baseStore.rollbackTransaction();
     }
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -100,6 +100,7 @@ import org.mockito.ArgumentMatchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jdo.JDODataStoreException;
 import javax.jdo.Query;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -1424,6 +1425,47 @@ public class TestObjectStore {
     Assert.assertEquals(1, directSqlErrors.getCount());
   }
 
+  @Test
+  public void testDirectSqlConnectionErrorInvalidatesRawStore() throws Exception {
+    AtomicBoolean runJdo = new AtomicBoolean(false);
+    MetaException directSqlFailure = null;
+    objectStore.openTransaction();
+    HMSHandlerContext.setRawStore(objectStore);
+    try {
+      new GetHelper<DatabaseName, Database>(objectStore.createRawStoreBundle(),
+          new DatabaseName(DEFAULT_CATALOG_NAME, "foo")) {
+        @Override
+        protected Database getSqlResult() throws MetaException {
+          MetaException ex = new MetaException("Direct SQL connection failure");
+          ex.initCause(new SQLException("Communication link failure", "08S01"));
+          throw ex;
+        }
+
+        @Override
+        protected String describeResult() {
+          return "";
+        }
+
+        @Override
+        protected Database getJdoResult() {
+          runJdo.set(true);
+          return null;
+        }
+      }.run(false);
+      Assert.fail("Expected a connection-level Direct SQL failure");
+    } catch (MetaException ex) {
+      directSqlFailure = ex;
+      Assert.assertFalse(HMSHandlerContext.getRawStore().isPresent());
+    } finally {
+      // Handlers that own an outer transaction still execute this cleanup after GetHelper fails.
+      objectStore.rollbackTransaction();
+      HMSHandlerContext.clear();
+    }
+
+    Assert.assertTrue(directSqlFailure.getCause() instanceof JDODataStoreException);
+    Assert.assertFalse(runJdo.get());
+  }
+
   @Test(expected = MetaException.class)
   public void testLockDbTableThrowsExceptionWhenTableIsNotAllowedToLock() throws Exception {
     MetaStoreDirectSql metaStoreDirectSql = new MetaStoreDirectSql(objectStore.getPersistenceManager(), conf, null);
@@ -2195,4 +2237,3 @@ public class TestObjectStore {
     };
   }
 }
-


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Direct SQL fails with a JDBC connection-level error, invalidate and shut
down the RawStore cached in `HMSHandlerContext` instead of falling back to ORM
with the same broken PersistenceManager/connection.

The change:

* preserves the original `SQLException` from `MetaStoreDirectSql.prepareTxn()`;
* recognizes SQLState class `08` and JDBC connection exception subclasses;
* removes the thread-local RawStore before shutdown;
* wraps the failure as a JDO datastore error so `RetryingHMSHandler` can retry;
* makes ObjectStore cleanup safe when an outer handler subsequently rolls back;
* keeps the existing ORM fallback for non-connection Direct SQL failures.

## Why are the changes needed?

After a transient metastore database communication failure, a handler thread
can retain a closed connection through its cached PersistenceManager. HikariCP
cannot replace that connection while the wrapper remains in use, so later RPCs
on the same handler thread can repeatedly fail with `Connection is closed`
until HMS is restarted.

JIRA: https://issues.apache.org/jira/browse/HIVE-29584

## How was this patch tested?

* Added a regression test for SQLState `08S01` that verifies no ORM fallback,
  RawStore invalidation, preservation of the JDO-backed error, and safe outer
  transaction rollback. The test failed with an NPE before the cleanup fix and
  passes afterward.
* `TestObjectStore#testDirectSqlConnectionErrorInvalidatesRawStore`
* `TestObjectStore#testDirectSqlErrorMetrics`
* `TestObjectStore#testNoJdoForUnrecoverableException`
* `TestRetriesInRetryingHMSHandler#testWrappedMetaExceptionRetry`
* `mvn -pl standalone-metastore/metastore-server -DskipTests checkstyle:check`
