### PR TITLE
HIVE-29827: Reactor build may resolve internal dependency from remote repository

### DIFF
--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-standalone-metastore-client</artifactId>
-      <version>${hive.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Reference Ticket -> https://issues.apache.org/jira/browse/HIVE-29827

**ROOT CAUSE**
`hive-standalone-metastore-server/pom.xml` currently declares:
```
<dependency>
  <groupId>org.apache.hive</groupId>
  <artifactId>hive-standalone-metastore-client</artifactId>
  <version>${hive.version}</version>
</dependency>
```
This appears to be the only internal Hive module dependency using `${hive.version}` instead of `${project.version}`.

If these values differ (for example, when a suffix is added to the project version), Maven may attempt to resolve `hive-standalone-metastore-client` from a remote repository rather than using the artifact built in the current reactor.

**SOLUTION**
The PR replaces `${hive.version}` with `${project.version}` to make the dependency consistent with the rest of the project and ensure proper reactor resolution.

**CHECKS**
Built the project after the change:
```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:25 min
[INFO] Finished at: 2026-08-20T16:59:38-04:00
```