### PR TITLE
HIVE-29842: fixing flaky TestYarnQueueMetricsCollector tests

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/monitoring/yarnqueue/TestYarnQueueMetricsCollector.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/monitoring/yarnqueue/TestYarnQueueMetricsCollector.java
@@ -112,6 +112,9 @@ public class TestYarnQueueMetricsCollector {
    * Called from {@code @Before} so all tests start with a consistent baseline.
    * Stubs are lenient so tests that don't exercise these mocks don't fail with
    * UnnecessaryStubbingException.
+   * Conversely, a per-test (strict) stub consumed only by the async refresh thread must be
+   * awaited ({@code waitForInvocationCount}/{@code waitForSnapshot}) before the collector is
+   * shut down, or the stub can go unused and strict-stub validation fails the whole class.
    */
   private void setupHappyPathMocks() throws Exception {
     lenient().when(mockQueueStats.getAllocatedMemoryMB()).thenReturn(1024L);
@@ -169,6 +172,12 @@ public class TestYarnQueueMetricsCollector {
 
     YarnQueueMetricsCollector collector = newCollector(mockYarnClient, "nonexistent", 10000, "test-query-2");
     try {
+      // The pre-first-poll state (also a null snapshot) is not deterministically observable,
+      // as the refresh task runs with no initial delay; await the poll so the null asserted
+      // below is attributable to the stubbed null QueueInfo, not to "no poll yet".
+      waitForInvocationCount(mockYarnClient, 1, WAIT_TIMEOUT_MS);
+      assertTrue("Refresh task should have polled YARN",
+          mockingDetails(mockYarnClient).getInvocations().size() >= 1);
       assertNull("Snapshot should be null for nonexistent queue", collector.getLatestSnapshot());
     } finally {
       collector.shutdown();
@@ -221,9 +230,7 @@ public class TestYarnQueueMetricsCollector {
   }
 
   @Test
-  public void testShutdownIdempotency() throws Exception {
-    when(mockYarnClient.getQueueInfo("default")).thenReturn(mockQueueInfo);
-
+  public void testShutdownIdempotency() {
     YarnQueueMetricsCollector collector = newCollector(mockYarnClient, "default", 10000, "test-query-4");
     collector.shutdown();
     collector.shutdown(); // second call must be safe
@@ -237,6 +244,9 @@ public class TestYarnQueueMetricsCollector {
 
     YarnQueueMetricsCollector collector = newCollector(mockYarnClient, "default", 10000, "test-query-5");
     try {
+      waitForInvocationCount(mockYarnClient, 1, WAIT_TIMEOUT_MS);
+      assertTrue("Refresh task should have polled YARN",
+          mockingDetails(mockYarnClient).getInvocations().size() >= 1);
       assertNull("Snapshot should be null after exception", collector.getLatestSnapshot());
     } finally {
       collector.shutdown();
@@ -244,11 +254,7 @@ public class TestYarnQueueMetricsCollector {
   }
 
   @Test
-  public void testQueueNameRetrieval() throws Exception {
-    when(mockYarnClient.getQueueInfo(anyString())).thenReturn(mockQueueInfo);
-    when(mockQueueInfo.getQueueStatistics()).thenReturn(null);
-    when(mockQueueInfo.getCapacity()).thenReturn(0.5f);
-
+  public void testQueueNameRetrieval() {
     YarnQueueMetricsCollector collector = newCollector(mockYarnClient, "production", 10000, "test-query-6");
     try {
       assertEquals("Queue name should match", "production", collector.getQueueName());
@@ -305,6 +311,9 @@ public class TestYarnQueueMetricsCollector {
 
     YarnQueueMetricsCollector collector = newCollector(mockYarnClient, "default", 10000, "init-fail-query");
     try {
+      waitForInvocationCount(mockYarnClient, 1, WAIT_TIMEOUT_MS);
+      assertTrue("Refresh task should have polled YARN",
+          mockingDetails(mockYarnClient).getInvocations().size() >= 1);
       assertNull("Snapshot should be null after init failure", collector.getLatestSnapshot());
     } finally {
       collector.shutdown();

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/monitoring/yarnqueue/TestYarnQueueMetricsCollector.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/monitoring/yarnqueue/TestYarnQueueMetricsCollector.java
@@ -108,6 +108,16 @@ public class TestYarnQueueMetricsCollector {
   }
 
   /**
+   * Awaits the first refresh poll and asserts it happened. Use before shutting down a
+   * collector whose per-test stubs are consumed only by the refresh thread.
+   */
+  private void awaitFirstPoll() {
+    waitForInvocationCount(mockYarnClient, 1, WAIT_TIMEOUT_MS);
+    assertTrue("Refresh task should have polled YARN",
+        mockingDetails(mockYarnClient).getInvocations().size() >= 1);
+  }
+
+  /**
    * Configures mock objects with standard happy-path values.
    * Called from {@code @Before} so all tests start with a consistent baseline.
    * Stubs are lenient so tests that don't exercise these mocks don't fail with
@@ -175,9 +185,7 @@ public class TestYarnQueueMetricsCollector {
       // The pre-first-poll state (also a null snapshot) is not deterministically observable,
       // as the refresh task runs with no initial delay; await the poll so the null asserted
       // below is attributable to the stubbed null QueueInfo, not to "no poll yet".
-      waitForInvocationCount(mockYarnClient, 1, WAIT_TIMEOUT_MS);
-      assertTrue("Refresh task should have polled YARN",
-          mockingDetails(mockYarnClient).getInvocations().size() >= 1);
+      awaitFirstPoll();
       assertNull("Snapshot should be null for nonexistent queue", collector.getLatestSnapshot());
     } finally {
       collector.shutdown();
@@ -244,9 +252,7 @@ public class TestYarnQueueMetricsCollector {
 
     YarnQueueMetricsCollector collector = newCollector(mockYarnClient, "default", 10000, "test-query-5");
     try {
-      waitForInvocationCount(mockYarnClient, 1, WAIT_TIMEOUT_MS);
-      assertTrue("Refresh task should have polled YARN",
-          mockingDetails(mockYarnClient).getInvocations().size() >= 1);
+      awaitFirstPoll();
       assertNull("Snapshot should be null after exception", collector.getLatestSnapshot());
     } finally {
       collector.shutdown();
@@ -311,9 +317,7 @@ public class TestYarnQueueMetricsCollector {
 
     YarnQueueMetricsCollector collector = newCollector(mockYarnClient, "default", 10000, "init-fail-query");
     try {
-      waitForInvocationCount(mockYarnClient, 1, WAIT_TIMEOUT_MS);
-      assertTrue("Refresh task should have polled YARN",
-          mockingDetails(mockYarnClient).getInvocations().size() >= 1);
+      awaitFirstPoll();
       assertNull("Snapshot should be null after init failure", collector.getLatestSnapshot());
     } finally {
       collector.shutdown();


### PR DESCRIPTION
### What changes were proposed in this pull request?
HIVE-29842: Test-only changes to `TestYarnQueueMetricsCollector` (no production code touched):
- Await the first refresh poll (new `awaitFirstPoll()` helper: `waitForInvocationCount` + count assert, the same idiom the class already uses) in the three tests whose stubs are consumed only by the async refresh thread, before asserting and shutting down.
- Remove four redundant strict stubs (and the `throws Exception` clauses only those stubs required): they either duplicate the lenient `@Before` defaults verbatim or set values the test's assertion never reads.
- Document the invariant in the `setupHappyPathMocks()` javadoc: a strict per-test stub consumed only by the refresh thread must be awaited before shutdown.

### Why are the changes needed?
Four tests stub interactions whose only consumer is the async refresh task (scheduled with `scheduleWithFixedDelay(task, 0, ...)`), then assert and call `shutdown()` without awaiting the poll. When `shutdown()` wins that race, the strict stub is never consumed and `MockitoJUnitRunner` fails the whole class with `UnnecessaryStubbingException` — this hit the precommit of an unrelated PR (run 6 of PR 6676; see HIVE-29842 for the link).

The tests usually pass only by accident: the collector's INFO logging during scheduling stalls the main thread long enough for the poll thread to sneak its call in. That makes the flake deterministic to reproduce on master:

```
mvn test -pl ql -Dtest=TestYarnQueueMetricsCollector -Dhive.log.level=OFF
```

(suppressing logging removes the log-I/O stall; the class then fails consistently pre-patch).

The awaits also make the assertions meaningful: previously `assertNull(getLatestSnapshot())` passed whether the stubbed condition was exercised or the poll simply had not run yet.

### Does this PR introduce _any_ user-facing change?
No. Test-only.

### How was this patch tested?
- The repro command above: consistent failure pre-patch, repeated passes post-patch.
- Full class with default logging: 23/23 green.
- Checkstyle: no new violations on changed lines.
