### PR TITLE
HIVE-28216: Add commons-configuration2 2.15.0 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
     <commons-collections4.version>4.4</commons-collections4.version>
     <commons-compress.version>1.26.0</commons-compress.version>
     <commons-configuration.version>1.10</commons-configuration.version>
+    <commons-configuration2.version>2.15.0</commons-configuration2.version>
     <commons-exec.version>1.1</commons-exec.version>
     <commons-io.version>2.16.1</commons-io.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -112,6 +112,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <version>${commons-configuration2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-dbcp2</artifactId>
     </dependency>
     <dependency>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -110,6 +110,11 @@
       <artifactId>commons-configuration</artifactId>
       <version>${commons-configuration.version}</version>
     </dependency>
+    <!-- Staged for a future migration off the unmaintained commons-configuration 1.x line.
+         Not wired into any call site yet: the only two consumers (AtlasRestClientBuilder and
+         TestAtlasDumpTask) feed org.apache.atlas.ApplicationProperties.set(Configuration), and
+         Atlas 2.4.0's API (pinned above) hardcodes commons-configuration 1.x's Configuration type.
+         Migrating those call sites needs an Atlas client upgrade first, which is out of scope here. -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds `org.apache.commons:commons-configuration2:2.15.0` as a dependency in `ql/pom.xml` (property declared in root `pom.xml`), alongside the existing `commons-configuration:commons-configuration:1.10` dependency, which is left untouched.

This picks up the thread from #5213, which proposed migrating `commons-configuration` 1.x to `commons-configuration2` but stalled after review.

## Why are the changes needed?

#5213 aimed to fix CVEs in commons-configuration 1.x by moving to config2. However, the only two consumers in this repo — `AtlasRestClientBuilder.java` and `TestAtlasDumpTask.java` — feed `org.apache.atlas.ApplicationProperties.set(Configuration)`, and Atlas 2.4.0's API (pinned in `ql/pom.xml`) hardcodes `org.apache.commons.configuration.Configuration` (config1). Swapping those call sites to config2's `ConfigurationConverter` does not compile against that Atlas API, and since Atlas itself depends on config1 internally, the vulnerable jar stays on the classpath transitively regardless of what Hive declares directly — a full fix needs an Atlas client upgrade as well, which is out of scope here.

This PR only adds the config2 dependency so it's available, without touching the Atlas-coupled call sites, so as not to break the build while that larger Atlas upgrade is out of scope.

## Does this PR introduce any user-facing change?

No.

## How was this patch tested?

`mvn install -DskipTests -pl ql -am` — dependency resolves and `ql` compiles cleanly with commons-configuration2 added alongside the existing commons-configuration 1.x dependency.

cc @ayushtkn @devaspatikrishnatri