### PR TITLE
HIVE-29806: upgrade graalvm to 25.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <hbase.version>2.5.6-hadoop3</hbase.version>
     <hppc.version>0.7.2</hppc.version>
-    <graalvm.version>23.0.8</graalvm.version>
+    <graalvm.version>25.1.3</graalvm.version>
     <!-- required for logging test to avoid including hbase which pulls disruptor transitively -->
     <disruptor.version>3.3.7</disruptor.version>
     <hikaricp.version>4.0.3</hikaricp.version>
@@ -429,7 +429,17 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.js</groupId>
-        <artifactId>js</artifactId>
+        <artifactId>js-language</artifactId>
+        <version>${graalvm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.graalvm.sdk</groupId>
+        <artifactId>graal-sdk</artifactId>
+        <version>${graalvm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.graalvm.truffle</groupId>
+        <artifactId>truffle-runtime</artifactId>
         <version>${graalvm.version}</version>
       </dependency>
       <dependency>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -38,7 +38,15 @@
     </dependency>
     <dependency>
       <groupId>org.graalvm.js</groupId>
-      <artifactId>js</artifactId>
+      <artifactId>js-language</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.sdk</groupId>
+      <artifactId>graal-sdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.truffle</groupId>
+      <artifactId>truffle-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.atlas</groupId>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR proposes upgrading the GraalVM dependency version to `25.1.3` in the project build configuration (e.g., `pom.xml`).

### Why are the changes needed?
This is a routine dependency and environment maintenance upgrade. Bumping GraalVM to `25.1.3` ensures that Apache Hive benefits from the latest compiler optimizations, performance enhancements, bug fixes, and security patches provided by the newer GraalVM release.

### Does this PR introduce _any_ user-facing change?
No. This is purely a backend dependency and build environment update. The functionality and APIs of Hive remain exactly the same for end users.

### How was this patch tested?
- Verified that the project builds successfully with the new GraalVM version (`mvn clean install -DskipTests`).
- Relying on the standard Apache Hive CI/CD pipeline to execute the full suite of unit and integration tests (PreCommit builds) to ensure no regressions in runtime performance or behavior.