### PR TITLE
HIVE-30017: Bump postgres driver version in docker README to 42.7.12

### DIFF
--- a/packaging/src/docker/README.md
+++ b/packaging/src/docker/README.md
@@ -108,7 +108,7 @@ For a quick start, launch the Metastore with Derby,
   docker run -d -p 9083:9083 --env SERVICE_NAME=metastore --env DB_DRIVER=postgres \
        --env SERVICE_OPTS="-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver -Djavax.jdo.option.ConnectionURL=jdbc:postgresql://postgres:5432/metastore_db -Djavax.jdo.option.ConnectionUserName=hive -Djavax.jdo.option.ConnectionPassword=password" \
        --mount source=warehouse,target=/opt/hive/data/warehouse \
-       --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar,target=/opt/hive/lib/postgres.jar \
+       --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.jar,target=/opt/hive/lib/postgres.jar \
        --name metastore-standalone apache/hive:${HIVE_VERSION}
   ```
 
@@ -117,7 +117,7 @@ For a quick start, launch the Metastore with Derby,
   ```shell
    docker run -d -p 9083:9083 --env SERVICE_NAME=metastore --env DB_DRIVER=postgres \
         -v /opt/hive/conf:/hive_custom_conf --env HIVE_CUSTOM_CONF_DIR=/hive_custom_conf \
-        --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar,target=/opt/hive/lib/postgres.jar \
+        --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.jar,target=/opt/hive/lib/postgres.jar \
         --name metastore apache/hive:${HIVE_VERSION}
   ```
 
@@ -165,8 +165,8 @@ export POSTGRES_LOCAL_PATH=your_local_path_to_postgres_driver
 ```
 Example:
 ```shell
-mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.7.3" && \
-export POSTGRES_LOCAL_PATH=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar 
+mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.7.12" && \
+export POSTGRES_LOCAL_PATH=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.jar 
 ```
 If you don't install maven or have problem in resolving the postgres driver, you can always download this jar yourself,
 change the `POSTGRES_LOCAL_PATH` to the path of the downloaded jar.

--- a/standalone-metastore/packaging/src/docker/README.md
+++ b/standalone-metastore/packaging/src/docker/README.md
@@ -96,7 +96,7 @@ Everything would be lost when the service is down. In order to save the Hive tab
 docker run -d -p 9083:9083 --env DB_DRIVER=postgres \
     --env SERVICE_OPTS="-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver -Djavax.jdo.option.ConnectionURL=jdbc:postgresql://postgres:5432/metastore_db -Djavax.jdo.option.ConnectionUserName=hive -Djavax.jdo.option.ConnectionPassword=password" \
     --mount source=warehouse,target=/opt/hive/data/warehouse \
-    --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar,target=/opt/hive/lib/postgres.jar \
+    --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.jar,target=/opt/hive/lib/postgres.jar \
     --name metastore-standalone apache/hive:standalone-metastore-${HIVE_VERSION}
 ```
 
@@ -105,7 +105,7 @@ If you want to use your own `hdfs-site.xml` for the service, you can provide the
 ```shell
 docker run -d -p 9083:9083 --env DB_DRIVER=postgres \
     -v /opt/hive/conf:/hive_custom_conf --env HIVE_CUSTOM_CONF_DIR=/hive_custom_conf \
-    --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar,target=/opt/hive/lib/postgres.jar \
+    --mount type=bind,source=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.jar,target=/opt/hive/lib/postgres.jar \
     --name metastore apache/hive:standalone-metastore-${HIVE_VERSION}
 ```
 
@@ -125,8 +125,8 @@ export POSTGRES_LOCAL_PATH=your_local_path_to_postgres_driver
 ```
 Example:
 ```shell
-mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.7.3" && \
-export POSTGRES_LOCAL_PATH=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.3/postgresql-42.7.3.jar 
+mvn dependency:copy -Dartifact="org.postgresql:postgresql:42.7.12" && \
+export POSTGRES_LOCAL_PATH=`mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.jar 
 ```
 If you don't install maven or have problem in resolving the postgres driver, you can always download this jar yourself,
 change the `POSTGRES_LOCAL_PATH` to the path of the downloaded jar.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the example commands in `packaging/src/docker/README.md` that reference the postgres JDBC driver, bumping the version from 42.7.3 to 42.7.12.

## Why are the changes needed?

Keep the documented driver version current.

## Does this PR introduce any user-facing change?

No, docs only.

## Is the change a dependency upgrade?

No, this only updates a documentation example; no build dependency is changed.