### PR TITLE
HIVE-29785: SkippingTextInputFormat: ClassCastException on skip.header.line.count files with lone-CR (\r) line endings

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/SkippingTextInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/SkippingTextInputFormat.java
@@ -116,7 +116,7 @@ public class SkippingTextInputFormat extends TextInputFormat {
         // readLine()+getPos() idiom, which throws ClassCastException on lone-CR files.
         // Deliberately not closed: LineReader.close() would close fis, which the
         // try-with-resources already owns.
-        LineReader reader = new LineReader(fis);
+        LineReader reader = new LineReader(fis, conf);
         Text headerLine = new Text();
         long currPos = 0;
         int delimiterIdx = -1;
@@ -170,12 +170,11 @@ public class SkippingTextInputFormat extends TextInputFormat {
             // A LineReader buffers read-ahead and is not seek-aware, so it is valid only
             // for the region following this seek and must not outlive the section: a
             // reader carried across the seek would keep serving bytes from the previously
-            // scanned section while offsets were counted from the new start. Sized to the
-            // section so a 5 KB window does not pull the 64 KB default; the single buffer
-            // of over-read past bufferSectionEnd is expected and discarded by
+            // scanned section while offsets were counted from the new start. The single
+            // buffer of over-read past bufferSectionEnd is expected and discarded by
             // LineBuffer.consume(). Deliberately not closed: that would close fis, which
             // the remaining sections still need.
-            LineReader reader = new LineReader(fis, bufferSectionSize);
+            LineReader reader = new LineReader(fis, conf);
             Text line = new Text();
             long pos = bufferSectionStart;
             while (pos < bufferSectionEnd) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/SkippingTextInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/SkippingTextInputFormat.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.Queue;
@@ -78,6 +79,10 @@ public class SkippingTextInputFormat extends TextInputFormat {
     } catch (IOException e) {
       LOG.warn("Could not detect header/footer", e);
       return new NullRowsInputFormat.DummyInputSplit(file);
+    } catch (RuntimeException e) {
+      // Report unexpected detection failures clearly instead of a cryptic cast.
+      throw new RuntimeException("Failed to detect header/footer boundaries for file "
+          + file + " during split generation", e);
     }
     if (cachedStart > start + length) {
       return new NullRowsInputFormat.DummyInputSplit(file);
@@ -105,15 +110,14 @@ public class SkippingTextInputFormat extends TextInputFormat {
     }
     Long startIndexForFile = startIndexMap.get(path);
     if (startIndexForFile == null) {
-      FileSystem fileSystem;
-      FSDataInputStream fis = null;
-      fileSystem = path.getFileSystem(conf);
-      try {
-        fis = fileSystem.open(path);
-        long currPos = fis.getPos();
+      FileSystem fileSystem = path.getFileSystem(conf);
+      // ByteCountingLineReader avoids the unreliable readLine()+getPos() idiom.
+      try (FSDataInputStream fis = fileSystem.open(path)) {
+        ByteCountingLineReader reader = new ByteCountingLineReader(fis);
+        long currPos = 0;
         int delimiterIdx = -1;
         for (int j = 0; j < headerCount; j++) {
-          String headerLine = fis.readLine();
+          String headerLine = reader.readLine();
           if (headerLine == null) {
             startIndexMap.put(path, Long.MAX_VALUE);
             return Long.MAX_VALUE;
@@ -124,10 +128,10 @@ public class SkippingTextInputFormat extends TextInputFormat {
             if (delimiter != null && !delimiter.isEmpty()) {
               delimiterIdx = headerLine.indexOf(delimiter);
             } else {
-              currPos = fis.getPos();
+              currPos = reader.getBytesConsumed();
             }
           } else {
-            currPos = fis.getPos();
+            currPos = reader.getBytesConsumed();
           }
         }
         // Readers skip the entire first row if the start index of the
@@ -136,10 +140,6 @@ public class SkippingTextInputFormat extends TextInputFormat {
         // is discarded instead of the first valid input row.
         // We consider record delimiters if they exist.
         startIndexForFile = currPos + delimiterIdx;
-      } finally {
-        if (fis != null) {
-          fis.close();
-        }
       }
       startIndexMap.put(path, startIndexForFile);
     }
@@ -160,20 +160,20 @@ public class SkippingTextInputFormat extends TextInputFormat {
 
         // we need 'footer count' lines and one space for EOF
         LineBuffer buffer = new LineBuffer(footerCount + 1);
-        FSDataInputStream fis = null;
-        try {
-          fis = fileSystem.open(path);
+        try (FSDataInputStream fis = fileSystem.open(path)) {
           while (bufferSectionEnd > bufferSectionStart) {
             fis.seek(bufferSectionStart);
-            long pos = fis.getPos();
+            // Fresh reader per seek; offsets are seek position + bytes consumed.
+            ByteCountingLineReader reader = new ByteCountingLineReader(fis);
+            long pos = bufferSectionStart;
             while (pos < bufferSectionEnd) {
-              if (fis.readLine() == null) {
+              if (reader.readLine() == null) {
                 // if there is not enough lines in this section, check the previous
                 // section. If this is the beginning section, there are simply not
                 // enough lines in the file.
                 break;
               }
-              pos = fis.getPos();
+              pos = bufferSectionStart + reader.getBytesConsumed();
               buffer.consume(pos, bufferSectionEnd);
             }
             if (buffer.getRemainingLineCount() == 0) {
@@ -193,15 +193,70 @@ public class SkippingTextInputFormat extends TextInputFormat {
             // there were not enough lines in the file to consume all footer rows.
             endIndexForFile = Long.MIN_VALUE;
           }
-        } finally {
-          if (fis != null) {
-            fis.close();
-          }
         }
       }
       endIndexMap.put(path, endIndexForFile);
     }
     return endIndexForFile;
+  }
+
+  /**
+   * Reads lines while counting bytes consumed, so offsets can be computed without
+   * {@link FSDataInputStream#getPos()} -- which is unreliable after {@code readLine()}:
+   * a lone {@code '\r'} makes it swap in a non-Seekable {@code PushbackInputStream}, so
+   * the next {@code getPos()} throws {@code ClassCastException}. Handles {@code '\n'},
+   * {@code '\r\n'} and lone {@code '\r'}; after {@link #readLine()},
+   * {@link #getBytesConsumed()} is the offset just past the line's terminator.
+   */
+  static final class ByteCountingLineReader {
+    private final InputStream in;
+    private long bytesConsumed;
+    // Look-ahead byte past a '\r' (belongs to the next line, not yet counted); -1 = empty.
+    private int pushedBack = -1;
+
+    ByteCountingLineReader(InputStream in) {
+      this.in = in;
+    }
+
+    long getBytesConsumed() {
+      return bytesConsumed;
+    }
+
+    private int nextByte() throws IOException {
+      if (pushedBack != -1) {
+        int b = pushedBack;
+        pushedBack = -1;
+        return b;
+      }
+      return in.read();
+    }
+
+    /** Returns the next line without its terminator, or {@code null} at end of stream. */
+    String readLine() throws IOException {
+      int c = nextByte();
+      if (c == -1) {
+        return null;
+      }
+      StringBuilder sb = new StringBuilder();
+      while (c != -1) {
+        bytesConsumed++;
+        if (c == '\n') {
+          return sb.toString();
+        }
+        if (c == '\r') {
+          int next = nextByte();
+          if (next == '\n') {
+            bytesConsumed++;
+          } else if (next != -1) {
+            pushedBack = next; // belongs to the next line, not yet counted
+          }
+          return sb.toString();
+        }
+        sb.append((char) c);
+        c = nextByte();
+      }
+      return sb.toString();
+    }
   }
 
   static class LineBuffer {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/SkippingTextInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/SkippingTextInputFormat.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
@@ -109,10 +108,14 @@ public class SkippingTextInputFormat extends TextInputFormat {
     Long startIndexForFile = startIndexMap.get(path);
     if (startIndexForFile == null) {
       FileSystem fileSystem = path.getFileSystem(conf);
-      // Hadoop's LineReader counts bytes internally and handles '\n', '\r\n' and
-      // lone '\r', so we avoid the unreliable readLine()+getPos() idiom that throws
-      // ClassCastException on lone-CR files.
+      String delimiter = conf.get("textinputformat.record.delimiter");
+      boolean hasDelimiter = delimiter != null && !delimiter.isEmpty();
       try (FSDataInputStream fis = fileSystem.open(path)) {
+        // LineReader terminates on '\n', '\r\n' and lone '\r' and returns the number of
+        // bytes it consumed, so offsets come from that count instead of the
+        // readLine()+getPos() idiom, which throws ClassCastException on lone-CR files.
+        // Deliberately not closed: LineReader.close() would close fis, which the
+        // try-with-resources already owns.
         LineReader reader = new LineReader(fis);
         Text headerLine = new Text();
         long currPos = 0;
@@ -123,19 +126,14 @@ public class SkippingTextInputFormat extends TextInputFormat {
             startIndexMap.put(path, Long.MAX_VALUE);
             return Long.MAX_VALUE;
           }
-          if (j == headerCount-1) {
-            String delimiter = conf.get("textinputformat.record.delimiter");
-            // If record delimiter is defined
-            if (delimiter != null && !delimiter.isEmpty()) {
-              // Decode as ISO-8859-1 (one char per byte) so the delimiter's index is a
-              // byte offset, matching currPos. Text.toString() would decode UTF-8 and
-              // shift the index for multi-byte header bytes preceding the delimiter.
-              String lastHeader =
-                  new String(headerLine.getBytes(), 0, headerLine.getLength(), StandardCharsets.ISO_8859_1);
-              delimiterIdx = lastHeader.indexOf(delimiter);
-            } else {
-              currPos += bytesRead;
-            }
+          if (j == headerCount - 1 && hasDelimiter) {
+            // Decode one char per byte so indexOf() yields a byte offset comparable with
+            // currPos. This preserves the old DataInputStream.readLine(), which
+            // zero-extended each byte to a char; Text.toString() would decode UTF-8 and
+            // shift the index whenever the header holds multi-byte characters.
+            String lastHeader =
+                new String(headerLine.getBytes(), 0, headerLine.getLength(), StandardCharsets.ISO_8859_1);
+            delimiterIdx = lastHeader.indexOf(delimiter);
           } else {
             currPos += bytesRead;
           }
@@ -155,7 +153,7 @@ public class SkippingTextInputFormat extends TextInputFormat {
   private long getCachedEndIndex(Path path) throws IOException {
     Long endIndexForFile = endIndexMap.get(path);
     if (endIndexForFile == null) {
-      final long bufferSectionSize = 5 * 1024;
+      final int bufferSectionSize = 5 * 1024;
       FileSystem fileSystem = path.getFileSystem(conf);
       long endOfFile = fileSystem.getFileStatus(path).getLen();
       if (footerCount == 0) {
@@ -167,12 +165,18 @@ public class SkippingTextInputFormat extends TextInputFormat {
         // we need 'footer count' lines and one space for EOF
         LineBuffer buffer = new LineBuffer(footerCount + 1);
         try (FSDataInputStream fis = fileSystem.open(path)) {
-          Text line = new Text();
           while (bufferSectionEnd > bufferSectionStart) {
             fis.seek(bufferSectionStart);
-            // Fresh reader per seek; offsets are seek position + bytes consumed.
-            LineReader reader = new LineReader(fis);
-            long consumed = 0;
+            // A LineReader buffers read-ahead and is not seek-aware, so it is valid only
+            // for the region following this seek and must not outlive the section: a
+            // reader carried across the seek would keep serving bytes from the previously
+            // scanned section while offsets were counted from the new start. Sized to the
+            // section so a 5 KB window does not pull the 64 KB default; the single buffer
+            // of over-read past bufferSectionEnd is expected and discarded by
+            // LineBuffer.consume(). Deliberately not closed: that would close fis, which
+            // the remaining sections still need.
+            LineReader reader = new LineReader(fis, bufferSectionSize);
+            Text line = new Text();
             long pos = bufferSectionStart;
             while (pos < bufferSectionEnd) {
               int bytesRead = reader.readLine(line);
@@ -182,8 +186,7 @@ public class SkippingTextInputFormat extends TextInputFormat {
                 // enough lines in the file.
                 break;
               }
-              consumed += bytesRead;
-              pos = bufferSectionStart + consumed;
+              pos += bytesRead;
               buffer.consume(pos, bufferSectionEnd);
             }
             if (buffer.getRemainingLineCount() == 0) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/SkippingTextInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/SkippingTextInputFormat.java
@@ -21,13 +21,15 @@ package org.apache.hadoop.hive.ql.io;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
+import org.apache.hadoop.util.LineReader;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.Queue;
@@ -79,10 +81,6 @@ public class SkippingTextInputFormat extends TextInputFormat {
     } catch (IOException e) {
       LOG.warn("Could not detect header/footer", e);
       return new NullRowsInputFormat.DummyInputSplit(file);
-    } catch (RuntimeException e) {
-      // Report unexpected detection failures clearly instead of a cryptic cast.
-      throw new RuntimeException("Failed to detect header/footer boundaries for file "
-          + file + " during split generation", e);
     }
     if (cachedStart > start + length) {
       return new NullRowsInputFormat.DummyInputSplit(file);
@@ -111,14 +109,17 @@ public class SkippingTextInputFormat extends TextInputFormat {
     Long startIndexForFile = startIndexMap.get(path);
     if (startIndexForFile == null) {
       FileSystem fileSystem = path.getFileSystem(conf);
-      // ByteCountingLineReader avoids the unreliable readLine()+getPos() idiom.
+      // Hadoop's LineReader counts bytes internally and handles '\n', '\r\n' and
+      // lone '\r', so we avoid the unreliable readLine()+getPos() idiom that throws
+      // ClassCastException on lone-CR files.
       try (FSDataInputStream fis = fileSystem.open(path)) {
-        ByteCountingLineReader reader = new ByteCountingLineReader(fis);
+        LineReader reader = new LineReader(fis);
+        Text headerLine = new Text();
         long currPos = 0;
         int delimiterIdx = -1;
         for (int j = 0; j < headerCount; j++) {
-          String headerLine = reader.readLine();
-          if (headerLine == null) {
+          int bytesRead = reader.readLine(headerLine);
+          if (bytesRead == 0) {
             startIndexMap.put(path, Long.MAX_VALUE);
             return Long.MAX_VALUE;
           }
@@ -126,12 +127,17 @@ public class SkippingTextInputFormat extends TextInputFormat {
             String delimiter = conf.get("textinputformat.record.delimiter");
             // If record delimiter is defined
             if (delimiter != null && !delimiter.isEmpty()) {
-              delimiterIdx = headerLine.indexOf(delimiter);
+              // Decode as ISO-8859-1 (one char per byte) so the delimiter's index is a
+              // byte offset, matching currPos. Text.toString() would decode UTF-8 and
+              // shift the index for multi-byte header bytes preceding the delimiter.
+              String lastHeader =
+                  new String(headerLine.getBytes(), 0, headerLine.getLength(), StandardCharsets.ISO_8859_1);
+              delimiterIdx = lastHeader.indexOf(delimiter);
             } else {
-              currPos = reader.getBytesConsumed();
+              currPos += bytesRead;
             }
           } else {
-            currPos = reader.getBytesConsumed();
+            currPos += bytesRead;
           }
         }
         // Readers skip the entire first row if the start index of the
@@ -161,19 +167,23 @@ public class SkippingTextInputFormat extends TextInputFormat {
         // we need 'footer count' lines and one space for EOF
         LineBuffer buffer = new LineBuffer(footerCount + 1);
         try (FSDataInputStream fis = fileSystem.open(path)) {
+          Text line = new Text();
           while (bufferSectionEnd > bufferSectionStart) {
             fis.seek(bufferSectionStart);
             // Fresh reader per seek; offsets are seek position + bytes consumed.
-            ByteCountingLineReader reader = new ByteCountingLineReader(fis);
+            LineReader reader = new LineReader(fis);
+            long consumed = 0;
             long pos = bufferSectionStart;
             while (pos < bufferSectionEnd) {
-              if (reader.readLine() == null) {
+              int bytesRead = reader.readLine(line);
+              if (bytesRead == 0) {
                 // if there is not enough lines in this section, check the previous
                 // section. If this is the beginning section, there are simply not
                 // enough lines in the file.
                 break;
               }
-              pos = bufferSectionStart + reader.getBytesConsumed();
+              consumed += bytesRead;
+              pos = bufferSectionStart + consumed;
               buffer.consume(pos, bufferSectionEnd);
             }
             if (buffer.getRemainingLineCount() == 0) {
@@ -198,65 +208,6 @@ public class SkippingTextInputFormat extends TextInputFormat {
       endIndexMap.put(path, endIndexForFile);
     }
     return endIndexForFile;
-  }
-
-  /**
-   * Reads lines while counting bytes consumed, so offsets can be computed without
-   * {@link FSDataInputStream#getPos()} -- which is unreliable after {@code readLine()}:
-   * a lone {@code '\r'} makes it swap in a non-Seekable {@code PushbackInputStream}, so
-   * the next {@code getPos()} throws {@code ClassCastException}. Handles {@code '\n'},
-   * {@code '\r\n'} and lone {@code '\r'}; after {@link #readLine()},
-   * {@link #getBytesConsumed()} is the offset just past the line's terminator.
-   */
-  static final class ByteCountingLineReader {
-    private final InputStream in;
-    private long bytesConsumed;
-    // Look-ahead byte past a '\r' (belongs to the next line, not yet counted); -1 = empty.
-    private int pushedBack = -1;
-
-    ByteCountingLineReader(InputStream in) {
-      this.in = in;
-    }
-
-    long getBytesConsumed() {
-      return bytesConsumed;
-    }
-
-    private int nextByte() throws IOException {
-      if (pushedBack != -1) {
-        int b = pushedBack;
-        pushedBack = -1;
-        return b;
-      }
-      return in.read();
-    }
-
-    /** Returns the next line without its terminator, or {@code null} at end of stream. */
-    String readLine() throws IOException {
-      int c = nextByte();
-      if (c == -1) {
-        return null;
-      }
-      StringBuilder sb = new StringBuilder();
-      while (c != -1) {
-        bytesConsumed++;
-        if (c == '\n') {
-          return sb.toString();
-        }
-        if (c == '\r') {
-          int next = nextByte();
-          if (next == '\n') {
-            bytesConsumed++;
-          } else if (next != -1) {
-            pushedBack = next; // belongs to the next line, not yet counted
-          }
-          return sb.toString();
-        }
-        sb.append((char) c);
-        c = nextByte();
-      }
-      return sb.toString();
-    }
   }
 
   static class LineBuffer {

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/TestSkippingTextInputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/TestSkippingTextInputFormat.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -192,6 +193,135 @@ public class TestSkippingTextInputFormat {
       }
       reader.close();
     }
+  }
+
+  /**
+   * Reproduces ClassCastException (PushbackInputStream cannot be cast to Seekable)
+   * during split generation when a header line ends in a lone CR ('\r') followed
+   * by a non-'\n' byte (classic-Mac line endings). readLine() swaps the stream's
+   * inner input for a non-Seekable PushbackInputStream; the following getPos() casts.
+   * With the byte-counting reader this now succeeds instead of throwing.
+   */
+  @Test
+  public void testSkipFileSplitsLoneCR() throws Exception {
+    FileInputFormat.setInputPaths(job, dataDir);
+    Path loneCrFile = new Path(dataDir, "data1_cr_only.csv");
+    // Exact bytes from HIVE-29785:
+    //   printf "id;name;place;\n1;smruti;ctc;\n2;biswal;bbsr;\n3;'';NULL;\n" | tr '\n' '\r'
+    writeTextFile(loneCrFile,
+        "id;name;place;\r" +
+        "1;smruti;ctc;\r" +
+        "2;biswal;bbsr;\r" +
+        "3;'';NULL;\r");
+
+    SkippingTextInputFormat inputFormat = new SkippingTextInputFormat();
+    inputFormat.configure(job, 1, 0); // skip.header.line.count = 1, no footer
+    FileInputFormat.setInputPaths(job, loneCrFile);
+
+    // On unmodified master this throws ClassCastException during split generation.
+    InputSplit[] splits = inputFormat.getSplits(job, 1);
+    assertTrue(splits.length >= 1);
+
+    // Read every row back: the header must be skipped and no data row truncated,
+    // i.e. SELECT COUNT(*) would return the 3 data rows.
+    List<String> received = new ArrayList<String>();
+    for (InputSplit split : splits) {
+      RecordReader<LongWritable, Text> reader =
+          inputFormat.getRecordReader(split, job, reporter);
+      LongWritable key = reader.createKey();
+      Text value = reader.createValue();
+      while (reader.next(key, value)) {
+        received.add(value.toString());
+      }
+      reader.close();
+    }
+    assertEquals(3, received.size());
+    assertEquals("1;smruti;ctc;", received.get(0));
+    assertEquals("2;biswal;bbsr;", received.get(1));
+    assertEquals("3;'';NULL;", received.get(2));
+  }
+
+  /**
+   * The lone-CR fix must not move split boundaries for the well-behaved cases.
+   * The same logical content is written with LF, lone-CR and CRLF terminators;
+   * LF and lone-CR share a one-byte terminator so their (start, length) must be
+   * identical, while CRLF's two-byte terminator shifts the header boundary by one.
+   */
+  @Test
+  public void testSkipHeaderSplitOffsetsAcrossLineEndings() throws Exception {
+    Path lf = new Path(dataDir, "lf.csv");
+    writeTextFile(lf,
+        "id;name;place;\n1;smruti;ctc;\n2;biswal;bbsr;\n3;'';NULL;\n");
+    Path cr = new Path(dataDir, "cr.csv");
+    writeTextFile(cr,
+        "id;name;place;\r1;smruti;ctc;\r2;biswal;bbsr;\r3;'';NULL;\r");
+    Path crlf = new Path(dataDir, "crlf.csv");
+    writeTextFile(crlf,
+        "id;name;place;\r\n1;smruti;ctc;\r\n2;biswal;bbsr;\r\n3;'';NULL;\r\n");
+
+    FileSplit lfSplit = singleHeaderSplit(lf);
+    FileSplit crSplit = singleHeaderSplit(cr);
+    FileSplit crlfSplit = singleHeaderSplit(crlf);
+
+    // LF and lone-CR: identical byte layout (1-byte terminator) => identical split.
+    assertEquals(14, lfSplit.getStart());
+    assertEquals(41, lfSplit.getLength());
+    assertEquals(lfSplit.getStart(), crSplit.getStart());
+    assertEquals(lfSplit.getLength(), crSplit.getLength());
+
+    // CRLF: 2-byte terminator shifts the header boundary by one; file is 4 bytes longer.
+    assertEquals(15, crlfSplit.getStart());
+    assertEquals(44, crlfSplit.getLength());
+  }
+
+  /**
+   * Exercises the footer detection path (getCachedEndIndex) with lone-CR line
+   * endings, which throws the same ClassCastException on unmodified master.
+   * The header and footer rows must be skipped and the two data rows read back.
+   */
+  @Test
+  public void testSkipFileSplitsLoneCRHeaderFooter() throws Exception {
+    FileInputFormat.setInputPaths(job, dataDir);
+    Path file = new Path(dataDir, "cr_header_footer.csv");
+    writeTextFile(file,
+        "dir1_header\r" +
+        "dir1_file1_line1\r" +
+        "dir1_file1_line2\r" +
+        "dir1_footer");
+
+    SkippingTextInputFormat inputFormat = new SkippingTextInputFormat();
+    inputFormat.configure(job, 1, 1); // skip one header and one footer line
+    FileInputFormat.setInputPaths(job, file);
+    InputSplit[] splits = inputFormat.getSplits(job, 2);
+
+    List<String> received = new ArrayList<String>();
+    for (int i = 0; i < splits.length; i++) {
+      RecordReader<LongWritable, Text> reader =
+          inputFormat.getRecordReader(splits[i], job, reporter);
+      LongWritable key = reader.createKey();
+      Text value = reader.createValue();
+      while (reader.next(key, value)) {
+        received.add(value.toString());
+      }
+      reader.close();
+    }
+    assertEquals(2, received.size());
+    assertTrue(!received.get(0).contains("header"));
+    assertTrue(!received.get(received.size() - 1).contains("footer"));
+  }
+
+  /**
+   * Generates the single (header-adjusted) split for the given file with
+   * skip.header.line.count=1 and no footer.
+   */
+  private FileSplit singleHeaderSplit(Path file) throws Exception {
+    SkippingTextInputFormat inputFormat = new SkippingTextInputFormat();
+    inputFormat.configure(job, 1, 0);
+    FileInputFormat.setInputPaths(job, file);
+    InputSplit[] splits = inputFormat.getSplits(job, 1);
+    assertEquals(1, splits.length);
+    assertTrue(splits[0] instanceof FileSplit);
+    return (FileSplit) splits[0];
   }
 
   /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/TestSkippingTextInputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/TestSkippingTextInputFormat.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -311,6 +312,32 @@ public class TestSkippingTextInputFormat {
   }
 
   /**
+   * Header skipping with a custom textinputformat.record.delimiter must locate the
+   * delimiter by BYTE offset. The last header line is decoded one char per byte
+   * (ISO-8859-1) so indexOf() lines up with the byte-counting currPos; decoding the
+   * header as UTF-8 (Text.toString()) would shrink the index by one for every
+   * multi-byte character preceding the delimiter and shift the split start.
+   */
+  @Test
+  public void testSkipHeaderMultiByteWithRecordDelimiter() throws Exception {
+    // 'é' is two UTF-8 bytes (0xC3 0xA9), so the '~' delimiter sits at byte offset 7
+    // ("h", "é" [2 bytes], "a", "d", "e", "r", "~") but at char index 6 under UTF-8.
+    Path file = new Path(dataDir, "multibyte_delim.csv");
+    writeUtf8File(file, "héader~data_row1~data_row2");
+
+    job.set("textinputformat.record.delimiter", "~");
+    SkippingTextInputFormat inputFormat = new SkippingTextInputFormat();
+    inputFormat.configure(job, 1, 0); // skip one header "line", no footer
+    FileInputFormat.setInputPaths(job, file);
+    InputSplit[] splits = inputFormat.getSplits(job, 1);
+
+    assertEquals(1, splits.length);
+    assertTrue(splits[0] instanceof FileSplit);
+    // Byte offset of the delimiter; char-based UTF-8 decoding would wrongly yield 6.
+    assertEquals(7, ((FileSplit) splits[0]).getStart());
+  }
+
+  /**
    * Generates the single (header-adjusted) split for the given file with
    * skip.header.line.count=1 and no footer.
    */
@@ -331,5 +358,16 @@ public class TestSkippingTextInputFormat {
     OutputStreamWriter writer = new OutputStreamWriter(fileSystem.create(file));
     writer.write(content);
     writer.close();
+  }
+
+  /**
+   * Writes the given string to the given file as UTF-8, so multi-byte characters
+   * land as a deterministic byte sequence regardless of the platform default charset.
+   */
+  private void writeUtf8File(Path file, String content) throws IOException {
+    try (OutputStreamWriter writer =
+        new OutputStreamWriter(fileSystem.create(file), StandardCharsets.UTF_8)) {
+      writer.write(content);
+    }
   }
 }


### PR DESCRIPTION
For tables with skip.header.line.count/skip.footer.line.count, SkippingTextInputFormat called readLine() then getPos() on the same FSDataInputStream (in getCachedStartIndex and getCachedEndIndex). When the data contains a lone \r (not followed by \n), DataInputStream.readLine() pushes back its look-ahead byte by wrapping the stream in a non-Seekable PushbackInputStream. The following getPos() then throws ClassCastException during Tez split generation. LF, CRLF, and \r-at-EOF were unaffected.

Replace readLine()+getPos() in both methods with a ByteCountingLineReader that handles \n, \r\n, and lone \r, computing offsets from bytes consumed, so getPos() is never called on a mutated stream. Offset behavior is unchanged. As a safety net, makeSplitInternal now turns any unexpected error from header/footer detection into a clear, file-specific message instead of a raw ClassCastException

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Added unit tests in `TestSkippingTextInputFormat`:

- **`testSkipFileSplitsLoneCR`** — reproduces the `ClassCastException` on a lone-CR file with `skip.header.line.count=1` (fails on master, passes with this fix).
- **`testSkipHeaderSplitOffsetsAcrossLineEndings`** — writes the same content with LF, lone-CR, and CRLF terminators and asserts exact split `getStart()`/`getLength()`, proving lone-CR matches LF and there is no boundary regression.
- **`testSkipFileSplitsLoneCRHeaderFooter`** — exercises the footer path (`getCachedEndIndex`) with lone-CR and skip header/footer, verifying the header and footer rows are skipped.