### PR TITLE
HIVE-29815: Iceberg: [V3] Support ROW LINEAGE in Copy-On-Write DELETE operations

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/row_lineage.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/row_lineage.q
@@ -101,3 +101,36 @@ DELETE FROM ice_cow_delete WHERE id = 2;
 SELECT id, data, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
 FROM ice_cow_delete
 ORDER BY id;
+
+-- cow delete partitioned
+CREATE TABLE ice_cow_delete_part (
+  id INT,
+  data STRING
+)
+PARTITIONED BY (part STRING)
+STORED BY iceberg
+TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='copy-on-write');
+
+-- Snapshot 1: Sequence 1
+INSERT INTO ice_cow_delete_part VALUES
+  (1, 'apple', 'p1'),
+  (2, 'banana', 'p1'),
+  (3, 'cherry', 'p2'),
+  (4, 'date', 'p2');
+
+-- Snapshot 2: Sequence 2 (Adding more data to partition p1 to mix sequence numbers)
+INSERT INTO ice_cow_delete_part VALUES
+  (5, 'elderberry', 'p1');
+
+SELECT id, data, part, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete_part
+ORDER BY id;
+
+-- Snapshot 3: Delete across partitions (Affects data files in both p1 and p2)
+DELETE FROM ice_cow_delete_part WHERE id = 2 OR id = 3;
+
+-- id=1 and id=4 should retain Sequence 1
+-- id=5 should retain Sequence 2
+SELECT id, data, part, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete_part
+ORDER BY id;

--- a/iceberg/iceberg-handler/src/test/queries/positive/row_lineage.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/row_lineage.q
@@ -78,3 +78,26 @@ WHEN MATCHED THEN
 SELECT id, data, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
 FROM ice_merge_cow
 ORDER BY ROW__LINEAGE__ID;
+
+-- cow delete
+CREATE TABLE ice_cow_delete (
+  id INT,
+  data STRING
+)
+STORED BY iceberg
+TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='copy-on-write');
+
+INSERT INTO ice_cow_delete VALUES
+  (1, 'apple'),
+  (2, 'banana'),
+  (3, 'cherry');
+
+SELECT id, data, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete
+ORDER BY id;
+
+DELETE FROM ice_cow_delete WHERE id = 2;
+
+SELECT id, data, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete
+ORDER BY id;

--- a/iceberg/iceberg-handler/src/test/results/positive/row_lineage.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/row_lineage.q.out
@@ -383,3 +383,89 @@ POSTHOOK: Input: default@ice_cow_delete
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	apple	0	1
 3	cherry	2	1
+PREHOOK: query: CREATE TABLE ice_cow_delete_part (
+  id INT,
+  data STRING
+)
+PARTITIONED BY (part STRING)
+STORED BY iceberg
+TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='copy-on-write')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_cow_delete_part
+POSTHOOK: query: CREATE TABLE ice_cow_delete_part (
+  id INT,
+  data STRING
+)
+PARTITIONED BY (part STRING)
+STORED BY iceberg
+TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='copy-on-write')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_cow_delete_part
+PREHOOK: query: INSERT INTO ice_cow_delete_part VALUES
+  (1, 'apple', 'p1'),
+  (2, 'banana', 'p1'),
+  (3, 'cherry', 'p2'),
+  (4, 'date', 'p2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_cow_delete_part
+POSTHOOK: query: INSERT INTO ice_cow_delete_part VALUES
+  (1, 'apple', 'p1'),
+  (2, 'banana', 'p1'),
+  (3, 'cherry', 'p2'),
+  (4, 'date', 'p2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_cow_delete_part
+PREHOOK: query: INSERT INTO ice_cow_delete_part VALUES
+  (5, 'elderberry', 'p1')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_cow_delete_part
+POSTHOOK: query: INSERT INTO ice_cow_delete_part VALUES
+  (5, 'elderberry', 'p1')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_cow_delete_part
+PREHOOK: query: SELECT id, data, part, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete_part
+ORDER BY id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_cow_delete_part
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT id, data, part, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete_part
+ORDER BY id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_cow_delete_part
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	apple	p1	0	1
+2	banana	p1	1	1
+3	cherry	p2	2	1
+4	date	p2	3	1
+5	elderberry	p1	4	2
+PREHOOK: query: DELETE FROM ice_cow_delete_part WHERE id = 2 OR id = 3
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_cow_delete_part
+PREHOOK: Output: default@ice_cow_delete_part
+POSTHOOK: query: DELETE FROM ice_cow_delete_part WHERE id = 2 OR id = 3
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_cow_delete_part
+POSTHOOK: Output: default@ice_cow_delete_part
+PREHOOK: query: SELECT id, data, part, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete_part
+ORDER BY id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_cow_delete_part
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT id, data, part, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete_part
+ORDER BY id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_cow_delete_part
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	apple	p1	0	1
+4	date	p2	3	1
+5	elderberry	p1	4	2

--- a/iceberg/iceberg-handler/src/test/results/positive/row_lineage.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/row_lineage.q.out
@@ -314,3 +314,72 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	a	0	1
 2	bb_changed	1	2
 3	c	2	1
+PREHOOK: query: CREATE TABLE ice_cow_delete (
+  id INT,
+  data STRING
+)
+STORED BY iceberg
+TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='copy-on-write')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_cow_delete
+POSTHOOK: query: CREATE TABLE ice_cow_delete (
+  id INT,
+  data STRING
+)
+STORED BY iceberg
+TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='copy-on-write')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_cow_delete
+PREHOOK: query: INSERT INTO ice_cow_delete VALUES
+  (1, 'apple'),
+  (2, 'banana'),
+  (3, 'cherry')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_cow_delete
+POSTHOOK: query: INSERT INTO ice_cow_delete VALUES
+  (1, 'apple'),
+  (2, 'banana'),
+  (3, 'cherry')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_cow_delete
+PREHOOK: query: SELECT id, data, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete
+ORDER BY id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_cow_delete
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT id, data, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete
+ORDER BY id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_cow_delete
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	apple	0	1
+2	banana	1	1
+3	cherry	2	1
+PREHOOK: query: DELETE FROM ice_cow_delete WHERE id = 2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_cow_delete
+PREHOOK: Output: default@ice_cow_delete
+POSTHOOK: query: DELETE FROM ice_cow_delete WHERE id = 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_cow_delete
+POSTHOOK: Output: default@ice_cow_delete
+PREHOOK: query: SELECT id, data, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete
+ORDER BY id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_cow_delete
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT id, data, ROW__LINEAGE__ID, LAST__UPDATED__SEQUENCE__NUMBER
+FROM ice_cow_delete
+ORDER BY id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_cow_delete
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	apple	0	1
+3	cherry	2	1

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteDeleteRewriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/rewrite/CopyOnWriteDeleteRewriter.java
@@ -29,6 +29,9 @@ import org.apache.hadoop.hive.ql.parse.rewrite.sql.COWWithClauseBuilder;
 import org.apache.hadoop.hive.ql.parse.rewrite.sql.MultiInsertSqlGenerator;
 import org.apache.hadoop.hive.ql.parse.rewrite.sql.SqlGeneratorFactory;
 
+import static org.apache.hadoop.hive.ql.metadata.RowLineageUtils.addSourceColumnsForRowLineage;
+import static org.apache.hadoop.hive.ql.metadata.RowLineageUtils.supportsRowLineage;
+
 public class CopyOnWriteDeleteRewriter implements Rewriter<DeleteStatement> {
 
   private final HiveConf conf;
@@ -45,6 +48,8 @@ public class CopyOnWriteDeleteRewriter implements Rewriter<DeleteStatement> {
   public ParseUtils.ReparseResult rewrite(Context context, DeleteStatement deleteBlock)
       throws SemanticException {
 
+    boolean isRowLineageSupported = supportsRowLineage(deleteBlock.getTargetTable());
+
     ASTNode whereTree = deleteBlock.getWhereTree();
     String whereClause = "true";
     if (whereTree != null) {
@@ -56,7 +61,8 @@ public class CopyOnWriteDeleteRewriter implements Rewriter<DeleteStatement> {
 
     MultiInsertSqlGenerator sqlGenerator = sqlGeneratorFactory.createSqlGenerator();
 
-    cowWithClauseBuilder.appendWith(sqlGenerator, filePathCol, whereClause);
+    cowWithClauseBuilder.appendWith(
+        sqlGenerator, null, filePathCol, whereClause, true, isRowLineageSupported, "");
 
     sqlGenerator.append("insert into table ");
     sqlGenerator.append(sqlGenerator.getTargetTableFullName());
@@ -65,6 +71,7 @@ public class CopyOnWriteDeleteRewriter implements Rewriter<DeleteStatement> {
     sqlGenerator.append(" select ");
     sqlGenerator.appendAcidSelectColumns(Context.Operation.DELETE);
     sqlGenerator.removeLastChar();
+    addSourceColumnsForRowLineage(isRowLineageSupported, sqlGenerator, "", conf);
 
     sqlGenerator.append(" from ");
     sqlGenerator.append(sqlGenerator.getTargetTableFullName());


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Check [HIVE-29815](https://issues.apache.org/jira/browse/HIVE-29815)
This PR updates `CopyOnWriteDeleteRewriter.java` to explicitly select and preserve `ROW__LINEAGE__ID` and `LAST__UPDATED__SEQUENCE__NUMBER` when rewriting files during a Copy-On-Write DELETE operation on Iceberg V3 tables.

### Why are the changes needed?
Currently, when a user deletes a row in COW mode, the surviving rows are rewritten into a new file without their original lineage metadata. As a result, they get assigned brand new lineage IDs and sequence numbers

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
With q file and on spark engine as well
