### PR TITLE
HIVE-29819: Fix Iceberg COW UPDATE for null identity partition column…

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -93,11 +93,14 @@ public class HiveIcebergSerDe extends AbstractSerDe {
     // executor, but serDeProperties are populated by HiveIcebergStorageHandler.configureInputJobProperties() and
     // the resulting properties are serialized and distributed to the executors
 
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+
     if (serDeProperties.get(InputFormatConfig.TABLE_SCHEMA) != null) {
       this.tableSchema = SchemaParser.fromJson(serDeProperties.getProperty(InputFormatConfig.TABLE_SCHEMA));
       if (serDeProperties.get(InputFormatConfig.PARTITION_SPEC) != null) {
         PartitionSpec spec =
             PartitionSpecParser.fromJson(tableSchema, serDeProperties.getProperty(InputFormatConfig.PARTITION_SPEC));
+        partitionSpec = spec;
         this.partitionColumns = spec.fields().stream().map(PartitionField::name).collect(Collectors.toList());
       } else {
         this.partitionColumns = ImmutableList.of();
@@ -107,6 +110,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
         Table table = IcebergTableUtil.getTable(conf, serDeProperties);
         // always prefer the original table schema if there is one
         this.tableSchema = table.schema();
+        partitionSpec = table.spec();
         this.partitionColumns = table.spec().fields().stream().map(PartitionField::name).collect(Collectors.toList());
         LOG.info("Using schema from existing table {}", SchemaParser.toJson(tableSchema));
       } catch (Exception e) {
@@ -119,6 +123,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
           try (FileIO fileIO = new HadoopFileIO(conf)) {
             TableMetadata metadata = TableMetadataParser.read(fileIO, serDeProperties.getProperty("metadata_location"));
             this.tableSchema = metadata.schema();
+            partitionSpec = metadata.spec();
             this.partitionColumns =
                 metadata.spec().fields().stream().map(PartitionField::name).collect(Collectors.toList());
             // Validate no schema is provided via create command
@@ -140,7 +145,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
       }
     }
 
-    this.projectedSchema = projectedSchema(conf, serDeProperties, tableSchema, jobConf);
+    this.projectedSchema =
+        projectedSchema(conf, serDeProperties, tableSchema, partitionSpec, jobConf);
 
     if (!IcebergTableUtil.isFanoutEnabled(serDeProperties::getProperty)) {
       // ClusteredWriter requires that records are ordered by partition keys.
@@ -156,7 +162,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
   }
 
   private static Schema projectedSchema(Configuration conf, Properties serDeProperties,
-      Schema tableSchema, Map<String, String> jobConf) {
+      Schema tableSchema, PartitionSpec partitionSpec, Map<String, String> jobConf) {
     String tableName = serDeProperties.getProperty(Catalogs.NAME);
     Context.Operation operation = HiveCustomStorageHandlerUtils.getWriteOperation(conf::get, tableName);
 
@@ -176,7 +182,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
             MetadataColumns.schemaWithRowLineage(tableSchema) :
             tableSchema;
       } else {
-        return projectedSchema;
+        return IcebergTableUtil.includeIdentityPartitionSourceColumns(
+            projectedSchema, tableSchema, partitionSpec, partitionSpec.identitySourceIds());
       }
     }
     boolean isCOW = IcebergTableUtil.isCopyOnWriteMode(operation, conf::get);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergTableUtil.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -56,6 +57,7 @@ import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.utils.TableFetcher;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.metadata.DummyPartition;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -65,7 +67,9 @@ import org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.TransformSpec;
 import org.apache.hadoop.hive.ql.parse.TransformSpec.TransformType;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.PlanUtils;
+import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionStateUtil;
 import org.apache.hadoop.util.Sets;
@@ -98,6 +102,7 @@ import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdatePartitionSpec;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -117,10 +122,12 @@ import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PartitionUtil;
+import org.apache.iceberg.util.SerializationUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.StructProjection;
 import org.slf4j.Logger;
@@ -456,6 +463,96 @@ public class IcebergTableUtil {
       deleteFiles = deleteFiles.toBranch(HiveUtils.getTableSnapshotRef(branchName));
     }
     deleteFiles.deleteFromRowFilter(exp).commit();
+  }
+
+  /**
+   * Returns identity partition source column ids that should be included in a read schema.
+   */
+  public static Set<Integer> requiredIdentityPartitionSourceIds(Configuration conf, Schema tableSchema,
+      PartitionSpec spec, String[] selectedColumnNames) {
+    if (spec == null || spec.isUnpartitioned()) {
+      return Collections.emptySet();
+    }
+
+    Set<Integer> required = new LinkedHashSet<>();
+    if (selectedColumnNames != null) {
+      for (String name : selectedColumnNames) {
+        Types.NestedField field = tableSchema.findField(name);
+        if (field != null) {
+          required.add(field.fieldId());
+        }
+      }
+    }
+
+    Expression filter = filterExpressionFromConf(conf);
+    if (filter != null && filter != Expressions.alwaysTrue()) {
+      boolean caseSensitive = conf.getBoolean(
+          InputFormatConfig.CASE_SENSITIVE, InputFormatConfig.CASE_SENSITIVE_DEFAULT);
+      required.addAll(Binder.boundReferences(tableSchema.asStruct(), Collections.singletonList(filter), caseSensitive));
+    }
+
+    Set<Integer> identitySourceIds = spec.identitySourceIds();
+    required.retainAll(identitySourceIds);
+    return required;
+  }
+
+  private static Expression filterExpressionFromConf(Configuration conf) {
+    String encodedFilter = conf.get(InputFormatConfig.FILTER_EXPRESSION);
+    if (encodedFilter != null) {
+      return SerializationUtil.deserializeFromBase64(encodedFilter);
+    }
+
+    String hiveFilter = conf.get(TableScanDesc.FILTER_EXPR_CONF_STR);
+    if (hiveFilter != null) {
+      ExprNodeGenericFuncDesc exprNodeDesc =
+          SerializationUtilities.deserializeObject(hiveFilter, ExprNodeGenericFuncDesc.class);
+      return HiveIcebergInputFormat.getFilterExpr(conf, exprNodeDesc);
+    }
+
+    return null;
+  }
+
+  /**
+   * Include identity partition source columns in the schema so that partition constants can be injected even when the
+   * columns are omitted from the read projection.
+   */
+  public static Schema includeIdentityPartitionSourceColumns(Schema schema, Schema tableSchema, PartitionSpec spec,
+      Set<Integer> requiredSourceIds) {
+    if (spec == null || spec.isUnpartitioned() || requiredSourceIds == null || requiredSourceIds.isEmpty()) {
+      return schema;
+    }
+
+    Set<Integer> projectedIds = schema.columns().stream()
+        .map(Types.NestedField::fieldId)
+        .collect(Collectors.toSet());
+    Set<Integer> identitySourceIds = spec.identitySourceIds();
+    Set<Integer> sourceIdsToAdd = requiredSourceIds.stream()
+        .filter(identitySourceIds::contains)
+        .filter(id -> !projectedIds.contains(id))
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+    if (sourceIdsToAdd.isEmpty()) {
+      return schema;
+    }
+
+    Set<Integer> tableFieldIds = tableSchema.columns().stream()
+        .map(Types.NestedField::fieldId)
+        .collect(Collectors.toSet());
+    List<Types.NestedField> metaColumns = Lists.newArrayList();
+    Set<Integer> tableProjectionIds = new LinkedHashSet<>();
+    for (Types.NestedField field : schema.columns()) {
+      if (tableFieldIds.contains(field.fieldId())) {
+        tableProjectionIds.add(field.fieldId());
+      } else {
+        metaColumns.add(field);
+      }
+    }
+    tableProjectionIds.addAll(sourceIdsToAdd);
+
+    List<Types.NestedField> columns = Lists.newArrayListWithCapacity(
+        metaColumns.size() + tableProjectionIds.size());
+    columns.addAll(metaColumns);
+    columns.addAll(TypeUtil.select(tableSchema, tableProjectionIds).columns());
+    return new Schema(columns);
   }
 
   /**

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveBatchIterator.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveBatchIterator.java
@@ -22,9 +22,12 @@ package org.apache.iceberg.mr.hive.vector;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.LongStream;
+import org.apache.hadoop.hive.common.type.DataTypePhysicalVariation;
 import org.apache.hadoop.hive.llap.LlapHiveUtils;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedBatchUtil;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatchCtx;
 import org.apache.hadoop.hive.ql.io.RowPositionAwareVectorizedRecordReader;
@@ -101,10 +104,18 @@ public final class HiveBatchIterator implements CloseableIterator<HiveBatchConte
         if (partitionColIndices != null) {
           for (int i = 0; i < partitionColIndices.length; ++i) {
             int colIdx = partitionColIndices[i];
-            // The partition column might not be part of the current projection - in which case no CV is inited
-            if (batch.cols[colIdx] != null) {
-              vrbCtx.addPartitionColsToBatch(batch.cols[colIdx], partitionValues[i], partitionColIndices[i]);
+            ColumnVector partitionColVector = batch.cols[colIdx];
+            // The partition column might not be part of the current projection - allocate a CV and inject constants.
+            if (partitionColVector == null) {
+              DataTypePhysicalVariation[] variations = vrbCtx.getRowdataTypePhysicalVariations();
+              DataTypePhysicalVariation variation = variations != null ?
+                  variations[colIdx] : DataTypePhysicalVariation.NONE;
+              partitionColVector = VectorizedBatchUtil.createColumnVector(
+                  vrbCtx.getRowColumnTypeInfos()[colIdx], variation);
+              partitionColVector.init();
+              batch.cols[colIdx] = partitionColVector;
             }
+            vrbCtx.addPartitionColsToBatch(partitionColVector, partitionValues[i], colIdx);
           }
         }
         // Fill virtual columns

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/AbstractIcebergRecordReader.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/AbstractIcebergRecordReader.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.mr.mapreduce;
 
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -67,18 +68,23 @@ public abstract class AbstractIcebergRecordReader<T> extends RecordReader<Void, 
 
   private static Schema readSchema(Configuration conf, Table table, boolean caseSensitive) {
     Schema readSchema = InputFormatConfig.readSchema(conf);
+    String[] selectedColumns = InputFormatConfig.selectedColumns(conf);
+    Set<Integer> requiredSourceIds = requiredIdentityPartitionSourceIds(conf, table, selectedColumns);
 
     if (readSchema != null) {
-      return readSchema;
+      return IcebergTableUtil.includeIdentityPartitionSourceColumns(
+          readSchema, table.schema(), table.spec(), requiredSourceIds);
     }
 
-    String[] selectedColumns = InputFormatConfig.selectedColumns(conf);
     readSchema = table.schema();
 
     if (selectedColumns != null) {
       readSchema = caseSensitive ?
           readSchema.select(selectedColumns) : readSchema.caseInsensitiveSelect(selectedColumns);
     }
+
+    readSchema = IcebergTableUtil.includeIdentityPartitionSourceColumns(
+        readSchema, table.schema(), table.spec(), requiredSourceIds);
 
     if (InputFormatConfig.fetchVirtualColumns(conf)) {
       readSchema = IcebergAcidUtil.createFileReadSchemaWithVirtualColums(readSchema.columns());
@@ -88,6 +94,20 @@ public abstract class AbstractIcebergRecordReader<T> extends RecordReader<Void, 
     }
 
     return readSchema;
+  }
+
+  /**
+   * For explicit READ_SCHEMA (Iceberg InputFormat API / unit tests), only expand for columns
+   * referenced by the scan filter. For Hive execution (column names pushed via SELECTED_COLUMNS),
+   * include all identity partition source columns to match HiveIcebergSerDe.
+   */
+  private static Set<Integer> requiredIdentityPartitionSourceIds(Configuration conf, Table table,
+      String[] selectedColumns) {
+    if (InputFormatConfig.readSchema(conf) != null) {
+      return IcebergTableUtil.requiredIdentityPartitionSourceIds(
+          conf, table.schema(), table.spec(), selectedColumns);
+    }
+    return table.spec().identitySourceIds();
   }
 
   CloseableIterable<T> applyResidualFiltering(CloseableIterable<T> iter, Expression residual,

--- a/iceberg/iceberg-handler/src/test/queries/positive/update_iceberg_cow_null_identity_partition.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/update_iceberg_cow_null_identity_partition.q
@@ -1,0 +1,33 @@
+-- SORT_QUERY_RESULTS
+
+drop table if exists iceberg_cow_partitioned;
+
+create external table iceberg_cow_partitioned (
+  index int,
+  string_col string,
+  boolean_col boolean,
+  str_col string,
+  tinyint_col int
+) partitioned by spec(str_col, tinyint_col)
+stored by iceberg
+tblproperties ('write.update.mode'='copy-on-write');
+
+insert into iceberg_cow_partitioned partition (str_col, tinyint_col)
+  values (1, 'a', true, null, 0);
+
+explain update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null;
+update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null;
+
+select * from iceberg_cow_partitioned;
+
+-- Disable vectorization
+
+set hive.vectorized.execution.enabled=false;
+
+insert into iceberg_cow_partitioned partition (str_col, tinyint_col)
+  values (2, 'b', false, null, 1);
+
+explain update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null;
+update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null;
+
+select * from iceberg_cow_partitioned;

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_cow_null_identity_partition.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_cow_null_identity_partition.q.out
@@ -1,0 +1,253 @@
+PREHOOK: query: drop table if exists iceberg_cow_partitioned
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: drop table if exists iceberg_cow_partitioned
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: create external table iceberg_cow_partitioned (
+  index int,
+  string_col string,
+  boolean_col boolean,
+  str_col string,
+  tinyint_col int
+) partitioned by spec(str_col, tinyint_col)
+stored by iceberg
+tblproperties ('write.update.mode'='copy-on-write')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@iceberg_cow_partitioned
+POSTHOOK: query: create external table iceberg_cow_partitioned (
+  index int,
+  string_col string,
+  boolean_col boolean,
+  str_col string,
+  tinyint_col int
+) partitioned by spec(str_col, tinyint_col)
+stored by iceberg
+tblproperties ('write.update.mode'='copy-on-write')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@iceberg_cow_partitioned
+PREHOOK: query: insert into iceberg_cow_partitioned partition (str_col, tinyint_col)
+  values (1, 'a', true, null, 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@iceberg_cow_partitioned
+POSTHOOK: query: insert into iceberg_cow_partitioned partition (str_col, tinyint_col)
+  values (1, 'a', true, null, 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@iceberg_cow_partitioned
+PREHOOK: query: explain update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@iceberg_cow_partitioned
+PREHOOK: Output: default@iceberg_cow_partitioned
+POSTHOOK: query: explain update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@iceberg_cow_partitioned
+POSTHOOK: Output: default@iceberg_cow_partitioned
+Vertex dependency in root stage
+Map 1 <- Union 2 (CONTAINS)
+Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 2 (CONTAINS)
+Reducer 6 <- Map 5 (SIMPLE_EDGE)
+Reducer 7 <- Map 5 (SIMPLE_EDGE), Union 2 (CONTAINS)
+
+Stage-3
+  Stats Work{}
+    Stage-0
+      Move Operator
+        table:{"name:":"default.iceberg_cow_partitioned"}
+        Stage-2
+          Dependency Collection{}
+            Stage-1
+              Union 2
+              <-Map 1 [CONTAINS] vectorized
+                File Output Operator [FS_63]
+                  table:{"name:":"default.iceberg_cow_partitioned"}
+                  Select Operator [SEL_62] (rows=1 width=398)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                    TableScan [TS_48] (rows=1 width=97)
+                      default@iceberg_cow_partitioned,iceberg_cow_partitioned,Tbl:COMPLETE,Col:PARTIAL,Output:["index","string_col","boolean_col","tinyint_col"]
+              <-Reducer 4 [CONTAINS]
+                File Output Operator [FS_55]
+                  table:{"name:":"default.iceberg_cow_partitioned"}
+                  Select Operator [SEL_53] (rows=1 width=523)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                    Merge Join Operator [MERGEJOIN_52] (rows=1 width=523)
+                      Conds:RS_66._col7=RS_76._col0(Left Semi),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                    <-Map 3 [SIMPLE_EDGE] vectorized
+                      SHUFFLE [RS_66]
+                        PartitionCols:_col7
+                        Select Operator [SEL_65] (rows=1 width=476)
+                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                          Filter Operator [FIL_64] (rows=1 width=272)
+                            predicate:(FILE__PATH is not null and str_col is not null)
+                            TableScan [TS_3] (rows=1 width=272)
+                              default@iceberg_cow_partitioned,iceberg_cow_partitioned,Tbl:COMPLETE,Col:PARTIAL,Output:["index","string_col","boolean_col","str_col","tinyint_col"]
+                    <-Reducer 6 [SIMPLE_EDGE] vectorized
+                      SHUFFLE [RS_76]
+                        PartitionCols:_col0
+                        Group By Operator [GBY_75] (rows=1 width=13498)
+                          Output:["_col0"],keys:_col0
+                          Select Operator [SEL_74] (rows=1 width=13498)
+                            Output:["_col0"]
+                            Filter Operator [FIL_73] (rows=1 width=13498)
+                              predicate:(row_number_window_0 = 1)
+                              PTF Operator [PTF_72] (rows=1 width=13498)
+                                Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col7 ASC NULLS FIRST","partition by:":"_col7"}]
+                                Select Operator [SEL_71] (rows=1 width=13498)
+                                  Output:["_col7"]
+                                <-Map 5 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_69]
+                                    PartitionCols:FILE__PATH
+                                    Filter Operator [FIL_67] (rows=1 width=13498)
+                                      predicate:(FILE__PATH is not null and str_col is null)
+                                      TableScan [TS_6] (rows=1 width=13498)
+                                        default@iceberg_cow_partitioned,iceberg_cow_partitioned,Tbl:COMPLETE,Col:NONE,Output:["boolean_col","index","string_col","tinyint_col"]
+              <-Reducer 7 [CONTAINS] vectorized
+                File Output Operator [FS_81]
+                  table:{"name:":"default.iceberg_cow_partitioned"}
+                  Select Operator [SEL_80] (rows=1 width=385)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                    Filter Operator [FIL_79] (rows=1 width=293)
+                      predicate:(row_number_window_0 = 1)
+                      PTF Operator [PTF_78] (rows=1 width=293)
+                        Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col7 ASC NULLS FIRST","partition by:":"_col7"}]
+                        Select Operator [SEL_77] (rows=1 width=293)
+                          Output:["_col0","_col1","_col2","_col4","_col5","_col6","_col7"]
+                        <-Map 5 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_70]
+                            PartitionCols:FILE__PATH
+                            Filter Operator [FIL_68]
+                              predicate:str_col is null
+                               Please refer to the previous TableScan [TS_6]
+
+PREHOOK: query: update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@iceberg_cow_partitioned
+PREHOOK: Output: default@iceberg_cow_partitioned
+POSTHOOK: query: update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@iceberg_cow_partitioned
+POSTHOOK: Output: default@iceberg_cow_partitioned
+PREHOOK: query: select * from iceberg_cow_partitioned
+PREHOOK: type: QUERY
+PREHOOK: Input: default@iceberg_cow_partitioned
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from iceberg_cow_partitioned
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@iceberg_cow_partitioned
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	a	true	UPDATED NULLS	0
+PREHOOK: query: insert into iceberg_cow_partitioned partition (str_col, tinyint_col)
+  values (2, 'b', false, null, 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@iceberg_cow_partitioned
+POSTHOOK: query: insert into iceberg_cow_partitioned partition (str_col, tinyint_col)
+  values (2, 'b', false, null, 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@iceberg_cow_partitioned
+PREHOOK: query: explain update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@iceberg_cow_partitioned
+PREHOOK: Output: default@iceberg_cow_partitioned
+POSTHOOK: query: explain update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@iceberg_cow_partitioned
+POSTHOOK: Output: default@iceberg_cow_partitioned
+Vertex dependency in root stage
+Map 1 <- Union 2 (CONTAINS)
+Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 2 (CONTAINS)
+Reducer 6 <- Map 5 (SIMPLE_EDGE)
+Reducer 7 <- Map 5 (SIMPLE_EDGE), Union 2 (CONTAINS)
+
+Stage-3
+  Stats Work{}
+    Stage-0
+      Move Operator
+        table:{"name:":"default.iceberg_cow_partitioned"}
+        Stage-2
+          Dependency Collection{}
+            Stage-1
+              Union 2
+              <-Map 1 [CONTAINS]
+                File Output Operator [FS_51]
+                  table:{"name:":"default.iceberg_cow_partitioned"}
+                  Select Operator [SEL_49] (rows=1 width=398)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                    TableScan [TS_48] (rows=1 width=97)
+                      default@iceberg_cow_partitioned,iceberg_cow_partitioned,Tbl:COMPLETE,Col:PARTIAL,Output:["index","string_col","boolean_col","tinyint_col"]
+              <-Reducer 4 [CONTAINS]
+                File Output Operator [FS_55]
+                  table:{"name:":"default.iceberg_cow_partitioned"}
+                  Select Operator [SEL_53] (rows=1 width=16390)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                    Merge Join Operator [MERGEJOIN_52] (rows=1 width=16390)
+                      Conds:RS_17._col7=RS_18._col0(Left Semi),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                    <-Map 3 [SIMPLE_EDGE]
+                      SHUFFLE [RS_17]
+                        PartitionCols:_col7
+                        Select Operator [SEL_5] (rows=1 width=14900)
+                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                          Filter Operator [FIL_36] (rows=1 width=14900)
+                            predicate:FILE__PATH is not null
+                            TableScan [TS_3] (rows=1 width=14900)
+                              default@iceberg_cow_partitioned,iceberg_cow_partitioned,Tbl:COMPLETE,Col:NONE,Output:["index","string_col","boolean_col","str_col","tinyint_col"]
+                    <-Reducer 6 [SIMPLE_EDGE]
+                      SHUFFLE [RS_18]
+                        PartitionCols:_col0
+                        Group By Operator [GBY_16] (rows=1 width=13498)
+                          Output:["_col0"],keys:_col0
+                          Select Operator [SEL_11] (rows=1 width=13498)
+                            Output:["_col0"]
+                            Filter Operator [FIL_37] (rows=1 width=13498)
+                              predicate:(row_number_window_0 = 1)
+                              PTF Operator [PTF_10] (rows=1 width=13498)
+                                Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col7 ASC NULLS FIRST","partition by:":"_col7"}]
+                                Select Operator [SEL_9] (rows=1 width=13498)
+                                  Output:["_col7"]
+                                <-Map 5 [SIMPLE_EDGE]
+                                  SHUFFLE [RS_8]
+                                    PartitionCols:FILE__PATH
+                                    Filter Operator [FIL_38] (rows=1 width=13498)
+                                      predicate:(FILE__PATH is not null and str_col is null)
+                                      TableScan [TS_6] (rows=1 width=13498)
+                                        default@iceberg_cow_partitioned,iceberg_cow_partitioned,Tbl:COMPLETE,Col:NONE,Output:["boolean_col","index","string_col","tinyint_col"]
+              <-Reducer 7 [CONTAINS]
+                File Output Operator [FS_61]
+                  table:{"name:":"default.iceberg_cow_partitioned"}
+                  Select Operator [SEL_59] (rows=1 width=385)
+                    Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                    Filter Operator [FIL_58] (rows=1 width=293)
+                      predicate:(row_number_window_0 = 1)
+                      PTF Operator [PTF_57] (rows=1 width=293)
+                        Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col7 ASC NULLS FIRST","partition by:":"_col7"}]
+                        Select Operator [SEL_56] (rows=1 width=293)
+                          Output:["_col0","_col1","_col2","_col4","_col5","_col6","_col7"]
+                        <-Map 5 [SIMPLE_EDGE]
+                          SHUFFLE [RS_24]
+                            PartitionCols:FILE__PATH
+                            Filter Operator [FIL_47]
+                              predicate:str_col is null
+                               Please refer to the previous TableScan [TS_6]
+
+PREHOOK: query: update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@iceberg_cow_partitioned
+PREHOOK: Output: default@iceberg_cow_partitioned
+POSTHOOK: query: update iceberg_cow_partitioned set str_col = 'UPDATED NULLS' where str_col is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@iceberg_cow_partitioned
+POSTHOOK: Output: default@iceberg_cow_partitioned
+PREHOOK: query: select * from iceberg_cow_partitioned
+PREHOOK: type: QUERY
+PREHOOK: Input: default@iceberg_cow_partitioned
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from iceberg_cow_partitioned
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@iceberg_cow_partitioned
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	a	true	UPDATED NULLS	0
+2	b	false	UPDATED NULLS	1


### PR DESCRIPTION
… filters

### What changes were proposed in this pull request?
This PR fixes Iceberg copy-on-write UPDATE when you filter on a null partition column like WHERE str_col IS NULL.
Put missing identity partition columns back into the read schema when projection drops them.
In vectorized reads, create and fill the partition column in the batch if it was missing.

### Why are the changes needed?
In Iceberg tables, partition values often come from partition metadata rather than directly from the data files. Hive reads these values from the metadata and adds them during the scan. 
However, during a COW UPDATE, filter pushdown can remove the partition columns from the scan causing Hive to miss the partition values. As a result, a query like UPDATE ... WHERE str_col IS NULL may fail even when matching rows exist.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New qtest file :  update_iceberg_cow_null_identity_partition.q
