### PR TITLE
HIVE-29608: Support database-level Exclusion for Automatic Column Statistics Deletion

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/StatisticsManagementTask.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/StatisticsManagementTask.java
@@ -47,6 +47,9 @@ import javax.jdo.Query;
  * is older than {@code metastore.column.statistics.retention.period}, and deletes them.
  * Individual tables may opt out by setting the table property
  * {@value #STATISTICS_AUTO_DELETION_EXCLUDE_TBLPROPERTY} to {@code "true"}.
+ * Entire databases may opt out by setting the database property
+ * {@value #STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY} to {@code "true"},
+ * which excludes all tables in that database regardless of their individual table property.
  */
 public class StatisticsManagementTask extends ObjectStore implements MetastoreTaskThread {
 
@@ -57,6 +60,8 @@ public class StatisticsManagementTask extends ObjectStore implements MetastoreTa
    * statistics deletion regardless of the global retention setting.
    */
   public static final String STATISTICS_AUTO_DELETION_EXCLUDE_TBLPROPERTY =
+      "statistics.auto.deletion.exclude";
+  public static final String STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY =
       "statistics.auto.deletion.exclude";
 
   /** Separator used when building composite map keys; chosen to be safe in HMS identifiers. */
@@ -146,7 +151,8 @@ public class StatisticsManagementTask extends ObjectStore implements MetastoreTa
               + "table.database.name, "
               + "table.tableName, "
               + "colName, "
-              + "table.parameters.get(\"" + STATISTICS_AUTO_DELETION_EXCLUDE_TBLPROPERTY + "\")");
+              + "table.parameters.get(\"" + STATISTICS_AUTO_DELETION_EXCLUDE_TBLPROPERTY + "\"), "
+              + "table.database.parameters.get(\"" + STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY + "\")");
       @SuppressWarnings("unchecked")
       List<Object[]> rows = (List<Object[]>) tblQuery.execute(lastAnalyzedThreshold);
       return new ArrayList<>(rows);
@@ -174,7 +180,8 @@ public class StatisticsManagementTask extends ObjectStore implements MetastoreTa
       String tblName   = (String) row[2];
       String colName   = (String) row[3];
       String excludeVal = (String) row[4];
-      if (Boolean.parseBoolean(excludeVal)) {
+      String dbExcludeVal = (String) row[5];
+      if (Boolean.parseBoolean(excludeVal) || Boolean.parseBoolean(dbExcludeVal)) {
         LOG.info("Skipping auto deletion of table stats for {}.{} due to exclude property.",
             dbName, tblName);
         continue;
@@ -222,7 +229,8 @@ public class StatisticsManagementTask extends ObjectStore implements MetastoreTa
               + "partition.table.tableName, "
               + "partition.partitionName, "
               + "colName, "
-              + "partition.table.parameters.get(\"" + STATISTICS_AUTO_DELETION_EXCLUDE_TBLPROPERTY + "\")");
+              + "partition.table.parameters.get(\"" + STATISTICS_AUTO_DELETION_EXCLUDE_TBLPROPERTY + "\"), "
+              + "partition.table.database.parameters.get(\"" + STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY + "\")");
       @SuppressWarnings("unchecked")
       List<Object[]> rows = (List<Object[]>) partQuery.execute(lastAnalyzedThreshold);
       return new ArrayList<>(rows);
@@ -249,7 +257,8 @@ public class StatisticsManagementTask extends ObjectStore implements MetastoreTa
       String partName  = (String) row[3];
       String colName   = (String) row[4];
       String excludeVal = (String) row[5];
-      if (Boolean.parseBoolean(excludeVal)) {
+      String dbExcludeVal = (String) row[6];
+      if (Boolean.parseBoolean(excludeVal) || Boolean.parseBoolean(dbExcludeVal)) {
         LOG.info("Skipping auto deletion of partition stats for {}.{} due to exclude property.",
             dbName, tblName);
         continue;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestStatisticsManagement.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestStatisticsManagement.java
@@ -207,6 +207,115 @@ public class TestStatisticsManagement {
   }
 
   /**
+   * Verifies that setting {@value StatisticsManagementTask#STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY}
+   * to {@code "true"} on a database excludes all tables in that database from table-level
+   * column statistics auto-deletion, even if the individual table has no exclude property set.
+   */
+  @Test
+  public void testExcludedDatabaseTableStatsAreNotDeleted() throws Exception {
+    String dbName = "stats_db8";
+    String tableName = "tbl8";
+    createDbAndTable(dbName, tableName, false, true); // table not excluded, db excluded
+    writeTableLevelColStats(dbName, tableName, "c1");
+    assertHasTableColStats(dbName, tableName, "c1");
+    makeAllTableColStatsOlderThanRetention(dbName, tableName);
+
+    runStatisticsManagementTask(conf);
+
+    // Stats must still be present because the database is marked as excluded.
+    assertHasTableColStats(dbName, tableName, "c1");
+  }
+
+  /**
+   * Verifies that setting {@value StatisticsManagementTask#STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY}
+   * to {@code "true"} on a database excludes all partition-level column statistics for tables in
+   * that database from auto-deletion, even if the individual table has no exclude property set.
+   */
+  @Test
+  public void testExcludedDatabasePartitionStatsAreNotDeleted() throws Exception {
+    String dbName = "stats_db9";
+    String tableName = "tbl9";
+    String partVal = "p1";
+    createDbAndPartitionedTable(dbName, tableName, false, true); // table not excluded, db excluded
+    createPartition(dbName, tableName, partVal);
+
+    String partName = "part_col=" + partVal;
+    writePartitionLevelColStats(dbName, tableName, partName, "c1");
+    assertHasPartitionColStats(dbName, tableName, partName, "c1");
+    makeAllPartitionColStatsOlderThanRetention(dbName, tableName);
+
+    runStatisticsManagementTask(conf);
+
+    // Stats must still be present because the database is marked as excluded.
+    assertHasPartitionColStats(dbName, tableName, partName, "c1");
+  }
+
+  /**
+   * Verifies that setting {@value StatisticsManagementTask#STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY}
+   * to {@code "false"} on a database does not prevent deletion. Only an explicit {@code "true"}
+   * value on the database excludes its tables; any other value (including {@code "false"}) is
+   * treated as not excluded.
+   */
+  @Test
+  public void testDatabaseExcludePropertySetToFalseDoesNotPreventDeletion() throws Exception {
+    String dbName = "stats_db10";
+    String tableName = "tbl10";
+
+    Database db = new DatabaseBuilder()
+        .setName(dbName)
+        .setCatalogName(DEFAULT_CATALOG_NAME)
+        .create(client, conf);
+    db.getParameters().put(
+        StatisticsManagementTask.STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY, "false");
+    client.alterDatabase(dbName, db);
+
+    TableBuilder tb = new TableBuilder()
+        .inDb(db)
+        .setTableName(tableName)
+        .addCol("c1", "double")
+        .addCol("c2", "string")
+        .setInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat")
+        .setOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat");
+    client.createTable(tb.build(conf));
+    client.flushCache();
+
+    writeTableLevelColStats(dbName, tableName, "c1");
+    assertHasTableColStats(dbName, tableName, "c1");
+    makeAllTableColStatsOlderThanRetention(dbName, tableName);
+
+    runStatisticsManagementTask(conf);
+
+    // "false" is not a valid exclude signal; stats should be deleted.
+    assertNoTableColStats(dbName, tableName, "c1");
+  }
+
+  /**
+   * Verifies that when both the database and the table set the exclude property to conflicting
+   * values (db excluded, table explicitly not excluded), the database-level exclusion still wins
+   * and stats are preserved.
+   */
+  @Test
+  public void testDatabaseExclusionOverridesTableNonExclusion() throws Exception {
+    String dbName = "stats_db11";
+    String tableName = "tbl11";
+    // table's own exclude flag is "false" (explicitly not excluded), but db is excluded
+    createDbAndTable(dbName, tableName, false, true);
+    Table t = client.getTable(dbName, tableName);
+    t.getParameters().put(
+        StatisticsManagementTask.STATISTICS_AUTO_DELETION_EXCLUDE_TBLPROPERTY, "false");
+    client.alter_table(dbName, tableName, t);
+
+    writeTableLevelColStats(dbName, tableName, "c1");
+    assertHasTableColStats(dbName, tableName, "c1");
+    makeAllTableColStatsOlderThanRetention(dbName, tableName);
+
+    runStatisticsManagementTask(conf);
+
+    // Database-level exclusion should still protect the stats.
+    assertHasTableColStats(dbName, tableName, "c1");
+  }
+
+  /**
    * Verifies that fresh table-level column statistics whose {@code lastAnalyzed} is within the
    * retention period are not deleted when the task runs.
    */
@@ -257,12 +366,30 @@ public class TestStatisticsManagement {
    * @param exclude   if {@code true}, sets the auto-deletion exclude property on the table
    */
   private void createDbAndTable(String dbName, String tableName, boolean exclude) throws Exception {
+    createDbAndTable(dbName, tableName, exclude, false);
+  }
+
+  /**
+   * Creates a database (unless it is the default database) and a simple two-column test table.
+   *
+   * @param dbName    name of the database to create
+   * @param tableName name of the table to create
+   * @param exclude   if {@code true}, sets the auto-deletion exclude property on the table
+   * @param dbExclude if {@code true}, sets the auto-deletion exclude property on the database
+   */
+  private void createDbAndTable(String dbName, String tableName, boolean exclude,
+                                boolean dbExclude) throws Exception {
     Database db;
     if (!DEFAULT_DATABASE_NAME.equals(dbName)) {
-      db = new DatabaseBuilder()
+      DatabaseBuilder dbBuilder = new DatabaseBuilder()
           .setName(dbName)
-          .setCatalogName(DEFAULT_CATALOG_NAME)
-          .create(client, conf);
+          .setCatalogName(DEFAULT_CATALOG_NAME);
+      db = dbBuilder.create(client, conf);
+      if (dbExclude) {
+        db.getParameters().put(
+            StatisticsManagementTask.STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY, "true");
+        client.alterDatabase(dbName, db);
+      }
     } else {
       db = client.getDatabase(DEFAULT_CATALOG_NAME, DEFAULT_DATABASE_NAME);
     }
@@ -293,10 +420,28 @@ public class TestStatisticsManagement {
    */
   private void createDbAndPartitionedTable(String dbName, String tableName,
                                            boolean exclude) throws Exception {
-    Database db = new DatabaseBuilder()
+    createDbAndPartitionedTable(dbName, tableName, exclude, false);
+  }
+
+  /**
+   * Creates a database and a partitioned test table with one partition key {@code part_col}.
+   *
+   * @param dbName    name of the database to create
+   * @param tableName name of the table to create
+   * @param exclude   if {@code true}, sets the auto-deletion exclude property on the table
+   * @param dbExclude if {@code true}, sets the auto-deletion exclude property on the database
+   */
+  private void createDbAndPartitionedTable(String dbName, String tableName,
+                                           boolean exclude, boolean dbExclude) throws Exception {
+    DatabaseBuilder dbBuilder = new DatabaseBuilder()
         .setName(dbName)
-        .setCatalogName(DEFAULT_CATALOG_NAME)
-        .create(client, conf);
+        .setCatalogName(DEFAULT_CATALOG_NAME);
+    Database db = dbBuilder.create(client, conf);
+    if (dbExclude) {
+      db.getParameters().put(
+          StatisticsManagementTask.STATISTICS_AUTO_DELETION_EXCLUDE_DBPROPERTY, "true");
+      client.alterDatabase(dbName, db);
+    }
 
     TableBuilder tb = new TableBuilder()
         .inDb(db)


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Extends the automatic column statistics deletion task (HIVE-28755) to support a database-level exclude property (statistics.auto.deletion.exclude), alongside the existing table-level property. A table/partition is now skipped if either its table or its database has the property set to "true".


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, excluding tables from auto-deletion requires setting the property on every table individually. This lets users exclude an entire database in one step, covering current and future tables.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducible example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Users can set statistics.auto.deletion.exclude=true on a database to exclude all its tables from automatic column statistics deletion. Existing table-level behavior is unchanged; the two are combined with OR semantics.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests in TestStatisticsManagement.java covering: database-level exclusion of table and partition stats, database exclude property set to "false" not preventing deletion, and database-level exclusion taking precedence when the table property is explicitly "false".