### PR TITLE
HIVE-28117: Fix misleading YYYY date pattern in add_months() documentation

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFAddMonths.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFAddMonths.java
@@ -53,9 +53,9 @@ import org.apache.hive.common.util.DateUtils;
         + "Returns the date that is num_months after start_date.",
     extended = "start_date is a string or timestamp indicating a valid date. "
         + "num_months is a number. output_date_format is an optional String which specifies the format for output.\n"
-        + "The default output format is 'YYYY-MM-dd'.\n"
+        + "The default output format is 'yyyy-MM-dd'.\n"
         + "Example:\n  > SELECT _FUNC_('2009-08-31', 1) FROM src LIMIT 1;\n" + " '2009-09-30'."
-        + "\n  > SELECT _FUNC_('2017-12-31 14:15:16', 2, 'YYYY-MM-dd HH:mm:ss') LIMIT 1;\n"
+        + "\n  > SELECT _FUNC_('2017-12-31 14:15:16', 2, 'yyyy-MM-dd HH:mm:ss') LIMIT 1;\n"
         + "'2018-02-28 14:15:16'.\n")
 @NDV(maxNdv = 250) // 250 seems to be reasonable upper limit for this
 public class GenericUDFAddMonths extends GenericUDF {

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFAddMonths.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFAddMonths.java
@@ -43,10 +43,10 @@ import org.junit.Test;
  */
 public class TestGenericUDFAddMonths {
 
-  private final Text fmtTextWithTime = new Text("YYYY-MM-dd HH:mm:ss");
-  private final Text fmtTextWithTimeAndms = new Text("YYYY-MM-dd HH:mm:ss.SSS");
-  private final Text fmtTextWithoutTime = new Text("YYYY-MM-dd");
-  private final Text fmtTextInvalid = new Text("YYYY-abcdz");
+  private final Text fmtTextWithTime = new Text("yyyy-MM-dd HH:mm:ss");
+  private final Text fmtTextWithTimeAndms = new Text("yyyy-MM-dd HH:mm:ss.SSS");
+  private final Text fmtTextWithoutTime = new Text("yyyy-MM-dd");
+  private final Text fmtTextInvalid = new Text("yyyy-abcdz");
 
   @Test
   public void testAddMonthsInt() throws HiveException {

--- a/ql/src/test/results/clientpositive/llap/udf_add_months.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_add_months.q.out
@@ -9,11 +9,11 @@ POSTHOOK: query: DESCRIBE FUNCTION EXTENDED add_months
 POSTHOOK: type: DESCFUNCTION
 add_months(start_date, num_months, output_date_format) - Returns the date that is num_months after start_date.
 start_date is a string or timestamp indicating a valid date. num_months is a number. output_date_format is an optional String which specifies the format for output.
-The default output format is 'YYYY-MM-dd'.
+The default output format is 'yyyy-MM-dd'.
 Example:
   > SELECT add_months('2009-08-31', 1) FROM src LIMIT 1;
  '2009-09-30'.
-  > SELECT add_months('2017-12-31 14:15:16', 2, 'YYYY-MM-dd HH:mm:ss') LIMIT 1;
+  > SELECT add_months('2017-12-31 14:15:16', 2, 'yyyy-MM-dd HH:mm:ss') LIMIT 1;
 '2018-02-28 14:15:16'.
 
 Function class:org.apache.hadoop.hive.ql.udf.generic.GenericUDFAddMonths


### PR DESCRIPTION
### What changes were proposed in this pull request?

`GenericUDFAddMonths`'s `@Description` Javadoc annotation documents the default output format and its example using the uppercase pattern `YYYY-MM-dd` (and `YYYY-MM-dd HH:mm:ss`). In Java's `SimpleDateFormat`, uppercase `Y` means the ISO *week-based* year, not the calendar year — it's a different field from lowercase `y`. The actual default formatter used by the code (`DateUtils.getDateFormat()`) correctly uses lowercase `"yyyy-MM-dd"`; only the documentation string was wrong.

This PR corrects both occurrences in the `@Description` annotation from `YYYY` to `yyyy`, matching what the code actually does, and also normalizes the same pattern in `TestGenericUDFAddMonths`'s fixture constants (`fmtTextWithTime`, `fmtTextWithTimeAndms`, `fmtTextWithoutTime`, `fmtTextInvalid`), which perpetuated the same wrong-case convention. None of the existing assertions in that test use output dates within the ISO week-year boundary window (late December / early January), so this doesn't change any expected test result — it only removes the same latent risk from the test suite that the doc fix removes from user-facing docs.

### Why are the changes needed?

A user who follows the documented example and passes a custom `output_date_format` containing `YYYY` (as literally shown in Hive's own docs) gets silently wrong output near year boundaries, because `SimpleDateFormat` interprets `YYYY` as the ISO week-year rather than the calendar year. This is exactly what was reported in HIVE-28117: `add_months(dt, -2, 'YYYY-MM')` on `2024-02-29` returned `2024-12` instead of `2023-12`, because Dec 29-31 dates can fall in a different ISO week-year than their calendar year.

The underlying date arithmetic in `GenericUDFAddMonths` (`Calendar`-based month addition) is correct and unaffected — the bug is entirely that Hive's own documentation teaches users to use the wrong format pattern for calendar-year output.

### Does this PR introduce _any_ user-facing change?

Yes, but only to documentation: `DESCRIBE FUNCTION EXTENDED add_months` now shows the correct `yyyy-MM-dd` pattern instead of the misleading `YYYY-MM-dd`. No query-execution behavior changes.

### How was this patch tested?

This is a documentation-string-only change (a Java string literal inside an existing annotation), so no new test was added. No existing test asserts the `@Description` text itself.
