### PR TITLE
HIVE-30017: Upgrade postgresql to 42.7.12

### DIFF
--- a/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -110,13 +110,14 @@ public class TestBeelineArgParsing {
     extraContent.put(new File("META-INF/services/java.sql.Driver"), dummyDriverClazzName);
     File jarFile = HiveTestUtils.genLocalJarForTest(u, dummyDriverClazzName, extraContent);
     String pathToDummyDriver = jarFile.getAbsolutePath();
+    String postgresVersion = System.getProperty("postgres.version");
     String pathToPostgresJar = System.getProperty("maven.local.repository")
         + File.separator + "org"
         + File.separator + "postgresql"
         + File.separator + "postgresql"
-        + File.separator + "42.7.3"
+        + File.separator + postgresVersion
         + File.separator
-        + "postgresql-42.7.3.jar";
+        + "postgresql-" + postgresVersion + ".jar";
     return Arrays.asList(new Object[][] {
         { "jdbc:postgresql://host:5432/testdb", "org.postgresql.Driver", pathToPostgresJar, true },
         { "jdbc:dummy://host:5432/testdb", dummyDriverClazzName, pathToDummyDriver, false } });

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.2.0</mysql.version>
-    <postgres.version>42.7.3</postgres.version>
+    <postgres.version>42.7.12</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <opencsv.version>5.9</opencsv.version>
     <orc.version>2.1.2</orc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1903,6 +1903,8 @@
             <!-- required by a few tests to find the derby jar -->
             <derby.version>${derby.version}</derby.version>
             <derby.stream.error.file>${test.tmp.dir}/derby.log</derby.stream.error.file>
+            <!-- required by TestBeelineArgParsing to find the postgresql jar -->
+            <postgres.version>${postgres.version}</postgres.version>
             <derby.system.durability>test</derby.system.durability>
             <hadoop.bin.path>${hadoop.bin.path}</hadoop.bin.path>
             <!-- required by Hadoop's JobHistory -->

--- a/pom.xml
+++ b/pom.xml
@@ -1903,7 +1903,7 @@
             <!-- required by a few tests to find the derby jar -->
             <derby.version>${derby.version}</derby.version>
             <derby.stream.error.file>${test.tmp.dir}/derby.log</derby.stream.error.file>
-            <!-- required by TestBeelineArgParsing to find the postgresql jar -->
+            <!-- required by tests to find the postgresql jar -->
             <postgres.version>${postgres.version}</postgres.version>
             <derby.system.durability>test</derby.system.durability>
             <hadoop.bin.path>${hadoop.bin.path}</hadoop.bin.path>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -83,7 +83,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.2.0</mysql.version>
-    <postgres.version>42.7.3</postgres.version>
+    <postgres.version>42.7.12</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bumps `org.postgresql:postgresql` from 42.7.3 to 42.7.12 in `pom.xml` and `standalone-metastore/pom.xml`.

This supersedes #6599, which targeted 42.7.11 for the same CVE and stalled because the original author lacked ASF JIRA credentials to proceed. Picking it up here at a newer patch version per the discussion on that PR.

## Why are the changes needed?

Addresses the CVE affecting `org.postgresql:postgresql` versions `>= 42.2.0, < 42.7.11` by moving to a later patched release.

## Does this PR introduce any user-facing change?

No.

## How was this patch tested?

Dependency version bump only; existing test suite covers usage.

cc @deniskuzZ @uros-b @pranitatiwari-per