### PR TITLE
HIVE-29865: Fix database filtering failures with HiveMetaStoreAuthorizer

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/HiveMetaStoreAuthorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/HiveMetaStoreAuthorizer.java
@@ -140,10 +140,9 @@ public class HiveMetaStoreAuthorizer extends MetaStorePreEventListener implement
   @Override
   public final Database filterDatabase(Database database) throws MetaException, NoSuchObjectException {
     if (database != null) {
-      String dbName = database.getName();
-      List<String> databases = filterDatabases(database.getCatalogName(), Collections.singletonList(dbName));
+      List<Database> databases = filterDatabaseObjects(Collections.singletonList(database));
       if (databases.isEmpty()) {
-        throw new NoSuchObjectException(String.format("Database %s does not exist", dbName));
+        throw new NoSuchObjectException(String.format("Database %s does not exist", database.getName()));
       }
     }
     return database;

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/filtercontext/DatabaseFilterContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/filtercontext/DatabaseFilterContext.java
@@ -89,7 +89,7 @@ public class DatabaseFilterContext extends HiveMetaStoreAuthorizableEvent {
       if (db != null) {
         ret.add(getHivePrivilegeObject(db));
       } else {
-        HivePrivilegeObject hivePrivilegeObject = new HivePrivilegeObject(type, dbName);
+        HivePrivilegeObject hivePrivilegeObject = new HivePrivilegeObject(type, catName, dbName, dbName);
         ret.add(hivePrivilegeObject);
       }
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizerFilterDatabases.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizerFilterDatabases.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hadoop.hive.ql.security.authorization.plugin.metastore;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.fallback.FallbackHiveAuthorizerFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestHiveMetaStoreAuthorizerFilterDatabases {
+
+  private Configuration conf;
+  private int metastorePort = -1;
+  private HiveMetaStoreClient client;
+
+  @Before
+  public void setUp() throws Exception {
+    conf = MetastoreConf.newMetastoreConf();
+    MetastoreConf.setVar(conf, ConfVars.HIVE_AUTHORIZATION_MANAGER, FallbackHiveAuthorizerFactory.class.getName());
+    MetastoreConf.setVar(conf, ConfVars.FILTER_HOOK, HiveMetaStoreAuthorizer.class.getName());
+    MetastoreConf.setBoolVar(conf, ConfVars.METASTORE_CLIENT_FILTER_ENABLED, true);
+    MetaStoreTestUtils.setConfForStandloneMode(conf);
+    metastorePort = MetaStoreTestUtils.startMetaStoreWithRetry(conf);
+    client = new HiveMetaStoreClient(conf);
+  }
+
+  @After
+  public void tearDown() {
+    if (client != null) {
+      client.close();
+    }
+    if (metastorePort > 0) {
+      MetaStoreTestUtils.close(metastorePort);
+    }
+  }
+
+  @Test
+  public void testGetAllDatabasesReturnsNamesWithFilterHook() throws Exception {
+    List<String> databases = client.getAllDatabases();
+    assertFalse("getAllDatabases returned empty list", databases.isEmpty());
+    for (String dbName : databases) {
+      assertNotNull("getAllDatabases returned null DB name", dbName);
+    }
+    assertTrue("default database not present in DB list", databases.contains("default"));
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Update the HivePrivilegeObject constructor being used in DatabaseFilterContext
Update the filterDatabase in HiveMetaStoreAuthorizer to prevent StackOverflow with RangerHiveAuthorizer

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To Prevent Null DB Names being returned with HiveMetaStoreAuthorizer filter hook & StackOverflowError error when using RangerHiveAuthorizer & HiveMetaStoreAuthorizer filter hook.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, Fixes the NPE & StackOverflowError in Iceberg REST Catalog and end-user does not encounter Null Db Names when using HiveMetaStoreAuthorizer filter hook

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual Testing
