### PR TITLE
HIVE-29830: Build and Publish docker images fails due to expired setup-buildx-action

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -114,13 +114,13 @@ jobs:
           ls ./standalone-metastore/packaging/src/docker/
 
       - name: Login to Docker Hub
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
       - name: Build Hive Image locally
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a

--- a/.github/workflows/hive-postgres-tpcds-metastore.yml
+++ b/.github/workflows/hive-postgres-tpcds-metastore.yml
@@ -41,11 +41,11 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
       - name: Login to Docker Hub
         if: ${{ github.event.inputs.pushImage == 'true' }}
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade to latest docker actions currently available in: https://github.com/apache/infrastructure-actions/blame/69afc125e535c4c41e7f1b7470f583087e0f344b/actions.yml

### Why are the changes needed?
To avoid CI failures

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
TBD