### PR TITLE
HIVE-30011: MR jobs submitted outside ExecDriver miss the JDK 17 --add-opens flags

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/JavaVersionUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/JavaVersionUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.hadoop.hive.common;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class JavaVersionUtils {
   private JavaVersionUtils() {
     throw new IllegalStateException("Utility class");
@@ -49,5 +51,20 @@ public class JavaVersionUtils {
         " --add-opens=java.base/java.util.regex=ALL-UNNAMED" +
         " --add-opens=java.base/java.security=ALL-UNNAMED" +
         " --add-opens=java.base/sun.security.provider=ALL-UNNAMED";
+  }
+
+  /**
+   * Appends the --add-opens flags to the AM, map and reduce JVM options of an MR job
+   * that is about to be submitted, keeping whatever is already configured. Every code
+   * path that submits an MR job on Hive's behalf has to call this before creating the
+   * JobClient: ExecDriver, MergeFileTask, ColumnTruncateTask and MRCompactor.
+   */
+  public static void addOpensFlags(Configuration job) {
+    String addOpens = getAddOpensFlags();
+    for (String key : new String[] {"mapreduce.map.java.opts",
+        "mapreduce.reduce.java.opts", "yarn.app.mapreduce.am.command-opts"}) {
+      String current = job.get(key);
+      job.set(key, (current == null ? "" : current) + addOpens);
+    }
   }
 }

--- a/common/src/test/org/apache/hadoop/hive/common/TestJavaVersionUtils.java
+++ b/common/src/test/org/apache/hadoop/hive/common/TestJavaVersionUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hadoop.hive.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+public class TestJavaVersionUtils {
+
+  @Test
+  public void testAddOpensFlagsAppendedToMRJobOpts() {
+    Configuration job = new Configuration(false);
+    job.set("mapreduce.map.java.opts", "-Xmx800m");
+
+    JavaVersionUtils.addOpensFlags(job);
+
+    String flags = JavaVersionUtils.getAddOpensFlags();
+    assertTrue(flags.contains("--add-opens=java.base/java.net=ALL-UNNAMED"));
+    // existing options are kept and the flags appended; unset keys get just the flags
+    assertEquals("-Xmx800m" + flags, job.get("mapreduce.map.java.opts"));
+    assertEquals(flags, job.get("mapreduce.reduce.java.opts"));
+    assertEquals(flags, job.get("yarn.app.mapreduce.am.command-opts"));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
@@ -375,7 +375,7 @@ public class ExecDriver extends Task<MapredWork> implements Serializable, Hadoop
         }
       }
 
-      addOpensFlags(job);
+      JavaVersionUtils.addOpensFlags(job);
       jc = new JobClient(job);
       // make this client wait if job tracker is not behaving well.
       Throttle.checkJobTracker(job, LOG);
@@ -494,16 +494,6 @@ public class ExecDriver extends Task<MapredWork> implements Serializable, Hadoop
     return (returnVal);
   }
 
-  private static void addOpensFlags(JobConf job) {
-    String addOpens = JavaVersionUtils.getAddOpensFlags();
-    addJavaOpts(job, "mapreduce.map.java.opts", addOpens);
-    addJavaOpts(job, "mapreduce.reduce.java.opts", addOpens);
-    addJavaOpts(job, "yarn.app.mapreduce.am.command-opts", addOpens);
-  }
-  private static void addJavaOpts(JobConf job, String conf, String extraOpts) {
-    String javaOpts = StringUtils.defaultString(job.get(conf));
-    job.set(conf, javaOpts + extraOpts);
-  }
 
   public static void propagateSplitSettings(JobConf job, MapWork work) {
     if (work.getNumMapTasks() != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/merge/MergeFileTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/merge/MergeFileTask.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.ql.exec.mr.ExecDriver;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaVersionUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.TaskQueue;
@@ -142,6 +143,9 @@ public class MergeFileTask extends Task<MergeFileWork> implements Serializable,
       if (pwd != null) {
         MetastoreConf.setVar(job, MetastoreConf.ConfVars.PWD, "HIVE");
       }
+
+      // the merge job is submitted directly, not through ExecDriver
+      JavaVersionUtils.addOpensFlags(job);
 
       // submit the job
       try (JobClient jc = new JobClient(job)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/truncate/ColumnTruncateTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/truncate/ColumnTruncateTask.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.JavaUtils;
+import org.apache.hadoop.hive.common.JavaVersionUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.TaskQueue;
@@ -171,6 +172,8 @@ public class ColumnTruncateTask extends Task<ColumnTruncateWork> implements Seri
       if (pwd != null) {
         HiveConf.setVar(job, HiveConf.ConfVars.METASTORE_PWD, "HIVE");
       }
+      // submitted directly, not through ExecDriver
+      JavaVersionUtils.addOpensFlags(job);
       JobClient jc = new JobClient(job);
 
       String addedJars = Utilities.getResourceFiles(job, SessionState.ResourceType.JAR);

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MRCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MRCompactor.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.JavaUtils;
+import org.apache.hadoop.hive.common.JavaVersionUtils;
 import org.apache.hadoop.hive.common.ValidCompactorWriteIdList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -389,6 +390,8 @@ public class MRCompactor implements Compactor {
               "count={}. TxnIdRange[{},{}}]",
           compactionType, job.getJobName(), job.getQueueName(), curDirNumber, obsoleteDirNumber, minTxn, maxTxn);
     }
+    // compaction jobs are submitted directly, not through ExecDriver
+    JavaVersionUtils.addOpensFlags(job);
     try (JobClient jc = new JobClient(job)) {
       RunningJob rj = jc.submitJob(job);
       if (LOG.isInfoEnabled()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move the `--add-opens` injection for MR jobs from a private method in `ExecDriver` into `JavaVersionUtils.addOpensFlags(Configuration)` and call it from every code path that submits an MR job through `JobClient`:

- `ExecDriver.execute` (unchanged behaviour, now delegates to the helper)
- `MergeFileTask.execute` (`ALTER TABLE ... CONCATENATE` on the MR engine)
- `ColumnTruncateTask.execute` (`TRUNCATE TABLE ... COLUMNS` on RCFile tables)
- `MRCompactor.launchCompactionJob` (MR-based ACID compaction launched by the metastore Worker)

The helper appends the flags to `mapreduce.map.java.opts`, `mapreduce.reduce.java.opts` and `yarn.app.mapreduce.am.command-opts`, keeping whatever is already configured. `TestJavaVersionUtils` is added to cover the helper.

### Why are the changes needed?

HIVE-28869 only injects the flags in `ExecDriver`. The three paths above submit MR jobs directly, so on a JDK 17 cluster whose `mapred-site.xml` does not carry the flags their task JVMs fail on the first reflective access into `java.base`, for example:

```
Error: java.lang.reflect.InaccessibleObjectException: Unable to make field private volatile java.lang.String java.net.URI.string accessible:
  module java.base does not "opens java.net" to unnamed module
    at org.apache.hadoop.hive.common.StringInternUtils.<clinit>
    at org.apache.hadoop.hive.ql.io.HiveInputFormat.init
```

`MRCompactor` is still the default compactor for full-CRUD tables (`hive.compactor.crud.query.based=false`), so this affects regular ACID maintenance, not only the MR engine.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- New unit test `TestJavaVersionUtils#testAddOpensFlagsAppendedToMRJobOpts` (existing `-Xmx` value preserved, all three keys end with the flag set).
- The qtest MiniMR drivers run tasks in the local job runner, where `*.java.opts` is ignored, so the container command line cannot be exercised in CI. An equivalent patch on a 3.1.x-based build was verified on a 3-node YARN cluster (Hadoop 3.4.3, JDK 17 on submitter and containers, no cluster-side `--add-opens`): before the patch `ALTER TABLE ... CONCATENATE` failed as above; after it the AM and task `launch_container.sh` of the merge job, the RCFile column-truncate job and a metastore-launched major compaction all carry the flags and the jobs succeed.
