### PR TITLE
HIVE-29820: Refactor and improve ObjectCache in some RecordProcessors

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ObjectCacheFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ObjectCacheFactory.java
@@ -19,13 +19,13 @@
 
 package org.apache.hadoop.hive.ql.exec;
 
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.llap.io.api.LlapProxy;
 import org.apache.hadoop.hive.llap.io.api.LlapProxy;
 import org.apache.hadoop.hive.ql.exec.tez.LlapObjectCache;
 
@@ -92,15 +92,11 @@ public class ObjectCacheFactory {
   private static ObjectCache getLlapObjectCache(String queryId) {
     // If order of events (i.e. dagstart and fragmentstart) was guaranteed, we could just
     // create the cache when dag starts, and blindly return it to execution here.
-    if (queryId == null) throw new RuntimeException("Query ID cannot be null");
-    ObjectCache result = llapQueryCaches.get(queryId);
-    if (result != null) return result;
-    result = new LlapObjectCache();
-    ObjectCache old = llapQueryCaches.putIfAbsent(queryId, result);
-    if (old == null) {
-      LOG.info("Created object cache for " + queryId);
-    }
-    return (old != null) ? old : result;
+    Objects.requireNonNull(queryId, "Query ID cannot be null");
+    return llapQueryCaches.computeIfAbsent(queryId, k -> {
+      LOG.info("Created object cache for {}", k);
+      return new LlapObjectCache();
+    });
   }
 
   public static void removeLlapQueryCache(String queryId) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/MapRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/MapRecordProcessor.java
@@ -46,8 +46,6 @@ import org.apache.hadoop.hive.ql.exec.DummyStoreOperator;
 import org.apache.hadoop.hive.ql.exec.HashTableDummyOperator;
 import org.apache.hadoop.hive.ql.exec.MapOperator;
 import org.apache.hadoop.hive.ql.exec.MapredContext;
-import org.apache.hadoop.hive.ql.exec.ObjectCache;
-import org.apache.hadoop.hive.ql.exec.ObjectCacheFactory;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.OperatorUtils;
 import org.apache.hadoop.hive.ql.exec.TezDummyStoreOperator;
@@ -93,20 +91,14 @@ public class MapRecordProcessor extends RecordProcessor {
   private final ExecMapperContext execContext;
   private MapWork mapWork;
   private List<MapWork> mergeWorkList;
-  private final List<String> cacheKeys = new ArrayList<>();
-  private final List<String> dynamicValueCacheKeys = new ArrayList<>();
-  private final ObjectCache cache, dynamicValueCache;
   // is this part of the query-based compaction process
   private final boolean isInCompaction;
 
   public MapRecordProcessor(final JobConf jconf, final ProcessorContext context) throws Exception {
     super(jconf, context);
-    String queryId = HiveConf.getVar(jconf, HiveConf.ConfVars.HIVE_QUERY_ID);
     if (LlapProxy.isDaemon()) {
       setLlapOfFragmentId(context);
     }
-    cache = ObjectCacheFactory.getCache(jconf, queryId, true);
-    dynamicValueCache = ObjectCacheFactory.getCache(jconf, queryId, false, true);
     execContext = new ExecMapperContext(jconf);
     execContext.setJc(jconf);
     isInCompaction = CompactorUtil.COMPACTOR.equalsIgnoreCase(
@@ -129,12 +121,10 @@ public class MapRecordProcessor extends RecordProcessor {
 
 
     String key = processorContext.getTaskVertexName() + MAP_PLAN_KEY;
-    cacheKeys.add(key);
-
 
     // create map and fetch operators
     if (!isInCompaction) {
-      mapWork = cache.retrieve(key, () -> Utilities.getMapWork(jconf));
+      mapWork = planCache.retrieve(key, () -> Utilities.getMapWork(jconf));
     } else {
       // During query-based compaction, we don't want to retrieve old MapWork from the cache, we want a new mapper
       // and new UDF validate_acid_sort_order instance for each bucket, otherwise validate_acid_sort_order will fail.
@@ -160,11 +150,10 @@ public class MapRecordProcessor extends RecordProcessor {
         }
 
         key = processorContext.getTaskVertexName() + prefix;
-        cacheKeys.add(key);
 
         checkAbortCondition();
         mergeWorkList.add(
-            (MapWork) cache.retrieve(key, () -> Utilities.getMergeWork(jconf, prefix)));
+            (MapWork) planCache.retrieve(key, () -> Utilities.getMergeWork(jconf, prefix)));
       }
     }
 
@@ -307,9 +296,8 @@ public class MapRecordProcessor extends RecordProcessor {
       checkAbortCondition();
       String valueRegistryKey = DynamicValue.DYNAMIC_VALUE_REGISTRY_CACHE_KEY;
       // On LLAP dynamic value registry might already be cached.
-      final DynamicValueRegistryTez registryTez = dynamicValueCache.retrieve(valueRegistryKey,
-          () -> new DynamicValueRegistryTez());
-      dynamicValueCacheKeys.add(valueRegistryKey);
+      final DynamicValueRegistryTez registryTez =
+          dynamicValueCache.retrieve(valueRegistryKey, () -> new DynamicValueRegistryTez());
       RegistryConfTez registryConf = new RegistryConfTez(jconf, mapWork, processorContext, inputs);
       registryTez.init(registryConf);
 
@@ -442,17 +430,7 @@ public class MapRecordProcessor extends RecordProcessor {
       setAborted(execContext.getIoCxt().getIOExceptions());
     }
 
-    if (cache != null) {
-      for (String k: cacheKeys) {
-        cache.release(k);
-      }
-    }
-
-    if (dynamicValueCache != null) {
-      for (String k: dynamicValueCacheKeys) {
-        dynamicValueCache.release(k);
-      }
-    }
+    releaseCache();
 
     // detecting failed executions by exceptions thrown by the operator tree
     try {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/MergeFileRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/MergeFileRecordProcessor.java
@@ -25,9 +25,7 @@ import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.MapredContext;
-import org.apache.hadoop.hive.ql.exec.ObjectCacheFactory;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.OperatorUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -59,11 +57,9 @@ public class MergeFileRecordProcessor extends RecordProcessor {
   protected Operator<? extends OperatorDesc> mergeOp;
   private ExecMapperContext execContext = null;
   protected static final String MAP_PLAN_KEY = "__MAP_PLAN__";
-  private String cacheKey;
   private MergeFileWork mfWork;
   MRInputLegacy mrInput = null;
   private final Object[] row = new Object[2];
-  org.apache.hadoop.hive.ql.exec.ObjectCache cache;
 
   public MergeFileRecordProcessor(final JobConf jconf, final ProcessorContext context) {
     super(jconf, context);
@@ -94,20 +90,10 @@ public class MergeFileRecordProcessor extends RecordProcessor {
           .initialize();
     }
 
-    String queryId = HiveConf.getVar(jconf, HiveConf.ConfVars.HIVE_QUERY_ID);
-    cache = ObjectCacheFactory.getCache(jconf, queryId, true);
-
     try {
       execContext.setJc(jconf);
 
-      cacheKey = MAP_PLAN_KEY;
-
-      MapWork mapWork = (MapWork) cache.retrieve(cacheKey, new Callable<Object>() {
-        @Override
-        public Object call() {
-          return Utilities.getMapWork(jconf);
-        }
-      });
+      MapWork mapWork = (MapWork) planCache.retrieve(MAP_PLAN_KEY, (Callable<Object>) () -> Utilities.getMapWork(jconf));
       Utilities.setMapWork(jconf, mapWork);
 
       if (mapWork instanceof MergeFileWork) {
@@ -162,9 +148,7 @@ public class MergeFileRecordProcessor extends RecordProcessor {
   @Override
   void close() {
 
-    if (cache != null && cacheKey != null) {
-      cache.release(cacheKey);
-    }
+    releaseCache();
 
     // check if there are IOExceptions
     if (!isAborted()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/RecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/RecordProcessor.java
@@ -22,8 +22,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.Callable;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.ObjectCache;
+import org.apache.hadoop.hive.ql.exec.ObjectCacheFactory;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.tez.TezProcessor.TezKVOutputCollector;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
@@ -59,9 +62,32 @@ public abstract class RecordProcessor extends InterruptibleProcessing {
   protected PerfLogger perfLogger = SessionState.getPerfLogger();
   protected String CLASS_NAME = RecordProcessor.class.getName();
 
+  protected final String queryId;
+
+  /**
+   * Per-processor plan cache — no daemon-wide sharing. Sharing would race on
+   * per-fragment operator state that {@code initializeOp()} resets (HIVE-14433:
+   * {@code FileSinkOperator.fsp}, {@code VectorGroupByOperator.aggregator},
+   * {@code Operator.childOperatorsArray}, {@code VectorTopNKeyOperator} filter
+   * state, ...) and yields NPE / {@code FileAlreadyExistsException}.
+   */
+  protected final TrackedCache planCache;
+
+  /**
+   * Dynamic value cache. On LLAP this is the per-query daemon-wide
+   * {@link LlapObjectCache}, so dynamic values computed once (e.g. broadcast
+   * hash tables, DPP registries) are reused across fragments of the same query.
+   */
+  protected final TrackedCache dynamicValueCache;
+
   public RecordProcessor(JobConf jConf, ProcessorContext processorContext) {
     this.jconf = jConf;
     this.processorContext = processorContext;
+    this.queryId = HiveConf.getVar(jConf, HiveConf.ConfVars.HIVE_QUERY_ID);
+    this.planCache = new TrackedCache(
+        ObjectCacheFactory.getCache(jConf, queryId, true, false));
+    this.dynamicValueCache = new TrackedCache(
+        ObjectCacheFactory.getCache(jConf, queryId, false, true));
   }
 
   /**
@@ -98,26 +124,60 @@ public abstract class RecordProcessor extends InterruptibleProcessing {
     }
   }
 
-  public List<BaseWork> getMergeWorkList(final JobConf jconf, String key, String queryId,
-      ObjectCache cache, List<String> cacheKeys) throws HiveException {
+  /**
+   * Release every key retrieved through the plan and dynamic-value caches.
+   * A no-op for {@link LlapObjectCache} (which relies on soft references), but
+   * preserved for correctness against other {@link ObjectCache} implementations.
+   */
+  protected void releaseCache() {
+    planCache.releaseAll();
+    dynamicValueCache.releaseAll();
+  }
+
+  public List<BaseWork> getMergeWorkList(final JobConf jconf) throws HiveException {
     String prefixes = jconf.get(DagUtils.TEZ_MERGE_WORK_FILE_PREFIXES);
-    if (prefixes != null) {
-      List<BaseWork> mergeWorkList = new ArrayList<>();
-
-      for (final String prefix : prefixes.split(",")) {
-        if (prefix.isEmpty()) {
-          continue;
-        }
-
-        key = prefix;
-        cacheKeys.add(key);
-
-        mergeWorkList.add(cache.retrieve(key, () -> Utilities.getMergeWork(jconf, prefix)));
-      }
-
-      return mergeWorkList;
-    } else {
+    if (prefixes == null) {
       return null;
+    }
+    List<BaseWork> mergeWorkList = new ArrayList<>();
+    for (final String prefix : prefixes.split(",")) {
+      if (prefix.isEmpty()) {
+        continue;
+      }
+      mergeWorkList.add(planCache.retrieve(prefix, () -> Utilities.getMergeWork(jconf, prefix)));
+    }
+    return mergeWorkList;
+  }
+
+  /**
+   * An {@link ObjectCache} paired with the set of keys retrieved through it, so
+   * {@link #releaseAll()} releases exactly those keys at close time. All retrievals
+   * that need to be released should go through {@link #retrieve} — calling
+   * {@link ObjectCache#retrieve} directly on the underlying cache bypasses the
+   * tracking and leaks the key.
+   */
+  protected static final class TrackedCache {
+    private final ObjectCache cache;
+    private final List<String> keys = new ArrayList<>();
+
+    TrackedCache(ObjectCache cache) {
+      this.cache = cache;
+    }
+
+    /** Retrieve (or compute) the value for {@code key}, tracking it for release. */
+    <T> T retrieve(String key, Callable<T> fn) throws HiveException {
+      keys.add(key);
+      return cache.retrieve(key, fn);
+    }
+
+    /** Release every key retrieved through this wrapper. Null-safe on the underlying cache. */
+    void releaseAll() {
+      if (cache == null) {
+        return;
+      }
+      for (String k : keys) {
+        cache.release(k);
+      }
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ReduceRecordProcessor.java
@@ -30,12 +30,9 @@ import java.util.TreeMap;
 import org.apache.hadoop.hive.llap.LlapUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.DummyStoreOperator;
 import org.apache.hadoop.hive.ql.exec.HashTableDummyOperator;
 import org.apache.hadoop.hive.ql.exec.MapredContext;
-import org.apache.hadoop.hive.ql.exec.ObjectCache;
-import org.apache.hadoop.hive.ql.exec.ObjectCacheFactory;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.OperatorUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -56,8 +53,6 @@ import org.apache.tez.runtime.api.LogicalOutput;
 import org.apache.tez.runtime.api.ProcessorContext;
 import org.apache.tez.runtime.api.Reader;
 
-import com.google.common.collect.Lists;
-
 /**
  * Process input from tez LogicalInput and write output - for a map plan
  * Just pump the records through the query plan.
@@ -67,13 +62,9 @@ public class ReduceRecordProcessor extends RecordProcessor {
 
   private static final String REDUCE_PLAN_KEY = "__REDUCE_PLAN__";
 
-  private final ObjectCache cache, dynamicValueCache;
-
   private ReduceWork reduceWork;
 
   private final List<BaseWork> mergeWorkList;
-  private final List<String> cacheKeys;
-  private final List<String> dynamicValueCacheKeys = new ArrayList<>();
 
   private final Map<Integer, DummyStoreOperator> connectOps = new TreeMap<>();
   private final Map<Integer, ReduceWork> tagToReducerMap = new HashMap<>();
@@ -87,16 +78,11 @@ public class ReduceRecordProcessor extends RecordProcessor {
   public ReduceRecordProcessor(final JobConf jconf, final ProcessorContext context) throws Exception {
     super(jconf, context);
 
-    String queryId = HiveConf.getVar(jconf, HiveConf.ConfVars.HIVE_QUERY_ID);
-    cache = ObjectCacheFactory.getCache(jconf, queryId, true);
-    dynamicValueCache = ObjectCacheFactory.getCache(jconf, queryId, false, true);
-
     String cacheKey = processorContext.getTaskVertexName() + REDUCE_PLAN_KEY;
-    cacheKeys = Lists.newArrayList(cacheKey);
-    reduceWork = cache.retrieve(cacheKey, () -> Utilities.getReduceWork(jconf));
+    reduceWork = planCache.retrieve(cacheKey, () -> Utilities.getReduceWork(jconf));
 
     Utilities.setReduceWork(jconf, reduceWork);
-    mergeWorkList = getMergeWorkList(jconf, cacheKey, queryId, cache, cacheKeys);
+    mergeWorkList = getMergeWorkList(jconf);
   }
 
   @Override
@@ -161,7 +147,6 @@ public class ReduceRecordProcessor extends RecordProcessor {
     String valueRegistryKey = DynamicValue.DYNAMIC_VALUE_REGISTRY_CACHE_KEY;
     DynamicValueRegistryTez registryTez =
         dynamicValueCache.retrieve(valueRegistryKey, () -> new DynamicValueRegistryTez());
-    dynamicValueCacheKeys.add(valueRegistryKey);
     RegistryConfTez registryConf = new RegistryConfTez(jconf, reduceWork, processorContext, inputs);
     registryTez.init(registryConf);
     checkAbortCondition();
@@ -339,17 +324,7 @@ public class ReduceRecordProcessor extends RecordProcessor {
 
   @Override
   void close() {
-    if (cache != null) {
-      for (String key : cacheKeys) {
-        cache.release(key);
-      }
-    }
-
-    if (dynamicValueCache != null) {
-      for (String k : dynamicValueCacheKeys) {
-        dynamicValueCache.release(k);
-      }
-    }
+    releaseCache();
 
     try {
       boolean abort = isAborted();

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestRecordProcessor.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestRecordProcessor.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.tez;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.llap.io.api.LlapProxy;
+import org.apache.hadoop.hive.ql.exec.ObjectCache;
+import org.apache.hadoop.hive.ql.exec.ObjectCacheFactory;
+import org.apache.hadoop.hive.ql.exec.tez.RecordProcessor.TrackedCache;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.tez.mapreduce.processor.MRTaskReporter;
+import org.apache.tez.runtime.api.LogicalInput;
+import org.apache.tez.runtime.api.LogicalOutput;
+import org.apache.tez.runtime.api.ProcessorContext;
+import org.junit.Test;
+
+/**
+ * Tests for {@link RecordProcessor}. Behaviour exercised here lives on the
+ * base class and is inherited by every subclass — {@link MapRecordProcessor},
+ * {@link ReduceRecordProcessor}, and {@link MergeFileRecordProcessor} — so
+ * covering it once here is enough.
+ */
+public class TestRecordProcessor {
+
+  private static <T> Callable<T> constant(T value) {
+    return () -> value;
+  }
+
+  /**
+   * {@code TrackedCache.retrieve} must delegate to the underlying cache and
+   * return the value the underlying cache produced — no wrapping, no
+   * substitution. Every subclass assigns this return value directly to a
+   * plan field ({@code mapWork}, {@code reduceWork}), so any drift here would
+   * be a silent bug.
+   */
+  @Test
+  public void retrieveReturnsUnderlyingValue() throws Exception {
+    ObjectCache backend = mock(ObjectCache.class);
+    Object sentinel = new Object();
+    when(backend.retrieve(anyString(), any())).thenReturn(sentinel);
+    TrackedCache planCache = new TrackedCache(backend);
+
+    Object got = planCache.retrieve("k", constant(sentinel));
+
+    assertEquals(sentinel, got);
+    verify(backend).retrieve(any(), any());
+  }
+
+  /**
+   * The plan cache and the dynamic-value cache must track their keys
+   * independently — releasing one must not touch the other. Map/Reduce
+   * processors rely on this invariant when they retrieve their plan plus
+   * the dynamic value registry from two separate {@link TrackedCache}s.
+   */
+  @Test
+  public void planAndDynamicValueCachesAreIndependent() throws Exception {
+    ObjectCache planBackend = mock(ObjectCache.class);
+    ObjectCache dvBackend = mock(ObjectCache.class);
+    when(planBackend.retrieve(anyString(), any())).thenReturn("plan");
+    when(dvBackend.retrieve(anyString(), any())).thenReturn("dv");
+
+    TrackedCache planCache = new TrackedCache(planBackend);
+    TrackedCache dynamicValueCache = new TrackedCache(dvBackend);
+
+    planCache.retrieve("Map 1__MAP_PLAN__", constant("plan"));
+    dynamicValueCache.retrieve("dyn-values", constant("dv"));
+
+    planCache.releaseAll();
+    verify(planBackend).release("Map 1__MAP_PLAN__");
+    verify(dvBackend, never()).release(anyString()); // dv registry key not touched yet
+    // dv still holds its key until we call its own releaseAll
+    dynamicValueCache.releaseAll();
+    verify(dvBackend).release("dyn-values");
+  }
+
+  /**
+   * Regression guard for the plan cache's LLAP wiring. Two processors of the
+   * same query on the same LLAP daemon must NOT share a deserialised plan —
+   * sharing would let concurrent fragments race on the per-fragment operator
+   * state ({@link org.apache.hadoop.hive.ql.exec.FileSinkOperator#fsp},
+   * {@code VectorGroupByOperator.aggregator}, {@code VectorTopNKeyOperator}
+   * filter state, {@link org.apache.hadoop.hive.ql.exec.Operator#childOperatorsArray})
+   * that {@code initializeOp()} resets, producing the
+   * {@code FileAlreadyExistsException} / {@code NullPointerException} class of
+   * failures HIVE-14433 documents.
+   *
+   * <p>The test drives the real code path — it flips {@link LlapProxy} into
+   * daemon mode, constructs two {@link StubRecordProcessor} instances through
+   * the production constructor, and calls {@code retrieve()} on their
+   * {@code planCache} fields. Each must load its own copy and the loader must
+   * fire once per processor. If {@code RecordProcessor}'s constructor ever
+   * flips its plan cache back to {@code llapCacheAlwaysEnabled=true}, this
+   * test fails.
+   */
+  @Test
+  public void plansAreNotSharedAcrossProcessorsOnLlap() throws Exception {
+    String queryId = "record-processor-test-" + System.nanoTime();
+    LlapProxy.setDaemon(true);
+    try {
+      JobConf conf = new JobConf();
+      HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "tez");
+      HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_QUERY_ID, queryId);
+      ProcessorContext ctx = mock(ProcessorContext.class);
+
+      RecordProcessor procOne = new StubRecordProcessor(conf, ctx);
+      RecordProcessor procTwo = new StubRecordProcessor(conf, ctx);
+
+      String key = "Reducer 2__REDUCE_PLAN__";
+      AtomicInteger loaderInvocations = new AtomicInteger();
+      Callable<Object> loader = () -> {
+        loaderInvocations.incrementAndGet();
+        return new Object();
+      };
+
+      Object planFromOne = procOne.planCache.retrieve(key, loader);
+      Object planFromTwo = procTwo.planCache.retrieve(key, loader);
+
+      assertEquals("each processor must load its own plan",
+          2, loaderInvocations.get());
+      assertNotSame("plans must not be shared across processors on LLAP",
+          planFromOne, planFromTwo);
+    } finally {
+      ObjectCacheFactory.removeLlapQueryCache(queryId);
+      LlapProxy.setDaemon(false);
+    }
+  }
+
+  /**
+   * Minimal {@link RecordProcessor} subclass so the test can construct one
+   * without pulling in a live Map/Reduce operator tree. The parent constructor
+   * is the only behaviour under test.
+   */
+  private static final class StubRecordProcessor extends RecordProcessor {
+    StubRecordProcessor(JobConf jconf, ProcessorContext context) {
+      super(jconf, context);
+    }
+
+    @Override
+    void init(MRTaskReporter mrReporter,
+        Map<String, LogicalInput> inputs, Map<String, LogicalOutput> outputs) {
+    }
+
+    @Override
+    void run() {
+    }
+
+    @Override
+    void close() {
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Introduces a `TrackedCache` nested class in `RecordProcessor` that pairs an `ObjectCache` with the list of keys retrieved through it, replacing the parallel `cache + cacheKeys` and `dynamicValueCache + dynamicValueCacheKeys` field pattern. `MapRecordProcessor`, `ReduceRecordProcessor`, and `MergeFileRecordProcessor` retrieve plans through the wrapper, and `releaseCache()` at close time releases every tracked key.
- Small cleanup in `ObjectCacheFactory.getLlapObjectCache`: removes a duplicate import, and swaps the get/putIfAbsent/log dance for `computeIfAbsent` with `Objects.requireNonNull`.
- Adds a regression test that pins the plan cache to per-processor `mr.ObjectCache` on LLAP — the safe default. See the note below on why plan sharing across fragments is deferred.

### Why are the changes needed?

The wrapper class removes the two parallel-list bookkeeping pattern that had drifted between subclasses and made "which cache owns this key" hard to see at the call sites. It's the seam a future daemon-wide plan-sharing change would need.

### Plan sharing across concurrent fragments on LLAP

An earlier iteration of this PR routed the plan cache through the daemon-wide `LlapObjectCache` (`ObjectCacheFactory.getCache(..., isPlanCache=true, llapCacheAlwaysEnabled=true)`) so N concurrent fragments would share one deserialised `MapWork`/`ReduceWork` instead of each running Kryo. Verifying against `TestMiniLlapLocalCliDriver -Dqfile=acid_globallimit.q` — which failed deterministically with `FileAlreadyExistsException: .../acidtest1/delta_0000001_0000001_0000/bucket_00000_0` and NPEs in `Operator.initialize` — showed this is unsafe today: operator trees in every `RecordProcessor` subclass carry per-fragment mutable state that `initializeOp()` resets (`FileSinkOperator.fsp`, `VectorGroupByOperator.aggregator`, `Operator.childOperatorsArray`, `VectorTopNKeyOperator`'s per-instance filter state, ...), and sharing the operator tree across concurrent fragments races on those fields — the HIVE-14433 class of failure.

Selective sharing (Map-only, per Reduce/MergeFile's own state) also failed the same qtest 2/2 with a `VectorHashKeyWrapperBase.isNull` NPE inside `TopNKeyFilter.compareWithBoundary` — Map-side operator trees carry per-fragment state too.

Kept off until an operator-tree refactor separates the plan descriptor from per-fragment state. The trap is documented on `RecordProcessor#planCache` so it doesn't have to be rediscovered.

### Does this PR introduce any user-facing change?

No. Internal refactor. Runtime behaviour is unchanged from pre-refactor: each processor deserialises its own plan.

### How was this patch tested?

New unit test `TestRecordProcessor`:

- **`retrieveReturnsUnderlyingValue`** — `TrackedCache.retrieve` is a pure pass-through to the underlying `ObjectCache`.
- **`planAndDynamicValueCachesAreIndependent`** — releasing one wrapper never touches the other.
- **`plansAreNotSharedAcrossProcessorsOnLlap`** — drives the real production path with `LlapProxy.setDaemon(true)`, constructs two `RecordProcessor` instances through the production constructor, and asserts each loads its own plan (loader fires twice, results are distinct). Guards against the plan cache being re-flipped to `llapCacheAlwaysEnabled=true` without a matching operator-tree fix.

Also verified `TestMiniLlapLocalCliDriver -Dqfile=acid_globallimit.q` — deterministic failure on the earlier iteration, green on this PR.
