### PR TITLE
HIVE-29787: Separate default JSON metrics file locations for HS2 and HMS to prevent overwriting

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3649,10 +3649,10 @@ public class HiveConf extends Configuration {
         "Deprecated, use HIVE_CODAHALE_METRICS_REPORTER_CLASSES instead. This configuration will be"
             + " overridden by HIVE_CODAHALE_METRICS_REPORTER_CLASSES if present. " +
             "Comma separated list of JMX, CONSOLE, JSON_FILE, HADOOP2"),
-    HIVE_METRICS_JSON_FILE_LOCATION("hive.service.metrics.file.location", "/tmp/report.json",
+    HIVE_METRICS_JSON_FILE_LOCATION("hive.service.metrics.file.location", "/tmp/hs2-report.json",
         "For metric class org.apache.hadoop.hive.common.metrics.metrics2.CodahaleMetrics JSON_FILE reporter, the location of local JSON metrics file.  " +
         "This file will get overwritten at every interval."),
-    HIVE_METRICS_JSON_FILE_INTERVAL("hive.service.metrics.file.frequency", "5000ms",
+    HIVE_METRICS_JSON_FILE_INTERVAL("hive.service.metrics.file.frequency", "60000ms",
         new TimeValidator(TimeUnit.MILLISECONDS),
         "For metric class org.apache.hadoop.hive.common.metrics.metrics2.JsonFileMetricsReporter, " +
         "the frequency of updating JSON metrics file."),

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1229,7 +1229,7 @@ public class MetastoreConf {
         "hive.service.metrics.file.frequency", 60000, TimeUnit.MILLISECONDS,
         "For json metric reporter, the frequency of updating JSON metrics file."),
     METRICS_JSON_FILE_LOCATION("metastore.metrics.file.location",
-        "hive.service.metrics.file.location", "/tmp/report.json",
+        "hive.service.metrics.file.location", "/tmp/hms-report.json",
         "For metric class json metric reporter, the location of local JSON metrics file.  " +
             "This file will get overwritten at every interval."),
     METRICS_SLF4J_LOG_FREQUENCY_MINS("metastore.metrics.slf4j.frequency",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check [HIVE-29787](https://issues.apache.org/jira/browse/HIVE-29787), The goal is to have separate json for hs2 and hms and additionally setting the default frequency for HS2 metrics to 60 sec i.e. same as of HMS


### Why are the changes needed?
When both HiveServer2 and Hive Metastore are running on the same host with the `JsonFileMetricsReporter` enabled, they experience a race condition resulting in telemetry/observability loss. Both processes default to writing their metric snapshots to the exact same file: `/tmp/report.json`


### Does this PR introduce _any_ user-facing change?
**Yes** . The `JsonFileMetricsReporter` dumping file name default fallback location is changing from `/tmp/report.json` -> `/tmp/hs2-report.json` or `/tmp/hms-report.json` accordingly. 

### How was this patch tested?
On Cluster testing
