### PR TITLE
HIVE-28721: Make QueryInfo use OperationState enum instead of a String

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/queryhistory/TestQueryHistoryService.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/queryhistory/TestQueryHistoryService.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.hive.shims.Utils;
+import org.apache.hive.service.rpc.thrift.TOperationState;
 import org.apache.tez.common.counters.DAGCounter;
 import org.apache.tez.common.counters.TaskCounter;
 import org.apache.tez.common.counters.TezCounters;
@@ -90,7 +91,7 @@ public class TestQueryHistoryService {
     service.start();
 
     // prepare the source object from which the QueryHistoryService will obtain query information
-    QueryInfo queryInfo = spy(new QueryInfo(DummyRecord.QUERY_STATE, DummyRecord.END_USER,
+    QueryInfo queryInfo = spy(new QueryInfo(TOperationState.INITIALIZED_STATE, DummyRecord.END_USER,
         DummyRecord.EXECUTION_ENGINE, DummyRecord.SESSION_ID,
         DummyRecord.OPERATION_ID));
     // elapsed time is calculated from System.currentTimeMillis(), let's mock it here for unit test convenience's sake

--- a/ql/src/java/org/apache/hadoop/hive/ql/QueryInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/QueryInfo.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hive.service.rpc.thrift.TOperationState;
 
 /**
  * The class is synchronized, as WebUI may access information about a running query.
@@ -32,12 +33,13 @@ public class QueryInfo {
   private final String operationId;
   private Long runtime;  // tracks only running portion of the query.
   private Long endTime;
-  private String state;
+  private TOperationState state;
   private QueryDisplay queryDisplay;
 
   private String operationLogLocation;
 
-  public QueryInfo(String state, String userName, String executionEngine, String sessionId, String operationId) {
+  public QueryInfo(TOperationState state, String userName, String executionEngine, String sessionId,
+      String operationId) {
     this.state = state;
     this.userName = userName;
     this.executionEngine = executionEngine;
@@ -47,7 +49,7 @@ public class QueryInfo {
   }
 
   public static QueryInfo getFromConf(HiveConf conf) {
-    return new QueryInfo("INITIALIZED", conf.get(DriverContext.DEFAULT_USER_NAME_PROP),
+    return new QueryInfo(TOperationState.INITIALIZED_STATE, conf.get(DriverContext.DEFAULT_USER_NAME_PROP),
         conf.getVar(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE), HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_SESSION_ID),
         conf.get(DriverContext.DEFAULT_OPERATION_ID_PROP));
   }
@@ -81,6 +83,10 @@ public class QueryInfo {
   }
 
   public synchronized String getState() {
+    return getDisplayState(state);
+  }
+
+  public synchronized TOperationState getOperationState() {
     return state;
   }
 
@@ -92,7 +98,7 @@ public class QueryInfo {
     return endTime;
   }
 
-  public synchronized void updateState(String state) {
+  public synchronized void updateState(TOperationState state) {
     this.state = state;
   }
 
@@ -122,5 +128,34 @@ public class QueryInfo {
 
   public void setOperationLogLocation(String operationLogLocation) {
     this.operationLogLocation = operationLogLocation;
+  }
+
+  private static String getDisplayState(TOperationState state) {
+    if (state == null) {
+      return "UNKNOWN";
+    }
+
+    switch (state) {
+    case INITIALIZED_STATE:
+      return "INITIALIZED";
+    case RUNNING_STATE:
+      return "RUNNING";
+    case FINISHED_STATE:
+      return "FINISHED";
+    case CANCELED_STATE:
+      return "CANCELED";
+    case CLOSED_STATE:
+      return "CLOSED";
+    case ERROR_STATE:
+      return "ERROR";
+    case UKNOWN_STATE:
+      return "UNKNOWN";
+    case PENDING_STATE:
+      return "PENDING";
+    case TIMEDOUT_STATE:
+      return "TIMEDOUT";
+    default:
+      return "UNKNOWN";
+    }
   }
 }

--- a/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -131,7 +131,7 @@ public class SQLOperation extends ExecuteStatementOperation {
 
     setupSessionIO(parentSession.getSessionState());
 
-    queryInfo = new QueryInfo(getState().toString(), getParentSession().getUserName(),
+    queryInfo = new QueryInfo(getState().toTOperationState(), getParentSession().getUserName(),
         getExecutionEngine(), getParentSession().getSessionHandle().getHandleIdentifier().toString(),
         getHandle().getHandleIdentifier().toString());
 
@@ -629,7 +629,7 @@ public class SQLOperation extends ExecuteStatementOperation {
       if (metrics.isPresent() && submittedQryScp.isPresent()) {
         metrics.get().endScope(submittedQryScp.get());
       }
-      queryInfo.updateState(state.toString());
+      queryInfo.updateState(state.toTOperationState());
       break;
     case CLOSED:
       queryInfo.setEndTime();
@@ -640,7 +640,7 @@ public class SQLOperation extends ExecuteStatementOperation {
         metrics.get().endScope(submittedQryScp.get());
       }
       markQueryMetric(MetricsFactory.getInstance(), MetricsConstant.HS2_FAILED_QUERIES);
-      queryInfo.updateState(state.toString());
+      queryInfo.updateState(state.toTOperationState());
       break;
     case FINISHED:
       queryInfo.setRuntime(getOperationComplete() - getOperationStart());
@@ -648,7 +648,7 @@ public class SQLOperation extends ExecuteStatementOperation {
         metrics.get().endScope(submittedQryScp.get());
       }
       markQueryMetric(MetricsFactory.getInstance(), MetricsConstant.HS2_SUCCEEDED_QUERIES);
-      queryInfo.updateState(state.toString());
+      queryInfo.updateState(state.toTOperationState());
       break;
     case INITIALIZED:
       /* fall through */
@@ -661,7 +661,7 @@ public class SQLOperation extends ExecuteStatementOperation {
     case UNKNOWN:
       /* fall through */
     default:
-      queryInfo.updateState(state.toString());
+      queryInfo.updateState(state.toTOperationState());
       break;
     }
   }

--- a/service/src/java/org/apache/hive/service/servlet/QueriesRESTfulAPIServlet.java
+++ b/service/src/java/org/apache/hive/service/servlet/QueriesRESTfulAPIServlet.java
@@ -23,9 +23,11 @@ import org.apache.hadoop.hive.ql.QueryInfo;
 import org.apache.hive.service.cli.operation.OperationManager;
 import org.apache.hive.service.cli.session.HiveSession;
 import org.apache.hive.service.cli.session.SessionManager;
+import org.apache.hive.service.rpc.thrift.TOperationState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.Version;
@@ -142,6 +144,7 @@ public class QueriesRESTfulAPIServlet extends HttpServlet {
     response.setContentType("application/json");
     response.setStatus(HttpServletResponse.SC_OK);
     ObjectMapper mapper = new ObjectMapper();
+    mapper.addMixIn(QueryInfo.class, QueryInfoJsonMixin.class);
     SimpleModule module = new SimpleModule("CustomSessionModule", new Version(1, 0, 0, null, null, null));
     module.addSerializer(HiveSession.class, new HiveSessionSerializer());
     mapper.registerModule(module);
@@ -156,6 +159,11 @@ public class QueriesRESTfulAPIServlet extends HttpServlet {
       LOG.error("Caught an exception while writing an HTTP response", e);
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
+  }
+
+  private abstract static class QueryInfoJsonMixin {
+    @JsonIgnore
+    abstract TOperationState getOperationState();
   }
 
   private static class HiveSessionSerializer extends JsonSerializer<HiveSession> {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Replace QueryInfo’s string operation state with TOperationState, update SQLOperation to write typed state, and keep REST/Web UI state values unchanged.


### Why are the changes needed?
To stop using loose strings for operation state and use a typed enum instead.


### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Ran targeted service unit tests and verified HS2 REST/Web UI behavior manually with Docker and Beeline.
