### PR TITLE
HIVE-29825:Fix stale CM root cache in ReplChangeManager after HDFS 

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestReplChangeManager.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestReplChangeManager.java
@@ -592,4 +592,47 @@ public class TestReplChangeManager {
     assertFalse(ReplChangeManager
         .isCMFileUri(new Path("/somepath/adir/", "ab.jar")));
   }
+
+  /**
+   * Regression test for stale CM-root cache bug: when the CM root directory is deleted from
+   * HDFS (e.g. by DROP DATABASE CASCADE) while the in-memory encryptionZoneToCmrootMapping
+   * still holds the cached path, getCmRoot() must detect the missing directory and recreate it.
+   */
+  @Test
+  public void testRecycleAfterCmRootDeletedFromHdfs() throws Exception {
+    Path dirDb = new Path(warehouse.getWhRoot(), "dbStaleCmRoot");
+    fs.delete(dirDb, true);
+    fs.mkdirs(dirDb);
+
+    Path sourceFile1 = new Path(dirDb, "file1");
+    createFile(sourceFile1, "content1");
+
+    ReplChangeManager cm = ReplChangeManager.getInstance(hiveConf);
+
+    // First recycle: CM root exists, cache is populated, file is moved successfully.
+    int ret = cm.recycle(sourceFile1, RecycleType.MOVE, false);
+    Assert.assertEquals(1, ret);
+    Assert.assertFalse(fs.exists(sourceFile1));
+
+    Path cmRootPath = new Path(cmroot);
+    Assert.assertTrue("CM root should exist after first recycle", fs.exists(cmRootPath));
+
+    // Simulate DROP DATABASE CASCADE removing .cmroot from HDFS.
+    fs.delete(cmRootPath, true);
+    Assert.assertFalse("CM root should be deleted from HDFS", fs.exists(cmRootPath));
+
+    // Do NOT reset ReplChangeManager — preserve stale in-memory cache.
+    Path sourceFile2 = new Path(dirDb, "file2");
+    createFile(sourceFile2, "content2");
+    String file2Checksum = ReplChangeManager.checksumFor(sourceFile2, fs);
+
+    // Second MOVE recycle: cache hit must detect missing CM root, recreate it, and succeed.
+    ret = cm.recycle(sourceFile2, RecycleType.MOVE, false);
+    Assert.assertEquals(1, ret);
+    Assert.assertFalse("Source file should be removed after successful recycle", fs.exists(sourceFile2));
+    Assert.assertTrue("CM root should be recreated on cache hit", fs.exists(cmRootPath));
+
+    Path cmFile2Path = ReplChangeManager.getCMPath(hiveConf, sourceFile2.getName(), file2Checksum, cmroot);
+    Assert.assertTrue("Recycled file should exist under recreated CM root", fs.exists(cmFile2Path));
+  }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
@@ -590,6 +590,14 @@ public class ReplChangeManager {
       }
       if (encryptionZoneToCmrootMapping.containsKey(encryptionZonePath)) {
         cmroot = new Path(encryptionZoneToCmrootMapping.get(encryptionZonePath));
+        FileSystem cmFs = cmroot.getFileSystem(conf);
+        if (!cmFs.exists(cmroot)) {
+          synchronized (instance) {
+            if (!cmFs.exists(cmroot)) {
+              createCmRoot(cmroot);
+            }
+          }
+        }
       } else {
         cmroot = new Path(cmrootDir);
         synchronized (instance) {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
A minimal fix in ReplChangeManager.getCmRoot() plus a regression test.

On a cache hit in encryptionZoneToCmrootMapping, the code now checks whether the cached CM root path still exists on HDFS. If it was deleted, it recreates the directory using the existing createCmRoot() helper (mkdirs + CM-root permissions), then returns the path.

Also added testRecycleAfterCmRootDeletedFromHdfs in TestReplChangeManager to cover the stale-cache scenario.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

ReplChangeManager keeps an in-memory map from encryption zone → CM root path. That map survives across requests in a long-lived HMS JVM, but the actual HDFS directory can be removed externally — for example when DROP DATABASE ... CASCADE deletes a database directory that contains .cmroot.

After that, later MOVE recycle operations still get a cache hit and use the stale path without verifying HDFS. Because the parent .cmroot directory no longer exists, rename() fails and the failure path calls setTimes() on a non-existent destination file, causing:

FileNotFoundException: .../.cmroot/bucket_XXXXX_<checksum> does not exist


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Local Testing 