### PR TITLE
HIVE-28184: Fix HiveServer2 WebUI "Configure logging" page

### DIFF
--- a/common/src/java/org/apache/hive/http/Log4j2ConfiguratorServlet.java
+++ b/common/src/java/org/apache/hive/http/Log4j2ConfiguratorServlet.java
@@ -228,31 +228,39 @@ public class Log4j2ConfiguratorServlet extends HttpServlet {
   }
 
   private void configureLogger(final ConfLoggers confLoggers) {
-    if (confLoggers != null) {
-      for (ConfLogger logger : confLoggers.getLoggers()) {
-        String loggerName = logger.getLogger();
-        Level logLevel = Level.getLevel(logger.getLevel());
-        if (logLevel == null) {
-          LOG.warn("Invalid log level: {} for logger: {}. Ignoring reconfiguration.", loggerName, logger.getLevel());
-          continue;
-        }
-
-        LoggerConfig loggerConfig = conf.getLoggerConfig(loggerName);
-        // if the logger name is not found, root logger is returned. We don't want to change root logger level
-        // since user either requested a new logger or specified invalid input. In which, we will add the logger
-        // that user requested.
-        if (!loggerName.equals(LogManager.ROOT_LOGGER_NAME) &&
-          loggerConfig.getName().equals(LogManager.ROOT_LOGGER_NAME)) {
-          LOG.debug("Requested logger ({}) not found. Adding as new logger with {} level", loggerName, logLevel);
-          // requested logger not found. Add the new logger with the requested level
-          conf.addLogger(loggerName, new LoggerConfig(loggerName, logLevel, true));
-        } else {
-          LOG.debug("Updating logger ({}) to {} level", loggerName, logLevel);
-          // update the log level for the specified logger
-          loggerConfig.setLevel(logLevel);
-        }
+    if (confLoggers == null) {
+      return;
+    }
+    for (ConfLogger logger : confLoggers.getLoggers()) {
+      String loggerName = logger.getLogger();
+      Level logLevel = Level.getLevel(logger.getLevel());
+      if (logLevel == null) {
+        LOG.warn("Invalid log level: {} for logger: {}. Ignoring reconfiguration.", logger.getLevel(), loggerName);
+        continue;
       }
-      context.updateLoggers(conf);
+      setLogLevel(loggerName, logLevel);
+    }
+    context.updateLoggers(conf);
+  }
+
+  /**
+   * Sets the level for a single logger, adding a new logger when it is not explicitly
+   * configured yet.
+   * <p>
+   * {@link Configuration#getLoggerConfig(String)} never returns {@code null}: for an
+   * unconfigured name it returns the closest configured ancestor (the root logger for a
+   * brand-new name). Comparing the requested name against the returned config's name is
+   * therefore required so that setting a level for a not-yet-configured child logger does
+   * not silently change one of its ancestors instead.
+   */
+  void setLogLevel(final String loggerName, final Level logLevel) {
+    LoggerConfig loggerConfig = conf.getLoggerConfig(loggerName);
+    if (loggerName.equals(loggerConfig.getName())) {
+      LOG.debug("Updating logger ({}) to {} level", loggerName, logLevel);
+      loggerConfig.setLevel(logLevel);
+    } else {
+      LOG.debug("Logger ({}) not configured. Adding as new logger with {} level", loggerName, logLevel);
+      conf.addLogger(loggerName, new LoggerConfig(loggerName, logLevel, true));
     }
   }
 

--- a/common/src/test/org/apache/hive/http/TestLog4j2ConfiguratorServlet.java
+++ b/common/src/test/org/apache/hive/http/TestLog4j2ConfiguratorServlet.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.http;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link Log4j2ConfiguratorServlet#setLogLevel(String, Level)}, the logic behind
+ * the HiveServer2 WebUI "Configure logging" page and the {@code /conflog} endpoint.
+ */
+public class TestLog4j2ConfiguratorServlet {
+
+  private static final String PARENT_LOGGER = "org.apache.hive.test.conflog";
+  private static final String CHILD_LOGGER = "org.apache.hive.test.conflog.child";
+
+  // The levels offered by the WebUI "Configure logging" page dropdown.
+  private static final Level[] SUPPORTED_LEVELS =
+      { Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR, Level.FATAL };
+
+  private Log4j2ConfiguratorServlet servlet;
+  private Configuration configuration;
+  private Level originalRootLevel;
+
+  @Before
+  public void setUp() throws Exception {
+    servlet = new Log4j2ConfiguratorServlet();
+    servlet.init();
+    configuration = ((LoggerContext) LogManager.getContext(false)).getConfiguration();
+    originalRootLevel = configuration.getRootLogger().getLevel();
+  }
+
+  @After
+  public void tearDown() {
+    // Restore the root level so this test cannot leak into other tests in the same JVM.
+    configuration.getRootLogger().setLevel(originalRootLevel);
+  }
+
+  /**
+   * Setting a level for a not-yet-configured child logger must create a dedicated logger for it
+   * and must not change the level of an existing ancestor logger.
+   */
+  @Test
+  public void testSetLevelOnNewLoggerDoesNotAffectAncestor() {
+    servlet.setLogLevel(PARENT_LOGGER, Level.INFO);
+    servlet.setLogLevel(CHILD_LOGGER, Level.DEBUG);
+
+    LoggerConfig childConfig = configuration.getLoggerConfig(CHILD_LOGGER);
+    assertEquals("Child logger should have its own configuration", CHILD_LOGGER, childConfig.getName());
+    assertEquals("Child logger level should be the requested one", Level.DEBUG, childConfig.getLevel());
+
+    LoggerConfig parentConfig = configuration.getLoggerConfig(PARENT_LOGGER);
+    assertEquals("Ancestor logger level must not change when a child is configured",
+        Level.INFO, parentConfig.getLevel());
+  }
+
+  /**
+   * Setting a level for an already-configured logger must update that logger in place.
+   */
+  @Test
+  public void testSetLevelUpdatesExistingLogger() {
+    servlet.setLogLevel(PARENT_LOGGER, Level.INFO);
+    servlet.setLogLevel(PARENT_LOGGER, Level.WARN);
+
+    LoggerConfig parentConfig = configuration.getLoggerConfig(PARENT_LOGGER);
+    assertEquals("Existing logger should be updated in place", PARENT_LOGGER, parentConfig.getName());
+    assertEquals("Existing logger level should reflect the last update", Level.WARN, parentConfig.getLevel());
+  }
+
+  /**
+   * The empty logger name is the Log4j2 root logger and must update the root config directly.
+   */
+  @Test
+  public void testSetLevelUpdatesRootLogger() {
+    servlet.setLogLevel(LogManager.ROOT_LOGGER_NAME, Level.ERROR);
+
+    LoggerConfig rootConfig = configuration.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+    assertEquals("Root logger name should stay empty", LogManager.ROOT_LOGGER_NAME, rootConfig.getName());
+    assertEquals("Root logger level should be the requested one", Level.ERROR, rootConfig.getLevel());
+  }
+
+  /**
+   * Every level offered by the WebUI must be applied to and reflected back by a normal logger.
+   */
+  @Test
+  public void testEveryLevelIsAppliedToLogger() {
+    for (Level level : SUPPORTED_LEVELS) {
+      servlet.setLogLevel(PARENT_LOGGER, level);
+      assertEquals("Logger level should reflect the requested level " + level,
+          level, configuration.getLoggerConfig(PARENT_LOGGER).getLevel());
+    }
+  }
+
+  /**
+   * Every level offered by the WebUI must be applied to and reflected back by the root logger.
+   */
+  @Test
+  public void testEveryLevelIsAppliedToRootLogger() {
+    for (Level level : SUPPORTED_LEVELS) {
+      servlet.setLogLevel(LogManager.ROOT_LOGGER_NAME, level);
+      assertEquals("Root logger level should reflect the requested level " + level,
+          level, configuration.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).getLevel());
+    }
+  }
+}

--- a/common/src/test/org/apache/hive/http/TestLog4j2ConfiguratorServlet.java
+++ b/common/src/test/org/apache/hive/http/TestLog4j2ConfiguratorServlet.java
@@ -9,11 +9,12 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.hive.http;
 
@@ -38,8 +39,9 @@ public class TestLog4j2ConfiguratorServlet {
   private static final String CHILD_LOGGER = "org.apache.hive.test.conflog.child";
 
   // The levels offered by the WebUI "Configure logging" page dropdown.
-  private static final Level[] SUPPORTED_LEVELS =
-      { Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR, Level.FATAL };
+  private static final Level[] SUPPORTED_LEVELS = new Level[] {
+      Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR, Level.FATAL
+  };
 
   private Log4j2ConfiguratorServlet servlet;
   private Configuration configuration;

--- a/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
+++ b/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
@@ -17,32 +17,7 @@
  * limitations under the License.
  */
 --%>
-<%@ page contentType="text/html;charset=UTF-8"
-         import="org.apache.hadoop.conf.Configuration"
-         import="org.apache.hadoop.hive.conf.HiveConf"
-         import="org.apache.hadoop.hive.conf.HiveConf.ConfVars"
-         import="org.apache.hive.common.util.HiveVersionInfo"
-         import="org.apache.hive.http.HttpServer"
-         import="org.apache.hive.service.cli.operation.Operation"
-         import="org.apache.hive.service.cli.operation.SQLOperation"
-         import="org.apache.hadoop.hive.ql.QueryInfo"
-         import="org.apache.hive.service.cli.session.SessionManager"
-         import="org.apache.hive.service.cli.session.HiveSession"
-         import="javax.servlet.ServletContext"
-         import="java.util.Collection"
-         import="java.util.Date"
-         import="java.util.List"
-         import="jodd.net.HtmlEncoder"
-%>
-
-<%
-    ServletContext ctx = getServletContext();
-    Configuration conf = (Configuration)ctx.getAttribute("hive.conf");
-    long startcode = conf.getLong("startcode", System.currentTimeMillis());
-    SessionManager sessionManager =
-            (SessionManager)ctx.getAttribute("hive.sm");
-    String remoteUser = request.getRemoteUser();
-%>
+<%@ page contentType="text/html;charset=UTF-8" %>
 
 <!--[if IE]>
 <!DOCTYPE html>
@@ -62,7 +37,7 @@
     <link rel="stylesheet" type="text/css" href="/static/css/json.human.css">
     <script src="/static/js/jquery.min.js"></script>
     <script src="/static/js/json.human.js"></script>
-    <script src="/static/js/logconf.js"></script>
+    <script src="/static/js/logconf.js?v=28184-2"></script>
 </head>
 
 <body>
@@ -112,32 +87,30 @@
                     </tbody>
                 </table>
             </div>
-            <% Collection<HiveSession> hiveSessions = sessionManager.getSessions();
-            for (HiveSession hiveSession: hiveSessions) {
-            if( hiveSessions.size() > 0 && HttpServer.hasAccess(remoteUser, hiveSession.getUserName(), ctx, request) ) { %>
             <h2>Set new logging rules</h2>
 
-            <form class="form-inline">
-                <div class="form-group">
-                    <input type="text" id="logger-name" class="form-control" placeholder="Logger name">
-                </div>
-                <div class="form-group">
-                    <select id="log-level" class="form-control">
-                        <option value="TRACE">TRACE</option>
-                        <option value="DEBUG">DEBUG</option>
-                        <option value="INFO">INFO</option>
-                        <option value="WARN">WARN</option>
-                        <option value="ERROR">ERROR</option>
-                        <option value="FATAL">FATAL</option>
-                    </select>
-                </div>
+            <p id="logconf-error" class="text-danger" style="display: none;"></p>
 
-                <button id="log-level-submit" type="button" class="btn btn-primary">Submit</button>
+            <form>
+                <div style="display: flex; align-items: flex-end; flex-wrap: wrap; gap: 12px;">
+                    <div class="form-group" style="margin: 0;">
+                        <label for="logger-name" style="display: block; margin-bottom: 4px;">Logger</label>
+                        <select id="logger-name" class="form-control" style="min-width: 320px;"></select>
+                    </div>
+                    <div class="form-group" style="margin: 0;">
+                        <label for="log-level" style="display: block; margin-bottom: 4px;">Level</label>
+                        <select id="log-level" class="form-control" style="min-width: 120px;">
+                            <option value="TRACE">TRACE</option>
+                            <option value="DEBUG">DEBUG</option>
+                            <option value="INFO">INFO</option>
+                            <option value="WARN">WARN</option>
+                            <option value="ERROR">ERROR</option>
+                            <option value="FATAL">FATAL</option>
+                        </select>
+                    </div>
+                    <button id="log-level-submit" type="button" class="btn btn-primary">Submit</button>
+                </div>
             </form>
-            <% } else {%>
-                <p>Cannot configure logging rules unless user <%= hiveSession.getUserName() %> has admin privileges</p>
-            <% }
-             } %>
         </div>
     </div>
 

--- a/service/src/resources/hive-webapps/static/js/logconf.js
+++ b/service/src/resources/hive-webapps/static/js/logconf.js
@@ -15,56 +15,90 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Current logger name -> level, populated from the /conflog response and used to
+// pre-select the level of the logger chosen in the dropdown.
+var currentLoggers = {};
+
 $(document).ready(function () {
 
-    // init the table with the current loggers
+    // init the table and the logger dropdown with the current loggers
     loadLoggers();
 
+    // keep the level dropdown in sync with the selected logger
+    $("#logger-name").change(function () {
+        syncLevelToSelectedLogger();
+    });
+
     // set up event handler for submitting the form
-    $("#log-level-submit").click(function(e) {
-        setLoggersWithLevel(e);
+    $("#log-level-submit").click(function (e) {
+        setLoggerLevel(e);
     });
 });
 
-function setLoggersWithLevel(e) {
-    console.log("handler called");
-    var loggerName = sanitize($("#logger-name").val());
-    var logLevel = $("#log-level").val();
-    var data = JSON.stringify( { "loggers" : [ { "logger" : loggerName, "level" : logLevel } ] } );
-
-    $.post('conflog', data, function() {
-        loadLoggers();
-    });
+// Log4j2 uses the empty string as the name of the root logger; show it explicitly.
+function displayName(loggerName) {
+    return loggerName === "" ? "(root)" : loggerName;
 }
 
 function loadLoggers() {
-    // clear the current content
-    $("#current-logs").html("");
-
-    // load and render the new
     $.getJSON('conflog', function (data) {
-        var loggers = data.loggers;
-
-        $.each(loggers, function(i, logger) {
-            var logger_information = "<tr>\n" +
-                "                        <td>" + logger.logger + "</td>\n" +
-                "                        <td>" + logger.level + "</td>\n" +
-                "                    </tr>";
-            $("#current-logs").append(logger_information);
+        var loggers = (data.loggers || []).slice().sort(function (a, b) {
+            return a.logger.localeCompare(b.logger);
         });
 
+        currentLoggers = {};
+        var logsTable = $("#current-logs").empty();
+        var loggerSelect = $("#logger-name").empty();
+
+        $.each(loggers, function (i, logger) {
+            currentLoggers[logger.logger] = logger.level;
+
+            // Build the row with text() so logger names/levels can never inject markup.
+            var row = $("<tr>");
+            $("<td>").text(displayName(logger.logger)).appendTo(row);
+            $("<td>").text(logger.level).appendTo(row);
+            logsTable.append(row);
+
+            $("<option>").val(logger.logger).text(displayName(logger.logger)).appendTo(loggerSelect);
+        });
+
+        syncLevelToSelectedLogger();
     });
 }
 
-function sanitize(string) {
-    const map = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#x27;',
-        "/": '&#x2F;',
-    };
-    const reg = /[&<>"'/]/ig;
-    return string.replace(reg, (match)=>(map[match]));
+function syncLevelToSelectedLogger() {
+    var loggerName = $("#logger-name").val();
+    if (loggerName !== null && currentLoggers.hasOwnProperty(loggerName)) {
+        $("#log-level").val(currentLoggers[loggerName]);
+    }
+}
+
+function setLoggerLevel(e) {
+    var loggerName = $("#logger-name").val();
+    var logLevel = $("#log-level").val();
+    if (loggerName === null) {
+        return;
+    }
+    $("#logconf-error").hide();
+    var data = JSON.stringify({ "loggers": [ { "logger": loggerName, "level": logLevel } ] });
+
+    $.ajax({
+        url: 'conflog',
+        type: 'POST',
+        contentType: 'application/json',
+        // The endpoint replies 200 with an empty body; avoid jQuery trying to parse it as JSON.
+        dataType: 'text',
+        data: data
+    }).done(function () {
+        loadLoggers();
+    }).fail(function (jqXHR) {
+        showError(jqXHR);
+    });
+}
+
+function showError(jqXHR) {
+    var message = jqXHR.status === 401
+        ? "You are not authorized to configure logging."
+        : "Failed to update logger level (HTTP " + jqXHR.status + ").";
+    $("#logconf-error").text(message).show();
 }


### PR DESCRIPTION




### What changes were proposed in this pull request?
1. logconf.jsp — always renders the "Set new logging rules" form (previously it was hidden unless a JDBC session existed and was rendered once per session). Replaces the free-text logger field with a dropdown and aligns the form controls.
2. logconf.js — populates the logger dropdown from /conflog, auto-selects the selected logger's current level, shows the root logger as (root), POSTs updates as application/json, treats the empty 200 response as success (fixing a false "failed" error), and builds the table with text() to prevent HTML injection.
3. Log4j2ConfiguratorServlet — fixes level updates so configuring a not-yet-defined child logger adds a new logger instead of silently changing one of its ancestors (getLoggerConfig returns the nearest ancestor for an unconfigured name).
4. Tests — adds TestLog4j2ConfiguratorServlet covering new-logger creation, in-place updates, the root logger, and every level offered by the UI.



### Why are the changes needed?

The page could not configure logging when there were no active sessions, could accidentally change a parent logger's level, displayed the root logger as a blank row, and showed a spurious error on every successful update. Together these made the feature effectively unusable.



### Does this PR introduce _any_ user-facing change?

Yes — WebUI only. The "Configure logging" page now shows a populated logger dropdown, correctly applies levels, labels the root logger (root), and no longer shows a false error on success. No API/CLI/config changes.


### How was this patch tested?

1. New unit test TestLog4j2ConfiguratorServlet (5 tests) — passing.
2. Manual end-to-end on a MiniHS2 LLAP cluster: verified all 32 runtime loggers × all 6 levels (TRACE→FATAL) applied and reflected back via /conflog, and that a new child logger did not alter its parent.

