### PR TITLE
HIVE-29662: Cannot execute a script with Beeline's -f <script>

### DIFF
--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -30,8 +30,7 @@
   <name>Hive HCatalog Pig Adapter</name>
   <properties>
     <hive.path.to.root>../..</hive.path.to.root>
-    <!-- HIVE-28992: only upgrade to newer than 3.25.0 if you tested the prompt -->
-    <jline.version>3.25.0</jline.version>
+    <jline.version>3.30.16</jline.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->

--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,7 @@
     <jettison.version>1.5.4</jettison.version>
     <jetty.version>9.4.57.v20241219</jetty.version>
     <jersey.version>1.19.4</jersey.version>
-    <!-- HIVE-28992: only upgrade to newer than 3.25.0 if you tested the prompt -->
-    <jline.version>3.25.0</jline.version>
+    <jline.version>3.30.16</jline.version>
     <jms.version>2.0.2</jms.version>
     <joda.version>2.13.0</joda.version>
     <jodd.version>6.0.0</jodd.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -107,8 +107,7 @@
     <io.grpc.version>1.72.0</io.grpc.version>
     <sqlline.version>1.9.0</sqlline.version>
     <netty.version>4.1.127.Final</netty.version>
-    <!-- HIVE-28992: only upgrade to newer than 3.25.0 if you tested the prompt -->
-    <jline.version>3.25.0</jline.version>
+    <jline.version>3.30.16</jline.version>
     <ST4.version>4.0.4</ST4.version>
     <storage-api.version>4.3.0-SNAPSHOT</storage-api.version>
     <beanutils.version>1.9.4</beanutils.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update jline to 3.30.16, which includes [the fix](https://github.com/jline/jline3/issues/2077) for [HIVE-29662](https://issues.apache.org/jira/browse/HIVE-29662): Make Beeline's `-f <script>` CLI actually execute the script.

### Why are the changes needed?
JLine had some bugs which broke Beeline's `-f <script>` feature.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Created a file `script.sql` containing some commands:
```
select 1;
use db;
select * from tab1;
select reflect("java.lang.Thread", "sleep", bigint(20000));
```

Built the PR and executed Beeline with `./beeline -u jdbc:hive2://localhost:10000 -n trebele --verbose=true -f /tmp/script.sql`. The script was executed as expected.

```
...
+-------+
|  _c0  |
+-------+
| null  |
+-------+
1 row selected (20.185 seconds)
>....>....Closing: 0: jdbc:hive2://localhost:10000
````

Interactive mode works as well. The prompt line starts with `0: jdbc:hive2://localhost:10000>`. I did not observe the problem described in [HIVE-28992](https://issues.apache.org/jira/browse/HIVE-28992). 