### PR TITLE
HIVE-29804: Include table inputs for HS2 authorization SHOW TBLPROPERTIES and SHOW TABLE EXTENDED

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/properties/ShowTablePropertiesAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/properties/ShowTablePropertiesAnalyzer.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.hive.ql.ddl.DDLWork;
 import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
+import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
@@ -45,7 +47,8 @@ public class ShowTablePropertiesAnalyzer extends BaseSemanticAnalyzer {
     TableName tableName = getQualifiedTableName((ASTNode) root.getChild(0));
     String propertyName = (root.getChildCount() > 1) ? unescapeSQLString(root.getChild(1).getText()) : null;
 
-    getTable(tableName); // validate that table exists
+    Table table = getTable(tableName);
+    inputs.add(new ReadEntity(table));
 
     ShowTablePropertiesDesc desc = new ShowTablePropertiesDesc(ctx.getResFile().toString(), tableName, propertyName);
     Task<DDLWork> task = TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc));

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/status/ShowTableStatusAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/status/ShowTableStatusAnalyzer.java
@@ -27,10 +27,11 @@ import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
 import org.apache.hadoop.hive.ql.ddl.table.partition.PartitionUtils;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
+import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
-import org.apache.hadoop.hive.ql.parse.HiveTableName;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
@@ -68,9 +69,12 @@ public class ShowTableStatusAnalyzer extends BaseSemanticAnalyzer {
       }
     }
 
+    Table table = getTable(dbName, tableNames, true);
+    inputs.add(new ReadEntity(table));
+
     if (partitionSpec != null) {
       // validate that partition exists
-      PartitionUtils.getPartition(db, getTable(HiveTableName.of(tableNames)), partitionSpec, true);
+      PartitionUtils.getPartition(db, table, partitionSpec, true);
     }
 
     ShowTableStatusDesc desc = new ShowTableStatusDesc(ctx.getResFile(), dbName, tableNames, partitionSpec);

--- a/ql/src/test/queries/clientnegative/authorization_show_tableextended_nosel.q
+++ b/ql/src/test/queries/clientnegative/authorization_show_tableextended_nosel.q
@@ -1,0 +1,10 @@
+--! qt:authorizer
+set user.name=user1;
+
+create table t_show_ext(i int);
+
+grant all on table t_show_ext to user user2;
+revoke select on table t_show_ext from user user2;
+
+set user.name=user2;
+show table extended like 't_show_ext';

--- a/ql/src/test/queries/clientnegative/authorization_show_tblproperties_nosel.q
+++ b/ql/src/test/queries/clientnegative/authorization_show_tblproperties_nosel.q
@@ -1,0 +1,10 @@
+--! qt:authorizer
+set user.name=user1;
+
+create table t_show_props(i int);
+
+grant all on table t_show_props to user user2;
+revoke select on table t_show_props from user user2;
+
+set user.name=user2;
+show tblproperties t_show_props;

--- a/ql/src/test/results/clientnegative/authorization_show_tableextended_nosel.q.out
+++ b/ql/src/test/results/clientnegative/authorization_show_tableextended_nosel.q.out
@@ -1,0 +1,21 @@
+PREHOOK: query: create table t_show_ext(i int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_show_ext
+POSTHOOK: query: create table t_show_ext(i int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_show_ext
+PREHOOK: query: grant all on table t_show_ext to user user2
+PREHOOK: type: GRANT_PRIVILEGE
+PREHOOK: Output: default@t_show_ext
+POSTHOOK: query: grant all on table t_show_ext to user user2
+POSTHOOK: type: GRANT_PRIVILEGE
+POSTHOOK: Output: default@t_show_ext
+PREHOOK: query: revoke select on table t_show_ext from user user2
+PREHOOK: type: REVOKE_PRIVILEGE
+PREHOOK: Output: default@t_show_ext
+POSTHOOK: query: revoke select on table t_show_ext from user user2
+POSTHOOK: type: REVOKE_PRIVILEGE
+POSTHOOK: Output: default@t_show_ext
+FAILED: HiveAccessControlException Permission denied: Principal [name=user2, type=USER] does not have following privileges for operation SHOW_TABLESTATUS [[SELECT] on Object [type=TABLE_OR_VIEW, name=hive.default.t_show_ext]]

--- a/ql/src/test/results/clientnegative/authorization_show_tblproperties_nosel.q.out
+++ b/ql/src/test/results/clientnegative/authorization_show_tblproperties_nosel.q.out
@@ -1,0 +1,21 @@
+PREHOOK: query: create table t_show_props(i int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_show_props
+POSTHOOK: query: create table t_show_props(i int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_show_props
+PREHOOK: query: grant all on table t_show_props to user user2
+PREHOOK: type: GRANT_PRIVILEGE
+PREHOOK: Output: default@t_show_props
+POSTHOOK: query: grant all on table t_show_props to user user2
+POSTHOOK: type: GRANT_PRIVILEGE
+POSTHOOK: Output: default@t_show_props
+PREHOOK: query: revoke select on table t_show_props from user user2
+PREHOOK: type: REVOKE_PRIVILEGE
+PREHOOK: Output: default@t_show_props
+POSTHOOK: query: revoke select on table t_show_props from user user2
+POSTHOOK: type: REVOKE_PRIVILEGE
+POSTHOOK: Output: default@t_show_props
+FAILED: HiveAccessControlException Permission denied: Principal [name=user2, type=USER] does not have following privileges for operation SHOW_TBLPROPERTIES [[SELECT] on Object [type=TABLE_OR_VIEW, name=hive.default.t_show_props]]


### PR DESCRIPTION

### What changes were proposed in this pull request?
Align authorization input registration for SHOW TBLPROPERTIES and SHOW TABLE EXTENDED 
with other metadata DDL commands (e.g. DESCRIBE TABLE) so the configured HS2 
authorizer receives the target table in the compile-time input set.

* ShowTablePropertiesAnalyzer — add ReadEntity(table) before DDLWork is created
* ShowTableStatusAnalyzer — add ReadEntity(table) before DDLWork is created


### Why are the changes needed?
Both analyzers already validate table existence; they were not registering the 
authorization checks.


### Does this PR introduce _any_ user-facing change?
Yes, commands will fail if user does not have SELECT access

### How was this patch tested?
authorization_show_tblproperties_nosel.q
authorization_show_tableextended_nosel.q 
