### PR TITLE
HIVE-29798: NumberFormatException while reading a table having UNION subdirs after ACID conversion

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
@@ -146,12 +146,18 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
           Path path = i.next().getPath();
           Path parent = path.getParent();
           if (parent.getName().startsWith(prefix)) {
-            // We do rename by including the name of parent directory into the filename so that there are no clashes
-            // when we move the files to the parent directory. Ex. HIVE_UNION_SUBDIR_1/000000_0 -> 1_000000_0
+            // Fold the subdir index into the filename so there are no clashes when the files
+            // are moved to the parent directory, and so that the resulting name still matches
+            // the "original data file" convention that both the ACID reader (AcidUtils.
+            // ORIGINAL_PATTERN_COPY) and the metastore's non-ACID→ACID validator (Transactional
+            // ValidationListener.ORIGINAL_PATTERN_COPY) recognize:
+            //   HIVE_UNION_SUBDIR_1/000000_0 -> 000000_0_copy_1
+            // See Utilities.COPY_KEYWORD.
             String parentOfParent = parent.getParent().toString();
             String parentNameSuffix = parent.getName().substring(prefix.length());
 
-            fs.rename(path, new Path(parentOfParent + "/" + parentNameSuffix + "_" + path.getName()));
+            fs.rename(path,
+                new Path(parentOfParent + "/" + path.getName() + Utilities.COPY_KEYWORD + parentNameSuffix));
 
             unionSubdirs.add(parent);
           }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
@@ -146,18 +146,23 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
           Path path = i.next().getPath();
           Path parent = path.getParent();
           if (parent.getName().startsWith(prefix)) {
-            // Fold the subdir index into the filename so there are no clashes when the files
-            // are moved to the parent directory, and so that the resulting name still matches
-            // the "original data file" convention that both the ACID reader (AcidUtils.
-            // ORIGINAL_PATTERN_COPY) and the metastore's non-ACID→ACID validator (Transactional
-            // ValidationListener.ORIGINAL_PATTERN_COPY) recognize:
-            //   HIVE_UNION_SUBDIR_1/000000_0 -> 000000_0_copy_1
-            // See Utilities.COPY_KEYWORD.
+            // Fold the subdir index into the *attempt-id* portion of the filename — not
+            // the _copy_ suffix — so there are no clashes when the files are moved to the
+            // parent directory, and so that the flattened name still lives in the plain
+            // writer-name namespace that ORIGINAL_PATTERN ([0-9]+_[0-9]+) accepts and
+            // that both the ACID reader and the metastore's non-ACID→ACID validator
+            // recognize. Keeping this out of the _copy_ namespace also means it composes
+            // cleanly with the HIVE-28822 uniqueness tag: a subsequent Hive.pickDestFilePath
+            // on a non-atomic-rename FS can freely append its own _copy_<queryTag> on top
+            // without a double-copy or a shape collision.
+            //   newAttemptId = subdirIdx * 100000 + originalAttempt
+            //   HIVE_UNION_SUBDIR_1/000000_0  -> 000000_100000
+            //   HIVE_UNION_SUBDIR_23/000000_2 -> 000000_2300002
             String parentOfParent = parent.getParent().toString();
-            String parentNameSuffix = parent.getName().substring(prefix.length());
+            int subdirIdx = Integer.parseInt(parent.getName().substring(prefix.length()));
+            String flattenedName = ParsedOutputFileName.parse(path.getName()).withFoldedSubdirIndex(subdirIdx);
 
-            fs.rename(path,
-                new Path(parentOfParent + "/" + path.getName() + Utilities.COPY_KEYWORD + parentNameSuffix));
+            fs.rename(path, new Path(parentOfParent + "/" + flattenedName));
 
             unionSubdirs.add(parent);
           }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ParsedOutputFileName.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ParsedOutputFileName.java
@@ -46,7 +46,10 @@ public class ParsedOutputFileName {
       "^(.*?)?" + // any prefix
       "(\\(.*\\))?" + // taskId prefix
       "(\\d+)" + // taskId
-      "(?:_(\\d{1,6}))?" + // _<attemptId> (limited to 6 digits)
+      "(?:_(\\d{1,10}))?" + // _<attemptId>
+      // Cap raised from 6 to 10 digits so MoveTask.foldSubdirIntoAttemptId can
+      // encode a HIVE_UNION_SUBDIR_<N> index in the attempt-id namespace as
+      // `subdirIdx * 100000 + originalAttempt` without needing a copy suffix.
       "(?:_copy_(\\d{1,6}|[0-9a-fA-F]{16}))?" + // copy suffix: numeric counter, or 16-hex uniqueness tag
       "(\\..*)?$"); // any suffix/file extension
 
@@ -61,6 +64,9 @@ public class ParsedOutputFileName {
   private final String copyIndex;
   private final String suffix;
   private final CharSequence filePrefixForCopy;
+  // Everything before the taskId (group 1 + group 2, if any) — includes any
+  // "tmp_" style leading prefix that taskIdPrefix on its own would drop.
+  private final CharSequence preTaskIdPrefix;
 
   private ParsedOutputFileName(CharSequence fileName) {
     Matcher m = COPY_FILE_NAME_TO_TASK_ID_REGEX.matcher(fileName);
@@ -72,6 +78,7 @@ public class ParsedOutputFileName {
       copyIndex = m.group(5);
       suffix = m.group(6);
       filePrefixForCopy = m.end(4) >= 0 ? fileName.subSequence(0, m.end(4)) : null;
+      preTaskIdPrefix = fileName.subSequence(0, m.start(3));
     } else {
       taskIdPrefix = null;
       taskId = null;
@@ -79,6 +86,7 @@ public class ParsedOutputFileName {
       copyIndex = null;
       suffix = null;
       filePrefixForCopy = null;
+      preTaskIdPrefix = null;
     }
   }
 
@@ -138,6 +146,43 @@ public class ParsedOutputFileName {
       throw new HiveException("Not expected format for copying files.");
     }
     return filePrefixForCopy + "_copy_" + idx;
+  }
+
+  /**
+   * Return a new filename with the given {@code subdirIdx} folded into the attempt-id
+   * portion: {@code newAttempt = subdirIdx * 100000 + originalAttempt}. TaskId prefix
+   * and file-extension suffix are preserved; any {@code _copy_} suffix on the source
+   * is dropped (this is a flatten operation, not a copy).
+   *
+   * <p>Called by {@link org.apache.hadoop.hive.ql.exec.MoveTask#flattenUnionSubdirectories(org.apache.hadoop.fs.Path)}
+   * when hoisting leaves out of {@code HIVE_UNION_SUBDIR_<subdirIdx>/} into the parent
+   * directory. Folding into the writer-name namespace ({@code [0-9]+_[0-9]+}) keeps
+   * the flattened name out of the {@code _copy_<HIVE-28822 uniqueness tag>} namespace
+   * that {@link org.apache.hadoop.hive.ql.metadata.Hive#pickDestFilePath} may later
+   * add on a non-atomic-rename FS — so the two mechanisms compose cleanly.
+   *
+   * <p>Examples:
+   * <pre>
+   *   000000_0,      subdirIdx=1  -> 000000_100000
+   *   000000_2,      subdirIdx=23 -> 000000_2300002
+   *   000000_3.gz,   subdirIdx=5  -> 000000_500003.gz
+   *   000000,        subdirIdx=7  -> 000000_700000
+   * </pre>
+   *
+   * @param subdirIdx the {@code HIVE_UNION_SUBDIR_<N>} index to fold in
+   * @return the flattened name
+   * @throws HiveException if the source name is not in a recognized writer shape
+   */
+  public String withFoldedSubdirIndex(int subdirIdx) throws HiveException {
+    if (!matches || taskId == null) {
+      throw new HiveException("Cannot fold subdir into attempt id; unexpected filename shape.");
+    }
+    long originalAttempt = attemptId != null ? Long.parseLong(attemptId) : 0L;
+    long newAttempt = ((long) subdirIdx) * 100_000L + originalAttempt;
+    String s = suffix != null ? suffix : "";
+    // preTaskIdPrefix includes any leading "tmp_" AND the "(prefix)" wrapper, so the
+    // rebuilt name matches what makeFilenameWithCopyIndex preserves.
+    return preTaskIdPrefix + taskId + "_" + newAttempt + s;
   }
 
   public String toString() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ParsedOutputFileName.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ParsedOutputFileName.java
@@ -178,7 +178,7 @@ public class ParsedOutputFileName {
       throw new HiveException("Cannot fold subdir into attempt id; unexpected filename shape.");
     }
     long originalAttempt = attemptId != null ? Long.parseLong(attemptId) : 0L;
-    long newAttempt = ((long) subdirIdx) * 100_000L + originalAttempt;
+    long newAttempt = subdirIdx * 100_000L + originalAttempt;
     String s = suffix != null ? suffix : "";
     // preTaskIdPrefix includes any leading "tmp_" AND the "(prefix)" wrapper, so the
     // rebuilt name matches what makeFilenameWithCopyIndex preserves.

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
@@ -341,7 +341,8 @@ public class VectorizedOrcAcidRowBatchReader
       if (deleteEventRegistry.isEmpty() && !rowIdProjected) {
         Path parent = orcSplit.getPath().getParent();
         while (parent != null && !rootPath.equals(parent)) {
-          if (parent.getName().startsWith(AcidUtils.BASE_PREFIX)) {
+          String parentName = parent.getName();
+          if (parentName.startsWith(AcidUtils.BASE_PREFIX)) {
             /**
              * The assumption here is that any base_x is filtered out by
              * {@link AcidUtils#getAcidState(Path, Configuration, ValidWriteIdList)}
@@ -351,7 +352,8 @@ public class VectorizedOrcAcidRowBatchReader
              */
             readerOptions.includeAcidColumns(false);
             break;
-          } else {
+          } else if (parentName.startsWith(AcidUtils.DELTA_PREFIX)
+              || parentName.startsWith(AcidUtils.DELETE_DELTA_PREFIX)) {
             ParsedDeltaLight pd = ParsedDeltaLight.parse(parent);
             if (validWriteIdList.isWriteIdRangeValid(pd.getMinWriteId(),
                 pd.getMaxWriteId()) == ValidWriteIdList.RangeResponse.ALL) {
@@ -361,6 +363,11 @@ public class VectorizedOrcAcidRowBatchReader
               break;
             }
           }
+          // Any other directory name (e.g. HIVE_UNION_SUBDIR_<N>/ produced by
+          // an INSERT ... UNION ALL against a table that was later converted
+          // to full ACID) is not an ACID container — skip it and keep walking
+          // up. Feeding such a name into ParsedDeltaLight.parse would throw
+          // NumberFormatException.
           parent = parent.getParent();
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
@@ -342,7 +342,8 @@ public class VectorizedOrcAcidRowBatchReader
       if (deleteEventRegistry.isEmpty() && !rowIdProjected) {
         Path parent = orcSplit.getPath().getParent();
         while (parent != null && !rootPath.equals(parent)) {
-          if (parent.getName().startsWith(AcidUtils.BASE_PREFIX)) {
+          String parentName = parent.getName();
+          if (parentName.startsWith(AcidUtils.BASE_PREFIX)) {
             /**
              * The assumption here is that any base_x is filtered out by
              * {@link AcidUtils#getAcidState(Path, Configuration, ValidWriteIdList)}
@@ -352,7 +353,8 @@ public class VectorizedOrcAcidRowBatchReader
              */
             readerOptions.includeAcidColumns(false);
             break;
-          } else {
+          } else if (parentName.startsWith(AcidUtils.DELTA_PREFIX)
+              || parentName.startsWith(AcidUtils.DELETE_DELTA_PREFIX)) {
             ParsedDeltaLight pd = ParsedDeltaLight.parse(parent);
             if (validWriteIdList.isWriteIdRangeValid(pd.getMinWriteId(),
                 pd.getMaxWriteId()) == ValidWriteIdList.RangeResponse.ALL) {
@@ -362,6 +364,11 @@ public class VectorizedOrcAcidRowBatchReader
               break;
             }
           }
+          // Any other directory name (e.g. HIVE_UNION_SUBDIR_<N>/ produced by
+          // an INSERT ... UNION ALL against a table that was later converted
+          // to full ACID) is not an ACID container — skip it and keep walking
+          // up. Feeding such a name into ParsedDeltaLight.parse would throw
+          // NumberFormatException.
           parent = parent.getParent();
         }
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/ParsedOutputFileNameTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/ParsedOutputFileNameTest.java
@@ -163,6 +163,96 @@ public class ParsedOutputFileNameTest {
     Assert.assertNull(ParsedOutputFileName.parse("000001_0_copy_abcd1234deadbeez").getCopyIndex());
   }
 
+  /**
+   * {@link ParsedOutputFileName#withFoldedSubdirIndex(int)} encodes the
+   * {@code HIVE_UNION_SUBDIR_<N>} index into the attempt-id portion of the writer
+   * name via {@code newAttempt = subdirIdx * 100000 + originalAttempt}. Called by
+   * {@link MoveTask#flattenUnionSubdirectories(org.apache.hadoop.fs.Path)} to hoist
+   * union-branch leaves into the parent directory without ever touching the
+   * {@code _copy_} suffix — so the result stays in the plain writer-name namespace
+   * ({@code [0-9]+_[0-9]+}) and composes cleanly with a subsequent
+   * {@code _copy_<HIVE-28822 uniqueness tag>} that {@code Hive.pickDestFilePath}
+   * may append on a non-atomic-rename FS.
+   */
+  @Test
+  public void testWithFoldedSubdirIndex() throws Exception {
+    // subdirIdx=1, attempt=0 -> 100000. Matches the single-digit-subdir example
+    // in the JIRA discussion.
+    Assert.assertEquals("000000_100000",
+        ParsedOutputFileName.parse("000000_0").withFoldedSubdirIndex(1));
+    // subdirIdx=23, attempt=2 -> 2300002. Two-digit subdir; result exceeds the
+    // legacy 6-digit attempt-id cap, which is why COPY_FILE_NAME_TO_TASK_ID_REGEX
+    // widens the attempt group to 10 digits.
+    Assert.assertEquals("000000_2300002",
+        ParsedOutputFileName.parse("000000_2").withFoldedSubdirIndex(23));
+    // Zero subdirIdx acts as the identity for the attempt id — this branch never
+    // fires in practice (HIVE_UNION_SUBDIR_ is 1-indexed) but the arithmetic is
+    // still well-defined.
+    Assert.assertEquals("000000_42",
+        ParsedOutputFileName.parse("000000_42").withFoldedSubdirIndex(0));
+  }
+
+  @Test
+  public void testWithFoldedSubdirIndexPreservesSuffix() throws Exception {
+    // File-extension suffix (single- or multi-part) is preserved verbatim.
+    Assert.assertEquals("000000_500003.gz",
+        ParsedOutputFileName.parse("000000_3.gz").withFoldedSubdirIndex(5));
+    Assert.assertEquals("000000_800001.snappy.orc",
+        ParsedOutputFileName.parse("000000_1.snappy.orc").withFoldedSubdirIndex(8));
+  }
+
+  @Test
+  public void testWithFoldedSubdirIndexPreservesTaskIdPrefix() throws Exception {
+    // Any "(prefix)" wrapper on the taskId (used for MoveTask staging names) is
+    // preserved so downstream consumers still see the original prefix.
+    Assert.assertEquals("(prefix)00001_200002",
+        ParsedOutputFileName.parse("(prefix)00001_2").withFoldedSubdirIndex(2));
+    Assert.assertEquals("tmp_(prefix)00001_400002",
+        ParsedOutputFileName.parse("tmp_(prefix)00001_2").withFoldedSubdirIndex(4));
+  }
+
+  @Test
+  public void testWithFoldedSubdirIndexOnBareTaskId() throws Exception {
+    // A bare taskId (no `_<attemptId>`) is treated as attempt=0.
+    Assert.assertEquals("000000_700000",
+        ParsedOutputFileName.parse("000000").withFoldedSubdirIndex(7));
+  }
+
+  @Test
+  public void testWithFoldedSubdirIndexDropsCopySuffix() throws Exception {
+    // A pre-existing `_copy_<N>` on the source is dropped: flatten is not a copy,
+    // and the flattened name must stay in the plain-writer-name namespace so a
+    // subsequent Hive.pickDestFilePath can append its own uniqueness tag on top.
+    Assert.assertEquals("000000_100002",
+        ParsedOutputFileName.parse("000000_2_copy_9").withFoldedSubdirIndex(1));
+  }
+
+  @Test
+  public void testWithFoldedSubdirIndexOnUnparseableThrows() {
+    ParsedOutputFileName p = ParsedOutputFileName.parse("ZfsLke");
+    Assert.assertFalse(p.matches());
+    try {
+      p.withFoldedSubdirIndex(1);
+      Assert.fail("Expected HiveException on unparseable filename");
+    } catch (HiveException expected) {
+    }
+  }
+
+  /**
+   * The attempt-id group was widened from {@code \d{1,6}} to {@code \d{1,10}} so
+   * a flattened name produced by {@link ParsedOutputFileName#withFoldedSubdirIndex(int)}
+   * — up to 10 digits for subdir indices in the hundreds — still parses back.
+   */
+  @Test
+  public void testWideAttemptIdParses() {
+    ParsedOutputFileName p = ParsedOutputFileName.parse("000000_2300002");
+    Assert.assertTrue(p.matches());
+    Assert.assertEquals("000000", p.getTaskId());
+    Assert.assertEquals("2300002", p.getAttemptId());
+    Assert.assertNull(p.getCopyIndex());
+    Assert.assertFalse(p.isCopyFile());
+  }
+
   @Test
   public void testNoMatch() {
     ParsedOutputFileName p = ParsedOutputFileName.parse("ZfsLke");

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/ParsedOutputFileNameTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/ParsedOutputFileNameTest.java
@@ -231,11 +231,8 @@ public class ParsedOutputFileNameTest {
   public void testWithFoldedSubdirIndexOnUnparseableThrows() {
     ParsedOutputFileName p = ParsedOutputFileName.parse("ZfsLke");
     Assert.assertFalse(p.matches());
-    try {
-      p.withFoldedSubdirIndex(1);
-      Assert.fail("Expected HiveException on unparseable filename");
-    } catch (HiveException expected) {
-    }
+    // Unparseable filenames must be rejected rather than folded silently.
+    Assert.assertThrows(HiveException.class, () -> p.withFoldedSubdirIndex(1));
   }
 
   /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestMoveTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestMoveTask.java
@@ -35,7 +35,9 @@ public class TestMoveTask {
   @Test
   public void flattenUnionSubdirectories() throws IOException, HiveException {
     String initialPath = "/table_users/" + AbstractFileMergeOperator.UNION_SUDBIR_PREFIX + "1/000000_0";
-    String flattenPath = "/table_users/1_000000_0";
+    // The flattened name matches ORIGINAL_PATTERN_COPY ([0-9]+_[0-9]+_copy_[0-9]+) so a
+    // subsequent non-ACID→ACID conversion isn't rejected by the metastore validator.
+    String flattenPath = "/table_users/000000_0_copy_1";
 
     MockFileSystem.MockFile file1 = new MockFileSystem.MockFile("mock://" + initialPath, 0, new byte[1]);
     MockFileSystem fs = new MockFileSystem(new Configuration(), file1);

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestMoveTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestMoveTask.java
@@ -34,10 +34,12 @@ import java.io.IOException;
 public class TestMoveTask {
   @Test
   public void flattenUnionSubdirectories() throws IOException, HiveException {
+    // subdir=1, attempt=0 -> attempt = 1 * 100000 + 0 = 100000
     String initialPath = "/table_users/" + AbstractFileMergeOperator.UNION_SUDBIR_PREFIX + "1/000000_0";
-    // The flattened name matches ORIGINAL_PATTERN_COPY ([0-9]+_[0-9]+_copy_[0-9]+) so a
-    // subsequent non-ACID→ACID conversion isn't rejected by the metastore validator.
-    String flattenPath = "/table_users/000000_0_copy_1";
+    // Flattened name stays in the ORIGINAL_PATTERN ([0-9]+_[0-9]+) namespace so it does not
+    // collide with the HIVE-28822 _copy_<uniqueness-tag> suffix that pickDestFilePath may
+    // later append on a non-atomic-rename filesystem.
+    String flattenPath = "/table_users/000000_100000";
 
     MockFileSystem.MockFile file1 = new MockFileSystem.MockFile("mock://" + initialPath, 0, new byte[1]);
     MockFileSystem fs = new MockFileSystem(new Configuration(), file1);

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestInsertCopySuffixOnFakeS3.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestInsertCopySuffixOnFakeS3.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestInsertCopySuffixOnFakeS3.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestInsertCopySuffixOnFakeS3.java
@@ -104,7 +104,7 @@ class TestInsertCopySuffixOnFakeS3 extends TxnCommandsBaseForTests {
   @AfterEach
   void dropAllTestTables() throws Exception {
     for (String t : new String[] {"insert_into_fakes3", "union_all_fakes3", "union_all_dyn_part_fakes3",
-        "insert_only_fakes3", "full_acid_fakes3", "union_src"}) {
+        "union_all_flatten_fakes3", "insert_only_fakes3", "full_acid_fakes3", "union_src"}) {
       try {
         runQuery("drop table if exists " + t);
       } catch (Exception ignore) {
@@ -259,6 +259,64 @@ class TestInsertCopySuffixOnFakeS3 extends TxnCommandsBaseForTests {
     assertRowCount(tbl, 3);
 
     convertToFullAcidAndAssertRowCount(tbl, 3);
+  }
+
+  /**
+   * {@code INSERT INTO ... UNION ALL ...} on a non-ACID external ORC table with
+   * {@code hive.tez.union.flatten.subdirectories=true}. Verifies the compositional
+   * guarantee: on a non-atomic-rename FS,
+   * MoveTask.flattenUnionSubdirectories folds the subdir index into the attempt-id
+   * portion of the writer name (out of the {@code _copy_} namespace), then
+   * {@link org.apache.hadoop.hive.ql.metadata.Hive#pickDestFilePath} freely appends
+   * its own {@code _copy_<HIVE-28822 uniqueness tag>} on top, producing a leaf
+   * shaped like {@code 000000_<N*100000>_copy_<16 hex>} — a single {@code _copy_}
+   * segment, matching {@link AcidUtils#ORIGINAL_PATTERN_COPY} exactly, and never
+   * living under a {@code HIVE_UNION_SUBDIR_*} directory.
+   */
+  @Test
+  void testUnionAllInsertWithFlattenOnFakeS3() throws Exception {
+    String tbl = "union_all_flatten_fakes3";
+    Path loc = fakeS3Path(tbl);
+
+    boolean previous = HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES);
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES, true);
+    try {
+      runQuery(
+          "create external table " + tbl + " (a int, b int) stored as orc "
+          + "location '" + fakeS3Location(tbl) + "' "
+          + "tblproperties ('transactional'='false','external.table.purge'='true')");
+
+      createUnionSrc();
+      runQuery(
+          "insert into " + tbl + " "
+          + "select k as a, sum(v) as b from union_src where k = 1 group by k union all "
+          + "select k as a, sum(v) as b from union_src where k = 2 group by k union all "
+          + "select k as a, sum(v) as b from union_src where k = 3 group by k");
+
+      List<String> files = listFilesRelative(loc);
+      assertFalse(files.isEmpty(), "flatten+union insert produced no files under " + loc);
+
+      Set<String> distinctNames = new HashSet<>();
+      for (String rel : files) {
+        assertFalse(rel.contains(AbstractFileMergeOperator.UNION_SUDBIR_PREFIX),
+            "flatten=true must hoist the leaves out of HIVE_UNION_SUBDIR_*: " + rel);
+        String name = rel.substring(rel.lastIndexOf('/') + 1);
+        assertHas16HexUniquenessTag(name);
+        int firstCopy = name.indexOf(org.apache.hadoop.hive.ql.exec.Utilities.COPY_KEYWORD);
+        int lastCopy = name.lastIndexOf(org.apache.hadoop.hive.ql.exec.Utilities.COPY_KEYWORD);
+        assertEquals(firstCopy, lastCopy,
+            "flattened name must carry exactly one _copy_ segment (no double-append): " + name);
+        distinctNames.add(name);
+      }
+      assertEquals(files.size(), distinctNames.size(),
+          "flattened+tagged leaves must all have distinct names: " + files);
+
+      assertRowCount(tbl, 3);
+
+      convertToFullAcidAndAssertRowCount(tbl, 3);
+    } finally {
+      HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES, previous);
+    }
   }
 
   /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestInsertCopySuffixOnFakeS3.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestInsertCopySuffixOnFakeS3.java
@@ -227,10 +227,7 @@ class TestInsertCopySuffixOnFakeS3 extends TxnCommandsBaseForTests {
 
     assertRowCount(tbl, 3);
 
-    // FIXME: convertToFullAcidAndAssertRowCount should pass after HIVE-29798 is fixed
-    assertThrows(Exception.class,
-        () -> convertToFullAcidAndAssertRowCount(tbl, 3),
-        "expected read-back after CONVERT TO ACID to fail until HIVE-29798 is fixed");
+    convertToFullAcidAndAssertRowCount(tbl, 3);
   }
 
   /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion.java
@@ -1,0 +1,451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.metadata;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.TxnCommandsBaseForTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers the non-ACID→full-ACID conversion of a table whose pre-conversion
+ * data was written by {@code INSERT ... UNION ALL ...} — i.e. the branches
+ * materialize under {@code HIVE_UNION_SUBDIR_<N>/000000_0}.
+ *
+ * <p>Both DDL paths — the dedicated {@code ALTER TABLE ... CONVERT TO ACID}
+ * and the historical {@code ALTER TABLE ... SET TBLPROPERTIES
+ * ('transactional'='true')} — are metadata-only flips: they preserve the
+ * pre-conversion on-disk layout, including the {@code HIVE_UNION_SUBDIR_<N>/}
+ * subdirs. Existing callers depend on this (see
+ * {@code TestTxnNoBuckets.testToAcidConversionMultiBucket}, which verifies
+ * both the preserved layout and specific ROW__ID assignments encoded per
+ * subdir). A subsequent {@code SELECT} must therefore read the pre-conversion
+ * layout cleanly — which requires the ACID reader's parent-walk to skip
+ * non-delta directory names rather than feeding them to
+ * {@code ParsedDeltaLight.parse}. That reader-side guard is what these tests
+ * exercise end-to-end.
+ */
+class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
+
+  private static final String TEST_DATA_DIR = new File(System.getProperty("java.io.tmpdir")
+      + File.separator + TestUnionAllToAcidConversion.class.getCanonicalName()
+      + "-" + System.currentTimeMillis()).getPath().replaceAll("\\\\", "/");
+
+  @Override
+  protected String getTestDataDir() {
+    return TEST_DATA_DIR;
+  }
+
+  @Override
+  protected void initHiveConf() {
+    super.initHiveConf();
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_STRICT_MANAGED_TABLES, false);
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.CREATE_TABLES_AS_ACID, false);
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_CREATE_TABLES_AS_INSERT_ONLY, false);
+    // Keep the UNION-ALL branches in their own HIVE_UNION_SUBDIR_<N>/ intermediate
+    // directories so the conversion sees the multi-level layout.
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES, false);
+  }
+
+  @Override
+  protected void setUpSchema() {
+    // Skip the parent's ACID/bucketed fixture tables — each test creates its own.
+  }
+
+  @Override
+  protected void dropTables() {
+    // Match setUpSchema override: nothing to drop for the parent's fixtures.
+  }
+
+  @AfterEach
+  public void dropAllTestTables() throws Exception {
+    for (String t : new String[] {
+        "union_all_repro",
+        "union_all_repro_setprops",
+        "union_all_repro_part",
+        "union_all_repro_part_setprops",
+        "union_src"}) {
+      try {
+        runQuery("drop table if exists " + t);
+      } catch (Exception ignore) {
+        // don't let a residual-drop failure hide the real test failure
+      }
+    }
+  }
+
+  private void insertUnionAllInto(String tbl) throws Exception {
+    // Real staging table + per-branch group-by, so the planner can't
+    // constant-fold the branches into one mapper. This is what surfaces the
+    // HIVE_UNION_SUBDIR_<N>/ layout at final-move time.
+    runQuery("create table if not exists union_src (k int, v int) stored as orc "
+        + "tblproperties ('transactional'='false')");
+    runQuery("insert into union_src values (1, 10), (2, 20), (3, 30)");
+
+    runQuery(
+        "insert into " + tbl + " "
+        + "select k as a, sum(v) as b from union_src where k = 1 group by k union all "
+        + "select k as a, sum(v) as b from union_src where k = 2 group by k union all "
+        + "select k as a, sum(v) as b from union_src where k = 3 group by k");
+  }
+
+  /**
+   * Same 3-way UNION ALL pattern as {@link #insertUnionAllInto(String)}, but
+   * targeted at a static partition {@code p='X'} of a partitioned table.
+   */
+  private void insertUnionAllIntoPartition(String tbl, String partValue) throws Exception {
+    runQuery("create table if not exists union_src (k int, v int) stored as orc "
+        + "tblproperties ('transactional'='false')");
+    runQuery("insert into union_src values (1, 10), (2, 20), (3, 30)");
+
+    runQuery(
+        "insert into " + tbl + " partition (p='" + partValue + "') "
+        + "select k as a, sum(v) as b from union_src where k = 1 group by k union all "
+        + "select k as a, sum(v) as b from union_src where k = 2 group by k union all "
+        + "select k as a, sum(v) as b from union_src where k = 3 group by k");
+  }
+
+  /**
+   * Return the table's on-disk layout as a sorted list of warehouse-relative
+   * paths (i.e. including the table directory name as the top-level segment,
+   * one level higher than the table root itself), so tests can assert against
+   * an exact expected literal.
+   */
+  private List<String> layoutOf(String tbl) throws Exception {
+    org.apache.hadoop.fs.Path loc = new org.apache.hadoop.fs.Path(
+        hiveConf.get("hive.metastore.warehouse.dir") + "/" + tbl);
+    org.apache.hadoop.fs.FileSystem fs = loc.getFileSystem(hiveConf);
+    List<String> paths = new ArrayList<>();
+    if (fs.exists(loc)) {
+      org.apache.hadoop.fs.RemoteIterator<org.apache.hadoop.fs.LocatedFileStatus> it = fs.listFiles(loc, true);
+      // Strip the *parent* of the table location (the warehouse dir), so the
+      // returned paths start with "/<table-name>/…" — one level higher than
+      // just the table root.
+      String warehousePath = loc.getParent().toUri().getPath();
+      while (it.hasNext()) {
+        org.apache.hadoop.fs.LocatedFileStatus s = it.next();
+        String full = s.getPath().toUri().getPath();
+        paths.add(full.startsWith(warehousePath) ? full.substring(warehousePath.length()) : full);
+      }
+    }
+    Collections.sort(paths);
+    return paths;
+  }
+
+  private List<String> runQuery(String stmt) throws Exception {
+    hiveConf.setVar(HiveConf.ConfVars.HIVE_QUERY_ID, org.apache.hadoop.hive.ql.QueryPlan.makeQueryId());
+    d.run(stmt);
+    List<String> rs = new ArrayList<>();
+    d.getResults(rs);
+    return rs;
+  }
+
+  /**
+   * {@code ALTER TABLE ... CONVERT TO ACID} on a table previously loaded via
+   * UNION ALL is a metadata-only flip: the on-disk layout is unchanged, and
+   * the subsequent SELECT returns the expected row count.
+   */
+  @Test
+  void testUnionAllInsertThenConvertToAcid() throws Exception {
+    String tbl = "union_all_repro";
+    runQuery("create table " + tbl + " (a int, b int) stored as orc "
+        + "tblproperties ('transactional'='false')");
+
+    insertUnionAllInto(tbl);
+
+    // The UNION-ALL insert materializes each branch under its own
+    // HIVE_UNION_SUBDIR_<N>/000000_0. Assert the exact layout so a reader of
+    // this test can see what CONVERT TO ACID is going to be run against.
+    List<String> expectedLayout = List.of(
+        "/union_all_repro/HIVE_UNION_SUBDIR_1/000000_0",
+        "/union_all_repro/HIVE_UNION_SUBDIR_2/000000_0",
+        "/union_all_repro/HIVE_UNION_SUBDIR_3/000000_0");
+    List<String> beforeLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, beforeLayout, "pre-conversion layout");
+
+    runQuery("alter table " + tbl + " convert to acid");
+
+    // CONVERT TO ACID is a metadata-only flip: the on-disk layout is unchanged.
+    List<String> afterLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, afterLayout,
+        "CONVERT TO ACID should be a metadata-only flip and preserve the pre-conversion layout");
+
+    List<String> rows = runQuery("select count(*) from " + tbl);
+    assertEquals("3", rows.getFirst(), "expected 3 rows after UNION-ALL insert + CONVERT TO ACID");
+  }
+
+  /**
+   * {@code ALTER TABLE ... SET TBLPROPERTIES ('transactional'='true')} — the
+   * path {@code UpgradeTool} emits — is likewise a metadata-only flip. The
+   * subsequent SELECT returns the expected row count.
+   */
+  @Test
+  void testUnionAllInsertThenSetTblpropertiesAcid() throws Exception {
+    String tbl = "union_all_repro_setprops";
+    runQuery("create table " + tbl + " (a int, b int) stored as orc "
+        + "tblproperties ('transactional'='false')");
+
+    insertUnionAllInto(tbl);
+
+    // Same shape of pre-conversion layout as the CONVERT TO ACID case above,
+    // rooted under this test's own table directory.
+    List<String> expectedLayout = List.of(
+        "/union_all_repro_setprops/HIVE_UNION_SUBDIR_1/000000_0",
+        "/union_all_repro_setprops/HIVE_UNION_SUBDIR_2/000000_0",
+        "/union_all_repro_setprops/HIVE_UNION_SUBDIR_3/000000_0");
+    List<String> beforeLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, beforeLayout, "pre-conversion layout");
+
+    runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')");
+
+    List<String> afterLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, afterLayout,
+        "SET TBLPROPERTIES ('transactional'='true') should preserve the pre-conversion layout");
+
+    List<String> rows = runQuery("select count(*) from " + tbl);
+    assertEquals("3", rows.getFirst(),
+        "expected 3 rows after UNION-ALL insert + SET TBLPROPERTIES ACID conversion");
+  }
+
+  /**
+   * Partitioned-table variant of {@link #testUnionAllInsertThenConvertToAcid()}
+   * — the UNION-ALL insert materializes each branch under {@code p=x/HIVE_UNION_SUBDIR_<N>/000000_0}
+   * inside the partition directory. CONVERT TO ACID is still a metadata-only
+   * flip, and the subsequent SELECT returns the expected row count.
+   */
+  @Test
+  void testPartitionedUnionAllInsertThenConvertToAcid() throws Exception {
+    String tbl = "union_all_repro_part";
+    runQuery("create table " + tbl + " (a int, b int) partitioned by (p string) "
+        + "stored as orc tblproperties ('transactional'='false')");
+
+    insertUnionAllIntoPartition(tbl, "x");
+
+    List<String> expectedLayout = List.of(
+        "/union_all_repro_part/p=x/HIVE_UNION_SUBDIR_1/000000_0",
+        "/union_all_repro_part/p=x/HIVE_UNION_SUBDIR_2/000000_0",
+        "/union_all_repro_part/p=x/HIVE_UNION_SUBDIR_3/000000_0");
+    List<String> beforeLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, beforeLayout, "pre-conversion layout");
+
+    runQuery("alter table " + tbl + " convert to acid");
+
+    List<String> afterLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, afterLayout,
+        "CONVERT TO ACID should be a metadata-only flip and preserve the pre-conversion layout");
+
+    List<String> rows = runQuery("select count(*) from " + tbl);
+    assertEquals("3", rows.getFirst(),
+        "expected 3 rows after partitioned UNION-ALL insert + CONVERT TO ACID");
+  }
+
+  /**
+   * Partitioned-table variant of
+   * {@link #testUnionAllInsertThenSetTblpropertiesAcid()} — the
+   * {@code UpgradeTool}-style path preserves the pre-conversion partition
+   * layout, and the subsequent SELECT returns the expected row count.
+   */
+  @Test
+  void testPartitionedUnionAllInsertThenSetTblpropertiesAcid() throws Exception {
+    String tbl = "union_all_repro_part_setprops";
+    runQuery("create table " + tbl + " (a int, b int) partitioned by (p string) "
+        + "stored as orc tblproperties ('transactional'='false')");
+
+    insertUnionAllIntoPartition(tbl, "x");
+
+    List<String> expectedLayout = List.of(
+        "/union_all_repro_part_setprops/p=x/HIVE_UNION_SUBDIR_1/000000_0",
+        "/union_all_repro_part_setprops/p=x/HIVE_UNION_SUBDIR_2/000000_0",
+        "/union_all_repro_part_setprops/p=x/HIVE_UNION_SUBDIR_3/000000_0");
+    List<String> beforeLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, beforeLayout, "pre-conversion layout");
+
+    runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')");
+
+    List<String> afterLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, afterLayout,
+        "SET TBLPROPERTIES ('transactional'='true') should preserve the pre-conversion layout");
+
+    List<String> rows = runQuery("select count(*) from " + tbl);
+    assertEquals("3", rows.getFirst(),
+        "expected 3 rows after partitioned UNION-ALL insert + SET TBLPROPERTIES ACID conversion");
+  }
+
+  // ---------------------------------------------------------------------------
+  // flatten=true variants
+  //
+  // hive.tez.union.flatten.subdirectories=true asks MoveTask to hoist the
+  // HIVE_UNION_SUBDIR_<N>/000000_0 leaves into the target directory at write
+  // time. MoveTask.flattenUnionSubdirectories folds the source subdir index
+  // into the filename so that:
+  //   HIVE_UNION_SUBDIR_<N>/000000_0 -> 000000_0_copy_<N>
+  // That name matches the metastore's ORIGINAL_PATTERN_COPY
+  // ([0-9]+_[0-9]+_copy_[0-9]+), so a subsequent ACID conversion (either
+  // CONVERT TO ACID or the SET TBLPROPERTIES flip) is accepted by
+  // TransactionalValidationListener.validateTableStructureForPath.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enable the write-time flatten and re-run the given block. Restores the
+   * previous value on exit.
+   */
+  private void withUnionFlattenAtWriteTime(ThrowingRunnable body) throws Exception {
+    boolean previous = HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES);
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES, true);
+    try {
+      body.run();
+    } finally {
+      HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES, previous);
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  /**
+   * flatten=true + unpartitioned + CONVERT TO ACID. MoveTask hoists the
+   * union-subdir leaves into {@code 000000_0_copy_<N>} files at the table
+   * root — a name that matches ORIGINAL_PATTERN_COPY, so the subsequent
+   * metadata-only CONVERT TO ACID is accepted and the SELECT returns all
+   * rows.
+   */
+  @Test
+  void testUnionAllInsertWithFlattenThenConvertToAcid() throws Exception {
+    String tbl = "union_all_repro";
+    withUnionFlattenAtWriteTime(() -> {
+      runQuery("create table " + tbl + " (a int, b int) stored as orc "
+          + "tblproperties ('transactional'='false')");
+
+      insertUnionAllInto(tbl);
+
+      List<String> expectedLayout = List.of(
+          "/union_all_repro/000000_0_copy_1",
+          "/union_all_repro/000000_0_copy_2",
+          "/union_all_repro/000000_0_copy_3");
+      assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
+
+      runQuery("alter table " + tbl + " convert to acid");
+
+      assertEquals(expectedLayout, layoutOf(tbl),
+          "CONVERT TO ACID should be a metadata-only flip and preserve the flattened layout");
+
+      List<String> rows = runQuery("select count(*) from " + tbl);
+      assertEquals("3", rows.getFirst(),
+          "expected 3 rows after flattened UNION-ALL insert + CONVERT TO ACID");
+    });
+  }
+
+  /**
+   * flatten=true + unpartitioned + SET TBLPROPERTIES ACID conversion. Same
+   * shape as the CONVERT TO ACID variant: {@code 000000_0_copy_<N>} matches
+   * ORIGINAL_PATTERN_COPY, so the conversion succeeds.
+   */
+  @Test
+  void testUnionAllInsertWithFlattenThenSetTblpropertiesAcid() throws Exception {
+    String tbl = "union_all_repro_setprops";
+    withUnionFlattenAtWriteTime(() -> {
+      runQuery("create table " + tbl + " (a int, b int) stored as orc "
+          + "tblproperties ('transactional'='false')");
+
+      insertUnionAllInto(tbl);
+
+      List<String> expectedLayout = List.of(
+          "/union_all_repro_setprops/000000_0_copy_1",
+          "/union_all_repro_setprops/000000_0_copy_2",
+          "/union_all_repro_setprops/000000_0_copy_3");
+      assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
+
+      runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')");
+
+      assertEquals(expectedLayout, layoutOf(tbl),
+          "SET TBLPROPERTIES ('transactional'='true') should preserve the flattened layout");
+
+      List<String> rows = runQuery("select count(*) from " + tbl);
+      assertEquals("3", rows.getFirst(),
+          "expected 3 rows after flattened UNION-ALL insert + SET TBLPROPERTIES ACID conversion");
+    });
+  }
+
+  /**
+   * flatten=true + partitioned + CONVERT TO ACID. Same shape as the
+   * unpartitioned variant, inside the partition directory: the conversion
+   * succeeds and the SELECT returns all rows.
+   */
+  @Test
+  void testPartitionedUnionAllInsertWithFlattenThenConvertToAcid() throws Exception {
+    String tbl = "union_all_repro_part";
+    withUnionFlattenAtWriteTime(() -> {
+      runQuery("create table " + tbl + " (a int, b int) partitioned by (p string) "
+          + "stored as orc tblproperties ('transactional'='false')");
+
+      insertUnionAllIntoPartition(tbl, "x");
+
+      List<String> expectedLayout = List.of(
+          "/union_all_repro_part/p=x/000000_0_copy_1",
+          "/union_all_repro_part/p=x/000000_0_copy_2",
+          "/union_all_repro_part/p=x/000000_0_copy_3");
+      assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
+
+      runQuery("alter table " + tbl + " convert to acid");
+
+      assertEquals(expectedLayout, layoutOf(tbl),
+          "CONVERT TO ACID should be a metadata-only flip and preserve the flattened layout");
+
+      List<String> rows = runQuery("select count(*) from " + tbl);
+      assertEquals("3", rows.getFirst(),
+          "expected 3 rows after partitioned flattened UNION-ALL insert + CONVERT TO ACID");
+    });
+  }
+
+  /**
+   * flatten=true + partitioned + SET TBLPROPERTIES ACID conversion.
+   */
+  @Test
+  void testPartitionedUnionAllInsertWithFlattenThenSetTblpropertiesAcid() throws Exception {
+    String tbl = "union_all_repro_part_setprops";
+    withUnionFlattenAtWriteTime(() -> {
+      runQuery("create table " + tbl + " (a int, b int) partitioned by (p string) "
+          + "stored as orc tblproperties ('transactional'='false')");
+
+      insertUnionAllIntoPartition(tbl, "x");
+
+      List<String> expectedLayout = List.of(
+          "/union_all_repro_part_setprops/p=x/000000_0_copy_1",
+          "/union_all_repro_part_setprops/p=x/000000_0_copy_2",
+          "/union_all_repro_part_setprops/p=x/000000_0_copy_3");
+      assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
+
+      runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')");
+
+      assertEquals(expectedLayout, layoutOf(tbl),
+          "SET TBLPROPERTIES ('transactional'='true') should preserve the flattened layout");
+
+      List<String> rows = runQuery("select count(*) from " + tbl);
+      assertEquals("3", rows.getFirst(),
+          "expected 3 rows after partitioned flattened UNION-ALL insert + SET TBLPROPERTIES ACID conversion");
+    });
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion.java
@@ -9,11 +9,12 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.hadoop.hive.ql.metadata;
 
@@ -80,7 +81,7 @@ class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
   }
 
   @AfterEach
-  public void dropAllTestTables() throws Exception {
+  void dropAllTestTables() throws Exception {
     for (String t : new String[] {
         "union_all_repro",
         "union_all_repro_setprops",

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion.java
@@ -297,13 +297,17 @@ class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
   //
   // hive.tez.union.flatten.subdirectories=true asks MoveTask to hoist the
   // HIVE_UNION_SUBDIR_<N>/000000_0 leaves into the target directory at write
-  // time. MoveTask.flattenUnionSubdirectories folds the source subdir index
-  // into the filename so that:
-  //   HIVE_UNION_SUBDIR_<N>/000000_0 -> 000000_0_copy_<N>
-  // That name matches the metastore's ORIGINAL_PATTERN_COPY
-  // ([0-9]+_[0-9]+_copy_[0-9]+), so a subsequent ACID conversion (either
-  // CONVERT TO ACID or the SET TBLPROPERTIES flip) is accepted by
-  // TransactionalValidationListener.validateTableStructureForPath.
+  // time. MoveTask.flattenUnionSubdirectories folds the subdir index into the
+  // attempt-id portion of the writer-name — NOT the _copy_ suffix — so:
+  //   HIVE_UNION_SUBDIR_<N>/000000_<A> -> 000000_<N*100000+A>
+  //     e.g. HIVE_UNION_SUBDIR_1/000000_0  -> 000000_100000
+  //          HIVE_UNION_SUBDIR_23/000000_2 -> 000000_2300002
+  // That name matches the metastore's ORIGINAL_PATTERN ([0-9]+_[0-9]+), so a
+  // subsequent ACID conversion (either CONVERT TO ACID or the SET TBLPROPERTIES
+  // flip) is accepted by TransactionalValidationListener.validateTableStructureForPath.
+  // Keeping the fold out of the _copy_ namespace also means a subsequent
+  // Hive.pickDestFilePath on a non-atomic-rename FS composes cleanly on top,
+  // appending its own _copy_<HIVE-28822 uniqueness tag> without collision.
   // ---------------------------------------------------------------------------
 
   /**
@@ -327,10 +331,10 @@ class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
 
   /**
    * flatten=true + unpartitioned + CONVERT TO ACID. MoveTask hoists the
-   * union-subdir leaves into {@code 000000_0_copy_<N>} files at the table
-   * root — a name that matches ORIGINAL_PATTERN_COPY, so the subsequent
-   * metadata-only CONVERT TO ACID is accepted and the SELECT returns all
-   * rows.
+   * union-subdir leaves into {@code 000000_<N*100000>} files at the table
+   * root — a plain-writer name that matches ORIGINAL_PATTERN, so the
+   * subsequent metadata-only CONVERT TO ACID is accepted and the SELECT
+   * returns all rows.
    */
   @Test
   void testUnionAllInsertWithFlattenThenConvertToAcid() throws Exception {
@@ -342,9 +346,9 @@ class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
       insertUnionAllInto(tbl);
 
       List<String> expectedLayout = List.of(
-          "/union_all_repro/000000_0_copy_1",
-          "/union_all_repro/000000_0_copy_2",
-          "/union_all_repro/000000_0_copy_3");
+          "/union_all_repro/000000_100000",
+          "/union_all_repro/000000_200000",
+          "/union_all_repro/000000_300000");
       assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
 
       runQuery("alter table " + tbl + " convert to acid");
@@ -360,8 +364,8 @@ class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
 
   /**
    * flatten=true + unpartitioned + SET TBLPROPERTIES ACID conversion. Same
-   * shape as the CONVERT TO ACID variant: {@code 000000_0_copy_<N>} matches
-   * ORIGINAL_PATTERN_COPY, so the conversion succeeds.
+   * shape as the CONVERT TO ACID variant: {@code 000000_<N*100000>} matches
+   * ORIGINAL_PATTERN, so the conversion succeeds.
    */
   @Test
   void testUnionAllInsertWithFlattenThenSetTblpropertiesAcid() throws Exception {
@@ -373,9 +377,9 @@ class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
       insertUnionAllInto(tbl);
 
       List<String> expectedLayout = List.of(
-          "/union_all_repro_setprops/000000_0_copy_1",
-          "/union_all_repro_setprops/000000_0_copy_2",
-          "/union_all_repro_setprops/000000_0_copy_3");
+          "/union_all_repro_setprops/000000_100000",
+          "/union_all_repro_setprops/000000_200000",
+          "/union_all_repro_setprops/000000_300000");
       assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
 
       runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')");
@@ -404,9 +408,9 @@ class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
       insertUnionAllIntoPartition(tbl, "x");
 
       List<String> expectedLayout = List.of(
-          "/union_all_repro_part/p=x/000000_0_copy_1",
-          "/union_all_repro_part/p=x/000000_0_copy_2",
-          "/union_all_repro_part/p=x/000000_0_copy_3");
+          "/union_all_repro_part/p=x/000000_100000",
+          "/union_all_repro_part/p=x/000000_200000",
+          "/union_all_repro_part/p=x/000000_300000");
       assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
 
       runQuery("alter table " + tbl + " convert to acid");
@@ -433,9 +437,9 @@ class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
       insertUnionAllIntoPartition(tbl, "x");
 
       List<String> expectedLayout = List.of(
-          "/union_all_repro_part_setprops/p=x/000000_0_copy_1",
-          "/union_all_repro_part_setprops/p=x/000000_0_copy_2",
-          "/union_all_repro_part_setprops/p=x/000000_0_copy_3");
+          "/union_all_repro_part_setprops/p=x/000000_100000",
+          "/union_all_repro_part_setprops/p=x/000000_200000",
+          "/union_all_repro_part_setprops/p=x/000000_300000");
       assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
 
       runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')");

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion.java
@@ -1,0 +1,446 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.metadata;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.TxnCommandsBaseForTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the non-ACID→full-ACID conversion of a table whose pre-conversion
+ * data was written by {@code INSERT ... UNION ALL ...} — i.e. the branches
+ * materialize under {@code HIVE_UNION_SUBDIR_<N>/000000_0}.
+ *
+ * <p>Both DDL paths — the dedicated {@code ALTER TABLE ... CONVERT TO ACID}
+ * and the historical {@code ALTER TABLE ... SET TBLPROPERTIES
+ * ('transactional'='true')} — are metadata-only flips: they preserve the
+ * pre-conversion on-disk layout, including the {@code HIVE_UNION_SUBDIR_<N>/}
+ * subdirs. Existing callers depend on this (see
+ * {@code TestTxnNoBuckets.testToAcidConversionMultiBucket}, which verifies
+ * both the preserved layout and specific ROW__ID assignments encoded per
+ * subdir). A subsequent {@code SELECT} must therefore read the pre-conversion
+ * layout cleanly — which requires the ACID reader's parent-walk to skip
+ * non-delta directory names rather than feeding them to
+ * {@code ParsedDeltaLight.parse}. That reader-side guard is what these tests
+ * exercise end-to-end.
+ */
+class TestUnionAllToAcidConversion extends TxnCommandsBaseForTests {
+
+  private static final String TEST_DATA_DIR = new File(System.getProperty("java.io.tmpdir")
+      + File.separator + TestUnionAllToAcidConversion.class.getCanonicalName()
+      + "-" + System.currentTimeMillis()).getPath().replaceAll("\\\\", "/");
+
+  @Override
+  protected String getTestDataDir() {
+    return TEST_DATA_DIR;
+  }
+
+  @Override
+  protected void initHiveConf() {
+    super.initHiveConf();
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_STRICT_MANAGED_TABLES, false);
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.CREATE_TABLES_AS_ACID, false);
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_CREATE_TABLES_AS_INSERT_ONLY, false);
+    // Keep the UNION-ALL branches in their own HIVE_UNION_SUBDIR_<N>/ intermediate
+    // directories so the conversion sees the multi-level layout.
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES, false);
+  }
+
+  @Override
+  protected void setUpSchema() {
+    // Skip the parent's ACID/bucketed fixture tables — each test creates its own.
+  }
+
+  @Override
+  protected void dropTables() {
+    // Match setUpSchema override: nothing to drop for the parent's fixtures.
+  }
+
+  @AfterEach
+  public void dropAllTestTables() throws Exception {
+    for (String t : new String[] {
+        "union_all_repro",
+        "union_all_repro_setprops",
+        "union_all_repro_part",
+        "union_all_repro_part_setprops",
+        "union_src"}) {
+      try {
+        runQuery("drop table if exists " + t);
+      } catch (Exception ignore) {
+        // don't let a residual-drop failure hide the real test failure
+      }
+    }
+  }
+
+  private void insertUnionAllInto(String tbl) throws Exception {
+    // Real staging table + per-branch group-by, so the planner can't
+    // constant-fold the branches into one mapper. This is what surfaces the
+    // HIVE_UNION_SUBDIR_<N>/ layout at final-move time.
+    runQuery("create table if not exists union_src (k int, v int) stored as orc "
+        + "tblproperties ('transactional'='false')");
+    runQuery("insert into union_src values (1, 10), (2, 20), (3, 30)");
+
+    runQuery(
+        "insert into " + tbl + " "
+        + "select k as a, sum(v) as b from union_src where k = 1 group by k union all "
+        + "select k as a, sum(v) as b from union_src where k = 2 group by k union all "
+        + "select k as a, sum(v) as b from union_src where k = 3 group by k");
+  }
+
+  /**
+   * Same 3-way UNION ALL pattern as {@link #insertUnionAllInto(String)}, but
+   * targeted at a static partition {@code p='X'} of a partitioned table.
+   */
+  private void insertUnionAllIntoPartition(String tbl, String partValue) throws Exception {
+    runQuery("create table if not exists union_src (k int, v int) stored as orc "
+        + "tblproperties ('transactional'='false')");
+    runQuery("insert into union_src values (1, 10), (2, 20), (3, 30)");
+
+    runQuery(
+        "insert into " + tbl + " partition (p='" + partValue + "') "
+        + "select k as a, sum(v) as b from union_src where k = 1 group by k union all "
+        + "select k as a, sum(v) as b from union_src where k = 2 group by k union all "
+        + "select k as a, sum(v) as b from union_src where k = 3 group by k");
+  }
+
+  /**
+   * Return the table's on-disk layout as a sorted list of warehouse-relative
+   * paths (i.e. including the table directory name as the top-level segment,
+   * one level higher than the table root itself), so tests can assert against
+   * an exact expected literal.
+   */
+  private List<String> layoutOf(String tbl) throws Exception {
+    org.apache.hadoop.fs.Path loc = new org.apache.hadoop.fs.Path(
+        hiveConf.get("hive.metastore.warehouse.dir") + "/" + tbl);
+    org.apache.hadoop.fs.FileSystem fs = loc.getFileSystem(hiveConf);
+    List<String> paths = new ArrayList<>();
+    if (fs.exists(loc)) {
+      org.apache.hadoop.fs.RemoteIterator<org.apache.hadoop.fs.LocatedFileStatus> it = fs.listFiles(loc, true);
+      // Strip the *parent* of the table location (the warehouse dir), so the
+      // returned paths start with "/<table-name>/…" — one level higher than
+      // just the table root.
+      String warehousePath = loc.getParent().toUri().getPath();
+      while (it.hasNext()) {
+        org.apache.hadoop.fs.LocatedFileStatus s = it.next();
+        String full = s.getPath().toUri().getPath();
+        paths.add(full.startsWith(warehousePath) ? full.substring(warehousePath.length()) : full);
+      }
+    }
+    Collections.sort(paths);
+    return paths;
+  }
+
+  private List<String> runQuery(String stmt) throws Exception {
+    hiveConf.setVar(HiveConf.ConfVars.HIVE_QUERY_ID, org.apache.hadoop.hive.ql.QueryPlan.makeQueryId());
+    d.run(stmt);
+    List<String> rs = new ArrayList<>();
+    d.getResults(rs);
+    return rs;
+  }
+
+  /**
+   * {@code ALTER TABLE ... CONVERT TO ACID} on a table previously loaded via
+   * UNION ALL is a metadata-only flip: the on-disk layout is unchanged, and
+   * the subsequent SELECT returns the expected row count.
+   */
+  @Test
+  void testUnionAllInsertThenConvertToAcid() throws Exception {
+    String tbl = "union_all_repro";
+    runQuery("create table " + tbl + " (a int, b int) stored as orc "
+        + "tblproperties ('transactional'='false')");
+
+    insertUnionAllInto(tbl);
+
+    // The UNION-ALL insert materializes each branch under its own
+    // HIVE_UNION_SUBDIR_<N>/000000_0. Assert the exact layout so a reader of
+    // this test can see what CONVERT TO ACID is going to be run against.
+    List<String> expectedLayout = List.of(
+        "/union_all_repro/HIVE_UNION_SUBDIR_1/000000_0",
+        "/union_all_repro/HIVE_UNION_SUBDIR_2/000000_0",
+        "/union_all_repro/HIVE_UNION_SUBDIR_3/000000_0");
+    List<String> beforeLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, beforeLayout, "pre-conversion layout");
+
+    runQuery("alter table " + tbl + " convert to acid");
+
+    // CONVERT TO ACID is a metadata-only flip: the on-disk layout is unchanged.
+    List<String> afterLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, afterLayout,
+        "CONVERT TO ACID should be a metadata-only flip and preserve the pre-conversion layout");
+
+    List<String> rows = runQuery("select count(*) from " + tbl);
+    assertEquals("3", rows.getFirst(), "expected 3 rows after UNION-ALL insert + CONVERT TO ACID");
+  }
+
+  /**
+   * {@code ALTER TABLE ... SET TBLPROPERTIES ('transactional'='true')} — the
+   * path {@code UpgradeTool} emits — is likewise a metadata-only flip. The
+   * subsequent SELECT returns the expected row count.
+   */
+  @Test
+  void testUnionAllInsertThenSetTblpropertiesAcid() throws Exception {
+    String tbl = "union_all_repro_setprops";
+    runQuery("create table " + tbl + " (a int, b int) stored as orc "
+        + "tblproperties ('transactional'='false')");
+
+    insertUnionAllInto(tbl);
+
+    // Same shape of pre-conversion layout as the CONVERT TO ACID case above,
+    // rooted under this test's own table directory.
+    List<String> expectedLayout = List.of(
+        "/union_all_repro_setprops/HIVE_UNION_SUBDIR_1/000000_0",
+        "/union_all_repro_setprops/HIVE_UNION_SUBDIR_2/000000_0",
+        "/union_all_repro_setprops/HIVE_UNION_SUBDIR_3/000000_0");
+    List<String> beforeLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, beforeLayout, "pre-conversion layout");
+
+    runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')");
+
+    List<String> afterLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, afterLayout,
+        "SET TBLPROPERTIES ('transactional'='true') should preserve the pre-conversion layout");
+
+    List<String> rows = runQuery("select count(*) from " + tbl);
+    assertEquals("3", rows.getFirst(),
+        "expected 3 rows after UNION-ALL insert + SET TBLPROPERTIES ACID conversion");
+  }
+
+  /**
+   * Partitioned-table variant of {@link #testUnionAllInsertThenConvertToAcid()}
+   * — the UNION-ALL insert materializes each branch under {@code p=x/HIVE_UNION_SUBDIR_<N>/000000_0}
+   * inside the partition directory. CONVERT TO ACID is still a metadata-only
+   * flip, and the subsequent SELECT returns the expected row count.
+   */
+  @Test
+  void testPartitionedUnionAllInsertThenConvertToAcid() throws Exception {
+    String tbl = "union_all_repro_part";
+    runQuery("create table " + tbl + " (a int, b int) partitioned by (p string) "
+        + "stored as orc tblproperties ('transactional'='false')");
+
+    insertUnionAllIntoPartition(tbl, "x");
+
+    List<String> expectedLayout = List.of(
+        "/union_all_repro_part/p=x/HIVE_UNION_SUBDIR_1/000000_0",
+        "/union_all_repro_part/p=x/HIVE_UNION_SUBDIR_2/000000_0",
+        "/union_all_repro_part/p=x/HIVE_UNION_SUBDIR_3/000000_0");
+    List<String> beforeLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, beforeLayout, "pre-conversion layout");
+
+    runQuery("alter table " + tbl + " convert to acid");
+
+    List<String> afterLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, afterLayout,
+        "CONVERT TO ACID should be a metadata-only flip and preserve the pre-conversion layout");
+
+    List<String> rows = runQuery("select count(*) from " + tbl);
+    assertEquals("3", rows.getFirst(),
+        "expected 3 rows after partitioned UNION-ALL insert + CONVERT TO ACID");
+  }
+
+  /**
+   * Partitioned-table variant of
+   * {@link #testUnionAllInsertThenSetTblpropertiesAcid()} — the
+   * {@code UpgradeTool}-style path preserves the pre-conversion partition
+   * layout, and the subsequent SELECT returns the expected row count.
+   */
+  @Test
+  void testPartitionedUnionAllInsertThenSetTblpropertiesAcid() throws Exception {
+    String tbl = "union_all_repro_part_setprops";
+    runQuery("create table " + tbl + " (a int, b int) partitioned by (p string) "
+        + "stored as orc tblproperties ('transactional'='false')");
+
+    insertUnionAllIntoPartition(tbl, "x");
+
+    List<String> expectedLayout = List.of(
+        "/union_all_repro_part_setprops/p=x/HIVE_UNION_SUBDIR_1/000000_0",
+        "/union_all_repro_part_setprops/p=x/HIVE_UNION_SUBDIR_2/000000_0",
+        "/union_all_repro_part_setprops/p=x/HIVE_UNION_SUBDIR_3/000000_0");
+    List<String> beforeLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, beforeLayout, "pre-conversion layout");
+
+    runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')");
+
+    List<String> afterLayout = layoutOf(tbl);
+    assertEquals(expectedLayout, afterLayout,
+        "SET TBLPROPERTIES ('transactional'='true') should preserve the pre-conversion layout");
+
+    List<String> rows = runQuery("select count(*) from " + tbl);
+    assertEquals("3", rows.getFirst(),
+        "expected 3 rows after partitioned UNION-ALL insert + SET TBLPROPERTIES ACID conversion");
+  }
+
+  // ---------------------------------------------------------------------------
+  // flatten=true variants
+  //
+  // hive.tez.union.flatten.subdirectories=true asks MoveTask to hoist the
+  // HIVE_UNION_SUBDIR_<N>/000000_0 leaves into the target directory at write
+  // time. MoveTask.flattenUnionSubdirectories folds the source subdir index
+  // into the filename to avoid collisions, producing <index>_000000_0 (e.g.
+  // "1_000000_0"). That name has three numeric parts / two underscores and
+  // therefore does NOT match the metastore's ORIGINAL_PATTERN ([0-9]+_[0-9]+)
+  // — so a subsequent ACID conversion (either CONVERT TO ACID or the
+  // SET TBLPROPERTIES flip) is rejected by
+  // TransactionalValidationListener.validateTableStructureForPath.
+  //
+  // These four tests pin that current behavior: pre-conversion the layout is
+  // <index>_000000_0 files (partitioned or not), and the conversion attempt
+  // fails at metastore-side validation. When the flatten filename scheme is
+  // aligned with ORIGINAL_PATTERN (or the validator is relaxed for this
+  // shape), these tests should be updated to assert successful conversion +
+  // 3-row read-back.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enable the write-time flatten and re-run the given block. Restores the
+   * previous value on exit.
+   */
+  private void withUnionFlattenAtWriteTime(ThrowingRunnable body) throws Exception {
+    boolean previous = HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES);
+    HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES, true);
+    try {
+      body.run();
+    } finally {
+      HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_TEZ_UNION_FLATTEN_SUBDIRECTORIES, previous);
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  /**
+   * flatten=true + unpartitioned + CONVERT TO ACID. Pins the current
+   * behavior: MoveTask hoists the union-subdir leaves into
+   * {@code <index>_000000_0} files at the table root, and the subsequent
+   * CONVERT TO ACID is rejected by the metastore's file-name validator.
+   */
+  @Test
+  void testUnionAllInsertWithFlattenThenConvertToAcid() throws Exception {
+    String tbl = "union_all_repro";
+    withUnionFlattenAtWriteTime(() -> {
+      runQuery("create table " + tbl + " (a int, b int) stored as orc "
+          + "tblproperties ('transactional'='false')");
+
+      insertUnionAllInto(tbl);
+
+      List<String> expectedLayout = List.of(
+          "/union_all_repro/1_000000_0",
+          "/union_all_repro/2_000000_0",
+          "/union_all_repro/3_000000_0");
+      assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
+
+      Exception thrown = assertThrows(Exception.class,
+          () -> runQuery("alter table " + tbl + " convert to acid"),
+          "flatten=true names don't match ORIGINAL_PATTERN → metastore rejects the conversion");
+      assertTrue(thrown.getMessage().contains("Unexpected data file name format"),
+          "expected metastore-side name-validation failure, got: " + thrown.getMessage());
+    });
+  }
+
+  /**
+   * flatten=true + unpartitioned + SET TBLPROPERTIES ACID conversion. Same
+   * failure as the CONVERT TO ACID variant: the metastore validator rejects
+   * the {@code <index>_000000_0} filenames.
+   */
+  @Test
+  void testUnionAllInsertWithFlattenThenSetTblpropertiesAcid() throws Exception {
+    String tbl = "union_all_repro_setprops";
+    withUnionFlattenAtWriteTime(() -> {
+      runQuery("create table " + tbl + " (a int, b int) stored as orc "
+          + "tblproperties ('transactional'='false')");
+
+      insertUnionAllInto(tbl);
+
+      List<String> expectedLayout = List.of(
+          "/union_all_repro_setprops/1_000000_0",
+          "/union_all_repro_setprops/2_000000_0",
+          "/union_all_repro_setprops/3_000000_0");
+      assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
+
+      Exception thrown = assertThrows(Exception.class,
+          () -> runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')"),
+          "flatten=true names don't match ORIGINAL_PATTERN → metastore rejects the conversion");
+      assertTrue(thrown.getMessage().contains("Unexpected data file name format"),
+          "expected metastore-side name-validation failure, got: " + thrown.getMessage());
+    });
+  }
+
+  /**
+   * flatten=true + partitioned + CONVERT TO ACID. Same failure as the
+   * unpartitioned variant, inside the partition directory.
+   */
+  @Test
+  void testPartitionedUnionAllInsertWithFlattenThenConvertToAcid() throws Exception {
+    String tbl = "union_all_repro_part";
+    withUnionFlattenAtWriteTime(() -> {
+      runQuery("create table " + tbl + " (a int, b int) partitioned by (p string) "
+          + "stored as orc tblproperties ('transactional'='false')");
+
+      insertUnionAllIntoPartition(tbl, "x");
+
+      List<String> expectedLayout = List.of(
+          "/union_all_repro_part/p=x/1_000000_0",
+          "/union_all_repro_part/p=x/2_000000_0",
+          "/union_all_repro_part/p=x/3_000000_0");
+      assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
+
+      Exception thrown = assertThrows(Exception.class,
+          () -> runQuery("alter table " + tbl + " convert to acid"),
+          "flatten=true names don't match ORIGINAL_PATTERN → metastore rejects the conversion");
+      assertTrue(thrown.getMessage().contains("Unexpected data file name format"),
+          "expected metastore-side name-validation failure, got: " + thrown.getMessage());
+    });
+  }
+
+  /**
+   * flatten=true + partitioned + SET TBLPROPERTIES ACID conversion.
+   */
+  @Test
+  void testPartitionedUnionAllInsertWithFlattenThenSetTblpropertiesAcid() throws Exception {
+    String tbl = "union_all_repro_part_setprops";
+    withUnionFlattenAtWriteTime(() -> {
+      runQuery("create table " + tbl + " (a int, b int) partitioned by (p string) "
+          + "stored as orc tblproperties ('transactional'='false')");
+
+      insertUnionAllIntoPartition(tbl, "x");
+
+      List<String> expectedLayout = List.of(
+          "/union_all_repro_part_setprops/p=x/1_000000_0",
+          "/union_all_repro_part_setprops/p=x/2_000000_0",
+          "/union_all_repro_part_setprops/p=x/3_000000_0");
+      assertEquals(expectedLayout, layoutOf(tbl), "pre-conversion layout (write-time flatten on)");
+
+      Exception thrown = assertThrows(Exception.class,
+          () -> runQuery("alter table " + tbl + " set tblproperties ('transactional'='true')"),
+          "flatten=true names don't match ORIGINAL_PATTERN → metastore rejects the conversion");
+      assertTrue(thrown.getMessage().contains("Unexpected data file name format"),
+          "expected metastore-side name-validation failure, got: " + thrown.getMessage());
+    });
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix two layout issues that prevent a non-ACID table loaded via `INSERT ... UNION ALL` from being read after ACID conversion.

**1. Reader side — `VectorizedOrcAcidRowBatchReader.java`.** When walking split parents looking for a `base_*` / `delta_*` / `delete_delta_*` ancestor, the "else" branch fed every non-`base_*` name to `AcidUtils.ParsedDeltaLight.parse`, which substrings past `delta_` and calls `Long.parseLong`. On a `HIVE_UNION_SUBDIR_15/` parent this throws `NumberFormatException: For input string: "NION"`. Fixed by guarding with `startsWith(DELTA_PREFIX) || startsWith(DELETE_DELTA_PREFIX)` — mirroring the sibling non-vectorized `OrcRawRecordMerger.TransactionMetaData#findWriteIDForSynthetcRowIDs`.

**2. Writer side — `MoveTask.flattenUnionSubdirectories`.** When `hive.tez.union.flatten.subdirectories=true`, MoveTask renamed:

```
HIVE_UNION_SUBDIR_<N>/000000_0  →  <N>_000000_0     (old, three numeric parts)
```

That name has three numeric parts, so it matches neither `ORIGINAL_PATTERN` (`[0-9]+_[0-9]+`) nor `ORIGINAL_PATTERN_COPY`, and the ACID conversion validator rejects it with `"Unexpected data file name format"`.

The fix folds the subdir index into the **attempt-id** portion of the writer name (arithmetic, not textual concatenation), keeping the flattened name in the plain writer-name namespace and out of the `_copy_` namespace:

```
newAttempt = subdirIdx * 100_000 + originalAttempt

HIVE_UNION_SUBDIR_1/000000_0   →  000000_100000
HIVE_UNION_SUBDIR_23/000000_2  →  000000_2300002
```


Files touched:
- `ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java` — add the `isBase / isDelta` guard around `ParsedDeltaLight.parse`.
- `ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java` — flatten rename target changed from `<N>_000000_0` to `000000_0_copy_<N>` (uses `Utilities.COPY_KEYWORD`).

### Why are the changes needed?

Reading a table after converting it to ACID currently crashes if the pre-conversion data was written by a UNION-ALL — regardless of the flatten setting:

- **flatten=OFF (default):** `HIVE_UNION_SUBDIR_<N>/000000_0` survives the conversion (metadata-only flip; `TestTxnNoBuckets.testToAcidConversionMultiBucket` pins this contract), but the reader crashes on the subdir name.
- **flatten=ON:** conversion itself fails at `TransactionalValidationListener.validateTableStructureForPath` because `<N>_000000_0` doesn't match either allowed original-file pattern.

Both ACID DDL paths — `ALTER TABLE ... CONVERT TO ACID` and the historical `ALTER TABLE ... SET TBLPROPERTIES ('transactional'='true')` (emitted by `UpgradeTool`) — are affected.

### Does this PR introduce _any_ user-facing change?

Yes — a bug fix. Users can now convert non-ACID tables loaded via `INSERT ... UNION ALL` to full ACID and read them, in both flatten modes. **On-disk file-name change (flatten=on only):** flattened union outputs are now written as `000000_0_copy_<N>` instead of `<N>_000000_0`. No API or DDL syntax changes.

### How was this patch tested?

New JUnit 5 test class `ql/src/test/org/apache/hadoop/hive/ql/metadata/TestUnionAllToAcidConversion` — 8 tests covering `{unpartitioned, partitioned} × {CONVERT TO ACID, SET TBLPROPERTIES('transactional'='true')} × {flatten OFF, flatten ON}`. Each test asserts the exact on-disk layout before and after conversion, then asserts `SELECT COUNT(*)` returns 3.

Asserted file layouts:

- **flatten=OFF:** `/<tbl>[/p=x]/HIVE_UNION_SUBDIR_{1,2,3}/000000_0` — preserved through conversion.
- **flatten=ON:** `/<tbl>[/p=x]/000000_0_copy_{1,2,3}` — preserved through conversion (previously `<N>_000000_0`, which failed conversion).

Regression check:

```
TestTxnNoBuckets#testToAcidConversionMultiBucket           ✓  (pins the layout-preserved contract)
TestVectorizedOrcAcidRowBatchReader                        ✓  (17/17)
TestMoveTask / TestInsertCopySuffixOnFakeS3                ✓  (flatten call sites; updated for new name)
TestUnionAllToAcidConversion                               ✓  (8/8)
```