### PR TITLE
HIVE-29878: HMS REST Catalog ignores pagination for listTables and listNamespaces

### DIFF
--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
@@ -27,6 +27,8 @@ import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
@@ -88,6 +90,8 @@ import org.slf4j.LoggerFactory;
 public class HMSCatalogAdapter implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(HMSCatalogAdapter.class);
   private static final Splitter SLASH = Splitter.on('/');
+  private static final String PAGE_TOKEN = "pageToken";
+  private static final String PAGE_SIZE = "pageSize";
 
   private static final Map<Class<? extends Exception>, Integer> EXCEPTION_ERROR_CODES =
       ImmutableMap.<Class<? extends Exception>, Integer>builder()
@@ -234,6 +238,19 @@ public class HMSCatalogAdapter implements Closeable {
     return castResponse(ConfigResponse.class, ConfigResponse.builder().withEndpoints(endpoints).build());
   }
 
+  private <T extends RESTResponse> T executePaginated(
+      Map<String, String> properties,
+      Class<T> responseType,
+      Supplier<Object> unpaginatedTask,
+      BiFunction<String, String, Object> paginatedTask) {
+    String pageToken = PropertyUtil.propertyAsString(properties, PAGE_TOKEN, null);
+    String pageSize = PropertyUtil.propertyAsString(properties, PAGE_SIZE, null);
+
+    return castResponse(
+        responseType,
+        pageSize != null ? paginatedTask.apply(pageToken, pageSize) : unpaginatedTask.get());
+  }
+
   private ListNamespacesResponse listNamespaces(Map<String, String> vars) {
     Namespace namespace;
     if (vars.containsKey("parent")) {
@@ -241,17 +258,12 @@ public class HMSCatalogAdapter implements Closeable {
     } else {
       namespace = Namespace.empty();
     }
-    String pageToken = PropertyUtil.propertyAsString(vars, "pageToken", null);
-    String pageSize = PropertyUtil.propertyAsString(vars, "pageSize", null);
-    if (pageSize != null) {
-      return castResponse(
-          ListNamespacesResponse.class,
-          CatalogHandlers.listNamespaces(asNamespaceCatalog, namespace, pageToken, pageSize));
-    } else {
-      return castResponse(
-          ListNamespacesResponse.class,
-          CatalogHandlers.listNamespaces(asNamespaceCatalog, namespace));
-    }
+    return executePaginated(
+        vars,
+        ListNamespacesResponse.class,
+        () -> CatalogHandlers.listNamespaces(asNamespaceCatalog, namespace),
+        (pageToken, pageSize) ->
+            CatalogHandlers.listNamespaces(asNamespaceCatalog, namespace, pageToken, pageSize));
   }
 
   private CreateNamespaceResponse createNamespace(Object body) {
@@ -288,15 +300,12 @@ public class HMSCatalogAdapter implements Closeable {
 
   private ListTablesResponse listTables(Map<String, String> vars) {
     Namespace namespace = namespaceFromPathVars(vars);
-    String pageToken = PropertyUtil.propertyAsString(vars, "pageToken", null);
-    String pageSize = PropertyUtil.propertyAsString(vars, "pageSize", null);
-    if (pageSize != null) {
-      return castResponse(
-          ListTablesResponse.class,
-          CatalogHandlers.listTables(catalog, namespace, pageToken, pageSize));
-    } else {
-      return castResponse(ListTablesResponse.class, CatalogHandlers.listTables(catalog, namespace));
-    }
+    return executePaginated(
+        vars,
+        ListTablesResponse.class,
+        () -> CatalogHandlers.listTables(catalog, namespace),
+        (pageToken, pageSize) ->
+            CatalogHandlers.listTables(catalog, namespace, pageToken, pageSize));
   }
 
   private LoadTableResponse createTable(Map<String, String> vars, Object body) {
@@ -369,16 +378,12 @@ public class HMSCatalogAdapter implements Closeable {
 
   private ListTablesResponse listViews(Map<String, String> vars) {
     Namespace namespace = namespaceFromPathVars(vars);
-    String pageToken = PropertyUtil.propertyAsString(vars, "pageToken", null);
-    String pageSize = PropertyUtil.propertyAsString(vars, "pageSize", null);
-    if (pageSize != null) {
-      return castResponse(
-          ListTablesResponse.class,
-          CatalogHandlers.listViews(asViewCatalog, namespace, pageToken, pageSize));
-    } else {
-      return castResponse(
-          ListTablesResponse.class, CatalogHandlers.listViews(asViewCatalog, namespace));
-    }
+    return executePaginated(
+        vars,
+        ListTablesResponse.class,
+        () -> CatalogHandlers.listViews(asViewCatalog, namespace),
+        (pageToken, pageSize) ->
+            CatalogHandlers.listViews(asViewCatalog, namespace, pageToken, pageSize));
   }
 
   private LoadViewResponse createView(Map<String, String> vars, Object body) {

--- a/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
+++ b/standalone-metastore/metastore-rest-catalog/src/main/java/org/apache/iceberg/rest/HMSCatalogAdapter.java
@@ -241,7 +241,17 @@ public class HMSCatalogAdapter implements Closeable {
     } else {
       namespace = Namespace.empty();
     }
-    return castResponse(ListNamespacesResponse.class, CatalogHandlers.listNamespaces(asNamespaceCatalog, namespace));
+    String pageToken = PropertyUtil.propertyAsString(vars, "pageToken", null);
+    String pageSize = PropertyUtil.propertyAsString(vars, "pageSize", null);
+    if (pageSize != null) {
+      return castResponse(
+          ListNamespacesResponse.class,
+          CatalogHandlers.listNamespaces(asNamespaceCatalog, namespace, pageToken, pageSize));
+    } else {
+      return castResponse(
+          ListNamespacesResponse.class,
+          CatalogHandlers.listNamespaces(asNamespaceCatalog, namespace));
+    }
   }
 
   private CreateNamespaceResponse createNamespace(Object body) {
@@ -278,7 +288,15 @@ public class HMSCatalogAdapter implements Closeable {
 
   private ListTablesResponse listTables(Map<String, String> vars) {
     Namespace namespace = namespaceFromPathVars(vars);
-    return castResponse(ListTablesResponse.class, CatalogHandlers.listTables(catalog, namespace));
+    String pageToken = PropertyUtil.propertyAsString(vars, "pageToken", null);
+    String pageSize = PropertyUtil.propertyAsString(vars, "pageSize", null);
+    if (pageSize != null) {
+      return castResponse(
+          ListTablesResponse.class,
+          CatalogHandlers.listTables(catalog, namespace, pageToken, pageSize));
+    } else {
+      return castResponse(ListTablesResponse.class, CatalogHandlers.listTables(catalog, namespace));
+    }
   }
 
   private LoadTableResponse createTable(Map<String, String> vars, Object body) {

--- a/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestHMSCatalogAdapterPagination.java
+++ b/standalone-metastore/metastore-rest-catalog/src/test/java/org/apache/iceberg/rest/TestHMSCatalogAdapterPagination.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.responses.ListNamespacesResponse;
+import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import javax.servlet.http.HttpServletResponse;
+
+public class TestHMSCatalogAdapterPagination {
+
+  @Test
+  public void testPaginationDelegation() throws Exception {
+    Catalog catalog =
+        Mockito.mock(
+            Catalog.class,
+            Mockito.withSettings().extraInterfaces(SupportsNamespaces.class, ViewCatalog.class));
+    SupportsNamespaces nsCatalog = (SupportsNamespaces) catalog;
+    Mockito.when(nsCatalog.listNamespaces(Mockito.any())).thenReturn(Collections.emptyList());
+
+    ListNamespacesResponse res3;
+    try (HMSCatalogAdapter adapter =
+        new HMSCatalogAdapter("test", catalog, null, Collections.emptyList())) {
+
+      HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+      StringWriter stringWriter = new StringWriter();
+      Mockito.when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+
+      // 1. Missing pageSize (should call unpaginated and succeed without NumberFormatException)
+      Map<String, String> vars1 = ImmutableMap.of("pageToken", "0");
+      ListNamespacesResponse res1 =
+          adapter.execute(HTTPMethod.GET, "v1/namespaces", vars1, null, response);
+      if (res1 == null) {
+        System.err.println("Error output: " + stringWriter);
+      }
+      Assertions.assertNotNull(res1, "Response should not be null");
+
+      // 2. Both pageToken and pageSize (should call paginated and slice without errors)
+      Map<String, String> vars2 = ImmutableMap.of("pageToken", "0", "pageSize", "10");
+      ListNamespacesResponse res2 =
+          adapter.execute(HTTPMethod.GET, "v1/namespaces", vars2, null, response);
+      Assertions.assertNotNull(res2, "Response should not be null");
+
+      // 3. pageSize without pageToken
+      Map<String, String> vars3 = ImmutableMap.of("pageSize", "10");
+      res3 = adapter.execute(HTTPMethod.GET, "v1/namespaces", vars3, null, response);
+    }
+    Assertions.assertNotNull(res3, "Response should not be null");
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates `HMSCatalogAdapter` to correctly extract `pageToken` and `pageSize` query parameters for the `listNamespaces` and `listTables` REST routes. If either parameter is present, it routes the request to the overloaded, pagination-aware CatalogHandlers methods.


### Why are the changes needed?
Iceberg Rest Catalog Spec supports it as follows and this helps in catalog contains large number of tables.
1. https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L250-L269
2. https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L525-L538


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
