### PR TITLE
HIVE-29301: Missing histogram in DESCRIBE FORMATTED after prior column DESCRIBE

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/processors/SetProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/processors/SetProcessor.java
@@ -37,8 +37,12 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveVariableSource;
 import org.apache.hadoop.hive.conf.VariableSubstitution;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Schema;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.orc.OrcConf;
 import org.slf4j.Logger;
@@ -76,6 +80,12 @@ public class SetProcessor implements CommandProcessor {
 
   private static final Pattern TIME_ZONE_PATTERN =
       Pattern.compile("^time(\\s)+zone\\s", Pattern.CASE_INSENSITIVE);
+
+  private static final Set<String> EMBEDDED_MS_STATS_FETCH_KEYS = Sets.newHashSet(
+      MetastoreConf.ConfVars.STATS_FETCH_KLL.getVarname(),
+      MetastoreConf.ConfVars.STATS_FETCH_KLL.getHiveName(),
+      MetastoreConf.ConfVars.STATS_FETCH_BITVECTOR.getVarname(),
+      MetastoreConf.ConfVars.STATS_FETCH_BITVECTOR.getHiveName());
 
   public static boolean getBoolean(String value) {
     if (value.equals("on") || value.equals("true")) {
@@ -273,7 +283,26 @@ public class SetProcessor implements CommandProcessor {
     if (register) {
       ss.getOverriddenConfigurations().put(key, value);
     }
+    syncEmbeddedMetastoreConfIfNeeded(conf, key);
     return result;
+  }
+
+  /**
+   * Session SET updates HiveConf in place, but embedded ObjectStore may still read a stale
+   * Configuration reference. Rebind handler and ObjectStore when stats fetch flags change.
+   */
+  private static void syncEmbeddedMetastoreConfIfNeeded(HiveConf conf, String key) {
+    if (!EMBEDDED_MS_STATS_FETCH_KEYS.contains(key)) {
+      return;
+    }
+    try {
+      IMetaStoreClient msc = Hive.get(conf).getMSC();
+      if (msc.isLocalMetaStore()) {
+        msc.syncEmbeddedHandlerConf(conf);
+      }
+    } catch (HiveException | MetaException e) {
+      LOG.warn("Failed to sync embedded metastore configuration for {}", key, e);
+    }
   }
 
   private SortedMap<String,String> propertiesToSortedMap(Properties p){

--- a/ql/src/test/queries/clientpositive/stats_histogram_order_broken.q
+++ b/ql/src/test/queries/clientpositive/stats_histogram_order_broken.q
@@ -1,0 +1,15 @@
+set hive.stats.kll.enable=true;
+set metastore.stats.fetch.bitvector=true;
+
+CREATE TABLE tab1 AS (SELECT 1 as key);
+
+DESCRIBE FORMATTED tab1 key;
+set metastore.stats.fetch.kll=true;
+
+CREATE TABLE tab2 AS (SELECT 1 as key);
+
+ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS;
+DESCRIBE FORMATTED tab2 key;
+
+DROP TABLE tab1;
+DROP TABLE tab2;

--- a/ql/src/test/queries/clientpositive/stats_histogram_order_working.q
+++ b/ql/src/test/queries/clientpositive/stats_histogram_order_working.q
@@ -1,0 +1,15 @@
+set hive.stats.kll.enable=true;
+set metastore.stats.fetch.bitvector=true;
+
+CREATE TABLE tab1 AS (SELECT 1 as key);
+
+set metastore.stats.fetch.kll=true;
+DESCRIBE FORMATTED tab1 key;
+
+CREATE TABLE tab2 AS (SELECT 1 as key);
+
+ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS;
+DESCRIBE FORMATTED tab2 key;
+
+DROP TABLE tab1;
+DROP TABLE tab2;

--- a/ql/src/test/results/clientpositive/llap/stats_histogram_order_broken.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_histogram_order_broken.q.out
@@ -43,12 +43,12 @@ PREHOOK: query: ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS
 PREHOOK: type: ANALYZE_TABLE
 PREHOOK: Input: default@tab2
 PREHOOK: Output: default@tab2
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS
 POSTHOOK: type: ANALYZE_TABLE
 POSTHOOK: Input: default@tab2
 POSTHOOK: Output: default@tab2
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 PREHOOK: query: DESCRIBE FORMATTED tab2 key
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@tab2

--- a/ql/src/test/results/clientpositive/llap/stats_histogram_order_broken.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_histogram_order_broken.q.out
@@ -1,0 +1,91 @@
+PREHOOK: query: CREATE TABLE tab1 AS (SELECT 1 as key)
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tab1
+POSTHOOK: query: CREATE TABLE tab1 AS (SELECT 1 as key)
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tab1
+POSTHOOK: Lineage: tab1.key SIMPLE []
+PREHOOK: query: DESCRIBE FORMATTED tab1 key
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@tab1
+POSTHOOK: query: DESCRIBE FORMATTED tab1 key
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@tab1
+col_name            	key                 
+data_type           	int                 
+min                 	1                   
+max                 	1                   
+num_nulls           	0                   
+distinct_count      	1                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"key\":\"true\"}}
+PREHOOK: query: CREATE TABLE tab2 AS (SELECT 1 as key)
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tab2
+POSTHOOK: query: CREATE TABLE tab2 AS (SELECT 1 as key)
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tab2
+POSTHOOK: Lineage: tab2.key SIMPLE []
+PREHOOK: query: ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: default@tab2
+PREHOOK: Output: default@tab2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: default@tab2
+POSTHOOK: Output: default@tab2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: DESCRIBE FORMATTED tab2 key
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@tab2
+POSTHOOK: query: DESCRIBE FORMATTED tab2 key
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@tab2
+col_name            	key                 
+data_type           	int                 
+min                 	1                   
+max                 	1                   
+num_nulls           	0                   
+distinct_count      	1                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: 1, Q2: 1, Q3: 1 
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"key\":\"true\"}}
+PREHOOK: query: DROP TABLE tab1
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@tab1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tab1
+POSTHOOK: query: DROP TABLE tab1
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@tab1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tab1
+PREHOOK: query: DROP TABLE tab2
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@tab2
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tab2
+POSTHOOK: query: DROP TABLE tab2
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@tab2
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tab2

--- a/ql/src/test/results/clientpositive/llap/stats_histogram_order_working.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_histogram_order_working.q.out
@@ -1,0 +1,92 @@
+PREHOOK: query: CREATE TABLE tab1 AS (SELECT 1 as key)
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tab1
+POSTHOOK: query: CREATE TABLE tab1 AS (SELECT 1 as key)
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tab1
+POSTHOOK: Lineage: tab1.key SIMPLE []
+PREHOOK: query: DESCRIBE FORMATTED tab1 key
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@tab1
+POSTHOOK: query: DESCRIBE FORMATTED tab1 key
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@tab1
+col_name            	key                 
+data_type           	int                 
+min                 	1                   
+max                 	1                   
+num_nulls           	0                   
+distinct_count      	1                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: 1, Q2: 1, Q3: 1 
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"key\":\"true\"}}
+PREHOOK: query: CREATE TABLE tab2 AS (SELECT 1 as key)
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tab2
+POSTHOOK: query: CREATE TABLE tab2 AS (SELECT 1 as key)
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tab2
+POSTHOOK: Lineage: tab2.key SIMPLE []
+PREHOOK: query: ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: default@tab2
+PREHOOK: Output: default@tab2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: default@tab2
+POSTHOOK: Output: default@tab2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: DESCRIBE FORMATTED tab2 key
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@tab2
+POSTHOOK: query: DESCRIBE FORMATTED tab2 key
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@tab2
+col_name            	key                 
+data_type           	int                 
+min                 	1                   
+max                 	1                   
+num_nulls           	0                   
+distinct_count      	1                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: 1, Q2: 1, Q3: 1 
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"key\":\"true\"}}
+PREHOOK: query: DROP TABLE tab1
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@tab1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tab1
+POSTHOOK: query: DROP TABLE tab1
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@tab1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tab1
+PREHOOK: query: DROP TABLE tab2
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@tab2
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tab2
+POSTHOOK: query: DROP TABLE tab2
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@tab2
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tab2

--- a/ql/src/test/results/clientpositive/llap/stats_histogram_order_working.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_histogram_order_working.q.out
@@ -44,12 +44,12 @@ PREHOOK: query: ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS
 PREHOOK: type: ANALYZE_TABLE
 PREHOOK: Input: default@tab2
 PREHOOK: Output: default@tab2
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: ANALYZE TABLE tab2 COMPUTE STATISTICS FOR COLUMNS
 POSTHOOK: type: ANALYZE_TABLE
 POSTHOOK: Input: default@tab2
 POSTHOOK: Output: default@tab2
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 PREHOOK: query: DESCRIBE FORMATTED tab2 key
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@tab2

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -74,6 +74,15 @@ public interface IMetaStoreClient extends AutoCloseable {
   }
 
   /**
+   * Rebind embedded metastore handler configuration after session-level SET.
+   * Default no-op; only embedded clients override this. 
+   * Remote metastore clients must not perform any work here.
+   */
+  @InterfaceAudience.Private
+  default void syncEmbeddedHandlerConf(Configuration conf) {
+  }
+
+  /**
    *  Tries to reconnect this MetaStoreClient to the MetaStore.
    */
   void reconnect() throws MetaException;

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/MetaStoreClientWrapper.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/MetaStoreClientWrapper.java
@@ -61,6 +61,11 @@ public abstract class MetaStoreClientWrapper extends BaseMetaStoreClient {
   }
 
   @Override
+  public void syncEmbeddedHandlerConf(Configuration conf) {
+    delegate.syncEmbeddedHandlerConf(conf);
+  }
+
+  @Override
   public void reconnect() throws MetaException {
     delegate.reconnect();
   }

--- a/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-client/src/main/java/org/apache/hadoop/hive/metastore/client/ThriftHiveMetaStoreClient.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.metastore.DefaultMetaStoreFilterHookImpl;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreFilterHook;
 import org.apache.hadoop.hive.metastore.MetaStorePlainSaslHelper;
 import org.apache.hadoop.hive.metastore.PartitionDropOptions;
@@ -430,6 +431,20 @@ public class ThriftHiveMetaStoreClient extends BaseMetaStoreClient {
   @Override
   public boolean isLocalMetaStore() {
     return localMetaStore;
+  }
+
+  @Override
+  public void syncEmbeddedHandlerConf(Configuration conf) {
+    if (!localMetaStore || client == null) {
+      return;
+    }
+    try {
+      java.lang.reflect.Method setConfMethod =
+          client.getClass().getMethod("setConf", Configuration.class);
+      setConfMethod.invoke(client, conf);
+    } catch (ReflectiveOperationException e) {
+      LOG.warn("Failed to sync embedded metastore handler configuration", e);
+    }
   }
 
   @Override


### PR DESCRIPTION
For embedded metastore, session level SET updates HiveConf in place, but embedded ObjectStore can keep a stale Configuration reference after an earlier column stats fetch, leaving describe formatted histogram values empty despite metastore.stats.fetch.kll=true. Rebind the embedded handler and ObjectStore when
stats fetch keys change in embedded mode only. Add order-dependent qfile reproducers verified with TestMiniLlapCliDriver.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When `metastore.stats.fetch.kll=true` is set after an earlier `DESCRIBE FORMATTED` on a column in the same session, histogram may be shown as empty on a subsequent `DESCRIBE FORMATTED` even when kll data exists in the metastore.
This PR fixes that for embedded metastore by re-syncing the embedded handler and ObjectStore configuration after session level config set for stats-fetch flags.

Added `syncEmbeddedHandlerConf` method under `IMetaStoreClient` (default no-op), delegate through `MetaStoreClientWrapper`, implemented in `ThriftHiveMetaStoreClient` to rebind embedded handler/ObjectStore when performing set on stats-fetch keys.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For embedded metastore, session level set updates session HiveConf in place, but embedded ObjectStore can retain a stale config reference after an earlier column stats fetch, causing inconsistency between display and actual metadata storage.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. For embedded metastore sessions, set metastore.stats.fetch.kll=true after an earlier column desc formatted statement now correctly populates histogram values on subsequent desc formatted commands.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added the qtest files using the examples from the jira https://issues.apache.org/jira/browse/HIVE-29301