### PR TITLE
HIVE-28405: Align hive.repl.cm.retain declared time unit with metastore (documentation only)

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -401,9 +401,10 @@ public class HiveConf extends Configuration {
         "Turn on ChangeManager, so delete files will go to cmrootdir."),
     REPL_CM_DIR("hive.repl.cmrootdir","/user/${system:user.name}/cmroot/",
         "Root dir for ChangeManager, used for deleted files."),
-    REPL_CM_RETAIN("hive.repl.cm.retain","10d",
-        new TimeValidator(TimeUnit.DAYS),
-        "Time to retain removed files in cmrootdir."),
+    REPL_CM_RETAIN("hive.repl.cm.retain","240h",
+        new TimeValidator(TimeUnit.HOURS),
+        "Time to retain removed files in cmrootdir. A unit-less value is interpreted in hours, "
+            + "matching the metastore counterpart metastore.repl.cm.retain. Default is 240h (10 days)."),
     REPL_CM_ENCRYPTED_DIR("hive.repl.cm.encryptionzone.rootdir", ".cmroot",
             "Root dir for ChangeManager if encryption zones are enabled, used for deleted files."),
     REPL_CM_FALLBACK_NONENCRYPTED_DIR("hive.repl.cm.nonencryptionzone.rootdir",

--- a/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
+++ b/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
@@ -125,7 +125,7 @@ public class TestHiveConf {
   }
 
   @Test
-  public void testReplCmRetainTimeUnit() throws Exception {
+  public void testReplCmRetainTimeUnit() {
     HiveConf conf = new HiveConf();
 
     // The default (240h) is 10 days. Guards against accidentally changing the default duration.

--- a/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
+++ b/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
@@ -125,6 +125,25 @@ public class TestHiveConf {
   }
 
   @Test
+  public void testReplCmRetainTimeUnit() throws Exception {
+    HiveConf conf = new HiveConf();
+
+    // The default (240h) is 10 days. Guards against accidentally changing the default duration.
+    Assert.assertEquals(10, conf.getTimeVar(ConfVars.REPL_CM_RETAIN, TimeUnit.DAYS));
+    Assert.assertEquals(240, conf.getTimeVar(ConfVars.REPL_CM_RETAIN, TimeUnit.HOURS));
+
+    // A unit-less value is interpreted in hours, matching the metastore counterpart
+    // metastore.repl.cm.retain, which uses a HOURS base unit.
+    Assert.assertEquals(TimeUnit.HOURS, HiveConf.getDefaultTimeUnit(ConfVars.REPL_CM_RETAIN));
+    conf.setVar(ConfVars.REPL_CM_RETAIN, "10");
+    Assert.assertEquals(10, conf.getTimeVar(ConfVars.REPL_CM_RETAIN, TimeUnit.HOURS));
+
+    // An explicit unit suffix is still honoured.
+    conf.setVar(ConfVars.REPL_CM_RETAIN, "10d");
+    Assert.assertEquals(10, conf.getTimeVar(ConfVars.REPL_CM_RETAIN, TimeUnit.DAYS));
+  }
+
+  @Test
   public void testToSizeBytes() throws Exception {
     Assert.assertEquals(1L, HiveConf.toSizeBytes("1b"));
     Assert.assertEquals(1L, HiveConf.toSizeBytes("1bytes"));


### PR DESCRIPTION
### What changes were proposed in this pull request?
`hive.repl.cm.retain` declared a DAYS-based `TimeValidator`, while the
equivalent metastore config `metastore.repl.cm.retain` uses a HOURS base
unit. As a result a unit-less value (e.g. `10`) was documented as days on
the HiveConf side but interpreted as hours by the metastore.

This PR changes the HiveConf `TimeValidator` to `HOURS` and expresses the
default as `240h` so the declared unit and value match the metastore
counterpart. A `TestHiveConf` case is added asserting the default resolves
to 10 days and that unit-less values are interpreted in hours.

### Why are the changes needed?
To remove the misleading unit mismatch between the two equivalent configs.

### Does this PR introduce any user-facing change?
No functional change. `HiveConf.REPL_CM_RETAIN` is not read anywhere via
`getTimeVar`, and the default is unchanged (`240h` == `10d`). This is a
documentation/consistency change only.

### How was this patch tested?
Added `TestHiveConf#testReplCmRetainTimeUnit`.
