### PR TITLE
Upgrade guava from 22.0 to 33.3.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <esri.version>2.2.4</esri.version>
     <flatbuffers.version>1.12.0</flatbuffers.version>
     <jts.version>1.20.0</jts.version>
-    <guava.version>22.0</guava.version>
+    <guava.version>33.3.0-jre</guava.version>
     <groovy.version>2.4.21</groovy.version>
     <h2database.version>2.2.220</h2database.version>
     <hadoop.version>3.4.2</hadoop.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bumps the `guava.version` property from `22.0` to `33.3.0-jre`. Every module in this repo declares the bare `guava` artifactId with no `-jre`/`-android` classifier and relies on `${guava.version}` to supply it — Guava stopped publishing unsuffixed artifacts after 22.0, so the new version carries the `-jre` suffix directly in the property value.

## Why are the changes needed?

22.0 was released in 2017 and predates fixes for known Guava CVEs, including CVE-2020-8908 and CVE-2023-2976, both involving `Files.createTempDir()` creating a world-readable/writable temporary directory.

## Does this PR introduce any user-facing change?

No.

## How was this patch tested?

Checked the most common cross-major-version Guava breakage pattern before bumping: every `Futures.addCallback(...)` call site in this repo already uses the 3-argument form with an explicit `Executor`, so the 2-argument overload removed in later Guava versions doesn't affect this codebase. Also confirmed no `dependencyConvergence`/`requireUpperBoundDeps` enforcer rule would block on this. Could not run a full Maven build in my environment to compile-verify beyond that — appreciate extra CI/review scrutiny here given the size of the version jump.