### PR TITLE
HIVE-28820: HMS might only creates the external directory and not the managed directory

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/CreateDatabaseHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/handler/CreateDatabaseHandler.java
@@ -76,6 +76,11 @@ public class CreateDatabaseHandler
     Map<String, String> transactionalListenersResponses = Collections.emptyMap();
     Path dbExtPath = new Path(db.getLocationUri());
     Path dbMgdPath = db.getManagedLocationUri() != null ? new Path(db.getManagedLocationUri()) : null;
+
+    // HIVE-28820: create the default managed database directory even when MANAGEDLOCATION
+    // is not explicitly specified. Do not persist this default path into Database.managedLocationUri.
+    Path managedPathToCreate = dbMgdPath != null ? dbMgdPath : wh.getDefaultDatabasePath(db.getName(), false);
+    boolean explicitManagedLocation = dbMgdPath != null;
     boolean isInTest = MetastoreConf.getBoolVar(handler.getConf(), HIVE_IN_TEST);
     try {
       Database authDb = new Database(db);
@@ -97,53 +102,20 @@ public class CreateDatabaseHandler
           madeExternalDir = true;
         }
       } else {
-        if (dbMgdPath != null) {
-          try {
-            // Since this may be done as random user (if doAs=true) he may not have access
-            // to the managed directory. We run this as an admin user
-            madeManagedDir = UserGroupInformation.getLoginUser().doAs((PrivilegedExceptionAction<Boolean>) () -> {
-              if (!wh.isDir(dbMgdPath)) {
-                LOG.info("Creating database path in managed directory {}", dbMgdPath);
-                if (!wh.mkdirs(dbMgdPath)) {
-                  throw new MetaException("Unable to create database managed path " + dbMgdPath +
-                      ", failed to create database " + db.getName());
-                }
-                return true;
-              }
-              return false;
-            });
-            if (madeManagedDir) {
-              LOG.info("Created database path in managed directory {}", dbMgdPath);
-            } else if (!isInTest || !isDbReplicationTarget(db)) { // Hive replication tests doesn't drop the db after each test
-              throw new MetaException("Unable to create database managed directory " + dbMgdPath +
-                  ", failed to create database " + db.getName());
-            }
-          } catch (IOException | InterruptedException e) {
-            throw new MetaException(
-                "Unable to create database managed directory " + dbMgdPath + ", failed to create database " +
-                    db.getName() + ":" + e.getMessage());
-          }
+        madeManagedDir = createDbDirectory(managedPathToCreate, true, "managed", true);
+        if (madeManagedDir) {
+          LOG.info("Created database path in managed directory {}", managedPathToCreate);
+        } else if (explicitManagedLocation && (!isInTest || !isDbReplicationTarget(db))) {
+          throw new MetaException("Unable to create database managed directory " + managedPathToCreate +
+              ", failed to create database " + db.getName());
         }
-        try {
-          madeExternalDir = UserGroupInformation.getCurrentUser().doAs((PrivilegedExceptionAction<Boolean>) () -> {
-            if (!wh.isDir(dbExtPath)) {
-              LOG.info("Creating database path in external directory {}", dbExtPath);
-              return wh.mkdirs(dbExtPath);
-            }
-            return false;
-          });
-          if (madeExternalDir) {
-            LOG.info("Created database path in external directory {}", dbExtPath);
-          } else {
-            LOG.warn(
-                "Failed to create external path {} for database {}. " +
-                    "This may result in access not being allowed if the StorageBasedAuthorizationProvider is enabled",
-                dbExtPath, db.getName());
-          }
-        } catch (IOException | InterruptedException | UndeclaredThrowableException e) {
-          throw new MetaException("Failed to create external path " + dbExtPath + " for database " + db.getName() +
-                  ". This may result in access not being allowed if the " +
-              "StorageBasedAuthorizationProvider is enabled: " + e.getMessage());
+        madeExternalDir = createDbDirectory(dbExtPath, false, "external", false);
+        if (madeExternalDir) {
+          LOG.info("Created database path in external directory {}", dbExtPath);
+        } else {
+          LOG.warn("Failed to create external path {} for database {}. " +
+                  "This may result in access not being allowed if the StorageBasedAuthorizationProvider is enabled",
+              dbExtPath, db.getName());
         }
       }
 
@@ -166,15 +138,15 @@ public class CreateDatabaseHandler
             wh.deleteDir(dbMgdPath, true, db);
           }
         } else {
-          if (madeManagedDir && dbMgdPath != null) {
+          if (madeManagedDir) {
             try {
               UserGroupInformation.getLoginUser().doAs((PrivilegedExceptionAction<Void>) () -> {
-                wh.deleteDir(dbMgdPath, true, db);
+                wh.deleteDir(managedPathToCreate, true, db);
                 return null;
               });
             } catch (IOException | InterruptedException e) {
               LOG.error("Couldn't delete managed directory {} after it was created for database {} {}",
-                  dbMgdPath, db.getName(), e.getMessage());
+                  managedPathToCreate, db.getName(), e.getMessage());
             }
           }
 
@@ -269,4 +241,44 @@ public class CreateDatabaseHandler
                                      Map<String, String> transactionalListenersResponses) implements Result {
 
   }
+
+  /**
+   * Creates the given database directory (managed or external) as the given user,
+   * running the actual mkdir as an admin (login) or current user depending on runAsLoginUser.
+   *
+   * @param path the directory path to create
+   * @param runAsLoginUser true to run as the login (admin) user (used for managed dir,
+   *                        since the calling user may not have access to it),
+   *                        false to run as the current user (used for external dir)
+   * @param dirLabel a short label ("managed"/"external") used only for log/error messages
+   * @param throwOnMkdirFailure true to throw the exception about create database dir
+   * @return true if the directory was created by this call, false if it already existed
+   * @throws MetaException if directory creation fails
+   */
+  private boolean createDbDirectory(Path path, boolean runAsLoginUser, String dirLabel,
+                                    boolean throwOnMkdirFailure) throws MetaException {
+    try {
+      UserGroupInformation ugi = runAsLoginUser
+          ? UserGroupInformation.getLoginUser()
+          : UserGroupInformation.getCurrentUser();
+      return ugi.doAs((PrivilegedExceptionAction<Boolean>) () -> {
+        if (!wh.isDir(path)) {
+          LOG.info("Creating database path in {} directory {}", dirLabel, path);
+          if (!wh.mkdirs(path)) {
+            if (throwOnMkdirFailure) {
+              throw new MetaException("Unable to create database " + dirLabel + " path " + path +
+                  ", failed to create database " + db.getName());
+            }
+            return false;
+          }
+          return true;
+        }
+        return false;
+      });
+    } catch (IOException | InterruptedException | UndeclaredThrowableException e) {
+      throw new MetaException("Unable to create database " + dirLabel + " directory " + path +
+          ", failed to create database " + db.getName() + ": " + e.getMessage());
+    }
+  }
+
 }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
@@ -162,12 +162,40 @@ public class TestDatabases extends MetaStoreClientTest {
     Assert.assertNull("Comparing description", createdDatabase.getDescription());
     Assert.assertEquals("Comparing location", metaStore.getExternalWarehouseRoot() + "/" +
                                                   createdDatabase.getName() + ".db", createdDatabase.getLocationUri());
+    Assert.assertNull("Default managed location should not be persisted",
+        createdDatabase.getManagedLocationUri());
+
+    Path defaultManagedPath = new Warehouse(metaStore.getConf())
+        .getDefaultDatabasePath(createdDatabase.getName(), false);
+    Assert.assertTrue("Default managed database directory should be created",
+        metaStore.isPathExists(defaultManagedPath));
     Assert.assertEquals("Comparing parameters", new HashMap<String, String>(),
         createdDatabase.getParameters());
     Assert.assertNull("Comparing privileges", createdDatabase.getPrivileges());
     Assert.assertEquals("Comparing owner name", SecurityUtils.getUser(),
         createdDatabase.getOwnerName());
     Assert.assertEquals("Comparing owner type", PrincipalType.USER, createdDatabase.getOwnerType());
+  }
+
+  @Test
+  public void testCreateDatabaseWithExplicitManagedLocation() throws Exception {
+    String dbName = "test_explicit_managed_location";
+    String managedLocation = MetaStoreTestUtils.getTestWarehouseDir(dbName + "_managed");
+
+    Database database = new DatabaseBuilder()
+        .setName(dbName)
+        .build(metaStore.getConf());
+    database.setManagedLocationUri(managedLocation);
+
+    client.createDatabase(database);
+
+    Database createdDatabase = client.getDatabase(dbName);
+    Warehouse warehouse = new Warehouse(metaStore.getConf());
+    Path expectedManagedLocation = warehouse.getDnsPath(new Path(managedLocation));
+    Assert.assertEquals("Explicit managed location should be persisted",
+        expectedManagedLocation.toString(), createdDatabase.getManagedLocationUri());
+    Assert.assertTrue("Explicit managed database directory should be created",
+        metaStore.isPathExists(expectedManagedLocation));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes CreateDatabaseHandler.java so that the managed directory for a database is always created, regardless of whether MANAGEDLOCATION is explicitly specified at database creation time.

Previously, dbMgdPath was only set when the user explicitly passed a managed location URI; otherwise it was left null, and the managed directory creation logic (guarded by if (dbMgdPath != null)) was skipped entirely. This PR changes dbMgdPath to fall back to the already-computed defaultDbMgdPath when no managed location is explicitly specified, so the managed directory is always created using either the user-specified or the default path.

As part of this fix, the duplicated directory-creation logic for the managed and external directories (each previously implemented as separate doAs + isDir + mkdirs blocks) has been consolidated into a single private helper method, createDbDirectory, parameterized by the target path, whether to run as the login (admin) user or the current user, and a label used for logging/error messages.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The correct behavior is for HMS to always create a managed directory path for a database, whether or not a managed location is explicitly specified — mirroring how the external directory is always created via a default fallback path. Without this fix, some databases end up with only an external directory and no managed directory, which can cause downstream failures for any operation that expects the managed directory to exist (e.g. copying files into it).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Previously, creating a database without an explicit MANAGEDLOCATION could result in no managed directory being created on the filesystem. After this change, the managed directory is always created at the default managed location if one is not explicitly specified.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New unit tests added.

### Summary
The PR preserves the existing metadata semantics while fixing the filesystem behavior.
With an explicit MANAGEDLOCATION, HMS stores the normalized managed location in database metadata and creates that directory.
Without an explicit MANAGEDLOCATION, HMS keeps Database.managedLocationUri as null, meaning there is no database-level override, but it still creates the default managed database directory. This fixes the issue where CREATE DATABASE could create only the external directory and skip the managed directory.