### PR TITLE
[HIVE-30027] Upgrade avro from 1.12.0 to 1.12.2 vul fix

### DIFF
--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -613,6 +613,14 @@
             <additionalClasspathElement>${test.conf.dir}</additionalClasspathElement>
             <additionalClasspathElement>${basedir}/${hive.path.to.root}/conf</additionalClasspathElement>
           </additionalClasspathElements>
+          <!-- MiniKafkaCliConfig (kafka_storage_handler.q) produces test data via
+               QTestMiniClusters#getAvroRows(), which resolves the generated
+               org.apache.hive.kafka.Wikipedia SpecificRecord fixture. Avro's
+               ClassSecurityValidator (introduced in 1.12.x) forbids that resolution
+               unless the class is explicitly trusted. -->
+          <systemPropertyVariables>
+            <org.apache.avro.SERIALIZABLE_CLASSES>org.apache.hive.kafka.Wikipedia</org.apache.avro.SERIALIZABLE_CLASSES>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -227,6 +227,20 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Avro's ClassSecurityValidator reads the trusted-classes allowlist once when it is
+               first loaded, so it must be present as a JVM system property from fork startup;
+               setting it at test runtime (e.g. in @BeforeClass) is too late. Scoped to this
+               module's own SimpleRecord test fixture (used by AvroBytesConverterTest), not a
+               repo-wide trust grant. -->
+          <systemPropertyVariables>
+            <org.apache.avro.SERIALIZABLE_CLASSES>org.apache.hadoop.hive.kafka.SimpleRecord</org.apache.avro.SERIALIZABLE_CLASSES>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <!-- Make sure to sync it with standalone-metastore/pom.xml -->
     <antlr4.version>4.9.3</antlr4.version>
     <apache-directory-server.version>2.0.0-M24</apache-directory-server.version>
-    <avro.version>1.12.0</avro.version>
+    <avro.version>1.12.2</avro.version>
     <awaitility.version>4.2.1</awaitility.version>
     <azure-storage-file-datalake.version>12.22.0</azure-storage-file-datalake.version>
     <bcprov-jdk18on.version>1.84</bcprov-jdk18on.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bumps the `avro.version` property from `1.12.0` to `1.12.2` — a patch-level release within the same minor line.

## Why are the changes needed?

Picks up upstream Avro bug fixes from the 1.12.x line. All modules in this repo declare the bare `avro`/`avro-mapred` artifacts with no version override, relying on the root pom's `dependencyManagement` via `${avro.version}`, so this single property change covers the whole build consistently.

## Does this PR introduce any user-facing change?

No.

## How was this patch tested?

Verified no module declares an independent avro version that would need to stay in sync (checked `standalone-metastore/pom.xml` specifically, which has its own copies of some other version properties, but not avro). Could not run a full Maven build in my environment to compile-verify.