### PR TITLE
HIVE-29611: upgrade log4jcore to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.25.3</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.2.0</mysql.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -97,7 +97,7 @@
     <junit.platform.version>1.13.3</junit.platform.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.25.3</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <mockito-core.version>5.17.0</mockito-core.version>
     <orc.version>2.1.2</orc.version>
     <protobuf.version>3.25.5</protobuf.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes upgrading the Log4j2 dependency version (specifically `log4j-core` and its associated modules) from `2.25.3` to `2.25.4` in the root `pom.xml`.

### Why are the changes needed?
This upgrade is necessary to address two specific vulnerabilities identified in Log4j2 versions 2.25.3 and below:

*   **CVE-2026-34480:** Resolves an XML external/forbidden character sanitization flaw in `XmlLayout` that can cause log loss or errors.
*   **CVE-2026-34481:** Fixes a non-finite floating-point formatting issue in `JsonTemplateLayout` that violates RFC 8259.

Bumping the version to `2.25.4` ensures Apache Hive includes these upstream patches and maintains stable, compliant logging behavior.

### Does this PR introduce _any_ user-facing change?
No. This is purely a backend security and dependency update. The logging behavior and configuration formats remain exactly the same for end users.

### How was this patch tested?
- Verified that the project builds successfully with the new dependency version (`mvn clean install -DskipTests`).
- Relying on the standard Apache Hive CI/CD pipeline to execute the full suite of unit and integration tests (PreCommit builds) to ensure no regressions in logging functionality due to the layout patches.