### PR TITLE
HIVE-29851: Bump netty version to 4.1.137.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
     <mockito-core.version>5.17.0</mockito-core.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <mina.version>2.0.0-M5</mina.version>
-    <netty.version>4.1.127.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <pac4j-saml.version>4.5.8</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
     <parquet.version>1.16.0</parquet.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -110,7 +110,7 @@
     <reflections.version>0.10.2</reflections.version>
     <io.grpc.version>1.72.0</io.grpc.version>
     <sqlline.version>1.9.0</sqlline.version>
-    <netty.version>4.1.127.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <jline.version>3.30.16</jline.version>
     <ST4.version>4.0.4</ST4.version>
     <storage-api.version>4.3.0-SNAPSHOT</storage-api.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -33,7 +33,7 @@
     <checkstyle.version>11.1.0</checkstyle.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <netty.version>4.1.127.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <guava.version>22.0</guava.version>
     <hadoop.version>3.4.2</hadoop.version>
     <jackson.version>2.21.5</jackson.version>


### PR DESCRIPTION

### What changes were proposed in this pull request?
netty version bump to 4.1.137 to resolve CVEs
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
CVE fixes


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UTs


Dep Tree: 
[netty_tree.txt](https://github.com/user-attachments/files/31997441/netty_tree.txt)
