### PR TITLE
HIVE-30016: Fix miscellaneous typos in comments, docs, and a test script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,7 @@ Please clarify why the changes are needed. For instance,
 ### Does this PR introduce _any_ user-facing change?
 <!--
 Note that it means *any* user-facing change including all aspects such as the documentation fix.
-If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
+If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducible example to show the behavior difference if possible.
 If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
 If no, write 'No'.
 -->

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveClientCache.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveClientCache.java
@@ -200,7 +200,7 @@ public class HiveClientCache {
     // Add a shutdown hook for cleanup, if there are elements remaining in the cache which were not cleaned up.
     // This is the best effort approach. Ignore any error while doing so. Notice that most of the clients
     // would get cleaned up via either the removalListener or the close() call, only the active clients
-    // that are in the cache or expired but being used in other threads wont get cleaned. The following code will only
+    // that are in the cache or expired but being used in other threads won't get cleaned. The following code will only
     // clean the active cache ones. The ones expired from cache but being hold by other threads are in the mercy
     // of finalize() being called.
     Thread cleanupHiveClientShutdownThread = new Thread() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/debug/Utils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/debug/Utils.java
@@ -62,7 +62,7 @@ public class Utils {
   }
 
   /**
-   * Dumps process heap to a file in temp directoty.
+   * Dumps process heap to a file in temp directory.
    * @param args Strings to use to build a file name (dump_arg0_arg1_....).
    */
   public static void dumpHeapToTmp(String... args) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4737,7 +4737,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
     return results;
   }
 
-  // This method converts PartitionSpec to Partiton.
+  // This method converts PartitionSpec to Partition.
   // This is required because listPartitionsSpecByExpr return set of PartitionSpec but hive
   // require Partition
   static List<Partition> convertFromPartSpec(Iterator<PartitionSpec> iterator, Table tbl)
@@ -5074,7 +5074,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
 
         final String msg = "Unable to move source " + srcP + " to destination " + destf;
 
-        // If we do a rename for a non-local file, we will be transfering the original
+        // If we do a rename for a non-local file, we will be transferring the original
         // file permissions from source to the destination. Else, in case of mvFile() where we
         // copy from source to destination, we will inherit the destination's parent group ownership.
         if (null == pool) {
@@ -5533,7 +5533,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
   }
 
   /**
-   * If moving across different FileSystems or differnent encryption zone, need to do a File copy instead of rename.
+   * If moving across different FileSystems or different encryption zone, need to do a File copy instead of rename.
    * TODO- consider if need to do this for different file authority.
    * @throws HiveException
    */

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -388,7 +388,7 @@ public final class HiveMaterializedViewsRegistry {
 
     // 1. Create column schema
     final RowResolver rr = new RowResolver();
-    // 1.1 Add Column info for non partion cols (Object Inspector fields)
+    // 1.1 Add Column info for non partition cols (Object Inspector fields)
     StructObjectInspector rowObjectInspector;
     try {
       rowObjectInspector = (StructObjectInspector) viewTable.getDeserializer()

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveUtils.java
@@ -103,7 +103,7 @@ public final class HiveUtils {
         escape.append('t');
         break;
       default:
-        // Control characeters! According to JSON RFC u0020
+        // Control characters! According to JSON RFC u0020
         if (c < ' ') {
           String hex = Integer.toHexString(c);
           escape.append('\\');

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionIterable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionIterable.java
@@ -209,7 +209,7 @@ public class PartitionIterable implements Iterable<Partition> {
           partitionNames = db.getPartitionNamesByPartitionVals(table, pVals, (short) -1);
           break;
         case BY_EXPR:
-          // TO-DO: this can be dealt with in a seperate PR. The current changes does not have a particular use case for this.
+          // TO-DO: this can be dealt with in a separate PR. The current changes does not have a particular use case for this.
           throw new HiveException("getpartitionsbyexpr is currently unsupported for the getpartitionswithspecs API");
         default:
           throw new HiveException("No such partition filter mode: " + filterMode);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionTree.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionTree.java
@@ -214,7 +214,7 @@ final class PartitionTree {
    */
   void alterPartitions(List<Partition> newParts)
       throws MetaException, InvalidOperationException, NoSuchObjectException {
-    //altering partitions in a batch must be transactional, therefore bofore starting the altering, clone the original
+    //altering partitions in a batch must be transactional, therefore before starting the altering, clone the original
     //partitions map. If something fails, revert it back.
     Map<String, Partition> clonedPartitions = new LinkedHashMap<>();
     parts.forEach((key, value) -> clonedPartitions.put(key, new Partition(value)));

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsNoJobTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsNoJobTask.java
@@ -460,7 +460,7 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
       ImmutableList<StatCollector> values = collectorsByTable.get(partName);
 
       if (values == null) {
-        throw new RuntimeException("very intresting");
+        throw new RuntimeException("very interesting");
       }
 
       if (values.get(0).result instanceof Table) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsPublisher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsPublisher.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hive.common.classification.InterfaceStability;
 import java.util.Map;
 
 /**
- * An interface for any possible implementation for publishing statics.
+ * An interface for any possible implementation for publishing statistics.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable

--- a/serde/src/java/org/apache/hadoop/hive/serde2/variant/VariantBuilder.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/variant/VariantBuilder.java
@@ -95,7 +95,7 @@ public class VariantBuilder {
     }
     // Determine the number of bytes required per offset entry.
     // The largest offset is the one-past-the-end value, which is total string size. It's very
-    // unlikely that the number of keys could be larger, but incorporate that into the calcualtion
+    // unlikely that the number of keys could be larger, but incorporate that into the calculation
     // in case of pathological data.
     long maxSize = Math.max(dictionaryStringSize, numKeys);
     if (maxSize > SIZE_LIMIT) {

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/README.md
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/README.md
@@ -75,11 +75,11 @@ target directory has two mega-jars which have all the dependencies.
 
 ### Using single jar
 
-    java -jar hmsbench.jar <optins> [test]...
+    java -jar hmsbench.jar <options> [test]...
 
 ### Using hbench on kerberized cluster
 
-    java -jar hmsbench.jar -H `hostname` <optins> [test]...
+    java -jar hmsbench.jar -H `hostname` <options> [test]...
 
 ### Examples
 1. Run all tests with default settings

--- a/testutils/metastore/metastore-validation-test.sh
+++ b/testutils/metastore/metastore-validation-test.sh
@@ -207,7 +207,7 @@ fi
 
 
 FCOUNT=0
-# function to count the number of occurances of a string within another string
+# function to count the number of occurrences of a string within another string
 num_occurances() {
   fulltext="$1"
   searchChars="$2"
@@ -294,28 +294,28 @@ put() {
 }
 
 # function to retrieve an entry from the map.
-# arg1 is name of the map to retrive from.
+# arg1 is name of the map to retrieve from.
 # arg2 is the key for entry
 get() {
   grep "^$2=" /tmp/hashmap.$1 | cut -d'=' -f2
 }
 
 # function that returns the size of the map (aka number if entries)
-# arg1 is name of the map to retrive from.
+# arg1 is name of the map to retrieve from.
 size() {
   echo `cat /tmp/hashmap.$1 | wc -l`
 }
 
 # function that returns the key for the first entry in the map.
 # maps to the key of the first line in the file on disk.
-# arg1 is name of the map to retrive from.
+# arg1 is name of the map to retrieve from.
 firstKey() {
   head -n 1 /tmp/hashmap.$1 | cut -d'=' -f1
 }
 
 # function that returns the value of the first entry in the map.
 # maps to the value of the first line in the file on disk.
-# arg1 is name of the map to retrive from.
+# arg1 is name of the map to retrieve from.
 firstValue() {
   head -n 1 /tmp/hashmap.$1 | cut -d'=' -f2
 }
@@ -324,7 +324,7 @@ firstValue() {
 # arg1 is name of the map to retrieve from.
 # arg2 key to be found in the map.
 containsKey() {
-  # find a line that contains the key value at the begining of line.
+  # find a line that contains the key value at the beginning of line.
   ret=$(grep "^$2=" /tmp/hashmap.$1 | cut -d'=' -f1)
   if [[ "$2" = "$ret" ]]
   then
@@ -713,7 +713,7 @@ parse_schema() {
   done < "$1";
 }
 
-# function to detemine if an argument is a number. This is used to determine the
+# function to determine if an argument is a number. This is used to determine the
 # length of the column values that are to be generated.
 is_int() {
   return $(test "$@" -eq "$@" > /dev/null 2>&1);
@@ -889,7 +889,7 @@ localize_colname() {
 }
 
 # extracts the name of the table from a create statement from the parsed SQL.
-# Assumes that the thrid SPACE-separated token is the name of the table.
+# Assumes that the third SPACE-separated token is the name of the table.
 # ex: CREATE TABLE DBS ( DB_ID bigint(20) );
 extract_tablename() {
   if [[ "$DB_SERVER" = "derby" ]]
@@ -916,7 +916,7 @@ insert_column_names() {
 }
 
 # extracts the name of the table in its native form from a create statement from the parsed SQL.
-# Assumes that the thrid SPACE-separated token is the name of the table. if there are quotes around it will 
+# Assumes that the third SPACE-separated token is the name of the table. if there are quotes around it will 
 # return the quotes too.
 # ex: CREATE TABLE DBS ( DB_ID bigint(20) );
 extract_raw_tablename() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes several unrelated small misspellings found while reviewing comments and docs:

- `metastore-benchmarks` README: `<optins>` -> `<options>` (2 occurrences)
- `.github/pull_request_template.md`: "reproducable" -> "reproducible"
- `Hive.java`: "Partiton" -> "Partition", "transfering" -> "transferring", "differnent" -> "different"
- `PartitionIterable.java`: "seperate" -> "separate"
- `PartitionTree.java`: "bofore" -> "before"
- `StatsPublisher.java`: "statics" -> "statistics" (Javadoc)
- `VariantBuilder.java`: "calcualtion" -> "calculation"
- `HiveMaterializedViewsRegistry.java`: "partion" -> "partition"
- `HiveUtils.java`: "characeters" -> "characters"
- `BasicStatsNoJobTask.java`: "intresting" -> "interesting" (exception message)
- `debug/Utils.java`: "directoty" -> "directory"
- `HiveClientCache.java`: "wont" -> "won't"
- `metastore-validation-test.sh`: "occurances" -> "occurrences", "retrive" -> "retrieve" (x4), "begining" -> "beginning", "detemine" -> "determine", "thrid" -> "third" (x2) — comment text only, the `num_occurances()` function name is left unchanged to avoid touching code structure

No JIRA ticket filed since this is a comment/doc-only, non-functional change with no behavior impact — happy to file one if a reviewer prefers that.

### Why are the changes needed?
Spelling correctness in comments, docs, and a dev/test script. No behavior change.

### Does this PR introduce any user-facing change?
No. Only comment/doc/string text changes. The one exception message text change (`BasicStatsNoJobTask.java`) is not asserted by any existing test.

### How was this patch tested?
Comment/doc/string-only changes; no test behavior is affected.