### PR TITLE
HIVE-26089: ported TestAsyncPbRpcProxy to junit5, front-loaded JVM warmup and un-ignored a test

### DIFF
--- a/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
+++ b/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
@@ -35,26 +35,26 @@ import org.apache.hadoop.hive.llap.tez.LlapProtocolClientProxy;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class TestAsyncPbRpcProxy {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TestAsyncPbRpcProxy.class);
-
   /**
-   * Front-loads one-time initialization (Mockito mock generation, classloading, log4j2
-   * setup) so the per-test timeouts guard only the code under test. A timeout here
-   * indicates a starved executor, not a test bug (HIVE-26089).
+   * Front-loads one-time initialization (Mockito, log4j2 (transitively), classloading) that would
+   * otherwise happen inside the first test's timeout window. A timeout here indicates a
+   * starved executor, not a test bug (HIVE-26089).
    */
   @BeforeAll
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   static void warmUp() {
+    // Initializes Mockito (agent attach, mock-class generation). Mock classes are
+    // generated and cached per type, so warm both types the tests use.
     mock(Message.class);
     mock(LlapProtocolClientProxy.ExecuteRequestCallback.class);
-    LOG.info("warm-up");
+    // Loads the RequestManager class hierarchy. Also initializes log4j2, because the
+    // constructor touches a logger (via AsyncResponseHandler).
     new RequestManagerForTest(1);
-    LlapNodeId.getInstance("warmup-host", 1025);
+    // Loads the request classes and LlapNodeId, including its Guava cache.
+    new CallableRequestForTest(LlapNodeId.getInstance("warmup-host", 0), null, null);
   }
 
   @Test
@@ -135,7 +135,7 @@ class TestAsyncPbRpcProxy {
     int numSubmissionsCounters = 0;
     private Map<LlapNodeId, MutableInt> numInvocationsPerNode = new HashMap<>();
 
-    public RequestManagerForTest(int numThreads) {
+    RequestManagerForTest(int numThreads) {
       super(numThreads, 1);
     }
 

--- a/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
+++ b/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
@@ -30,13 +30,16 @@ import java.util.Map;
 
 import com.google.protobuf.Message;
 import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.hadoop.hive.llap.LlapNodeId;
 import org.apache.hadoop.hive.llap.tez.LlapProtocolClientProxy;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class TestAsyncPbRpcProxy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestAsyncPbRpcProxy.class);
 
   /**
    * Front-loads one-time initialization (Mockito mock generation, classloading, log4j2
@@ -48,7 +51,7 @@ class TestAsyncPbRpcProxy {
   static void warmUp() {
     mock(Message.class);
     mock(LlapProtocolClientProxy.ExecuteRequestCallback.class);
-    org.slf4j.LoggerFactory.getLogger(TestAsyncPbRpcProxy.class).info("warm-up");
+    LOG.info("warm-up");
     new RequestManagerForTest(1);
     LlapNodeId.getInstance("warmup-host", 1025);
   }

--- a/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
+++ b/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-public class TestAsyncPbRpcProxy {
+class TestAsyncPbRpcProxy {
 
   /**
    * Front-loads one-time initialization (Mockito mock generation, classloading, log4j2

--- a/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
+++ b/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import com.google.protobuf.Message;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -47,7 +48,7 @@ class TestAsyncPbRpcProxy {
    * indicates a starved executor, not a test bug (HIVE-26089).
    */
   @BeforeAll
-  @Timeout(value = 60, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   static void warmUp() {
     mock(Message.class);
     mock(LlapProtocolClientProxy.ExecuteRequestCallback.class);
@@ -57,7 +58,7 @@ class TestAsyncPbRpcProxy {
   }
 
   @Test
-  @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   void testMultipleNodes() throws Exception {
     RequestManagerForTest requestManager = new RequestManagerForTest(1);
 
@@ -87,7 +88,7 @@ class TestAsyncPbRpcProxy {
   }
 
   @Test
-  @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   void testSingleInvocationPerNode() throws Exception {
     RequestManagerForTest requestManager = new RequestManagerForTest(1);
 

--- a/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
+++ b/llap-client/src/test/org/apache/hadoop/hive/llap/TestAsyncPbRpcProxy.java
@@ -19,10 +19,10 @@
 
 package org.apache.hadoop.hive.llap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
@@ -32,13 +32,30 @@ import com.google.protobuf.Message;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.hadoop.hive.llap.LlapNodeId;
 import org.apache.hadoop.hive.llap.tez.LlapProtocolClientProxy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestAsyncPbRpcProxy {
 
-  @Test (timeout = 5000)
-  public void testMultipleNodes() throws Exception {
+  /**
+   * Front-loads one-time initialization (Mockito mock generation, classloading, log4j2
+   * setup) so the per-test timeouts guard only the code under test. A timeout here
+   * indicates a starved executor, not a test bug (HIVE-26089).
+   */
+  @BeforeAll
+  @Timeout(value = 60, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  static void warmUp() {
+    mock(Message.class);
+    mock(LlapProtocolClientProxy.ExecuteRequestCallback.class);
+    org.slf4j.LoggerFactory.getLogger(TestAsyncPbRpcProxy.class).info("warm-up");
+    new RequestManagerForTest(1);
+    LlapNodeId.getInstance("warmup-host", 1025);
+  }
+
+  @Test
+  @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  void testMultipleNodes() throws Exception {
     RequestManagerForTest requestManager = new RequestManagerForTest(1);
 
     LlapNodeId nodeId1 = LlapNodeId.getInstance("host1", 1025);
@@ -59,16 +76,16 @@ public class TestAsyncPbRpcProxy {
     assertEquals(2, requestManager.numSubmissionsCounters);
     assertNotNull(requestManager.numInvocationsPerNode.get(nodeId1));
     assertNotNull(requestManager.numInvocationsPerNode.get(nodeId2));
-    Assert.assertEquals(1, requestManager.numInvocationsPerNode.get(nodeId1).getValue().intValue());
-    Assert.assertEquals(1, requestManager.numInvocationsPerNode.get(nodeId2).getValue().intValue());
+    assertEquals(1, requestManager.numInvocationsPerNode.get(nodeId1).getValue().intValue());
+    assertEquals(1, requestManager.numInvocationsPerNode.get(nodeId2).getValue().intValue());
     assertEquals(0, requestManager.currentLoopSkippedRequests.size());
     assertEquals(0, requestManager.currentLoopSkippedRequests.size());
     assertEquals(0, requestManager.currentLoopDisabledNodes.size());
   }
 
-  @org.junit.Ignore("HIVE-26089")
-  @Test(timeout = 5000)
-  public void testSingleInvocationPerNode() throws Exception {
+  @Test
+  @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  void testSingleInvocationPerNode() throws Exception {
     RequestManagerForTest requestManager = new RequestManagerForTest(1);
 
     LlapNodeId nodeId1 = LlapNodeId.getInstance("host1", 1025);
@@ -83,7 +100,7 @@ public class TestAsyncPbRpcProxy {
     requestManager.process();
     assertEquals(1, requestManager.numSubmissionsCounters);
     assertNotNull(requestManager.numInvocationsPerNode.get(nodeId1));
-    Assert.assertEquals(1, requestManager.numInvocationsPerNode.get(nodeId1).getValue().intValue());
+    assertEquals(1, requestManager.numInvocationsPerNode.get(nodeId1).getValue().intValue());
     assertEquals(0, requestManager.currentLoopSkippedRequests.size());
 
     // Second request for host. Single invocation since the last has not completed.
@@ -92,7 +109,7 @@ public class TestAsyncPbRpcProxy {
     requestManager.process();
     assertEquals(1, requestManager.numSubmissionsCounters);
     assertNotNull(requestManager.numInvocationsPerNode.get(nodeId1));
-    Assert.assertEquals(1, requestManager.numInvocationsPerNode.get(nodeId1).getValue().intValue());
+    assertEquals(1, requestManager.numInvocationsPerNode.get(nodeId1).getValue().intValue());
     assertEquals(1, requestManager.currentLoopSkippedRequests.size());
     assertEquals(1, requestManager.currentLoopDisabledNodes.size());
     assertTrue(requestManager.currentLoopDisabledNodes.contains(nodeId1));
@@ -102,7 +119,7 @@ public class TestAsyncPbRpcProxy {
     requestManager.process();
     assertEquals(2, requestManager.numSubmissionsCounters);
     assertNotNull(requestManager.numInvocationsPerNode.get(nodeId1));
-    Assert.assertEquals(2, requestManager.numInvocationsPerNode.get(nodeId1).getValue().intValue());
+    assertEquals(2, requestManager.numInvocationsPerNode.get(nodeId1).getValue().intValue());
     assertEquals(0, requestManager.currentLoopSkippedRequests.size());
     assertEquals(0, requestManager.currentLoopDisabledNodes.size());
     assertFalse(requestManager.currentLoopDisabledNodes.contains(nodeId1));


### PR DESCRIPTION
### What changes were proposed in this pull request?
Test-only changes to `TestAsyncPbRpcProxy` (no production code, no pom changes — JUnit 5 was
already a llap-client test dependency):
- Ported the class to JUnit 5.
- Front-loaded the one-time JVM initialization into a `@BeforeAll warmUp()` with its own
  60-second `@Timeout`: Mockito mock generation for the two mocked types, logging setup, and
  classloading of the classes under test.
- Kept the original 5-second per-test budgets as `@Timeout(value = 5, threadMode =
  SEPARATE_THREAD)` — `SEPARATE_THREAD` is required for JUnit 4-equivalent preemption
  (Jupiter's default mode only interrupts, which would not stop a hard hang).
- Un-ignored `testSingleInvocationPerNode`, disabled since 2022.

This supersedes the approach of #6440 (`@Ignore` on `testMultipleNodes`) while restoring the
coverage removed by the 2022 direct-to-master disable
([cc6c02da9](https://github.com/apache/hive/commit/cc6c02da94e0dd65dd1501ce3ca5d37980805cfd)).

### Why are the changes needed?
Both recorded failures of this class timed out during one-time JVM bootstrap, never in the
code under test: the original HIVE-26089 report died in classloading (`ZipFile.getEntry`),
and a recent precommit occurrence
([PR 6729, first run](https://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-6729/1/tests))
died inside the first `Mockito.mock()` call while ByteBuddy generated the mock class. With
surefire's `reuseForks=false`, every test class starts a cold JVM, so this cost is paid per
class and lands on whichever timed test runs first. The 5s timeouts exist to catch deadlocks
in `RequestManager`'s lock/condition logic (the tests complete in ~0.5s) — they were never
meant to time JVM startup.

The flake reproduces deterministically with no code changes by simulating a starved executor
with a CPU quota — a fresh JVM per run matches `reuseForks=false`:

```
# from the repo root, on master (pre-patch)
mvn -pl llap-client test-compile dependency:build-classpath -Dmdep.outputFile=cp.txt -Dmdep.includeScope=test
podman run --rm --cpus=0.15 -v "$PWD:$PWD" -v "$HOME/.m2:$HOME/.m2" docker.io/eclipse-temurin:21-jdk \
  java -cp "$PWD/llap-client/target/test-classes:$PWD/llap-client/target/classes:$(cat cp.txt)" \
  org.junit.runner.JUnitCore org.apache.hadoop.hive.llap.TestAsyncPbRpcProxy
```

At `--cpus=0.15` the unmodified test fails every run (observed 4/4) with the exact CI stack —
`TestTimedOutException` frozen inside Mockito/ByteBuddy bootstrap at the first `mock()` call —
and passes from `--cpus=0.35` up (docker works the same as podman here).

Splitting the budgets keeps both signals sharp: a 5s per-test timeout still catches a
deadlock, while an init overrun now fails as `warmUp() timed out` — an environment problem,
clearly distinguished from a test failure.

### Does this PR introduce _any_ user-facing change?
No. Test-only.

### How was this patch tested?
- CPU-quota measurements (fresh JVM per run): unmodified test FAILS 4/4 at 0.15 CPU; with this
  patch both tests PASS at 0.15 and 0.10; at 0.05 (1/20 of a core) the init budget fails the
  class with `warmUp() timed out after 60 seconds` and zero test failures — the intended
  broken-executor signal.
- Negative controls: with the warm-up body emptied, both tests fail preemptively at 5s from
  the JUnit timeout thread (proving `SEPARATE_THREAD` preemption); with a 1-millisecond init
  budget, the class container fails naming `warmUp()` before any test runs (proving the
  init/test signal separation).
- `mvn test -pl llap-client -Dtest=TestAsyncPbRpcProxy`: 2/2 green in ~0.5s (confirms surefire
  discovers the Jupiter tests).
- Checkstyle: no new violations.
